### PR TITLE
fix(grpc_client): pass through request.seed in vLLM SamplingParams builders

### DIFF
--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -201,6 +201,10 @@ impl VllmEngineClient {
     }
 
     /// Build gRPC SamplingParams from ChatCompletionRequest
+    #[expect(
+        deprecated,
+        reason = "ChatCompletionRequest.seed is marked Legacy by openai-protocol, but vLLM still honors it"
+    )]
     fn build_grpc_sampling_params_from_chat(
         request: &ChatCompletionRequest,
         tool_call_constraint: Option<(String, String)>,
@@ -237,6 +241,13 @@ impl VllmEngineClient {
             ignore_eos: request.ignore_eos,
             n: request.n.unwrap_or(1),
             logprobs,
+            // Proto seed is i32 (line 48 of generated vllm.grpc.engine.rs);
+            // OpenAI request seed is i64. Saturating cast keeps "set" vs
+            // "unset" distinction (None stays None — vLLM will pick a random
+            // seed itself, matching prior behaviour).
+            seed: request
+                .seed
+                .map(|s| s.clamp(i32::MIN as i64, i32::MAX as i64) as i32),
             constraint: Self::build_constraint_for_chat(request, tool_call_constraint)?,
             ..Default::default()
         })
@@ -533,6 +544,9 @@ impl VllmEngineClient {
             include_stop_str_in_output: request.no_stop_trim,
             n: request.n.unwrap_or(1),
             logprobs,
+            seed: request
+                .seed
+                .map(|s| s.clamp(i32::MIN as i64, i32::MAX as i64) as i32),
             constraint,
             ..Default::default()
         })
@@ -673,6 +687,48 @@ impl VllmEngineClient {
 mod tests {
     use super::*;
 
+    /// Minimal valid CompletionRequest for tests that only care about
+    /// sampling-param passthrough. CompletionRequest doesn't derive Default,
+    /// so we provide the required fields here.
+    fn minimal_completion_request() -> CompletionRequest {
+        CompletionRequest {
+            model: String::new(),
+            prompt: StringOrArray::String(String::new()),
+            best_of: None,
+            echo: false,
+            frequency_penalty: None,
+            logit_bias: None,
+            logprobs: None,
+            max_tokens: None,
+            n: None,
+            presence_penalty: None,
+            seed: None,
+            stop: None,
+            stream: false,
+            stream_options: None,
+            suffix: None,
+            temperature: None,
+            top_p: None,
+            user: None,
+            top_k: None,
+            min_p: None,
+            min_tokens: None,
+            repetition_penalty: None,
+            regex: None,
+            ebnf: None,
+            json_schema: None,
+            stop_token_ids: None,
+            no_stop_trim: false,
+            ignore_eos: false,
+            skip_special_tokens: true,
+            lora_path: None,
+            session_params: None,
+            return_hidden_states: false,
+            sampling_seed: None,
+            other: Default::default(),
+        }
+    }
+
     #[test]
     fn test_proto_types_compilation() {
         let _health_req = proto::HealthCheckRequest {};
@@ -761,6 +817,44 @@ mod tests {
     // TODO: SessionParams not in current proto - skip test
 
     #[test]
+    #[expect(
+        deprecated,
+        reason = "ChatCompletionRequest.seed is marked Legacy by openai-protocol, but vLLM still honors it"
+    )]
+    fn test_chat_sampling_params_seed_is_passed_through() {
+        // Regression guard: build_grpc_sampling_params_from_chat() previously
+        // omitted the seed field, so `..Default::default()` filled proto seed
+        // with None even when the request set it. At temp=0 this was inert
+        // (vLLM's gumbel sampler gates seed use on temp != 0), but at temp>0
+        // it silently broke reproducibility.
+        let request = ChatCompletionRequest {
+            seed: Some(42),
+            ..Default::default()
+        };
+        let params = VllmEngineClient::build_grpc_sampling_params_from_chat(&request, None)
+            .expect("build sampling params");
+        assert_eq!(params.seed, Some(42));
+
+        // No seed in the request → proto seed stays None (vLLM picks one).
+        let unset = ChatCompletionRequest {
+            seed: None,
+            ..Default::default()
+        };
+        let unset_params = VllmEngineClient::build_grpc_sampling_params_from_chat(&unset, None)
+            .expect("build sampling params");
+        assert_eq!(unset_params.seed, None);
+
+        // Saturating cast: request.seed is i64, proto seed is i32.
+        let huge = ChatCompletionRequest {
+            seed: Some(i64::MAX),
+            ..Default::default()
+        };
+        let huge_params = VllmEngineClient::build_grpc_sampling_params_from_chat(&huge, None)
+            .expect("build sampling params");
+        assert_eq!(huge_params.seed, Some(i32::MAX));
+    }
+
+    #[test]
     fn test_responses_sampling_params_are_passed_through() {
         use openai_protocol::responses::ResponsesRequest;
 
@@ -794,6 +888,38 @@ mod tests {
             VllmEngineClient::build_grpc_sampling_params_from_responses(&disabled, None)
                 .expect("build sampling params");
         assert_eq!(disabled_params.top_k, 0);
+    }
+
+    #[test]
+    fn test_completion_sampling_params_seed_is_passed_through() {
+        // Regression guard: build_grpc_sampling_params_from_completion()
+        // previously omitted the seed field, so `..Default::default()`
+        // filled proto seed with None even when the request set it.
+        let request = CompletionRequest {
+            seed: Some(42),
+            ..minimal_completion_request()
+        };
+        let params = VllmEngineClient::build_grpc_sampling_params_from_completion(&request)
+            .expect("build sampling params");
+        assert_eq!(params.seed, Some(42));
+
+        // No seed → proto seed stays None.
+        let unset = CompletionRequest {
+            seed: None,
+            ..minimal_completion_request()
+        };
+        let unset_params = VllmEngineClient::build_grpc_sampling_params_from_completion(&unset)
+            .expect("build sampling params");
+        assert_eq!(unset_params.seed, None);
+
+        // Saturating cast: request.seed is i64, proto seed is i32.
+        let huge = CompletionRequest {
+            seed: Some(i64::MAX),
+            ..minimal_completion_request()
+        };
+        let huge_params = VllmEngineClient::build_grpc_sampling_params_from_completion(&huge)
+            .expect("build sampling params");
+        assert_eq!(huge_params.seed, Some(i32::MAX));
     }
 
     #[test]


### PR DESCRIPTION
I've been working to swap our stack to use smg instead of litellm and in parity testing noticed that seeds were getting dropped. This ensures the seeds are getting piped through.

### Problem

The `build_grpc_sampling_params_from_chat()` and
`build_grpc_sampling_params_from_completion()` helpers omitted the `seed`
field when constructing `proto::SamplingParams`. The `..Default::default()`
fill silently set `proto::SamplingParams.seed = None` even when the
incoming OpenAI request specified `seed`.

At `temperature=0` this was inert — vLLM's gumbel sampler gates seed
consumption on `temp != 0` (`gumbel.py:97-110`). But at `temp > 0` any
client relying on `seed` for reproducibility got silently-random outputs
through the gRPC path.

Note: only `ChatCompletionRequest` and `CompletionRequest` define a `seed`
field in the openai-protocol crate. `CreateMessageRequest` (Anthropic
Messages API) and `ResponsesRequest` (Responses API) do not expose `seed`,
so their builders are unaffected.

The `ChatCompletionRequest.seed` field is marked `#[deprecated]` with
reason "Legacy mode" by the openai-protocol crate. This appears to be
upstream tracking of OpenAI's marketing deprecation — the field still
works in practice (the OpenAI API continues to accept it, and vLLM
honors it). The `#[expect(deprecated)]` annotations in this PR are
intentional.

### Solution

Set `seed` in both `build_grpc_sampling_params_from_chat()` and
`build_grpc_sampling_params_from_completion()` with a saturating
`i64 → i32` cast (proto field is `Option<i32>`; OpenAI request field is
`Option<i64>`). `None` maps to `None` — vLLM picks its own seed, matching
prior behavior.

## Changes

- `crates/grpc_client/src/vllm_engine.rs`:
  - `build_grpc_sampling_params_from_chat()`: added `seed` field with
    saturating cast + `#[expect(deprecated)]` annotation.
  - `build_grpc_sampling_params_from_completion()`: same.
  - Added `test_chat_sampling_params_seed_is_passed_through` regression
    test (set / unset / overflow cases).
  - Added `test_completion_sampling_params_seed_is_passed_through`
    regression test (same three cases).
  - Added `minimal_completion_request()` test helper (`CompletionRequest`
    doesn't derive `Default`).

## Test Plan

```bash
cargo +nightly fmt --all                         # silent ✓
cargo clippy -p smg-grpc-client --all-targets -- -D warnings  # zero warnings ✓
cargo test -p smg-grpc-client --lib              # 57 passed, 3 pre-existing failures ✓
```

The 3 `test_client_connect_invalid_endpoint` failures are pre-existing
(tonic no longer rejects invalid URI schemes synchronously) and unrelated
to this change.

New tests exercise three cases per builder:
1. `seed: Some(42)` → proto seed is `Some(42)`
2. `seed: None` → proto seed is `None`
3. `seed: Some(i64::MAX)` → proto seed is `Some(i32::MAX)` (saturating)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed seed parameter propagation in chat and completion API requests to ensure seed values are correctly transferred to backend processing.
  * Enhanced handling of boundary seed values to prevent data loss during type conversions.

* **Tests**
  * Added comprehensive regression tests validating seed parameter behavior across various scenarios including null values, set values, and extreme edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->