### PR TITLE
fix(ci): give each runner its own hf-xet cache dir

### DIFF
--- a/scripts/ci_download_model.sh
+++ b/scripts/ci_download_model.sh
@@ -13,6 +13,23 @@
 set -euo pipefail
 
 export HF_HOME="${HF_HOME:-/models}"
+
+# Redirect the hf-xet working dir off the shared model cache.
+#
+# hf-xet (the default huggingface_hub download backend) writes its log files
+# and CAS chunk cache under "$HF_HOME/xet" by default. Because HF_HOME points at
+# the per-node hostPath model cache that every CI runner pod shares, multiple
+# pods racing on that single "$HF_HOME/xet" dir intermittently fail with
+# "Permission denied (os error 13)" while writing xet logs / chunks.
+#
+# Unlike "$HF_HOME/hub" (content-addressed snapshots, guarded by the per-model
+# flock below) and "$HF_HOME/.locks", the xet working dir is shared, unlocked,
+# and touched by every download regardless of model. Give each job its own xet
+# scratch dir off the shared mount; the snapshot cache in "$HF_HOME/hub" stays
+# shared, so cross-job model caching is unaffected.
+export HF_XET_CACHE="${HF_XET_CACHE:-${RUNNER_TEMP:-/tmp}/hf-xet}"
+mkdir -p "$HF_XET_CACHE"
+
 LOCK_DIR="${HF_HOME}/.locks"
 MAX_RETRIES=3
 RETRY_DELAY=30


### PR DESCRIPTION
## Problem

GPU e2e jobs intermittently fail in the **Download models** step with:

```
Error logging to file "/models/xet/logs/xet_<ts>.log" (Permission denied (os error 13))
OSError: I/O error: Permission denied (os error 13)
ERROR: Failed to download meta-llama/Llama-3.1-8B-Instruct after 3 attempts.
```

### Root cause

`scripts/ci_download_model.sh` sets `HF_HOME=/models`, which is the **per-node hostPath model cache** (`/raid/models`) shared by **every** ARC runner pod on the node (observed up to 5 co-located runner pods sharing it). `hf-xet` — the default `huggingface_hub` download backend — writes its **log files and CAS chunk cache** under `$HF_HOME/xet`.

That xet working dir is the one shared, **unlocked** path touched by *every* `hf download` regardless of model, so concurrent jobs race on it → intermittent `Permission denied`. By contrast:
- `$HF_HOME/hub` is content-addressed and already guarded by this script's per-model `flock` (+ huggingface_hub's own file locks), so it's safe to share.
- The OME `ome-model-agent` daemonset only writes the `root:root` `/models/<org>` direct-path model dirs (P2P torrent distribution) and **never touches `/models/xet`**.

So the conflict is specifically the shared, unsynchronized `/models/xet`.

## Fix

Redirect `HF_XET_CACHE` to a per-job dir (`$RUNNER_TEMP/hf-xet`), giving each job its own xet scratch space off the shared mount. This removes the only un-coordinated shared path. The snapshot cache in `$HF_HOME/hub` stays shared, so cross-job model caching is unaffected (and models are pre-staged by OME anyway).

One-line behavioral change; falls back to `/tmp/hf-xet` for local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Resolved intermittent permission errors occurring during concurrent model downloads in the continuous integration pipeline, improving overall build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->