### PR TITLE
docs: add TokenSpeed to engine support docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://pytorch.org/blog/lightseek-smg/"><img src="https://img.shields.io/badge/PyTorch-Technical%20Blog-EE4C2C?logo=pytorch&logoColor=white" alt="PyTorch Blog"></a>
 </p>
 
-High-performance model-routing gateway for large-scale LLM deployments. Centralizes worker lifecycle management, balances traffic across HTTP/gRPC/OpenAI-compatible backends, and provides enterprise-ready control over history storage, MCP tooling, and privacy-sensitive workflows.
+Engine-agnostic, high-performance model-routing gateway for large-scale LLM deployments. Centralizes worker lifecycle management, balances traffic across HTTP/gRPC/OpenAI-compatible backends, and provides enterprise-ready control over history storage, MCP tooling, and privacy-sensitive workflows.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/lightseekorg/smg/main/docs/assets/images/architecture-animated.svg" alt="SMG Architecture" width="100%">
@@ -26,8 +26,8 @@ High-performance model-routing gateway for large-scale LLM deployments. Centrali
 
 |                                 |                                                                                                                                                                  |
 |:--------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **🚀 Maximize GPU Utilization** | Cache-aware routing understands your inference engine's KV cache state—whether SGLang, vLLM, or TensorRT-LLM—to reuse prefixes and reduce redundant computation. |
-| **🔌 One API, Any Backend**     | Route to self-hosted models (SGLang, vLLM, TensorRT-LLM) or cloud providers (OpenAI, Anthropic, Gemini, Bedrock, and more) through a single unified endpoint.    |
+| **🚀 Maximize GPU Utilization** | Cache-aware routing understands your inference engine's KV cache state—whether vLLM, TensorRT-LLM, TokenSpeed, or SGLang—to reuse prefixes and reduce redundant computation. |
+| **🔌 One API, Any Backend**     | Route to self-hosted models (vLLM, TensorRT-LLM, TokenSpeed, SGLang) or cloud providers (OpenAI, Anthropic, Gemini, Bedrock, and more) through a single unified endpoint. |
 | **⚡ Built for Speed**           | Native Rust with gRPC pipelines, sub-millisecond routing decisions, and zero-copy tokenization. Circuit breakers and automatic failover keep things running.     |
 | **🔒 Enterprise Control**       | Multi-tenant rate limiting with OIDC, WebAssembly plugins for custom logic, and a privacy boundary that keeps conversation history within your infrastructure.   |
 | **📊 Full Observability**       | 40+ Prometheus metrics, OpenTelemetry tracing, and structured JSON logs with request correlation—know exactly what's happening at every layer.                   |
@@ -78,10 +78,11 @@ That's it. SMG is now load-balancing requests across your workers.
 | Self-Hosted | Cloud Providers |
 |-------------|-----------------|
 | vLLM | OpenAI |
-| SGLang | Anthropic |
-| TensorRT-LLM | Google Gemini |
-| Ollama | AWS Bedrock |
-| Any OpenAI-compatible server | Azure OpenAI |
+| TensorRT-LLM | Anthropic |
+| TokenSpeed | Google Gemini |
+| SGLang | AWS Bedrock |
+| Ollama | Azure OpenAI |
+| Any OpenAI-compatible server | Any OpenAI-compatible provider |
 
 ## Features
 

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -2,14 +2,14 @@
 name = "smg-grpc-client"
 version = "1.5.1"
 edition = "2021"
-description = "gRPC clients for SGLang and vLLM backends"
+description = "gRPC clients for vLLM, TensorRT-LLM, MLX, TokenSpeed, and SGLang backends"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
 authors = [
     "Simo Lin <linsimo.mark@gmail.com>",
     "Chang Su <mckvtl@gmail.com>",
 ]
-keywords = ["grpc", "sglang", "vllm", "llm"]
+keywords = ["grpc", "vllm", "tokenspeed", "llm", "sglang"]
 categories = ["api-bindings"]
 
 [lib]

--- a/crates/grpc_client/go/README.md
+++ b/crates/grpc_client/go/README.md
@@ -1,6 +1,6 @@
 # SMG gRPC Client (Go)
 
-This module contains auto-generated Go gRPC code for Shepherd Model Gateway services (SGLang, vLLM, TRT-LLM).
+This module contains auto-generated Go gRPC code for Shepherd Model Gateway services (vLLM, TRT-LLM, TokenSpeed, SGLang).
 
 ## Installation
 
@@ -16,9 +16,10 @@ The generated code is divided into packages under the `generated` directory:
 
 -   `generated/common`: Common types (e.g., KV Events)
 -   `generated/sglang_encoder`: SGLang Encoder service
--   `generated/sglang_scheduler`: SGLang Scheduler service
+-   `generated/tokenspeed_scheduler`: TokenSpeed Scheduler service
 -   `generated/trtllm`: TensorRT-LLM Service
 -   `generated/vllm`: vLLM Engine service
+-   `generated/sglang_scheduler`: SGLang Scheduler service
 
 ## Generation
 

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "smg-grpc-proto"
 version = "0.4.9"
-description = "SMG gRPC proto definitions for SGLang, vLLM, TRT-LLM, and MLX"
+description = "SMG gRPC proto definitions for vLLM, TRT-LLM, MLX, TokenSpeed, and SGLang"
 requires-python = ">=3.10"
 dependencies = [
     "grpcio>=1.78.0",

--- a/crates/grpc_client/src/lib.rs
+++ b/crates/grpc_client/src/lib.rs
@@ -1,8 +1,8 @@
-//! gRPC clients for SGLang, vLLM, TensorRT-LLM, MLX, and TokenSpeed backends.
+//! gRPC clients for vLLM, TensorRT-LLM, MLX, TokenSpeed, and SGLang backends.
 //!
 //! This crate provides gRPC client implementations for communicating with
-//! the SGLang scheduler, vLLM engine, TensorRT-LLM engine, MLX engine, and
-//! TokenSpeed scheduler backends.
+//! the vLLM engine, TensorRT-LLM engine, MLX engine, TokenSpeed scheduler,
+//! and SGLang scheduler backends.
 
 pub mod common_proto {
     #![allow(clippy::all, clippy::absolute_paths, unused_qualifications)]

--- a/deploy/helm/smg/README.md
+++ b/deploy/helm/smg/README.md
@@ -42,8 +42,8 @@ The gateway image is on Docker Hub, engine images are on GitHub Container Regist
 |-----------|----------|-------|
 | Gateway | `docker.io` | `lightseekorg/smg:1.3.3` |
 | vLLM worker | `ghcr.io` | `lightseekorg/smg:1.3.3-vllm-v0.18.0` |
-| SGLang worker | `ghcr.io` | `lightseekorg/smg:1.3.3-sglang-v0.5.9` |
 | TRT-LLM worker | `ghcr.io` | `lightseekorg/smg:1.3.3-trtllm-1.3.0rc8` |
+| SGLang worker | `ghcr.io` | `lightseekorg/smg:1.3.3-sglang-v0.5.9` |
 
 Worker images default to `ghcr.io`. Set `workers[].image.tag` to the engine-specific tag.
 

--- a/docs/assets/images/architecture-animated.svg
+++ b/docs/assets/images/architecture-animated.svg
@@ -199,16 +199,16 @@
   <rect x="660" y="70" width="145" height="24" rx="10" fill="url(#greenGrad)"/>
   <rect x="660" y="82" width="145" height="12" fill="url(#greenGrad)"/>
   <text x="732" y="88" text-anchor="middle" class="label" font-size="10" fill="white">gRPC Workers</text>
-  <text x="732" y="110" text-anchor="middle" class="feature">SGLang / vLLM / TRT-LLM</text>
-  <text x="732" y="124" text-anchor="middle" class="feature">Raw Inference + PD</text>
-  <text x="732" y="138" text-anchor="middle" class="feature">Max Performance</text>
+  <text x="732" y="110" text-anchor="middle" class="feature">vLLM / TRT-LLM</text>
+  <text x="732" y="124" text-anchor="middle" class="feature">TokenSpeed / SGLang</text>
+  <text x="732" y="138" text-anchor="middle" class="feature">Raw Inference + PD</text>
 
   <!-- HTTP Workers -->
   <rect x="660" y="170" width="145" height="75" rx="10" fill="#1e293b" stroke="#0ea5e9" stroke-width="2"/>
   <rect x="660" y="170" width="145" height="24" rx="10" fill="url(#blueGrad)"/>
   <rect x="660" y="182" width="145" height="12" fill="url(#blueGrad)"/>
   <text x="732" y="188" text-anchor="middle" class="label" font-size="10" fill="white">HTTP Workers</text>
-  <text x="732" y="210" text-anchor="middle" class="feature">SGLang / vLLM / TRT-LLM</text>
+  <text x="732" y="210" text-anchor="middle" class="feature">vLLM / TRT-LLM / SGLang</text>
   <text x="732" y="224" text-anchor="middle" class="feature">OpenAI-Compatible</text>
 
   <!-- External APIs -->

--- a/docs/assets/images/architecture-detailed.svg
+++ b/docs/assets/images/architecture-detailed.svg
@@ -206,7 +206,7 @@
     <rect x="820" y="195" width="90" height="55" rx="6" fill="#334155" stroke="#8b5cf6" stroke-width="1.5"/>
     <text x="865" y="215" text-anchor="middle" class="sublabel" font-size="9">gRPC Backend</text>
     <text x="865" y="230" text-anchor="middle" class="tiny">vLLM • TRT-LLM</text>
-    <text x="865" y="242" text-anchor="middle" class="tiny" font-size="8">TokenSpeed • SGLang</text>
+    <text x="865" y="242" text-anchor="middle" class="tiny">SGLang</text>
   </g>
   <g>
     <rect x="925" y="200" width="70" height="45" rx="6" fill="#334155" stroke="#10b981" stroke-width="1"/>

--- a/docs/assets/images/architecture-detailed.svg
+++ b/docs/assets/images/architecture-detailed.svg
@@ -205,8 +205,8 @@
   <g>
     <rect x="820" y="195" width="90" height="55" rx="6" fill="#334155" stroke="#8b5cf6" stroke-width="1.5"/>
     <text x="865" y="215" text-anchor="middle" class="sublabel" font-size="9">gRPC Backend</text>
-    <text x="865" y="230" text-anchor="middle" class="tiny">SGLang • vLLM</text>
-    <text x="865" y="242" text-anchor="middle" class="tiny">TensorRT-LLM</text>
+    <text x="865" y="230" text-anchor="middle" class="tiny">vLLM • TRT-LLM</text>
+    <text x="865" y="242" text-anchor="middle" class="tiny" font-size="8">TokenSpeed • SGLang</text>
   </g>
   <g>
     <rect x="925" y="200" width="70" height="45" rx="6" fill="#334155" stroke="#10b981" stroke-width="1"/>
@@ -269,8 +269,8 @@
   <g>
     <rect x="760" y="340" width="90" height="55" rx="6" fill="#334155" stroke="#8b5cf6" stroke-width="1.5"/>
     <text x="805" y="360" text-anchor="middle" class="sublabel" font-size="9">HTTP Backend</text>
-    <text x="805" y="375" text-anchor="middle" class="tiny">SGLang • vLLM</text>
-    <text x="805" y="387" text-anchor="middle" class="tiny">TensorRT-LLM</text>
+    <text x="805" y="375" text-anchor="middle" class="tiny">vLLM • TRT-LLM</text>
+    <text x="805" y="387" text-anchor="middle" class="tiny">SGLang</text>
   </g>
   <!-- HTTP arrows -->
   <path d="M470 355 L490 350" stroke="#475569" stroke-width="1.5" fill="none"/>

--- a/docs/assets/images/concepts-overview.svg
+++ b/docs/assets/images/concepts-overview.svg
@@ -122,8 +122,8 @@
   <rect x="650" y="70" width="120" height="26" rx="10" fill="url(#co-greenGrad)"/>
   <rect x="650" y="88" width="120" height="8" fill="url(#co-greenGrad)"/>
   <text x="710" y="88" text-anchor="middle" class="co-label" font-size="10" fill="white">Workers</text>
-  <text x="710" y="110" text-anchor="middle" class="co-feature" fill="#e2e8f0">SGLang / vLLM</text>
-  <text x="710" y="125" text-anchor="middle" class="co-feature">TensorRT-LLM</text>
+  <text x="710" y="110" text-anchor="middle" class="co-feature" fill="#e2e8f0">vLLM / TRT-LLM</text>
+  <text x="710" y="125" text-anchor="middle" class="co-feature">TokenSpeed / SGLang</text>
 
   <!-- Cloud APIs box -->
   <rect x="650" y="155" width="120" height="65" rx="10" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>

--- a/docs/assets/images/mcp-architecture.svg
+++ b/docs/assets/images/mcp-architecture.svg
@@ -95,7 +95,8 @@
     <text x="72" y="150" text-anchor="middle" class="mcp-feature">Tool Call:</text>
     <text x="72" y="165" text-anchor="middle" class="mcp-code" fill="#a78bfa">web_search</text>
     <text x="72" y="180" text-anchor="middle" class="mcp-code" fill="#94a3b8">{"query": "..."}</text>
-    <text x="72" y="200" text-anchor="middle" class="mcp-feature" fill="#64748b">SGLang / vLLM</text>
+    <text x="72" y="198" text-anchor="middle" class="mcp-feature" fill="#64748b">vLLM / TokenSpeed</text>
+    <text x="72" y="211" text-anchor="middle" class="mcp-feature" fill="#64748b">SGLang</text>
   </g>
 
   <!-- SMG Gateway Container -->

--- a/docs/assets/images/radix-tree.svg
+++ b/docs/assets/images/radix-tree.svg
@@ -215,7 +215,7 @@
 
   <!-- Backend scheduler info -->
   <rect x="655" y="350" width="300" height="115" rx="8" fill="#1e293b" stroke="#475569" stroke-width="1"/>
-  <text x="805" y="372" text-anchor="middle" class="rt-layer-label" fill="#10b981">SGLang / vLLM / TensorRT-LLM</text>
+  <text x="805" y="372" text-anchor="middle" class="rt-layer-label" fill="#10b981">vLLM / TensorRT-LLM / TokenSpeed / SGLang</text>
 
   <text x="735" y="395" text-anchor="middle" class="rt-feature" fill="#e2e8f0">• Token-based scheduling</text>
   <text x="735" y="412" text-anchor="middle" class="rt-feature" fill="#e2e8f0">• Page-aligned KV cache</text>

--- a/docs/assets/images/wasm-plugins.svg
+++ b/docs/assets/images/wasm-plugins.svg
@@ -158,8 +158,8 @@
   <rect x="630" y="150" width="85" height="26" rx="10" fill="url(#wp-greenGrad)"/>
   <rect x="630" y="168" width="85" height="8" fill="url(#wp-greenGrad)"/>
   <text x="672" y="169" text-anchor="middle" class="wp-label" font-size="10" fill="white">Worker</text>
-  <text x="672" y="195" text-anchor="middle" class="wp-feature" font-size="8">vLLM / TokenSpeed</text>
-  <text x="672" y="212" text-anchor="middle" class="wp-feature">SGLang</text>
+  <text x="672" y="195" text-anchor="middle" class="wp-feature">vLLM / SGLang</text>
+  <text x="672" y="212" text-anchor="middle" class="wp-feature">LLM Inference</text>
   <text x="672" y="229" text-anchor="middle" class="wp-feature">KV Cache</text>
 
   <!-- Response -->

--- a/docs/assets/images/wasm-plugins.svg
+++ b/docs/assets/images/wasm-plugins.svg
@@ -158,8 +158,8 @@
   <rect x="630" y="150" width="85" height="26" rx="10" fill="url(#wp-greenGrad)"/>
   <rect x="630" y="168" width="85" height="8" fill="url(#wp-greenGrad)"/>
   <text x="672" y="169" text-anchor="middle" class="wp-label" font-size="10" fill="white">Worker</text>
-  <text x="672" y="195" text-anchor="middle" class="wp-feature">SGLang / vLLM</text>
-  <text x="672" y="212" text-anchor="middle" class="wp-feature">LLM Inference</text>
+  <text x="672" y="195" text-anchor="middle" class="wp-feature" font-size="8">vLLM / TokenSpeed</text>
+  <text x="672" y="212" text-anchor="middle" class="wp-feature">SGLang</text>
   <text x="672" y="229" text-anchor="middle" class="wp-feature">KV Cache</text>
 
   <!-- Response -->

--- a/docs/concepts/architecture/overview.md
+++ b/docs/concepts/architecture/overview.md
@@ -116,9 +116,10 @@ The gRPC path provides maximum performance by handling all text processing at th
 
 ### Supported Backends
 
-- SGLang (gRPC)
 - vLLM (gRPC)
 - TensorRT-LLM (gRPC)
+- TokenSpeed (gRPC)
+- SGLang (gRPC)
 
 ---
 
@@ -141,9 +142,9 @@ Disaggregated inference with separate prefill and decode workers:
 
 ### Supported Backends
 
-- SGLang (HTTP)
 - vLLM (HTTP)
 - TensorRT-LLM (HTTP)
+- SGLang (HTTP)
 
 ---
 
@@ -218,7 +219,7 @@ The cache-aware policy optimizes for KV cache reuse:
 4. Otherwise, route to worker with most cache capacity
 5. Falls back to least-loaded when system is imbalanced
 
-This integrates with SGLang, vLLM, and TensorRT-LLM's native KV cache management.
+This integrates with vLLM, TensorRT-LLM, TokenSpeed, and SGLang's native KV cache management.
 
 ---
 

--- a/docs/concepts/routing/cache-aware.md
+++ b/docs/concepts/routing/cache-aware.md
@@ -24,7 +24,7 @@ SMG maintains an exact replica of each backend's KV cache structure, enabling 10
 
 ### :material-sync: Backend Synchronization
 
-Uses the same tokens, page sizes, and eviction policies as backend schedulers (SGLang, vLLM, TensorRT-LLM).
+Uses the same tokens, page sizes, and eviction policies as backend schedulers (vLLM, TensorRT-LLM, TokenSpeed, SGLang).
 
 </div>
 
@@ -135,7 +135,7 @@ The gateway's radix tree uses the **exact same parameters** as backend scheduler
 
 - **Perfect Cache Prediction**: Since the gateway tree mirrors backend behavior exactly, prefix match calculations are 100% accurate
 - **Kernel-Aware**: Honors page boundaries used by inference kernels (FlashInfer, Mamba, etc.)
-- **Eviction Parity**: Tracks the same eviction policy as SGLang/vLLM/TensorRT-LLM schedulers
+- **Eviction Parity**: Tracks the same eviction policy as vLLM/TensorRT-LLM/TokenSpeed/SGLang schedulers
 
 ---
 

--- a/docs/concepts/routing/pd-disaggregation.md
+++ b/docs/concepts/routing/pd-disaggregation.md
@@ -73,8 +73,8 @@ SMG supports PD disaggregation with two inference backends:
 
 | Runtime | Protocol | Dispatch | KV Transfer | Best For |
 |---------|----------|----------|-------------|----------|
-| **SGLang** | HTTP | Parallel | Bootstrap-based coordination | Production deployments with SGLang |
 | **vLLM** | gRPC | Sequential | NIXL or Mooncake | High-performance with RDMA/TCP networking |
+| **SGLang** | HTTP | Parallel | Bootstrap-based coordination | Production deployments with SGLang |
 
 ### vLLM KV Transfer Backends
 
@@ -301,16 +301,16 @@ The KV cache is transferred between workers using the backend's native mechanism
 
 | Backend | Transfer Method | Coordination |
 |---------|-----------------|--------------|
-| SGLang | NCCL/Gloo over network | Bootstrap metadata (host/port/room) |
 | vLLM + NIXL | RDMA | `kv_transfer_params` relayed by SMG |
 | vLLM + Mooncake | TCP/RDMA | P2P handshake via master server |
-
-**SGLang**: SMG injects bootstrap metadata (`DisaggregatedParams`) into requests, enabling workers to coordinate KV transfer through a shared "room".
+| SGLang | NCCL/Gloo over network | Bootstrap metadata (host/port/room) |
 
 **vLLM**: SMG uses the standard proxy pattern — sends `max_tokens=1` to prefill to trigger KV cache computation, then relays the engine's KV-transfer metadata to the decode request:
 
 - **NIXL**: SMG tags the prefill request with `do_remote_decode=true`; the engine holds its KV blocks and returns handoff params (e.g. `remote_engine_id`, `remote_request_id`, `remote_block_ids`, `remote_host`/`remote_port`, `tp_size`) that SMG forwards verbatim with the decode request, which pulls the blocks over RDMA
 - **Mooncake**: SMG injects the prefill worker's bootstrap host/port; workers coordinate via P2P handshake (no external metadata server required)
+
+**SGLang**: SMG injects bootstrap metadata (`DisaggregatedParams`) into requests, enabling workers to coordinate KV transfer through a shared "room".
 
 ---
 

--- a/docs/getting-started/grpc-workers.md
+++ b/docs/getting-started/grpc-workers.md
@@ -11,7 +11,7 @@ When workers connect via gRPC instead of HTTP, SMG becomes a full OpenAI-compati
 #### Before you begin
 
 - Completed the [Getting Started](index.md) guide
-- A gRPC-capable inference worker (vLLM with gRPC entrypoint)
+- A gRPC-capable inference worker (for example vLLM, TensorRT-LLM, TokenSpeed, or SGLang)
 - Access to the model weights or a HuggingFace model path (for tokenizer loading)
 
 </div>
@@ -35,16 +35,6 @@ In HTTP mode, SMG is a smart proxy — routing and failover only. In gRPC mode, 
 
 ## Start a gRPC Worker
 
-=== "SGLang"
-
-    ```bash
-    python -m sglang.launch_server \
-      --model-path meta-llama/Llama-3.1-8B-Instruct \
-      --host 0.0.0.0 \
-      --port 50051 \
-      --grpc-mode
-    ```
-
 === "vLLM"
 
     ```bash
@@ -63,6 +53,25 @@ In HTTP mode, SMG is a smart proxy — routing and failover only. In gRPC mode, 
       --host 0.0.0.0 \
       --port 50051 \
       --backend pytorch
+    ```
+
+=== "TokenSpeed"
+
+    ```bash
+    python -m smg_grpc_servicer.tokenspeed \
+      --model meta-llama/Llama-3.1-8B-Instruct \
+      --host 0.0.0.0 \
+      --port 50051
+    ```
+
+=== "SGLang"
+
+    ```bash
+    python -m sglang.launch_server \
+      --model-path meta-llama/Llama-3.1-8B-Instruct \
+      --host 0.0.0.0 \
+      --port 50051 \
+      --grpc-mode
     ```
 
 ---
@@ -209,7 +218,7 @@ Auto-detected from the model name. Override with `--tool-call-parser` if needed.
 
 | Use Case | Recommended Mode |
 |----------|-----------------|
-| Workers already run OpenAI servers (SGLang, vLLM HTTP) | HTTP |
+| Workers already run OpenAI servers (vLLM HTTP or SGLang) | HTTP |
 | You need gateway-level tool parsing or Responses MCP | gRPC |
 | You want token-aware load balancing | gRPC |
 | You use thinking models and want reasoning extraction | gRPC |

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -44,14 +44,14 @@ Shepherd Model Gateway (SMG) routes and manages LLM traffic across workers. This
     Engine images bundle SMG with a specific inference engine (x86_64/CUDA only). Use these when you want a single container that can both route and serve.
 
     ```bash
-    # SGLang
-    docker pull ghcr.io/lightseekorg/smg:1.4.1-sglang-v0.5.10
-
     # vLLM
     docker pull ghcr.io/lightseekorg/smg:1.4.1-vllm-v0.19.0
 
     # TensorRT-LLM
     docker pull ghcr.io/lightseekorg/smg:1.4.1-trtllm-1.3.0rc10
+
+    # SGLang
+    docker pull ghcr.io/lightseekorg/smg:1.4.1-sglang-v0.5.10
     ```
 
     Tag format: `{smg_version}-{engine}-{engine_version}`. Browse all tags at [ghcr.io/lightseekorg/smg](https://github.com/lightseekorg/smg/pkgs/container/smg).
@@ -79,18 +79,6 @@ Choose one of these startup paths.
 
 `smg serve` launches backend worker process(es) and then starts SMG with generated worker URLs.
 
-=== "SGLang"
-
-    ```bash
-    smg serve \
-      --backend sglang \
-      --model-path meta-llama/Llama-3.1-8B-Instruct \
-      --data-parallel-size 2 \
-      --connection-mode grpc \
-      --host 0.0.0.0 \
-      --port 30000
-    ```
-
 === "vLLM"
 
     ```bash
@@ -113,11 +101,23 @@ Choose one of these startup paths.
       --port 30000
     ```
 
+=== "SGLang"
+
+    ```bash
+    smg serve \
+      --backend sglang \
+      --model-path meta-llama/Llama-3.1-8B-Instruct \
+      --data-parallel-size 2 \
+      --connection-mode grpc \
+      --host 0.0.0.0 \
+      --port 30000
+    ```
+
 This starts `--data-parallel-size` worker replicas, waits for readiness, then starts the gateway.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--backend` | `sglang` | Inference backend: `sglang`, `vllm`, or `trtllm` |
+| `--backend` | `sglang` | Inference backend: `vllm`, `trtllm`, or `sglang` |
 | `--connection-mode` | `grpc` | Worker connection mode: `grpc` or `http` (TensorRT-LLM only supports gRPC) |
 | `--data-parallel-size` | `1` | Number of worker replicas (one per GPU) |
 | `--worker-base-port` | `31000` | Base port for worker processes |
@@ -215,25 +215,6 @@ curl http://localhost:30000/v1/responses \
 
 Use these when workers are not started via `smg serve`.
 
-=== "SGLang (gRPC)"
-
-    ```bash
-    python -m sglang.launch_server \
-      --model-path meta-llama/Llama-3.1-8B-Instruct \
-      --host 0.0.0.0 \
-      --port 50051 \
-      --grpc-mode
-    ```
-
-=== "SGLang (HTTP)"
-
-    ```bash
-    python -m sglang.launch_server \
-      --model-path meta-llama/Llama-3.1-8B-Instruct \
-      --host 0.0.0.0 \
-      --port 8000
-    ```
-
 === "vLLM (gRPC)"
 
     ```bash
@@ -254,6 +235,34 @@ Use these when workers are not started via `smg serve`.
       --port 50051 \
       --backend pytorch \
       --tp_size 1
+    ```
+
+=== "TokenSpeed (gRPC)"
+
+    ```bash
+    python -m smg_grpc_servicer.tokenspeed \
+      --model meta-llama/Llama-3.1-8B-Instruct \
+      --host 0.0.0.0 \
+      --port 50051
+    ```
+
+=== "SGLang (gRPC)"
+
+    ```bash
+    python -m sglang.launch_server \
+      --model-path meta-llama/Llama-3.1-8B-Instruct \
+      --host 0.0.0.0 \
+      --port 50051 \
+      --grpc-mode
+    ```
+
+=== "SGLang (HTTP)"
+
+    ```bash
+    python -m sglang.launch_server \
+      --model-path meta-llama/Llama-3.1-8B-Instruct \
+      --host 0.0.0.0 \
+      --port 8000
     ```
 
 ### PD Disaggregation Workers

--- a/docs/getting-started/multiple-workers.md
+++ b/docs/getting-started/multiple-workers.md
@@ -20,9 +20,10 @@ SMG connects to workers over HTTP or gRPC, and supports both local inference ser
 
 | Worker Type | Protocol | Example URL |
 |-------------|----------|-------------|
-| SGLang | HTTP / gRPC | `http://worker:8000` or `grpc://worker:50051` |
 | vLLM | gRPC | `grpc://worker:50051` |
 | TensorRT-LLM | gRPC | `grpc://worker:50051` |
+| TokenSpeed | gRPC | `grpc://worker:50051` |
+| SGLang | HTTP / gRPC | `http://worker:8000` or `grpc://worker:50051` |
 | OpenAI (GPT) | HTTP | `https://api.openai.com` |
 | Anthropic (Claude) | HTTP | `https://api.anthropic.com` |
 | xAI (Grok) | HTTP | `https://api.x.ai` |

--- a/docs/getting-started/pd-disaggregation.md
+++ b/docs/getting-started/pd-disaggregation.md
@@ -186,14 +186,14 @@ curl http://localhost:30000/v1/chat/completions \
 
 ---
 
-## SGLang vs vLLM PD at a Glance
+## vLLM vs SGLang PD at a Glance
 
-| | SGLang PD | vLLM PD |
-|---|-----------|---------|
-| **Protocol** | HTTP | gRPC |
-| **Dispatch** | Both workers receive request simultaneously | Prefill first, then decode |
-| **KV Transfer** | Bootstrap-based coordination | NIXL (RDMA) or Mooncake (TCP/RDMA) |
-| **SMG flags** | `--prefill http://... <bootstrap_port>` | `--prefill grpc://...` + `--model-path` |
+| | vLLM PD | SGLang PD |
+|---|---------|-----------|
+| **Protocol** | gRPC | HTTP |
+| **Dispatch** | Prefill first, then decode | Both workers receive request simultaneously |
+| **KV Transfer** | NIXL (RDMA) or Mooncake (TCP/RDMA) | Bootstrap-based coordination |
+| **SMG flags** | `--prefill grpc://...` + `--model-path` | `--prefill http://... <bootstrap_port>` |
 
 ---
 

--- a/docs/getting-started/service-discovery.md
+++ b/docs/getting-started/service-discovery.md
@@ -232,4 +232,4 @@ kubectl auth can-i watch pods -n inference --as=system:serviceaccount:inference:
 
 - [Service Discovery Concepts](../concepts/architecture/service-discovery.md) — Worker lifecycle, monitoring metrics, cross-namespace discovery
 - [Load Balancing](load-balancing.md) — Choose a routing policy for discovered workers
-- [PD Disaggregation](pd-disaggregation.md) — Full PD setup with SGLang and vLLM
+- [PD Disaggregation](pd-disaggregation.md) — Full PD setup with vLLM and SGLang

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,8 +41,9 @@ Route, balance, and orchestrate traffic across your LLM fleet with enterprise-gr
 <div class="backends-label">Works With</div>
 <div class="backends-grid">
 <span class="backend">vLLM</span>
-<span class="backend">SGLang</span>
 <span class="backend">TensorRT-LLM</span>
+<span class="backend">TokenSpeed</span>
+<span class="backend">SGLang</span>
 <span class="backend">OpenAI</span>
 <span class="backend">Claude</span>
 <span class="backend">Gemini</span>
@@ -107,7 +108,7 @@ Circuit breakers, automatic retries with exponential backoff, rate limiting, and
 
 **Gateway = Full Server**
 
-SMG handles everything: tokenization, chat templates, tool parsing, MCP loops, detokenization, and PD routing. Workers run raw inference on SGLang, vLLM, or TensorRT-LLM.
+SMG handles everything: tokenization, chat templates, tool parsing, MCP loops, detokenization, and PD routing. Workers run raw inference on vLLM, TensorRT-LLM, TokenSpeed, or SGLang.
 
 </div>
 
@@ -117,7 +118,7 @@ SMG handles everything: tokenization, chat templates, tool parsing, MCP loops, d
 
 **Gateway = Smart Proxy**
 
-SMG handles routing, load balancing, and failover. Workers run full OpenAI-compatible servers (SGLang, vLLM, TRT-LLM). Supports PD disaggregation.
+SMG handles routing, load balancing, and failover. Workers run full OpenAI-compatible servers (vLLM, TRT-LLM, SGLang). Supports PD disaggregation.
 
 </div>
 

--- a/docs/reference/api/messages.md
+++ b/docs/reference/api/messages.md
@@ -61,7 +61,7 @@ curl http://localhost:30000/v1/messages \
 
 ## gRPC Backend
 
-The Messages API works with gRPC backends such as SGLang and vLLM. When routing to a gRPC backend, SMG translates the Anthropic message format to the backend's native format and translates the response back.
+The Messages API works with gRPC backends such as vLLM, TensorRT-LLM, TokenSpeed, and SGLang. When routing to a gRPC backend, SMG translates the Anthropic message format to the backend's native format and translates the response back.
 
 !!! note
     When using the Messages API with gRPC backends, SMG handles format translation automatically. The backend receives requests in its native format.
@@ -73,7 +73,7 @@ The Messages API works with gRPC backends such as SGLang and vLLM. When routing 
 | Mode | Backend | Description |
 |------|---------|-------------|
 | HTTP (proxy) | Anthropic API | Forward requests to `api.anthropic.com` |
-| gRPC | SGLang/vLLM | Translate and route to local inference |
+| gRPC | vLLM/TensorRT-LLM/TokenSpeed/SGLang | Translate and route to local inference |
 
 ---
 

--- a/grpc_servicer/README.md
+++ b/grpc_servicer/README.md
@@ -1,6 +1,6 @@
 # smg-grpc-servicer
 
-gRPC servicer implementations for LLM inference engines. Supports vLLM and SGLang.
+gRPC servicer implementations for LLM inference engines. Supports vLLM, MLX, TokenSpeed, and SGLang.
 
 ## Installation
 
@@ -8,6 +8,18 @@ For vLLM:
 
 ```bash
 pip install smg-grpc-servicer[vllm]
+```
+
+For MLX:
+
+```bash
+pip install smg-grpc-servicer[mlx]
+```
+
+For TokenSpeed, install the TokenSpeed runtime first, then install the servicer bridge:
+
+```bash
+pip install smg-grpc-servicer
 ```
 
 For SGLang:
@@ -24,6 +36,18 @@ pip install smg-grpc-servicer[sglang]
 vllm serve meta-llama/Llama-2-7b-hf --grpc
 ```
 
+### MLX
+
+```bash
+python -m smg_grpc_servicer.mlx --model meta-llama/Llama-2-7b-hf --host 0.0.0.0 --port 50051
+```
+
+### TokenSpeed
+
+```bash
+python -m smg_grpc_servicer.tokenspeed --model meta-llama/Llama-2-7b-hf --host 0.0.0.0 --port 50051
+```
+
 ### SGLang
 
 ```bash
@@ -33,14 +57,16 @@ sglang serve --model-path meta-llama/Llama-2-7b-hf --grpc-mode
 ## Architecture
 
 ```
-smg-grpc-servicer[vllm]    ──optional dep──>  vllm     (lazy import)
-smg-grpc-servicer[sglang]  ──optional dep──>  sglang   (lazy import)
-smg-grpc-servicer           ──depends on──>  smg-grpc-proto  (hard dependency)
-vllm                        ──optional──>    smg-grpc-servicer (via vllm serve --grpc)
-sglang                      ──optional──>    smg-grpc-servicer (via --grpc-mode)
+smg-grpc-servicer[vllm]    ──optional dep──>  vllm       (lazy import)
+smg-grpc-servicer[mlx]     ──optional dep──>  mlx-lm     (lazy import)
+smg-grpc-servicer          ──external runtime──>  tokenspeed (lazy import)
+smg-grpc-servicer[sglang]  ──optional dep──>  sglang     (lazy import)
+smg-grpc-servicer          ──depends on────>  smg-grpc-proto  (hard dependency)
+vllm                       ──optional──────>  smg-grpc-servicer (via vllm serve --grpc)
+sglang                     ──optional──────>  smg-grpc-servicer (via --grpc-mode)
 ```
 
-Backend dependencies are isolated via extras to avoid conflicts between vLLM and SGLang.
+Backend dependencies are isolated via extras or runtime installs to avoid conflicts between vLLM, MLX, TokenSpeed, and SGLang.
 
 ## Development
 

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "smg-grpc-servicer"
 version = "0.5.4"
-description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, SGLang, MLX, TokenSpeed)"
+description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, MLX, TokenSpeed, SGLang)"
 requires-python = ">=3.10"
 dependencies = [
     "smg-grpc-proto>=0.4.9",


### PR DESCRIPTION
## Description

### Problem

Public docs and repository metadata still presented supported local engines as SGLang/vLLM/TRT-LLM in several generic engine lists, even though TokenSpeed support exists in the gRPC path. The GitHub About text also omitted TokenSpeed and listed SGLang first.

### Solution

Add TokenSpeed to supported engine copy across public docs, package metadata, and diagram labels. Reorder generic engine lists so SGLang appears last while preserving SGLang-specific setup and PD sections where they are intentionally engine-specific. The live GitHub repository description was also updated to list `vLLM, TRT-LLM, TokenSpeed, SGLang`.

## Changes

- Add TokenSpeed to README, docs homepage, gRPC worker docs, API docs, architecture/routing docs, and gRPC servicer docs.
- Refresh gRPC client/proto package descriptions to include TokenSpeed and keep SGLang last in generic engine lists.
- Update SVG diagram labels that list supported workers/backends.
- Reorder PD comparison tables and Helm/getting-started engine lists where they are generic.

## Test Plan

- `git diff --check`
- Commit-time pre-commit hooks passed, including `cargo +nightly fmt --all --`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `codespell`, TOML checks, DCO sign-off check, and no-AI-footer check.
- Verified with `rg` that old generic `SGLang, vLLM` / `SGLang / vLLM` style lists are removed from the touched public docs and metadata.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added TokenSpeed as a supported inference backend across documentation
  * Expanded supported backend listings to include TensorRT-LLM and MLX
  * Reorganized worker setup guides and gRPC/HTTP mode examples for clarity
  * Updated architecture overview with enhanced backend synchronization details
  * Improved getting-started guides with comprehensive worker configuration examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->