### PR TITLE
feat(grpc): add TokenSpeed FlushCache and profile RPCs

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -492,9 +492,14 @@ jobs:
             test_timeout: 18
           # tokenspeed builds from source (~30m cold), so keep the job
           # timeout generous even though the test step is short.
+          # Admin-ops e2e (flush/profile) piggybacks here because this is
+          # the only lane with tokenspeed installed — e2e-1gpu-gateway
+          # installs sglang/vllm only. The engine marker filter keeps the
+          # rest of e2e_test/router out of this job.
           - engine: tokenspeed
             timeout: 50
-            test_timeout: 15
+            test_timeout: 18
+            test_dirs: e2e_test/chat_completions e2e_test/router/test_admin_ops.py
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -502,7 +507,7 @@ jobs:
       runner: 1-gpu-h100
       timeout: ${{ matrix.timeout }}
       test_timeout: ${{ matrix.test_timeout }}
-      test_dirs: e2e_test/chat_completions
+      test_dirs: ${{ matrix.test_dirs || 'e2e_test/chat_completions' }}
     secrets: inherit
 
   e2e-1gpu-completions:

--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -4,8 +4,10 @@ package tokenspeed.grpc.scheduler;
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";
+import "common.proto";
 
-// TokenSpeed scheduler gRPC service. Fully self-contained wire definition.
+// TokenSpeed scheduler gRPC service. Self-contained wire definition apart
+// from the cross-engine admin messages in smg.grpc.common (flush/profile).
 // Trimmed to text+image generation (no embed, no PD-disaggregated, no
 // LoRA, no hidden-state forwarding). Multimodal carries preprocessed
 // tensors only — image fetch + per-model preprocess happen in the
@@ -17,6 +19,15 @@ service TokenSpeedScheduler {
   rpc GetModelInfo(GetModelInfoRequest) returns (GetModelInfoResponse);
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
   rpc GetLoads(GetLoadsRequest) returns (GetLoadsResponse);
+
+  // Flush the KV cache on the scheduler
+  rpc FlushCache(smg.grpc.common.FlushCacheRequest) returns (smg.grpc.common.FlushCacheResponse);
+
+  // Start the profiler on the scheduler
+  rpc StartProfile(smg.grpc.common.StartProfileRequest) returns (smg.grpc.common.ProfileResponse);
+
+  // Stop the profiler and export traces
+  rpc StopProfile(smg.grpc.common.StopProfileRequest) returns (smg.grpc.common.ProfileResponse);
 }
 
 // =====================

--- a/crates/grpc_client/src/tokenspeed_scheduler.rs
+++ b/crates/grpc_client/src/tokenspeed_scheduler.rs
@@ -167,6 +167,8 @@ impl TokenSpeedSchedulerClient {
         Ok(response.into_inner())
     }
 
+    crate::impl_admin_ops!();
+
     // ── Request builders ──────────────────────────────────────────────
 
     #[expect(

--- a/e2e_test/router/test_admin_ops.py
+++ b/e2e_test/router/test_admin_ops.py
@@ -141,3 +141,11 @@ class AdminOpsBehavior:
 @pytest.mark.parametrize("setup_backend", ["grpc", "http"], indirect=True)
 class TestAdminOps(AdminOpsBehavior):
     """SGLang serves both connection modes behind the gateway."""
+
+
+@pytest.mark.engine("tokenspeed")
+@pytest.mark.gpu(1)
+@pytest.mark.e2e
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestAdminOpsTokenSpeed(AdminOpsBehavior):
+    """TokenSpeed runs gRPC-only behind the gateway."""

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -538,7 +538,9 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             await context.abort(grpc.StatusCode.INTERNAL, f"Flush cache failed: {e}")
             return
 
-        message = result.message or (
+        # TokenSpeed's FlushCacheReqOutput only carries `success` (no message
+        # field); tolerate one appearing upstream later.
+        message = getattr(result, "message", "") or (
             "Cache flushed successfully" if result.success else "Cache flush failed"
         )
         return common_pb2.FlushCacheResponse(success=bool(result.success), message=message)

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -26,7 +26,7 @@ import torch
 from google.protobuf.struct_pb2 import Struct
 from google.protobuf.timestamp_pb2 import Timestamp
 from smg_grpc_proto import tokenspeed_scheduler_pb2_grpc
-from smg_grpc_proto.generated import tokenspeed_scheduler_pb2
+from smg_grpc_proto.generated import common_pb2, tokenspeed_scheduler_pb2
 from tokenspeed.runtime.multimodal.inputs import (
     Modality,
     MultimodalDataItem,
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 HEALTH_CHECK_TIMEOUT = int(os.getenv("TOKENSPEED_HEALTH_CHECK_TIMEOUT", "20"))
+# Profile round-trips include trace serialization, which can take minutes.
+PROFILE_TIMEOUT = 600.0
 
 
 def _lazy_generate_req_input():
@@ -509,6 +511,98 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             loads=scheduler_loads,
             aggregate=aggregate,
         )
+
+    async def FlushCache(
+        self,
+        request: common_pb2.FlushCacheRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> common_pb2.FlushCacheResponse:
+        """Flush the KV cache on the scheduler.
+
+        TokenSpeed's ``FlushCacheReqInput`` carries no wait-for-idle knob, so
+        ``timeout_s`` only widens the gRPC-side wait for the scheduler reply;
+        the flush itself is immediate (fails if requests are in flight).
+        """
+        logger.debug("Receive flush cache request")
+        comm_timeout = max(30.0, request.timeout_s + 10.0)
+        try:
+            result = await asyncio.wait_for(self.async_llm.flush_cache(), timeout=comm_timeout)
+        except TimeoutError:
+            await context.abort(
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+                f"Flush cache timed out after {comm_timeout}s",
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            logger.exception("FlushCache failed")
+            await context.abort(grpc.StatusCode.INTERNAL, f"Flush cache failed: {e}")
+            return
+
+        message = result.message or (
+            "Cache flushed successfully" if result.success else "Cache flush failed"
+        )
+        return common_pb2.FlushCacheResponse(success=bool(result.success), message=message)
+
+    async def StartProfile(
+        self,
+        request: common_pb2.StartProfileRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> common_pb2.ProfileResponse:
+        """Start the profiler on the scheduler.
+
+        ``AsyncLLM.start_profile`` owns the business logic (env-var defaults,
+        ProfileReq construction) and raises on failure.
+        """
+        logger.debug("Receive start profile request")
+        try:
+            await asyncio.wait_for(
+                self.async_llm.start_profile(
+                    output_dir=request.output_dir if request.HasField("output_dir") else None,
+                    start_step=request.start_step if request.HasField("start_step") else None,
+                    num_steps=request.num_steps if request.HasField("num_steps") else None,
+                    activities=list(request.activities) if request.activities else None,
+                    with_stack=request.with_stack if request.HasField("with_stack") else None,
+                    record_shapes=(
+                        request.record_shapes if request.HasField("record_shapes") else None
+                    ),
+                    profile_by_stage=request.profile_by_stage,
+                ),
+                timeout=PROFILE_TIMEOUT,
+            )
+        except TimeoutError:
+            await context.abort(
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+                f"Start profiling timed out after {PROFILE_TIMEOUT}s",
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            logger.exception("StartProfile failed")
+            await context.abort(grpc.StatusCode.INTERNAL, f"Start profiling failed: {e}")
+            return
+
+        return common_pb2.ProfileResponse(success=True, message="Start profiling succeeded")
+
+    async def StopProfile(
+        self,
+        request: common_pb2.StopProfileRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> common_pb2.ProfileResponse:
+        """Stop the profiler on the scheduler and export traces."""
+        logger.debug("Receive stop profile request")
+        try:
+            await asyncio.wait_for(self.async_llm.stop_profile(), timeout=PROFILE_TIMEOUT)
+        except TimeoutError:
+            await context.abort(
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+                f"Stop profiling timed out after {PROFILE_TIMEOUT}s",
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            logger.exception("StopProfile failed")
+            await context.abort(grpc.StatusCode.INTERNAL, f"Stop profiling failed: {e}")
+            return
+
+        return common_pb2.ProfileResponse(success=True, message="Stop profiling succeeded")
 
     # ------------------------------------------------------------------
     # Helpers

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -265,9 +265,10 @@ impl GrpcClient {
     ) -> Result<common_proto::FlushCacheResponse, tonic::Status> {
         match self {
             Self::Sglang(client) => client.flush_cache(timeout_s).await,
-            Self::Vllm(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => Err(
-                tonic::Status::unimplemented("FlushCache RPC not supported for this backend"),
-            ),
+            Self::TokenSpeed(client) => client.flush_cache(timeout_s).await,
+            Self::Vllm(_) | Self::Trtllm(_) | Self::Mlx(_) => Err(tonic::Status::unimplemented(
+                "FlushCache RPC not supported for this backend",
+            )),
         }
     }
 
@@ -279,9 +280,10 @@ impl GrpcClient {
     ) -> Result<common_proto::ProfileResponse, tonic::Status> {
         match self {
             Self::Sglang(client) => client.start_profile(req).await,
-            Self::Vllm(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => Err(
-                tonic::Status::unimplemented("StartProfile RPC not supported for this backend"),
-            ),
+            Self::TokenSpeed(client) => client.start_profile(req).await,
+            Self::Vllm(_) | Self::Trtllm(_) | Self::Mlx(_) => Err(tonic::Status::unimplemented(
+                "StartProfile RPC not supported for this backend",
+            )),
         }
     }
 
@@ -290,9 +292,10 @@ impl GrpcClient {
     pub async fn stop_profile(&self) -> Result<common_proto::ProfileResponse, tonic::Status> {
         match self {
             Self::Sglang(client) => client.stop_profile().await,
-            Self::Vllm(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => Err(
-                tonic::Status::unimplemented("StopProfile RPC not supported for this backend"),
-            ),
+            Self::TokenSpeed(client) => client.stop_profile().await,
+            Self::Vllm(_) | Self::Trtllm(_) | Self::Mlx(_) => Err(tonic::Status::unimplemented(
+                "StopProfile RPC not supported for this backend",
+            )),
         }
     }
 

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -122,6 +122,13 @@ fi
 # ── smg gRPC packages (same as other engines: from source so PR changes land) ─
 cd - > /dev/null
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."
+# TokenSpeed's engine package pins its own builds of these modules
+# (tokenspeed-smg-grpc-proto / tokenspeed-smg-grpc-servicer). Those dists
+# install the same smg_grpc_proto / smg_grpc_servicer import paths into
+# site-packages, which shadow the editable installs below — the worker
+# would then serve stale proto descriptors ("Method not found!" for any
+# RPC added in the PR). Drop them first; the source installs replace them.
+uv pip uninstall tokenspeed-smg-grpc-proto tokenspeed-smg-grpc-servicer
 uv pip install -e crates/grpc_client/python/
 uv pip install -e grpc_servicer/
 
@@ -131,5 +138,16 @@ python3 -c "from tokenspeed.runtime.engine.async_llm import AsyncLLM; \
     print('AsyncLLM bases:', [b.__name__ for b in AsyncLLM.__bases__])"
 python3 -c "from smg_grpc_servicer.tokenspeed.servicer import TokenSpeedSchedulerServicer; \
     print('gRPC servicer: importable')"
+python3 -c "
+import pathlib
+import smg_grpc_proto
+import smg_grpc_servicer
+
+repo = pathlib.Path.cwd().resolve()
+paths = [pathlib.Path(m.__file__).resolve() for m in (smg_grpc_proto, smg_grpc_servicer)]
+shadowed = [str(p) for p in paths if repo not in p.parents]
+assert not shadowed, f'smg gRPC modules shadowed by site-packages copies: {shadowed}'
+print('smg gRPC modules resolve to repo source: OK')
+"
 
 echo "TokenSpeed installation complete"


### PR DESCRIPTION
## Summary
Wires the cross-engine admin operations (KV-cache flush, profiler start/stop) to the **TokenSpeed** backend. Second part of the admin-ops work: #1655 added the shared proto messages, the `Worker`-trait dispatch, the router routes, and the sglang implementation — this PR only flips TokenSpeed on.

**Stacked on #1655** — review the last commit (`feat(grpc): add TokenSpeed FlushCache and profile RPCs`); the base commit is #1655.

### What changed
| Layer | Change |
|---|---|
| `tokenspeed_scheduler.proto` | `FlushCache` / `StartProfile` / `StopProfile` RPCs reusing the `smg.grpc.common` admin messages |
| `crates/grpc_client/src/tokenspeed_scheduler.rs` | one line: `crate::impl_admin_ops!()` — same local-deadline + trace-injection surface as the sglang client |
| `GrpcClient` dispatcher | `TokenSpeed` arms flip from `Unimplemented` to native RPC calls |
| `grpc_servicer/tokenspeed/servicer.py` | Handlers delegate to the engine's existing `AsyncLLM.flush_cache()` / `start_profile()` / `stop_profile()` control-plane methods (ZMQ communicators to the C++ scheduler already exist). Profile start/stop raise on failure, surfaced as `INTERNAL`; `FlushCacheReqInput` has no wait-for-idle knob, so the request's `timeout_s` only bounds the scheduler-reply wait |
| `e2e_test/router/test_admin_ops.py` | `TestAdminOpsTokenSpeed(AdminOpsBehavior)` — the full shared suite (flush full-cycle, profiling **with trace-artifact verification on disk**, URL-filter 404, malformed-JSON 400) on the gRPC backend |

**No changes are needed in the tokenspeed repository** — `AsyncLLM` already implements all three operations end-to-end (`runtime/engine/scheduler_control_client.py`). This also un-breaks tokenspeed's HTTP sidecar `/flush_cache`, `/start_profile`, `/stop_profile` routes, which proxy to the gateway and previously hit gRPC workers that ignored the ops.

## Test plan
- [x] `make pre-commit` (fmt, clippy `-D warnings`, full `cargo test`) — passed
- [x] `ruff check` + `ruff format` clean on touched Python
- [x] e2e suite shared with sglang: `pytest e2e_test/router/test_admin_ops.py` (`tokenspeed` engine lane, gRPC backend) — flush full cycle, profiling produces non-empty trace artifacts in the requested output dir
- [ ] CI e2e (tokenspeed lane)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TokenSpeed scheduler exposes three gRPC admin operations: FlushCache, StartProfile, StopProfile; clients and gateway now support them, enabling remote cache flushing and profiling control.

* **Tests**
  * Added end-to-end coverage exercising these admin operations for the TokenSpeed engine over gRPC.

* **Chores**
  * CI updated to run TokenSpeed tests with longer timeouts and stronger install checks to avoid shadowed packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->