### PR TITLE
fix(reasoning_parser): preserve whitespace in BaseReasoningParser

### DIFF
--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -201,6 +201,10 @@ impl VllmEngineClient {
     }
 
     /// Build gRPC SamplingParams from ChatCompletionRequest
+    #[expect(
+        deprecated,
+        reason = "ChatCompletionRequest.seed is marked Legacy by openai-protocol, but vLLM still honors it"
+    )]
     fn build_grpc_sampling_params_from_chat(
         request: &ChatCompletionRequest,
         tool_call_constraint: Option<(String, String)>,
@@ -237,6 +241,13 @@ impl VllmEngineClient {
             ignore_eos: request.ignore_eos,
             n: request.n.unwrap_or(1),
             logprobs,
+            // Proto seed is i32 (line 48 of generated vllm.grpc.engine.rs);
+            // OpenAI request seed is i64. Saturating cast keeps "set" vs
+            // "unset" distinction (None stays None — vLLM will pick a random
+            // seed itself, matching prior behaviour).
+            seed: request
+                .seed
+                .map(|s| s.clamp(i32::MIN as i64, i32::MAX as i64) as i32),
             constraint: Self::build_constraint_for_chat(request, tool_call_constraint)?,
             ..Default::default()
         })
@@ -533,6 +544,9 @@ impl VllmEngineClient {
             include_stop_str_in_output: request.no_stop_trim,
             n: request.n.unwrap_or(1),
             logprobs,
+            seed: request
+                .seed
+                .map(|s| s.clamp(i32::MIN as i64, i32::MAX as i64) as i32),
             constraint,
             ..Default::default()
         })
@@ -673,6 +687,48 @@ impl VllmEngineClient {
 mod tests {
     use super::*;
 
+    /// Minimal valid CompletionRequest for tests that only care about
+    /// sampling-param passthrough. CompletionRequest doesn't derive Default,
+    /// so we provide the required fields here.
+    fn minimal_completion_request() -> CompletionRequest {
+        CompletionRequest {
+            model: String::new(),
+            prompt: StringOrArray::String(String::new()),
+            best_of: None,
+            echo: false,
+            frequency_penalty: None,
+            logit_bias: None,
+            logprobs: None,
+            max_tokens: None,
+            n: None,
+            presence_penalty: None,
+            seed: None,
+            stop: None,
+            stream: false,
+            stream_options: None,
+            suffix: None,
+            temperature: None,
+            top_p: None,
+            user: None,
+            top_k: None,
+            min_p: None,
+            min_tokens: None,
+            repetition_penalty: None,
+            regex: None,
+            ebnf: None,
+            json_schema: None,
+            stop_token_ids: None,
+            no_stop_trim: false,
+            ignore_eos: false,
+            skip_special_tokens: true,
+            lora_path: None,
+            session_params: None,
+            return_hidden_states: false,
+            sampling_seed: None,
+            other: Default::default(),
+        }
+    }
+
     #[test]
     fn test_proto_types_compilation() {
         let _health_req = proto::HealthCheckRequest {};
@@ -761,6 +817,44 @@ mod tests {
     // TODO: SessionParams not in current proto - skip test
 
     #[test]
+    #[expect(
+        deprecated,
+        reason = "ChatCompletionRequest.seed is marked Legacy by openai-protocol, but vLLM still honors it"
+    )]
+    fn test_chat_sampling_params_seed_is_passed_through() {
+        // Regression guard: build_grpc_sampling_params_from_chat() previously
+        // omitted the seed field, so `..Default::default()` filled proto seed
+        // with None even when the request set it. At temp=0 this was inert
+        // (vLLM's gumbel sampler gates seed use on temp != 0), but at temp>0
+        // it silently broke reproducibility.
+        let request = ChatCompletionRequest {
+            seed: Some(42),
+            ..Default::default()
+        };
+        let params = VllmEngineClient::build_grpc_sampling_params_from_chat(&request, None)
+            .expect("build sampling params");
+        assert_eq!(params.seed, Some(42));
+
+        // No seed in the request → proto seed stays None (vLLM picks one).
+        let unset = ChatCompletionRequest {
+            seed: None,
+            ..Default::default()
+        };
+        let unset_params = VllmEngineClient::build_grpc_sampling_params_from_chat(&unset, None)
+            .expect("build sampling params");
+        assert_eq!(unset_params.seed, None);
+
+        // Saturating cast: request.seed is i64, proto seed is i32.
+        let huge = ChatCompletionRequest {
+            seed: Some(i64::MAX),
+            ..Default::default()
+        };
+        let huge_params = VllmEngineClient::build_grpc_sampling_params_from_chat(&huge, None)
+            .expect("build sampling params");
+        assert_eq!(huge_params.seed, Some(i32::MAX));
+    }
+
+    #[test]
     fn test_responses_sampling_params_are_passed_through() {
         use openai_protocol::responses::ResponsesRequest;
 
@@ -794,6 +888,38 @@ mod tests {
             VllmEngineClient::build_grpc_sampling_params_from_responses(&disabled, None)
                 .expect("build sampling params");
         assert_eq!(disabled_params.top_k, 0);
+    }
+
+    #[test]
+    fn test_completion_sampling_params_seed_is_passed_through() {
+        // Regression guard: build_grpc_sampling_params_from_completion()
+        // previously omitted the seed field, so `..Default::default()`
+        // filled proto seed with None even when the request set it.
+        let request = CompletionRequest {
+            seed: Some(42),
+            ..minimal_completion_request()
+        };
+        let params = VllmEngineClient::build_grpc_sampling_params_from_completion(&request)
+            .expect("build sampling params");
+        assert_eq!(params.seed, Some(42));
+
+        // No seed → proto seed stays None.
+        let unset = CompletionRequest {
+            seed: None,
+            ..minimal_completion_request()
+        };
+        let unset_params = VllmEngineClient::build_grpc_sampling_params_from_completion(&unset)
+            .expect("build sampling params");
+        assert_eq!(unset_params.seed, None);
+
+        // Saturating cast: request.seed is i64, proto seed is i32.
+        let huge = CompletionRequest {
+            seed: Some(i64::MAX),
+            ..minimal_completion_request()
+        };
+        let huge_params = VllmEngineClient::build_grpc_sampling_params_from_completion(&huge)
+            .expect("build sampling params");
+        assert_eq!(huge_params.seed, Some(i32::MAX));
     }
 
     #[test]

--- a/crates/reasoning_parser/src/parsers/base.rs
+++ b/crates/reasoning_parser/src/parsers/base.rs
@@ -57,10 +57,7 @@ impl ReasoningParser for BaseReasoningParser {
         }
 
         // The text is considered to be in a reasoning block.
-        let processed_text = text
-            .replace(&self.config.think_start_token, "")
-            .trim()
-            .to_string();
+        let processed_text = text.replace(&self.config.think_start_token, "").to_string();
 
         if !processed_text.contains(&self.config.think_end_token) {
             // Assume reasoning was truncated before end token
@@ -72,10 +69,7 @@ impl ReasoningParser for BaseReasoningParser {
             .splitn(2, &self.config.think_end_token)
             .collect();
         let reasoning_text = (*splits.first().unwrap_or(&"")).to_string();
-        let normal_text = splits
-            .get(1)
-            .map(|s| s.trim().to_string())
-            .unwrap_or_default();
+        let normal_text = splits.get(1).map(|s| s.to_string()).unwrap_or_default();
 
         Ok(ParserResult::new(normal_text, reasoning_text))
     }
@@ -127,7 +121,7 @@ impl ReasoningParser for BaseReasoningParser {
             };
             return Ok(ParserResult::new(
                 normal_text.to_string(),
-                reasoning_text.trim().to_string(),
+                reasoning_text.to_string(),
             ));
         }
 
@@ -198,7 +192,8 @@ mod tests {
         let result = parser
             .detect_and_parse_reasoning("<think>with reasoning</think> and more text.")
             .unwrap();
-        assert_eq!(result.normal_text, "and more text.");
+        // Leading space after </think> is preserved (matches vLLM behavior).
+        assert_eq!(result.normal_text, " and more text.");
         assert_eq!(result.reasoning_text, "with reasoning");
     }
 
@@ -220,6 +215,29 @@ mod tests {
             .unwrap();
         assert_eq!(result.normal_text, "");
         assert_eq!(result.reasoning_text, "with truncated reasoning");
+    }
+
+    #[test]
+    fn test_whitespace_preserved_after_think_tags() {
+        // Whitespace around reasoning and content must be preserved exactly as
+        // the model emitted it. vLLM's KimiK2ReasoningParser.extract_reasoning()
+        // returns raw string slices with no trimming; SMG must match.
+        let mut parser = create_test_parser(false, true);
+
+        // Non-streaming: leading space on content, no extra space on reasoning.
+        let result = parser
+            .detect_and_parse_reasoning("<think>foo</think> hello world")
+            .unwrap();
+        assert_eq!(result.reasoning_text, "foo");
+        assert_eq!(result.normal_text, " hello world");
+
+        // Streaming: same contract.
+        let mut streaming_parser = create_test_parser(false, true);
+        let result = streaming_parser
+            .parse_reasoning_streaming_incremental("<think>foo</think> hello world")
+            .unwrap();
+        assert_eq!(result.reasoning_text, "foo");
+        assert_eq!(result.normal_text, " hello world");
     }
 
     #[test]

--- a/crates/reasoning_parser/src/parsers/cohere_cmd.rs
+++ b/crates/reasoning_parser/src/parsers/cohere_cmd.rs
@@ -250,8 +250,8 @@ Let me analyze this step by step.
         let result = parser
             .detect_and_parse_reasoning("<|START_THINKING|>   \n\t  <|END_THINKING|>answer")
             .unwrap();
-        // BaseReasoningParser trims reasoning text
-        assert_eq!(result.reasoning_text, "");
+        // Whitespace is preserved (no trimming in BaseReasoningParser)
+        assert_eq!(result.reasoning_text, "   \n\t  ");
         assert_eq!(result.normal_text, "answer");
     }
 }

--- a/crates/reasoning_parser/src/parsers/deepseek_r1.rs
+++ b/crates/reasoning_parser/src/parsers/deepseek_r1.rs
@@ -114,7 +114,7 @@ mod tests {
         let result2 = parser
             .parse_reasoning_streaming_incremental(" the problem</think>answer")
             .unwrap();
-        assert_eq!(result2.reasoning_text, "the problem"); // Text is trimmed
+        assert_eq!(result2.reasoning_text, " the problem"); // Whitespace preserved
         assert_eq!(result2.normal_text, "answer");
     }
 

--- a/crates/reasoning_parser/src/parsers/minimax.rs
+++ b/crates/reasoning_parser/src/parsers/minimax.rs
@@ -114,7 +114,7 @@ mod tests {
         let result2 = parser
             .parse_reasoning_streaming_incremental(" the problem</think>answer")
             .unwrap();
-        assert_eq!(result2.reasoning_text, "the problem");
+        assert_eq!(result2.reasoning_text, " the problem");
         assert_eq!(result2.normal_text, "answer");
     }
 


### PR DESCRIPTION
Similar to the PR stacked below this, I also found in parity testing the grpc stack against http (litellm and smg versions) that whitespace is handled slightly differently. This PR makes sure that grpc matches the behavior of the http stack in both litellm and smg.

Note: Stacked on #1657 — review the second commit only, I can update this once that is merged if preferable

### Problem

`BaseReasoningParser`'s non-streaming (`detect_and_parse_reasoning`) and
streaming (`parse_reasoning_streaming_incremental`) entry points called
`.trim()` on the reasoning and/or content halves after splitting on the
think-end token. Specifically:

- `detect_and_parse_reasoning`: trimmed the entire text after removing
  `<think>` (line 62), and trimmed `normal_text` after splitting on
  `</think>` (line 77).
- `parse_reasoning_streaming_incremental`: trimmed `reasoning_text` when
  the end token was found (line 130).

This diverged from vLLM's `BaseThinkingReasoningParser.extract_reasoning()`,
which returns raw string slices with no whitespace normalization.

Effect: the same model output produced different `.content` strings
depending on which path it went through — e.g. `"hello world"` via SMG
gRPC vs `" hello world"` via vLLM HTTP. This affects byte-exact
cross-pool parity, JSON-mode framing, and eval harnesses that key on
whitespace.

### Solution

Remove the three `.trim()` calls. Whitespace emitted by the model is
preserved exactly as-is, matching vLLM's behavior.

**Minimal repro showing vLLM's behavior** — extracted from
[`BaseThinkingReasoningParser.extract_reasoning()`](https://github.com/vllm-project/vllm/blob/main/vllm/reasoning/basic_parsers.py)
in `vllm/reasoning/basic_parsers.py` (lines 153–177).
`DeepSeekR1ReasoningParser` inherits this without overriding it.

```python
def vllm_extract_reasoning(model_output, start_token="<think>", end_token="</think>"):
    """BaseThinkingReasoningParser.extract_reasoning() core logic."""
    # Lines 164-167: remove start token via str.partition()
    model_output_parts = model_output.partition(start_token)
    model_output = model_output_parts[2] if model_output_parts[1] else model_output_parts[0]

    # Lines 171-177: split on end token via str.partition() — no .strip()/.trim()
    if end_token not in model_output:
        return model_output, None
    reasoning, _, content = model_output.partition(end_token)
    return reasoning, content or None

cases = [
    "<think>foo</think> hello world",
    "<think>with reasoning</think> and more text.",
    "<think> padded reasoning </think> padded content ",
]
for text in cases:
    reasoning, content = vllm_extract_reasoning(text)
    print(f"input:     {text!r}")
    print(f"reasoning: {reasoning!r}")
    print(f"content:   {content!r}")
    print()
```

Output — `str.partition()` returns raw slices, no trimming:

```
input:     '<think>foo</think> hello world'
reasoning: 'foo'
content:   ' hello world'

input:     '<think>with reasoning</think> and more text.'
reasoning: 'with reasoning'
content:   ' and more text.'

input:     '<think> padded reasoning </think> padded content '
reasoning: ' padded reasoning '
content:   ' padded content '
```

## Changes

- `crates/reasoning_parser/src/parsers/base.rs`:
  - Removed `.trim()` after removing think-start token (non-streaming).
  - Removed `.trim()` on `normal_text` after splitting on think-end token
    (non-streaming).
  - Removed `.trim()` on `reasoning_text` when end token found
    (streaming).
  - Updated `test_detect_and_parse_reasoning` to expect leading space
    (`" and more text."` instead of `"and more text."`).
  - Added `test_whitespace_preserved_after_think_tags` exercising both
    non-streaming and streaming paths.

- `crates/reasoning_parser/src/parsers/deepseek_r1.rs`:
  - Updated `test_deepseek_r1_streaming` assertion (`" the problem"`
    instead of `"the problem"`).

- `crates/reasoning_parser/src/parsers/minimax.rs`:
  - Updated `test_minimax_streaming` assertion (same).

- `crates/reasoning_parser/src/parsers/cohere_cmd.rs`:
  - Updated `test_cohere_cmd_whitespace_only_thinking` assertion
    (whitespace-only reasoning is now preserved, not trimmed to empty).

## Test Plan

```bash
cargo +nightly fmt --all                              # silent ✓
cargo clippy -p reasoning-parser --all-targets -- -D warnings  # zero warnings ✓
cargo test -p reasoning-parser --lib                  # 75 passed, 0 failed ✓
```

All 75 reasoning-parser tests pass, including the new
`test_whitespace_preserved_after_think_tags` and the 5 updated assertions
across base, deepseek_r1, minimax, and cohere_cmd parsers.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Seed parameters are now explicitly supported and properly mapped for both chat and completion requests.

* **Bug Fixes**
  * Improved whitespace handling in reasoning text extraction to preserve spaces at block boundaries across parser implementations, aligning behavior with vLLM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->