### PR TITLE
feat(smg): outbound worker mesh sync — single-writer ownership, publish loop, tombstones, recovery

### DIFF
--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -195,6 +195,16 @@ impl GossipController {
             // Periodic retry-manager cleanup every 60 rounds (~60s).
             if cnt.is_multiple_of(60) {
                 retry_managers.retain(|peer_name, _| map.contains_key(peer_name));
+
+                // CRDT tombstone GC: reclaim grave markers older than the
+                // grace period, else every deleted key's tombstone is
+                // retained forever.
+                if let Some(mesh_kv) = &self.mesh_kv {
+                    let reclaimed = mesh_kv.gc_tombstones();
+                    if reclaimed > 0 {
+                        log::debug!(reclaimed, "reclaimed CRDT tombstones");
+                    }
+                }
             }
 
             // Stream round collection: drain stream namespace buffers and

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -195,16 +195,6 @@ impl GossipController {
             // Periodic retry-manager cleanup every 60 rounds (~60s).
             if cnt.is_multiple_of(60) {
                 retry_managers.retain(|peer_name, _| map.contains_key(peer_name));
-
-                // CRDT tombstone GC: reclaim grave markers older than the
-                // grace period, else every deleted key's tombstone is
-                // retained forever.
-                if let Some(mesh_kv) = &self.mesh_kv {
-                    let reclaimed = mesh_kv.gc_tombstones();
-                    if reclaimed > 0 {
-                        log::debug!(reclaimed, "reclaimed CRDT tombstones");
-                    }
-                }
             }
 
             // Stream round collection: drain stream namespace buffers and

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -531,6 +531,14 @@ impl MeshKV {
         self.chunk_assembler.clone()
     }
 
+    /// Reclaim tombstone metadata older than the default grace period
+    /// across every CRDT engine. Driven periodically by the gossip
+    /// controller's housekeeping; without it, every deleted key's grave
+    /// marker is retained forever. Returns the number reclaimed.
+    pub fn gc_tombstones(&self) -> usize {
+        self.store.gc_tombstones()
+    }
+
     /// Fire subscribers whose prefix matches `key`. Used by the gossip
     /// receive path when a chunked value completes (or a single-chunk
     /// entry arrives), so handlers can deliver into adapter-owned

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -532,9 +532,15 @@ impl MeshKV {
     }
 
     /// Reclaim tombstone metadata older than the default grace period
-    /// across every CRDT engine. Driven periodically by the gossip
-    /// controller's housekeeping; without it, every deleted key's grave
-    /// marker is retained forever. Returns the number reclaimed.
+    /// across every CRDT engine. Returns the number reclaimed.
+    ///
+    /// Deliberately not driven anywhere: time-based collection is unsound.
+    /// A peer absent longer than the grace still holds the deleted key's
+    /// older insert in its op-log and replays it on reconnect; with the
+    /// tombstone metadata gone, the stale insert lands on an empty entry
+    /// and resurrects the key. Collection is only safe at causal stability
+    /// — every live peer acked past the tombstone and absent peers
+    /// declared dead — so the caller must be the dead-node cleanup layer.
     pub fn gc_tombstones(&self) -> usize {
         self.store.gc_tombstones()
     }

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -190,6 +190,22 @@ async fn remote_tombstone_after_insert_notifies_none() {
 }
 
 #[test]
+fn gc_tombstones_respects_grace_through_mesh_kv() {
+    // The controller drives this periodically; a fresh tombstone must
+    // survive the grace period (engine-level reclamation is covered by
+    // the crdt_kv tests).
+    let mesh = MeshKV::new("node-a".into());
+    let ns = mesh.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    ns.put("worker:a", b"v".to_vec());
+    ns.delete("worker:a");
+    assert_eq!(
+        mesh.gc_tombstones(),
+        0,
+        "a fresh tombstone survives the grace period"
+    );
+}
+
+#[test]
 fn caught_up_peer_is_sent_nothing() {
     let sender = MeshKV::new("sender".to_string());
     let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);

--- a/crates/mesh/src/types.rs
+++ b/crates/mesh/src/types.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Worker state entry synced across mesh nodes. `spec` is an
-/// opaque bincode-serialized `WorkerSpec`; the mesh crate
+/// opaque JSON-serialized `WorkerSpec`; the mesh crate
 /// doesn't interpret it.
 ///
 /// `Eq`/`Hash` are intentionally omitted: `load: f64` can be
@@ -18,9 +18,10 @@ pub struct WorkerState {
     pub health: bool,
     pub load: f64,
     pub version: u64,
-    /// Opaque worker specification (bincode-serialized
-    /// `WorkerSpec` from the gateway). Empty on old nodes that
-    /// don't populate this field.
+    /// Opaque worker specification (JSON-serialized `WorkerSpec`
+    /// from the gateway; JSON because the type's serde-skip
+    /// attributes don't round-trip positional formats). Empty on
+    /// old nodes that don't populate this field.
     #[serde(default)]
     pub spec: Vec<u8>,
 }

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -9,10 +9,11 @@
 //! exist.
 //!
 //! Inbound: `start` also spawns a task that subscribes to the
-//! namespace and routes each non-tombstone update through
+//! namespace, routes each non-tombstone update through
 //! `WorkerRegistry::on_remote_worker_state` (registry-side URL-dedupe,
-//! health promotion, `Registered` event fan-out). Tombstones are
-//! logged at debug.
+//! health promotion, `Registered` event fan-out), and routes
+//! tombstones through `WorkerRegistry::remove_remote`, which removes
+//! only mesh-imported workers.
 //!
 //! The adapter writes through `CrdtNamespace::put`, which fires
 //! local subscribers in addition to gossiping. A local write
@@ -112,10 +113,17 @@ impl WorkerSyncAdapter {
                         }
                         this.apply_incoming(worker_id, &bytes);
                     }
-                    None => debug!(
-                        worker_id,
-                        "remote worker tombstone (no-op pending registry remove-by-mesh hook)"
-                    ),
+                    None => {
+                        // Tombstones resolve via the publisher's id, which the
+                        // import adopted. Only mesh-imported workers are
+                        // removed; a tombstone for a locally-owned or unknown
+                        // id is a no-op.
+                        let id = WorkerId::from_string(worker_id.to_string());
+                        match this.worker_registry.remove_remote(&id) {
+                            Some(_) => info!(worker_id, "removed worker on remote tombstone"),
+                            None => debug!(worker_id, "ignored tombstone (unknown or local)"),
+                        }
+                    }
                 }
             }
             debug!("WorkerSyncAdapter subscription closed");
@@ -421,6 +429,55 @@ mod tests {
         let ns = mesh.configure_crdt_prefix("policy:", MergeStrategy::LastWriterWins);
         let registry = Arc::new(WorkerRegistry::new());
         let _ = WorkerSyncAdapter::new(ns, registry);
+    }
+
+    #[tokio::test]
+    async fn remote_tombstone_removes_mesh_imported_worker() {
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+        adapter.start();
+
+        // Import a peer's worker, then deliver its tombstone.
+        ns.put(
+            "worker:peer-w1",
+            bincode::serialize(&sample_state("peer-w1", "http://remote:8080")).unwrap(),
+        );
+        assert!(
+            wait_for(|| registry.get_by_url("http://remote:8080").is_some()).await,
+            "import landed"
+        );
+
+        ns.delete("worker:peer-w1");
+        assert!(
+            wait_for(|| registry.get_by_url("http://remote:8080").is_none()).await,
+            "remote tombstone must remove the mesh-imported worker"
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_tombstone_never_removes_local_worker() {
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+        adapter.start();
+
+        let id = registry
+            .register(local_worker("http://local:8080"))
+            .unwrap();
+        let key = format!("worker:{}", id.as_str());
+        assert!(wait_for(|| ns.get(&key).is_some()).await, "publish landed");
+
+        // A hostile/buggy peer tombstones OUR key: the registry must
+        // refuse, and the worker stays registered.
+        ns.delete(&key);
+        sleep(Duration::from_millis(50)).await;
+        assert!(
+            registry.get(&id).is_some(),
+            "a remote tombstone must never remove a locally-owned worker"
+        );
     }
 
     #[tokio::test]

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -253,7 +253,16 @@ impl WorkerSyncAdapter {
 /// `WorkerSpec` so the importing side can rebuild the worker faithfully;
 /// `version` is the registry revision (informational — CRDT ordering is
 /// owned by the Lamport clock).
+///
+/// The spec is JSON, not bincode: `WorkerSpec` uses `skip_serializing_*`
+/// serde attributes, which a positional format cannot round-trip — bincode
+/// deserialization fails for every spec, silently downgrading imports to
+/// the minimal builder. JSON is self-describing and round-trips them.
 fn worker_state_of(worker_id: &WorkerId, worker: &Arc<dyn Worker>) -> WorkerState {
+    let spec = serde_json::to_vec(&worker.metadata().spec).unwrap_or_else(|err| {
+        warn!(url = %worker.url(), %err, "failed to encode WorkerSpec; publishing without spec");
+        Vec::new()
+    });
     WorkerState {
         worker_id: worker_id.as_str().to_string(),
         model_id: worker.model_id().to_string(),
@@ -261,7 +270,7 @@ fn worker_state_of(worker_id: &WorkerId, worker: &Arc<dyn Worker>) -> WorkerStat
         health: worker.is_healthy(),
         load: worker.load() as f64,
         version: worker.revision(),
-        spec: bincode::serialize(&worker.metadata().spec).unwrap_or_default(),
+        spec,
     }
 }
 
@@ -562,6 +571,49 @@ mod tests {
         assert!(
             wait_for(|| ns.get(&key).is_none()).await,
             "local removal was not tombstoned"
+        );
+    }
+
+    #[tokio::test]
+    async fn published_spec_round_trips_into_importing_registry() {
+        // The faithful-import contract: a gRPC decode worker published by
+        // one node must import as a gRPC decode worker, not fall back to
+        // the minimal HTTP/Regular builder. (bincode could not round-trip
+        // WorkerSpec's serde-skip attributes; JSON does.)
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+
+        let pub_registry = Arc::new(WorkerRegistry::new());
+        let publisher = WorkerSyncAdapter::new(ns.clone(), pub_registry.clone());
+        publisher.start();
+
+        let sub_registry = Arc::new(WorkerRegistry::new());
+        let subscriber = WorkerSyncAdapter::new(ns, sub_registry.clone());
+        subscriber.start();
+
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("grpc://remote:9000")
+                .model(ModelCard::new("llama-3"))
+                .connection_mode(crate::worker::ConnectionMode::Grpc)
+                .worker_type(crate::worker::WorkerType::Decode)
+                .build(),
+        );
+        pub_registry.register(worker).unwrap();
+
+        assert!(
+            wait_for(|| sub_registry.get_by_url("grpc://remote:9000").is_some()).await,
+            "import did not land"
+        );
+        let imported = sub_registry.get_by_url("grpc://remote:9000").unwrap();
+        assert_eq!(
+            *imported.connection_mode(),
+            crate::worker::ConnectionMode::Grpc,
+            "connection mode must survive the spec round trip"
+        );
+        assert_eq!(
+            *imported.worker_type(),
+            crate::worker::WorkerType::Decode,
+            "worker type must survive the spec round trip"
         );
     }
 

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -25,7 +25,9 @@
 //! node's `worker:` keys persist cluster-wide (imports stay registered,
 //! demoted by local probes), and a crash-restart that registers locally
 //! before its old state gossips back orphans up to one store key per
-//! worker per restart. Cleanup belongs to dead-node key GC.
+//! worker per restart. Tombstone metadata also accrues per removed
+//! worker (time-based collection would resurrect deleted keys; it is
+//! only sound at causal stability). Cleanup belongs to dead-node key GC.
 
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
@@ -107,6 +109,9 @@ impl WorkerSyncAdapter {
         )]
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
+            // The first tick resolves immediately and start() already
+            // backfills synchronously; skip the redundant pass.
+            interval.tick().await;
             loop {
                 interval.tick().await;
                 reconcile.reconcile_once();

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -23,7 +23,9 @@
 //!
 //! Known gap: only the owner tombstones its keys, so a permanently-dead
 //! node's `worker:` keys persist cluster-wide (imports stay registered,
-//! demoted by local probes). Cleanup belongs to dead-node key GC.
+//! demoted by local probes), and a crash-restart that registers locally
+//! before its old state gossips back orphans up to one store key per
+//! worker per restart. Cleanup belongs to dead-node key GC.
 
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
@@ -140,7 +142,11 @@ impl WorkerSyncAdapter {
     /// — the sink is idempotent on URL (health refresh short-circuit),
     /// so overlap with a concurrent live event is fine.
     fn backfill_existing(&self) {
-        for key in self.workers.keys("") {
+        self.backfill_keys(self.workers.keys(""));
+    }
+
+    fn backfill_keys(&self, keys: impl IntoIterator<Item = String>) {
+        for key in keys {
             let Some(worker_id) = key.strip_prefix(PREFIX).filter(|s| !s.is_empty()) else {
                 warn!(key, "worker: backfill yielded unexpected key shape");
                 continue;
@@ -158,7 +164,8 @@ impl WorkerSyncAdapter {
     /// key from another publisher can re-import in the same pass.
     fn reconcile_once(&self) {
         // Key-presence set: `keys()` avoids cloning every live value just
-        // to test membership.
+        // to test membership, and feeds the backfill below so the
+        // namespace is scanned once per pass.
         let live: HashSet<String> = self.workers.keys("").into_iter().collect();
         for (id, _) in self.worker_registry.get_all_with_ids() {
             let key = format!("{PREFIX}{}", id.as_str());
@@ -169,7 +176,7 @@ impl WorkerSyncAdapter {
                 self.sync_key_from_store(&key, id.as_str());
             }
         }
-        self.backfill_existing();
+        self.backfill_keys(live);
     }
 
     /// Bring the registry in line with the store's current state for one

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -21,7 +21,7 @@
 //! `on_remote_worker_state`, which ignores state for locally-owned
 //! workers — so the echo is inert.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use smg_mesh::{CrdtNamespace, WorkerState};
 use tokio::sync::broadcast;
@@ -30,6 +30,9 @@ use tracing::{debug, info, warn};
 use crate::worker::{event::WorkerEvent, registry::WorkerId, Worker, WorkerOrigin, WorkerRegistry};
 
 const PREFIX: &str = "worker:";
+
+/// Cadence of the inbound store↔registry reconcile pass.
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Bridge between the `worker:` CRDT namespace and the gateway's
 /// in-process `WorkerRegistry`.
@@ -85,10 +88,23 @@ impl WorkerSyncAdapter {
         let outbound = Arc::clone(self);
         #[expect(
             clippy::disallowed_methods,
-            reason = "publish loop ends automatically when the registry drops and closes the broadcast channel; no handle needed"
+            reason = "publish loop runs for the adapter's lifetime, which is the process lifetime; the task holds the registry alive, so the Closed arm is defensive only"
         )]
         tokio::spawn(async move {
             outbound.run_outbound(events).await;
+        });
+
+        let reconcile = Arc::clone(self);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "reconcile task runs for the adapter's lifetime, which is the process lifetime"
+        )]
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
+            loop {
+                interval.tick().await;
+                reconcile.reconcile_once();
+            }
         });
 
         let this = Arc::clone(self);
@@ -129,6 +145,37 @@ impl WorkerSyncAdapter {
         }
     }
 
+    /// One reconcile pass aligning the registry with the store. Subscription
+    /// notifications are delivered via a bounded `try_send` and a dropped one
+    /// is never re-fired (re-merged ops are idempotent no-ops), so this
+    /// periodic pass is the recovery path for missed puts — including a
+    /// cold-start merge burst larger than the channel — and missed
+    /// tombstones. Removal runs first so a same-URL key from another
+    /// publisher can re-import in the same pass.
+    fn reconcile_once(&self) {
+        for (id, worker) in self.worker_registry.get_all_with_ids() {
+            let key = format!("{PREFIX}{}", id.as_str());
+            if self.workers.get(&key).is_some() {
+                continue;
+            }
+            match self.worker_registry.origin_of(&id) {
+                Some(WorkerOrigin::Mesh) => {
+                    let removed = self.worker_registry.remove_remote(&id);
+                    if removed.is_some() {
+                        info!(worker_id = %id.as_str(), "reconcile removed worker with tombstoned key");
+                    }
+                }
+                // A local worker with no backing key: its publish (or its
+                // re-assert after a foreign tombstone) was lost. Re-publish.
+                Some(WorkerOrigin::Local) => {
+                    self.on_worker_changed(id.as_str(), &worker_state_of(&id, &worker));
+                }
+                None => {}
+            }
+        }
+        self.backfill_existing();
+    }
+
     /// Bring the registry in line with the store's current state for one
     /// key: a live value routes through `on_remote_worker_state`, a missing
     /// (tombstoned) one through `remove_remote`. Tombstones resolve via the
@@ -141,7 +188,25 @@ impl WorkerSyncAdapter {
                 let id = WorkerId::from_string(worker_id.to_string());
                 match self.worker_registry.remove_remote(&id) {
                     Some(_) => info!(worker_id, "removed worker on remote tombstone"),
-                    None => debug!(worker_id, "ignored tombstone (unknown or local)"),
+                    None => {
+                        // A tombstone for a key this node owns is anomalous
+                        // (buggy peer or bad tooling). The delete already
+                        // removed the key cluster-wide and peers dropped
+                        // their imports, so re-assert the state — otherwise
+                        // the worker stays delisted everywhere until its
+                        // next local status change.
+                        if self.worker_registry.origin_of(&id) == Some(WorkerOrigin::Local) {
+                            if let Some(worker) = self.worker_registry.get(&id) {
+                                warn!(
+                                    worker_id,
+                                    "re-publishing locally-owned worker after foreign tombstone"
+                                );
+                                self.on_worker_changed(worker_id, &worker_state_of(&id, &worker));
+                                return;
+                            }
+                        }
+                        debug!(worker_id, "ignored tombstone (unknown id)");
+                    }
                 }
             }
         }
@@ -486,9 +551,13 @@ mod tests {
         assert!(wait_for(|| ns.get(&key).is_some()).await, "publish landed");
 
         // A hostile/buggy peer tombstones OUR key: the registry must
-        // refuse, and the worker stays registered.
+        // refuse, the worker stays registered, and the key is re-asserted
+        // so peers that dropped their imports re-learn it.
         ns.delete(&key);
-        sleep(Duration::from_millis(50)).await;
+        assert!(
+            wait_for(|| ns.get(&key).is_some()).await,
+            "owned key must be re-published after a foreign tombstone"
+        );
         assert!(
             registry.get(&id).is_some(),
             "a remote tombstone must never remove a locally-owned worker"
@@ -571,6 +640,32 @@ mod tests {
         assert!(
             wait_for(|| ns.get(&key).is_none()).await,
             "local removal was not tombstoned"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_recovers_missed_put_and_missed_tombstone() {
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+        // No start(): models every notification being dropped.
+
+        ns.put(
+            "worker:peer-w1",
+            bincode::serialize(&sample_state("peer-w1", "http://remote:8080")).unwrap(),
+        );
+        adapter.reconcile_once();
+        assert!(
+            registry.get_by_url("http://remote:8080").is_some(),
+            "reconcile recovers a missed put"
+        );
+
+        ns.delete("worker:peer-w1");
+        adapter.reconcile_once();
+        assert!(
+            registry.get_by_url("http://remote:8080").is_none(),
+            "reconcile recovers a missed tombstone"
         );
     }
 

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -20,6 +20,10 @@
 //! therefore echoes back through the inbound loop and lands in
 //! `on_remote_worker_state`, which ignores state for locally-owned
 //! workers — so the echo is inert.
+//!
+//! Known gap: only the owner tombstones its keys, so a permanently-dead
+//! node's `worker:` keys persist cluster-wide (imports stay registered,
+//! demoted by local probes). Cleanup belongs to dead-node key GC.
 
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
@@ -150,63 +154,52 @@ impl WorkerSyncAdapter {
     /// is never re-fired (re-merged ops are idempotent no-ops), so this
     /// periodic pass is the recovery path for missed puts — including a
     /// cold-start merge burst larger than the channel — and missed
-    /// tombstones. Removal runs first so a same-URL key from another
-    /// publisher can re-import in the same pass.
+    /// tombstones. Missing-key handling runs before backfill so a same-URL
+    /// key from another publisher can re-import in the same pass.
     fn reconcile_once(&self) {
-        for (id, worker) in self.worker_registry.get_all_with_ids() {
+        // Key-presence set: `keys()` avoids cloning every live value just
+        // to test membership.
+        let live: HashSet<String> = self.workers.keys("").into_iter().collect();
+        for (id, _) in self.worker_registry.get_all_with_ids() {
             let key = format!("{PREFIX}{}", id.as_str());
-            if self.workers.get(&key).is_some() {
-                continue;
-            }
-            match self.worker_registry.origin_of(&id) {
-                Some(WorkerOrigin::Mesh) => {
-                    let removed = self.worker_registry.remove_remote(&id);
-                    if removed.is_some() {
-                        info!(worker_id = %id.as_str(), "reconcile removed worker with tombstoned key");
-                    }
-                }
-                // A local worker with no backing key: its publish (or its
-                // re-assert after a foreign tombstone) was lost. Re-publish.
-                Some(WorkerOrigin::Local) => {
-                    self.on_worker_changed(id.as_str(), &worker_state_of(&id, &worker));
-                }
-                None => {}
+            if !live.contains(&key) {
+                // Missing backing key: same handling as a live tombstone
+                // event — imports are removed, locally-owned state is
+                // re-asserted.
+                self.sync_key_from_store(&key, id.as_str());
             }
         }
         self.backfill_existing();
     }
 
     /// Bring the registry in line with the store's current state for one
-    /// key: a live value routes through `on_remote_worker_state`, a missing
-    /// (tombstoned) one through `remove_remote`. Tombstones resolve via the
-    /// publisher's id, which the import adopted; a tombstone for a
-    /// locally-owned or unknown id is a no-op.
+    /// key: a live value routes through `on_remote_worker_state`; a missing
+    /// (tombstoned) one removes a mesh import, re-asserts a locally-owned
+    /// worker's state, and ignores unknown ids. Tombstones resolve via the
+    /// publisher's id, which the import adopted.
     fn sync_key_from_store(&self, key: &str, worker_id: &str) {
         match self.workers.get(key) {
             Some(bytes) => self.apply_incoming(worker_id, &bytes),
             None => {
                 let id = WorkerId::from_string(worker_id.to_string());
+                // A missing key for a locally-owned worker is anomalous
+                // (foreign tombstone or a lost publish): the key is already
+                // gone cluster-wide and peers dropped their imports, so
+                // re-assert the authoritative state — otherwise the worker
+                // stays delisted everywhere until its next status change.
+                if self.worker_registry.origin_of(&id) == Some(WorkerOrigin::Local) {
+                    if let Some(worker) = self.worker_registry.get(&id) {
+                        warn!(
+                            worker_id,
+                            "re-publishing locally-owned worker after foreign tombstone"
+                        );
+                        self.on_worker_changed(worker_id, &worker_state_of(&id, &worker));
+                        return;
+                    }
+                }
                 match self.worker_registry.remove_remote(&id) {
                     Some(_) => info!(worker_id, "removed worker on remote tombstone"),
-                    None => {
-                        // A tombstone for a key this node owns is anomalous
-                        // (buggy peer or bad tooling). The delete already
-                        // removed the key cluster-wide and peers dropped
-                        // their imports, so re-assert the state — otherwise
-                        // the worker stays delisted everywhere until its
-                        // next local status change.
-                        if self.worker_registry.origin_of(&id) == Some(WorkerOrigin::Local) {
-                            if let Some(worker) = self.worker_registry.get(&id) {
-                                warn!(
-                                    worker_id,
-                                    "re-publishing locally-owned worker after foreign tombstone"
-                                );
-                                self.on_worker_changed(worker_id, &worker_state_of(&id, &worker));
-                                return;
-                            }
-                        }
-                        debug!(worker_id, "ignored tombstone (unknown id)");
-                    }
+                    None => debug!(worker_id, "ignored tombstone (unknown id)"),
                 }
             }
         }
@@ -314,10 +307,10 @@ impl WorkerSyncAdapter {
     }
 }
 
-/// Snapshot a live worker into the mesh wire shape. `spec` carries the full
-/// `WorkerSpec` so the importing side can rebuild the worker faithfully;
-/// `version` is the registry revision (informational — CRDT ordering is
-/// owned by the Lamport clock).
+/// Snapshot a live worker into the mesh wire shape. `spec` carries the
+/// `WorkerSpec` (minus `api_key`, which never leaves the node) so the
+/// importing side can rebuild the worker; `version` is the registry
+/// revision (informational — CRDT ordering is owned by the Lamport clock).
 ///
 /// The spec is JSON, not bincode: `WorkerSpec` uses `skip_serializing_*`
 /// serde attributes, which a positional format cannot round-trip — bincode

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -1,31 +1,33 @@
 //! `worker:` CRDT adapter: gateway ↔ mesh bridge for `WorkerState`.
 //!
-//! Outbound: `on_worker_changed` bincode-serialises a `WorkerState`
-//! and writes it under `worker:{worker_id}`. `on_worker_removed`
-//! writes a tombstone.
+//! Outbound: `start` spawns a loop over the registry's `WorkerEvent`
+//! stream that publishes every locally-owned worker's state under
+//! `worker:{worker_id}` (and a tombstone on removal). Mesh-imported
+//! workers are filtered out by their registration origin so a peer's
+//! state is never re-published. On broadcast lag the loop re-publishes
+//! all local workers and tombstones any it published that no longer
+//! exist.
 //!
-//! Inbound: `start` spawns a task that subscribes to the namespace
-//! and routes each non-tombstone update through
-//! `WorkerRegistry::on_remote_worker_state`, which performs the
-//! registry-side URL-dedupe, health promotion, and `Registered`
-//! event fan-out. Tombstones are logged at debug; the registry
-//! does not yet expose a remote-remove hook, and wiring one
-//! belongs in a later PR.
+//! Inbound: `start` also spawns a task that subscribes to the
+//! namespace and routes each non-tombstone update through
+//! `WorkerRegistry::on_remote_worker_state` (registry-side URL-dedupe,
+//! health promotion, `Registered` event fan-out). Tombstones are
+//! logged at debug.
 //!
 //! The adapter writes through `CrdtNamespace::put`, which fires
 //! local subscribers in addition to gossiping. A local write
-//! therefore echoes back through `start`'s loop and lands in
-//! `on_remote_worker_state`. That path is idempotent — the URL
-//! lookup short-circuits to a health refresh — so the loop is
-//! self-limiting.
+//! therefore echoes back through the inbound loop and lands in
+//! `on_remote_worker_state`, which ignores state for locally-owned
+//! workers — so the echo is inert.
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use bytes::Bytes;
 use smg_mesh::{CrdtNamespace, WorkerState};
-use tracing::{debug, warn};
+use tokio::sync::broadcast;
+use tracing::{debug, info, warn};
 
-use crate::worker::WorkerRegistry;
+use crate::worker::{event::WorkerEvent, registry::WorkerId, Worker, WorkerOrigin, WorkerRegistry};
 
 const PREFIX: &str = "worker:";
 
@@ -62,7 +64,9 @@ impl WorkerSyncAdapter {
         })
     }
 
-    /// Start the inbound path. Subscribes first so no live event is
+    /// Start both sync directions.
+    ///
+    /// Inbound: subscribes to the namespace first so no live event is
     /// lost, spawns the recv loop so it can start draining
     /// immediately, and then backfills from the calling thread — any
     /// entry already in the CRDT would otherwise have to wait for the
@@ -72,7 +76,21 @@ impl WorkerSyncAdapter {
     /// a blocked recv while backfill is running could drop updates on
     /// a busy startup. `on_remote_worker_state` is idempotent on URL,
     /// so a key seen by both paths only refreshes health.
+    ///
+    /// Outbound: subscribes to registry events before anything else so
+    /// no registration between the initial resync and the loop is
+    /// missed, then spawns the publish loop.
     pub fn start(self: &Arc<Self>) {
+        let events = self.worker_registry.subscribe_events();
+        let outbound = Arc::clone(self);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "publish loop ends automatically when the registry drops and closes the broadcast channel; no handle needed"
+        )]
+        tokio::spawn(async move {
+            outbound.run_outbound(events).await;
+        });
+
         let this = Arc::clone(self);
         let mut sub = self.workers.subscribe("");
         #[expect(
@@ -128,6 +146,79 @@ impl WorkerSyncAdapter {
         }
     }
 
+    /// Publish loop: forward every locally-owned worker mutation to the
+    /// mesh. `published` tracks the keys this loop has written so removals
+    /// can be tombstoned even after the registry has dropped the worker's
+    /// origin entry, and so lag recovery can tombstone removals missed in
+    /// the lag window.
+    async fn run_outbound(self: Arc<Self>, mut events: broadcast::Receiver<WorkerEvent>) {
+        let mut published: HashSet<WorkerId> = HashSet::new();
+        self.resync_local(&mut published);
+        loop {
+            match events.recv().await {
+                Ok(WorkerEvent::Registered { worker_id, worker }) => {
+                    if self.worker_registry.origin_of(&worker_id) == Some(WorkerOrigin::Local) {
+                        self.on_worker_changed(
+                            worker_id.as_str(),
+                            &worker_state_of(&worker_id, &worker),
+                        );
+                        published.insert(worker_id);
+                    }
+                }
+                Ok(WorkerEvent::Replaced { worker_id, new, .. }) => {
+                    if published.contains(&worker_id) {
+                        self.on_worker_changed(
+                            worker_id.as_str(),
+                            &worker_state_of(&worker_id, &new),
+                        );
+                    }
+                }
+                Ok(WorkerEvent::StatusChanged {
+                    worker_id, worker, ..
+                }) => {
+                    if published.contains(&worker_id) {
+                        self.on_worker_changed(
+                            worker_id.as_str(),
+                            &worker_state_of(&worker_id, &worker),
+                        );
+                    }
+                }
+                Ok(WorkerEvent::Removed { worker_id, .. }) => {
+                    if published.remove(&worker_id) {
+                        self.on_worker_removed(worker_id.as_str());
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(lagged = n, "outbound worker sync lagged; resyncing");
+                    self.resync_local(&mut published);
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    debug!("WorkerSyncAdapter outbound loop closed");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Re-publish every locally-owned worker and tombstone any key this
+    /// loop published whose worker no longer exists. Doubles as the
+    /// bootstrap (empty prior set) and the lag-recovery path; re-publishing
+    /// identical state is harmless (peers' URL-dedupe refreshes health).
+    fn resync_local(&self, published: &mut HashSet<WorkerId>) {
+        let mut current = HashSet::new();
+        for (id, worker) in self.worker_registry.get_all_with_ids() {
+            if self.worker_registry.origin_of(&id) == Some(WorkerOrigin::Local) {
+                self.on_worker_changed(id.as_str(), &worker_state_of(&id, &worker));
+                current.insert(id);
+            }
+        }
+        for stale in published.difference(&current) {
+            info!(worker_id = %stale.as_str(), "tombstoning worker removed during lag");
+            self.on_worker_removed(stale.as_str());
+        }
+        *published = current;
+    }
+
     /// Publish a worker update to the cluster. Callers pass the
     /// registry's current state; the adapter owns (de)serialisation
     /// and key formatting.
@@ -144,14 +235,32 @@ impl WorkerSyncAdapter {
     }
 }
 
+/// Snapshot a live worker into the mesh wire shape. `spec` carries the full
+/// `WorkerSpec` so the importing side can rebuild the worker faithfully;
+/// `version` is the registry revision (informational — CRDT ordering is
+/// owned by the Lamport clock).
+fn worker_state_of(worker_id: &WorkerId, worker: &Arc<dyn Worker>) -> WorkerState {
+    WorkerState {
+        worker_id: worker_id.as_str().to_string(),
+        model_id: worker.model_id().to_string(),
+        url: worker.url().to_string(),
+        health: worker.is_healthy(),
+        load: worker.load() as f64,
+        version: worker.revision(),
+        spec: bincode::serialize(&worker.metadata().spec).unwrap_or_default(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
+    use openai_protocol::model_card::ModelCard;
     use smg_mesh::{MergeStrategy, MeshKV};
     use tokio::time::sleep;
 
     use super::*;
+    use crate::worker::BasicWorkerBuilder;
 
     fn worker_namespace(mesh: &MeshKV) -> Arc<CrdtNamespace> {
         mesh.configure_crdt_prefix(PREFIX, MergeStrategy::LastWriterWins)
@@ -167,6 +276,25 @@ mod tests {
             version: 1,
             spec: vec![],
         }
+    }
+
+    fn local_worker(url: &str) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .model(ModelCard::new("llama-3"))
+                .build(),
+        )
+    }
+
+    /// Poll until `cond` is true or ~1s elapses.
+    async fn wait_for(mut cond: impl FnMut() -> bool) -> bool {
+        for _ in 0..100 {
+            if cond() {
+                return true;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        false
     }
 
     #[tokio::test]
@@ -293,5 +421,121 @@ mod tests {
         let ns = mesh.configure_crdt_prefix("policy:", MergeStrategy::LastWriterWins);
         let registry = Arc::new(WorkerRegistry::new());
         let _ = WorkerSyncAdapter::new(ns, registry);
+    }
+
+    #[tokio::test]
+    async fn outbound_publishes_local_registration() {
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+        adapter.start();
+
+        let id = registry
+            .register(local_worker("http://local:8080"))
+            .unwrap();
+
+        let key = format!("worker:{}", id.as_str());
+        assert!(
+            wait_for(|| ns.get(&key).is_some()).await,
+            "local registration was not published to mesh"
+        );
+        let decoded: WorkerState =
+            bincode::deserialize(&ns.get(&key).unwrap()).expect("published state decodes");
+        assert_eq!(decoded.worker_id, id.as_str());
+        assert_eq!(decoded.url, "http://local:8080");
+        assert_eq!(decoded.model_id, "llama-3");
+        assert!(
+            !decoded.spec.is_empty(),
+            "spec rides along for faithful import"
+        );
+    }
+
+    #[tokio::test]
+    async fn outbound_never_republishes_mesh_imported_worker() {
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+        adapter.start();
+
+        // A peer's state arrives (direct put models the gossiped write).
+        let original = sample_state("peer-w1", "http://remote:8080");
+        ns.put(
+            "worker:peer-w1",
+            bincode::serialize(&original).expect("state serializes"),
+        );
+        assert!(
+            wait_for(|| registry.get_by_url("http://remote:8080").is_some()).await,
+            "import did not land in the registry"
+        );
+
+        // The import fired a Registered event; give the outbound loop time
+        // to (wrongly) act on it, then prove the stored state is untouched.
+        sleep(Duration::from_millis(50)).await;
+        let stored: WorkerState =
+            bincode::deserialize(&ns.get("worker:peer-w1").unwrap()).expect("state decodes");
+        assert_eq!(
+            stored, original,
+            "a mesh-imported worker must never be re-published"
+        );
+    }
+
+    #[tokio::test]
+    async fn outbound_tombstones_local_removal() {
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+        adapter.start();
+
+        let id = registry
+            .register(local_worker("http://local:8080"))
+            .unwrap();
+        let key = format!("worker:{}", id.as_str());
+        assert!(wait_for(|| ns.get(&key).is_some()).await, "publish landed");
+
+        registry.remove(&id);
+        assert!(
+            wait_for(|| ns.get(&key).is_none()).await,
+            "local removal was not tombstoned"
+        );
+    }
+
+    #[tokio::test]
+    async fn resync_publishes_local_skips_mesh_and_tombstones_stale() {
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+
+        // One local worker, one mesh import, one phantom previously
+        // published id whose worker is gone.
+        let local_id = registry
+            .register(local_worker("http://local:8080"))
+            .unwrap();
+        registry.on_remote_worker_state(&sample_state("peer-w1", "http://remote:8080"));
+        let phantom = WorkerId::from_string("gone-w9".to_string());
+        ns.put(
+            "worker:gone-w9",
+            bincode::serialize(&sample_state("gone-w9", "http://gone:8080")).unwrap(),
+        );
+
+        let mut published: HashSet<WorkerId> = [phantom].into_iter().collect();
+        adapter.resync_local(&mut published);
+
+        assert!(
+            ns.get(&format!("worker:{}", local_id.as_str())).is_some(),
+            "local worker is re-published"
+        );
+        assert!(
+            ns.get("worker:gone-w9").is_none(),
+            "stale published key is tombstoned"
+        );
+        assert_eq!(
+            published,
+            [local_id].into_iter().collect(),
+            "published set tracks exactly the local workers"
+        );
     }
 }

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -23,7 +23,6 @@
 
 use std::{collections::HashSet, sync::Arc};
 
-use bytes::Bytes;
 use smg_mesh::{CrdtNamespace, WorkerState};
 use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
@@ -99,32 +98,17 @@ impl WorkerSyncAdapter {
             reason = "subscription task ends automatically when the mesh KV drops and closes the channel; no handle needed"
         )]
         tokio::spawn(async move {
-            while let Some((key, value)) = sub.receiver.recv().await {
+            while let Some((key, _snapshot)) = sub.receiver.recv().await {
                 let Some(worker_id) = key.strip_prefix(PREFIX).filter(|s| !s.is_empty()) else {
                     warn!(key, "worker: subscription yielded unexpected key shape");
                     continue;
                 };
-                match value {
-                    Some(fragments) => {
-                        let total = fragments.iter().map(Bytes::len).sum();
-                        let mut bytes = Vec::with_capacity(total);
-                        for frag in fragments {
-                            bytes.extend_from_slice(&frag);
-                        }
-                        this.apply_incoming(worker_id, &bytes);
-                    }
-                    None => {
-                        // Tombstones resolve via the publisher's id, which the
-                        // import adopted. Only mesh-imported workers are
-                        // removed; a tombstone for a locally-owned or unknown
-                        // id is a no-op.
-                        let id = WorkerId::from_string(worker_id.to_string());
-                        match this.worker_registry.remove_remote(&id) {
-                            Some(_) => info!(worker_id, "removed worker on remote tombstone"),
-                            None => debug!(worker_id, "ignored tombstone (unknown or local)"),
-                        }
-                    }
-                }
+                // Act on store truth, not the event's value snapshot: a
+                // queued event can be stale by the time it is drained (a put
+                // echo dequeued after the key was tombstoned would resurrect
+                // a removed worker; a stale state would regress health).
+                // Re-reading the namespace makes delivery order irrelevant.
+                this.sync_key_from_store(&key, worker_id);
             }
             debug!("WorkerSyncAdapter subscription closed");
         });
@@ -141,8 +125,24 @@ impl WorkerSyncAdapter {
                 warn!(key, "worker: backfill yielded unexpected key shape");
                 continue;
             };
-            if let Some(bytes) = self.workers.get(&key) {
-                self.apply_incoming(worker_id, &bytes);
+            self.sync_key_from_store(&key, worker_id);
+        }
+    }
+
+    /// Bring the registry in line with the store's current state for one
+    /// key: a live value routes through `on_remote_worker_state`, a missing
+    /// (tombstoned) one through `remove_remote`. Tombstones resolve via the
+    /// publisher's id, which the import adopted; a tombstone for a
+    /// locally-owned or unknown id is a no-op.
+    fn sync_key_from_store(&self, key: &str, worker_id: &str) {
+        match self.workers.get(key) {
+            Some(bytes) => self.apply_incoming(worker_id, &bytes),
+            None => {
+                let id = WorkerId::from_string(worker_id.to_string());
+                match self.worker_registry.remove_remote(&id) {
+                    Some(_) => info!(worker_id, "removed worker on remote tombstone"),
+                    None => debug!(worker_id, "ignored tombstone (unknown or local)"),
+                }
             }
         }
     }
@@ -571,6 +571,30 @@ mod tests {
         assert!(
             wait_for(|| ns.get(&key).is_none()).await,
             "local removal was not tombstoned"
+        );
+    }
+
+    #[tokio::test]
+    async fn rapid_put_then_delete_converges_to_absent() {
+        // Both queued events resolve against the store (which holds the
+        // tombstone by the time they drain), so a stale put echo can never
+        // resurrect a removed worker regardless of drain timing.
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+        adapter.start();
+
+        ns.put(
+            "worker:peer-w1",
+            bincode::serialize(&sample_state("peer-w1", "http://remote:8080")).unwrap(),
+        );
+        ns.delete("worker:peer-w1");
+
+        sleep(Duration::from_millis(100)).await;
+        assert!(
+            registry.get_by_url("http://remote:8080").is_none(),
+            "store truth wins: the tombstoned worker must not survive"
         );
     }
 

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -173,22 +173,28 @@ impl WorkerSyncAdapter {
                         published.insert(worker_id);
                     }
                 }
+                // Gated on live origin (not the published set) so a worker
+                // promoted to Local ownership mid-life — e.g. a mesh import
+                // claimed by register_or_replace — starts publishing from its
+                // next mutation.
                 Ok(WorkerEvent::Replaced { worker_id, new, .. }) => {
-                    if published.contains(&worker_id) {
+                    if self.worker_registry.origin_of(&worker_id) == Some(WorkerOrigin::Local) {
                         self.on_worker_changed(
                             worker_id.as_str(),
                             &worker_state_of(&worker_id, &new),
                         );
+                        published.insert(worker_id);
                     }
                 }
                 Ok(WorkerEvent::StatusChanged {
                     worker_id, worker, ..
                 }) => {
-                    if published.contains(&worker_id) {
+                    if self.worker_registry.origin_of(&worker_id) == Some(WorkerOrigin::Local) {
                         self.on_worker_changed(
                             worker_id.as_str(),
                             &worker_state_of(&worker_id, &worker),
                         );
+                        published.insert(worker_id);
                     }
                 }
                 Ok(WorkerEvent::Removed { worker_id, .. }) => {
@@ -556,6 +562,43 @@ mod tests {
         assert!(
             wait_for(|| ns.get(&key).is_none()).await,
             "local removal was not tombstoned"
+        );
+    }
+
+    #[tokio::test]
+    async fn claimed_import_publishes_from_next_mutation() {
+        // The restart race end-to-end: a mesh import wins the URL, the local
+        // workflow claims it via register_or_replace, and the worker must be
+        // published from its next mutation onward.
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+        adapter.start();
+
+        // Ghost state from a previous incarnation arrives first.
+        ns.put(
+            "worker:old-id",
+            bincode::serialize(&sample_state("old-id", "http://local:8080")).unwrap(),
+        );
+        assert!(
+            wait_for(|| registry.get_by_url("http://local:8080").is_some()).await,
+            "import landed"
+        );
+
+        // The local workflow claims the URL (register_or_replace path).
+        let claimed = registry.register_or_replace(local_worker("http://local:8080"));
+
+        // The Replaced event publishes the claimed worker (live origin gate).
+        let key = format!("worker:{}", claimed.as_str());
+        assert!(
+            wait_for(|| {
+                ns.get(&key)
+                    .and_then(|bytes| bincode::deserialize::<WorkerState>(&bytes).ok())
+                    .is_some_and(|s| !s.spec.is_empty())
+            })
+            .await,
+            "claimed worker must be published with its local spec"
         );
     }
 

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -34,7 +34,7 @@ use crate::{
         monitor::WorkerMonitor,
         registry::{WorkerDescriptor, WorkerId},
         worker::WorkerTypeExt,
-        ConnectionMode, Worker, WorkerRegistry, WorkerResult, WorkerType,
+        ConnectionMode, Worker, WorkerOrigin, WorkerRegistry, WorkerResult, WorkerType,
     },
     workflow::{Job, JobQueue},
 };
@@ -271,6 +271,7 @@ async fn run_health_loop(
         for removal in removals {
             if let Some(jq) = job_queue.as_ref() {
                 submit_removal_job(
+                    &registry,
                     &removal.worker_id,
                     &removal.url,
                     removal.expected_revision,
@@ -502,7 +503,7 @@ async fn apply_probe_completion(
         );
         if new == WorkerStatus::Failed {
             if let Some(jq) = job_queue {
-                submit_removal_job(&worker_id, worker.url(), expected_revision, jq).await;
+                submit_removal_job(registry, &worker_id, worker.url(), expected_revision, jq).await;
             }
         }
     }
@@ -655,12 +656,28 @@ fn compute_next_status(
     }
 }
 
+/// Failed mesh-imported workers stay registered (demoted, unroutable):
+/// they are owner-managed, and a local removal only desynchronizes this
+/// node — the live CRDT key re-imports the worker on the next reconcile,
+/// probes fail again, and the remove/re-import loop churns forever.
+fn should_remove_failed(registry: &Arc<WorkerRegistry>, worker_id: &WorkerId) -> bool {
+    registry.origin_of(worker_id) != Some(WorkerOrigin::Mesh)
+}
+
 async fn submit_removal_job(
+    registry: &Arc<WorkerRegistry>,
     worker_id: &WorkerId,
     worker_url: &str,
     expected_revision: u64,
     job_queue: &Arc<JobQueue>,
 ) {
+    if !should_remove_failed(registry, worker_id) {
+        debug!(
+            worker_id = %worker_id.as_str(),
+            "skipping removal of failed mesh-imported worker (owner-managed)"
+        );
+        return;
+    }
     let url = worker_url.to_string();
     warn!(
         worker_id = %worker_id.as_str(),
@@ -1022,6 +1039,34 @@ mod tests {
             disable_health_check: false,
             drain_settle_secs: 0,
         }
+    }
+
+    #[test]
+    fn failed_mesh_imported_workers_are_not_removed() {
+        let registry = Arc::new(WorkerRegistry::new());
+
+        let local_id = registry
+            .register(make_worker("http://local:1", 1, 1))
+            .unwrap();
+        assert!(
+            should_remove_failed(&registry, &local_id),
+            "failed local workers are removable"
+        );
+
+        registry.on_remote_worker_state(&smg_mesh::WorkerState {
+            worker_id: "peer-w1".to_string(),
+            model_id: "m".to_string(),
+            url: "http://remote:1".to_string(),
+            health: true,
+            load: 0.0,
+            version: 1,
+            spec: vec![],
+        });
+        let mesh_id = registry.get_id_by_url("http://remote:1").unwrap();
+        assert!(
+            !should_remove_failed(&registry, &mesh_id),
+            "failed mesh-imported workers stay registered (owner-managed)"
+        );
     }
 
     #[test]

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -41,7 +41,7 @@ pub use openai_protocol::{
     model_type::{Endpoint, ModelType},
     worker::{ProviderType, WorkerGroupKey},
 };
-pub use registry::WorkerRegistry;
+pub use registry::{WorkerOrigin, WorkerRegistry};
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};
 pub use sampling_defaults::DEFAULT_SAMPLING_PARAMS_LABEL;
 pub use service::WorkerService;

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -979,6 +979,28 @@ impl WorkerRegistry {
         self.remove(&worker_id)
     }
 
+    /// Remove a mesh-imported worker in response to a remote tombstone.
+    ///
+    /// Delegates to [`Self::remove`] only when the worker's origin is
+    /// [`WorkerOrigin::Mesh`]. A locally-owned worker is never removed by
+    /// a peer's tombstone — only the owning node retires its own key, so
+    /// a remote tombstone for a local worker is anomalous and is refused
+    /// with a warning. Returns the removed worker, or `None` if the id is
+    /// unknown or locally owned.
+    pub fn remove_remote(&self, worker_id: &WorkerId) -> Option<Arc<dyn Worker>> {
+        match self.origin_of(worker_id) {
+            Some(WorkerOrigin::Mesh) => self.remove(worker_id),
+            Some(WorkerOrigin::Local) => {
+                tracing::warn!(
+                    worker_id = %worker_id.as_str(),
+                    "Refusing remote tombstone for locally-owned worker"
+                );
+                None
+            }
+            None => None,
+        }
+    }
+
     // ───────────────────────────────────────────────────────────────────
     // 8. Internal helpers
     // ───────────────────────────────────────────────────────────────────
@@ -1268,18 +1290,42 @@ impl WorkerRegistry {
         // `Ready` to `NotReady` and leaves `Pending` / `Failed` alone
         // (those are owned by the local state machine, not by mesh
         // hints).
-        if let Some(existing) = self.get_by_url(&state.url) {
-            if state.health {
-                existing.set_status(WorkerStatus::Ready);
-            } else if existing.status() == WorkerStatus::Ready {
-                existing.set_status(WorkerStatus::NotReady);
+        if let Some(existing_id) = self.get_id_by_url(&state.url) {
+            // A locally-owned worker's state is published BY this node;
+            // a peer's echo of it must never mutate local status — the
+            // local health state machine is the single writer.
+            if self.origin_of(&existing_id) == Some(WorkerOrigin::Local) {
+                tracing::debug!(
+                    url = %state.url,
+                    "Ignoring mesh state for locally-owned worker"
+                );
+                return;
             }
-            tracing::debug!(
-                url = %state.url,
-                healthy = state.health,
-                "Updated health for existing mesh-synced worker"
-            );
-            return;
+            if let Some(existing) = self.get(&existing_id) {
+                if state.health {
+                    existing.set_status(WorkerStatus::Ready);
+                } else if existing.status() == WorkerStatus::Ready {
+                    existing.set_status(WorkerStatus::NotReady);
+                }
+                tracing::debug!(
+                    url = %state.url,
+                    healthy = state.health,
+                    "Updated health for existing mesh-synced worker"
+                );
+                return;
+            }
+        }
+
+        // Adopt the publisher's worker id for the import so a later
+        // tombstone for `worker:{id}` (which carries no value, only the
+        // key) resolves to this worker. A pre-existing reservation for
+        // the URL wins; the import then lives under the local id and a
+        // remote tombstone for it will not resolve (rare; local probes
+        // eventually demote it instead).
+        if !state.worker_id.is_empty() {
+            self.url_to_id
+                .entry(state.url.clone())
+                .or_insert_with(|| WorkerId::from_string(state.worker_id.clone()));
         }
 
         // New worker — build from the full WorkerSpec if available,
@@ -1294,8 +1340,13 @@ impl WorkerRegistry {
                 .build(),
         };
 
+        // An explicitly-unhealthy import must not be routable: the builder
+        // defaults `disable_health_check` workers to `Ready`, so the
+        // `false` case needs a forced demotion, not just no promotion.
         if state.health {
             worker.set_status(WorkerStatus::Ready);
+        } else {
+            worker.set_status(WorkerStatus::NotReady);
         }
 
         // A `Mesh` origin keeps the outbound sync from re-publishing the
@@ -1461,6 +1512,114 @@ mod tests {
         });
         let mesh_id = registry.get_id_by_url("http://remote:8080").unwrap();
         assert_eq!(registry.origin_of(&mesh_id), Some(WorkerOrigin::Mesh));
+    }
+
+    fn remote_state(
+        worker_id: &str,
+        url: &str,
+        health: bool,
+        spec: Vec<u8>,
+    ) -> smg_mesh::WorkerState {
+        smg_mesh::WorkerState {
+            worker_id: worker_id.to_string(),
+            model_id: "llama-3".to_string(),
+            url: url.to_string(),
+            health,
+            load: 0.0,
+            version: 1,
+            spec,
+        }
+    }
+
+    #[test]
+    fn mesh_import_adopts_publisher_worker_id() {
+        let registry = WorkerRegistry::new();
+        registry.on_remote_worker_state(&remote_state(
+            "peer-w1",
+            "http://remote:8080",
+            true,
+            vec![],
+        ));
+        assert_eq!(
+            registry.get_id_by_url("http://remote:8080"),
+            Some(WorkerId::from_string("peer-w1".to_string())),
+            "import keys under the publisher's id so its tombstone resolves"
+        );
+    }
+
+    #[test]
+    fn mesh_state_never_mutates_locally_owned_worker() {
+        let registry = WorkerRegistry::new();
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://local:8080")
+                .model(ModelCard::new("m"))
+                .build(),
+        );
+        let id = registry.register(worker.clone()).unwrap();
+        worker.set_status(WorkerStatus::Ready);
+
+        registry.on_remote_worker_state(&remote_state(
+            "peer-x",
+            "http://local:8080",
+            false,
+            vec![],
+        ));
+        assert_eq!(
+            registry.get(&id).unwrap().status(),
+            WorkerStatus::Ready,
+            "a peer's echo must not demote a locally-owned worker"
+        );
+    }
+
+    #[test]
+    fn unhealthy_import_with_disabled_health_check_is_not_ready() {
+        // The builder defaults disable_health_check workers to Ready; an
+        // explicitly-unhealthy import must still land unroutable.
+        let spec: openai_protocol::worker::WorkerSpec = serde_json::from_value(serde_json::json!({
+            "url": "http://remote:8080",
+            "health": { "disable_health_check": true }
+        }))
+        .unwrap();
+        let registry = WorkerRegistry::new();
+        registry.on_remote_worker_state(&remote_state(
+            "peer-w1",
+            "http://remote:8080",
+            false,
+            bincode::serialize(&spec).unwrap(),
+        ));
+        let worker = registry.get_by_url("http://remote:8080").expect("imported");
+        assert_ne!(
+            worker.status(),
+            WorkerStatus::Ready,
+            "an explicitly-unhealthy import must not be routable"
+        );
+    }
+
+    #[test]
+    fn remove_remote_only_removes_mesh_origin_workers() {
+        let registry = WorkerRegistry::new();
+
+        registry.on_remote_worker_state(&remote_state(
+            "peer-w1",
+            "http://remote:8080",
+            true,
+            vec![],
+        ));
+        let mesh_id = registry.get_id_by_url("http://remote:8080").unwrap();
+        assert!(registry.remove_remote(&mesh_id).is_some());
+        assert!(registry.get_by_url("http://remote:8080").is_none());
+
+        let local: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://local:8080")
+                .model(ModelCard::new("m"))
+                .build(),
+        );
+        let local_id = registry.register(local).unwrap();
+        assert!(registry.remove_remote(&local_id).is_none());
+        assert!(
+            registry.get(&local_id).is_some(),
+            "a locally-owned worker survives a remote tombstone"
+        );
     }
 
     #[test]

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -1139,6 +1139,12 @@ impl WorkerRegistry {
             return None;
         }
 
+        // Record origin BEFORE the worker becomes visible in `workers`:
+        // lock-free readers resolve workers by URL the moment the insert
+        // lands, and a visible worker with no origin would be treated as
+        // mesh-imported (peer state could mutate a local worker's status).
+        self.worker_origins.insert(worker_id.clone(), origin);
+
         self.workers.insert(worker_id.clone(), worker.clone());
 
         // Update model index for O(1) lookups using copy-on-write.
@@ -1159,10 +1165,6 @@ impl WorkerRegistry {
             .entry(*worker.connection_mode())
             .or_default()
             .push(worker_id.clone());
-
-        // Record origin under the lock, before the event, so any consumer
-        // that sees `Registered` can query the origin race-free.
-        self.worker_origins.insert(worker_id.clone(), origin);
 
         // Broadcast under the lock so event order per worker_id is
         // strictly: Registered → (Replaced | StatusChanged | Removed).

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -1315,10 +1315,12 @@ impl WorkerRegistry {
         // If worker already exists at this URL, update its health
         // status from the mesh state. Don't re-register — the existing
         // worker has full config from its creation workflow.
-        // `true` always promotes to `Ready`; `false` only demotes from
-        // `Ready` to `NotReady` and leaves `Pending` / `Failed` alone
-        // (those are owned by the local state machine, not by mesh
-        // hints).
+        // `true` promotes `Pending`/`NotReady` to `Ready`; `false` only
+        // demotes from `Ready` to `NotReady`. `Failed` and `Draining`
+        // are owned by the local state machine, never by mesh hints — a
+        // dead owner's stale `health=true` key replayed by the periodic
+        // reconcile would otherwise flap a probe-failed import back into
+        // rotation every pass.
         if let Some(existing_id) = self.get_id_by_url(&state.url) {
             // A locally-owned worker's state is published BY this node;
             // a peer's echo of it must never mutate local status — the
@@ -1331,9 +1333,12 @@ impl WorkerRegistry {
                 return;
             }
             if let Some(existing) = self.get(&existing_id) {
+                let status = existing.status();
                 if state.health {
-                    existing.set_status(WorkerStatus::Ready);
-                } else if existing.status() == WorkerStatus::Ready {
+                    if matches!(status, WorkerStatus::Pending | WorkerStatus::NotReady) {
+                        existing.set_status(WorkerStatus::Ready);
+                    }
+                } else if status == WorkerStatus::Ready {
                     existing.set_status(WorkerStatus::NotReady);
                 }
                 tracing::debug!(
@@ -1637,6 +1642,35 @@ mod tests {
             worker.status(),
             WorkerStatus::Ready,
             "an explicitly-unhealthy import must not be routable"
+        );
+    }
+
+    #[test]
+    fn stale_healthy_state_never_resurrects_probe_failed_import() {
+        // A dead owner's key keeps health=true forever; the periodic
+        // reconcile replays it. A probe-failed import must stay failed,
+        // not flap back into rotation every pass.
+        let registry = WorkerRegistry::new();
+        let state = remote_state("peer-w1", "http://remote:8080", true, vec![]);
+        registry.on_remote_worker_state(&state);
+        let worker = registry.get_by_url("http://remote:8080").unwrap();
+        assert_eq!(worker.status(), WorkerStatus::Ready);
+
+        worker.set_status(WorkerStatus::Failed);
+        registry.on_remote_worker_state(&state);
+        assert_eq!(
+            registry.get_by_url("http://remote:8080").unwrap().status(),
+            WorkerStatus::Failed,
+            "mesh hints must not resurrect probe-owned terminal states"
+        );
+
+        // NotReady is still promotable: the owner saying healthy again
+        // is the legitimate recovery signal.
+        worker.set_status(WorkerStatus::NotReady);
+        registry.on_remote_worker_state(&state);
+        assert_eq!(
+            registry.get_by_url("http://remote:8080").unwrap().status(),
+            WorkerStatus::Ready
         );
     }
 

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -599,7 +599,7 @@ impl WorkerRegistry {
     ///
     /// Emits [`WorkerEvent::Registered`] on success. Holds the per-worker
     /// mutation lock for the entire `register_inner` call — the index
-    /// updates, mesh sync, and event broadcast all run under the same
+    /// updates, origin record, and event broadcast all run under the same
     /// lock so subscribers cannot observe `Removed` / `Replaced` /
     /// `StatusChanged` events before the `Registered` event for a
     /// concurrent same-ID operation.
@@ -919,10 +919,10 @@ impl WorkerRegistry {
     /// Remove a worker by ID and clean up every index entry.
     ///
     /// Returns `Some(worker)` if the ID existed, `None` otherwise. Tears
-    /// down the URL mapping, per-worker mutation lock, model/type/
-    /// connection indexes, and per-model retry config when the last
-    /// worker for a model is removed. Also forwards the removal to mesh
-    /// sync and clears per-worker Prometheus metrics.
+    /// down the URL mapping, per-worker mutation lock, origin record,
+    /// model/type/connection indexes, and per-model retry config when the
+    /// last worker for a model is removed. Clears per-worker Prometheus
+    /// metrics; mesh tombstoning rides the `Removed` event.
     ///
     /// Emits [`WorkerEvent::Removed`] on success. Holds the per-worker
     /// mutation lock for the whole teardown so it cannot race a
@@ -973,6 +973,9 @@ impl WorkerRegistry {
                 worker.set_status(WorkerStatus::NotReady);
             }
             Metrics::remove_worker_metrics(worker.url());
+
+            // Mesh tombstoning rides the `Removed` event below: the
+            // outbound sync loop deletes `worker:{id}` for local workers.
 
             let _ = self.event_tx.send(WorkerEvent::Removed {
                 worker_id: worker_id.clone(),
@@ -1116,11 +1119,11 @@ impl WorkerRegistry {
     /// Core registration logic shared by local and mesh paths.
     ///
     /// Acquires the per-worker mutation lock before making the worker
-    /// visible in any index, and holds it for the full sequence — insert,
-    /// index updates, and the `Registered` event broadcast. Releasing the
-    /// lock only after the event is sent guarantees subscribers cannot
-    /// observe a mutation event for this `WorkerId` before the
-    /// `Registered` event that created it.
+    /// visible in any index, and holds it for the full sequence — origin
+    /// record, insert, index updates, and the `Registered` event
+    /// broadcast. Releasing the lock only after the event is sent
+    /// guarantees subscribers cannot observe a mutation event for this
+    /// `WorkerId` before the `Registered` event that created it.
     ///
     /// `origin` records whether this is a local workflow registration or a
     /// mesh import; the outbound mesh sync consults it so imported workers
@@ -1346,8 +1349,9 @@ impl WorkerRegistry {
         // tombstone for `worker:{id}` (which carries no value, only the
         // key) resolves to this worker. A pre-existing reservation for
         // the URL wins; the import then lives under the local id and a
-        // remote tombstone for it will not resolve (rare; local probes
-        // eventually demote it instead).
+        // remote tombstone for it will not resolve directly (rare; the
+        // adapter's reconcile pass removes the import once its backing
+        // key is gone).
         if !state.worker_id.is_empty() {
             self.url_to_id
                 .entry(state.url.clone())

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -61,6 +61,15 @@ impl Default for WorkerId {
     }
 }
 
+/// Where a worker's registration came from. `Local` workers are owned by
+/// this node (their state is published to the mesh); `Mesh` workers were
+/// imported from a peer's published state and must never be re-published.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerOrigin {
+    Local,
+    Mesh,
+}
+
 /// Side-effect-free worker snapshot for subscriber bootstrap or lag recovery.
 #[derive(Debug, Clone)]
 pub struct WorkerDescriptor {
@@ -108,6 +117,11 @@ pub struct WorkerRegistry {
     /// When retries are disabled, max_retries is set to 1.
     model_retry_configs: Arc<DashMap<String, RetryConfig>>,
 
+    /// Registration origin per worker (local vs mesh-imported). Written
+    /// under the per-worker mutation lock before the `Registered` event,
+    /// removed in `remove()` teardown.
+    worker_origins: Arc<DashMap<WorkerId, WorkerOrigin>>,
+
     /// Broadcast channel for worker state change events.
     event_tx: broadcast::Sender<WorkerEvent>,
 }
@@ -131,8 +145,16 @@ impl WorkerRegistry {
             url_to_id: Arc::new(DashMap::new()),
             worker_mutation_locks: Arc::new(DashMap::new()),
             model_retry_configs: Arc::new(DashMap::new()),
+            worker_origins: Arc::new(DashMap::new()),
             event_tx: broadcast::Sender::new(64),
         }
+    }
+
+    /// Registration origin for a worker, if it is currently registered.
+    /// `Local` workers are owned by this node; `Mesh` workers were
+    /// imported from a peer's published state.
+    pub fn origin_of(&self, worker_id: &WorkerId) -> Option<WorkerOrigin> {
+        self.worker_origins.get(worker_id).map(|entry| *entry)
     }
 
     /// Subscribe to the `WorkerEvent` broadcast stream.
@@ -582,7 +604,7 @@ impl WorkerRegistry {
     /// `StatusChanged` events before the `Registered` event for a
     /// concurrent same-ID operation.
     pub fn register(&self, worker: Arc<dyn Worker>) -> Option<WorkerId> {
-        self.register_inner(worker)
+        self.register_inner(worker, WorkerOrigin::Local)
     }
 
     /// Register or replace a worker (upsert).
@@ -896,6 +918,7 @@ impl WorkerRegistry {
             self.url_to_id.remove(worker.url());
             // We hold _guard; drop the DashMap entry but the Mutex stays alive via Arc.
             self.worker_mutation_locks.remove(worker_id);
+            self.worker_origins.remove(worker_id);
 
             for model_id in Self::worker_model_ids(&worker) {
                 self.remove_worker_from_model_index(&model_id, worker.url());
@@ -1052,7 +1075,11 @@ impl WorkerRegistry {
     /// lock only after the event is sent guarantees subscribers cannot
     /// observe a mutation event for this `WorkerId` before the
     /// `Registered` event that created it.
-    fn register_inner(&self, worker: Arc<dyn Worker>) -> Option<WorkerId> {
+    ///
+    /// `origin` records whether this is a local workflow registration or a
+    /// mesh import; the outbound mesh sync consults it so imported workers
+    /// are never re-published (which would version-bump the CRDT in a loop).
+    fn register_inner(&self, worker: Arc<dyn Worker>, origin: WorkerOrigin) -> Option<WorkerId> {
         // Resolve (or reserve) the worker_id from url_to_id. The entry
         // API is atomic per bucket, so concurrent callers either reuse
         // the same existing_id or serialize on vacant insertion.
@@ -1102,6 +1129,10 @@ impl WorkerRegistry {
             .entry(*worker.connection_mode())
             .or_default()
             .push(worker_id.clone());
+
+        // Record origin under the lock, before the event, so any consumer
+        // that sees `Registered` can query the origin race-free.
+        self.worker_origins.insert(worker_id.clone(), origin);
 
         // Broadcast under the lock so event order per worker_id is
         // strictly: Registered → (Replaced | StatusChanged | Removed).
@@ -1267,12 +1298,14 @@ impl WorkerRegistry {
             worker.set_status(WorkerStatus::Ready);
         }
 
-        // Publishes the local `Registered` event under the per-worker
-        // mutation lock so in-process subscribers (WorkerManager's health
-        // scheduler, etc.) pick up mesh-imported workers via the same
-        // event path as any other registration.
+        // A `Mesh` origin keeps the outbound sync from re-publishing the
+        // imported state (which would version-bump the CRDT in a loop),
+        // but still publishes the local `Registered` event under the
+        // per-worker mutation lock so in-process subscribers
+        // (WorkerManager's health scheduler, etc.) pick up mesh-imported
+        // workers via the same event path as any other registration.
         let worker: Arc<dyn Worker> = Arc::new(worker);
-        if let Some(id) = self.register_inner(worker) {
+        if let Some(id) = self.register_inner(worker, WorkerOrigin::Mesh) {
             tracing::info!(
                 worker_id = %id.as_str(),
                 url = %state.url,
@@ -1403,6 +1436,57 @@ mod tests {
 
         registry.remove(&worker_id);
         assert!(registry.get(&worker_id).is_none());
+    }
+
+    #[test]
+    fn origin_tracks_local_and_mesh_registrations() {
+        let registry = WorkerRegistry::new();
+
+        let local: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://local:8080")
+                .model(ModelCard::new("llama-3"))
+                .build(),
+        );
+        let local_id = registry.register(local).unwrap();
+        assert_eq!(registry.origin_of(&local_id), Some(WorkerOrigin::Local));
+
+        registry.on_remote_worker_state(&smg_mesh::WorkerState {
+            worker_id: "peer-w1".to_string(),
+            model_id: "llama-3".to_string(),
+            url: "http://remote:8080".to_string(),
+            health: true,
+            load: 0.0,
+            version: 1,
+            spec: vec![],
+        });
+        let mesh_id = registry.get_id_by_url("http://remote:8080").unwrap();
+        assert_eq!(registry.origin_of(&mesh_id), Some(WorkerOrigin::Mesh));
+    }
+
+    #[test]
+    fn origin_survives_replace_and_clears_on_remove() {
+        let registry = WorkerRegistry::new();
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8080")
+                .model(ModelCard::new("m"))
+                .build(),
+        );
+        let id = registry.register(worker).unwrap();
+
+        let replacement: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8080")
+                .model(ModelCard::new("m2"))
+                .build(),
+        );
+        assert!(registry.replace(&id, replacement));
+        assert_eq!(
+            registry.origin_of(&id),
+            Some(WorkerOrigin::Local),
+            "replace keeps the same id, so origin is untouched"
+        );
+
+        registry.remove(&id);
+        assert_eq!(registry.origin_of(&id), None, "remove clears the origin");
     }
 
     #[test]

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -625,17 +625,14 @@ impl WorkerRegistry {
             return id;
         }
 
-        // URL exists with an active worker — replace it
+        // URL exists with an active worker — replace it. This is the "node
+        // claims this URL" path (startup workflows, K8s discovery): if a
+        // mesh import won the race for the URL, the local registration must
+        // take ownership back, else the worker is never published and a peer
+        // tombstone could delete a locally-configured worker. The promotion
+        // happens inside replace_inner, under the per-worker mutation lock.
         if let Some(existing_id) = self.url_to_id.get(worker.url()).map(|e| e.clone()) {
-            if self.replace(&existing_id, worker) {
-                // This is the "node claims this URL" path (startup workflows,
-                // K8s discovery): if a mesh import won the race for the URL,
-                // the local registration must take ownership back, else the
-                // worker is never published and a peer tombstone could delete
-                // a locally-configured worker.
-                self.worker_origins
-                    .insert(existing_id.clone(), WorkerOrigin::Local);
-            } else {
+            if !self.replace_inner(&existing_id, worker, Some(WorkerOrigin::Local)) {
                 // replace() returned false — worker was removed concurrently.
                 // The mutation lock prevents stale indexes, so this is safe to ignore.
                 tracing::warn!(
@@ -672,6 +669,21 @@ impl WorkerRegistry {
     /// Emits [`WorkerEvent::Replaced`] on success. Holds the per-worker
     /// mutation lock for the entire diff + broadcast sequence.
     pub fn replace(&self, worker_id: &WorkerId, new_worker: Arc<dyn Worker>) -> bool {
+        self.replace_inner(worker_id, new_worker, None)
+    }
+
+    /// Core replacement shared by [`Self::replace`] and
+    /// [`Self::register_or_replace`]. `promote_origin` is applied under the
+    /// per-worker mutation lock, before the `Replaced` event, so consumers
+    /// observing the event see the final origin (the outbound mesh sync
+    /// publishes a claimed worker immediately) and a concurrent `remove()`
+    /// cannot orphan the entry.
+    fn replace_inner(
+        &self,
+        worker_id: &WorkerId,
+        new_worker: Arc<dyn Worker>,
+        promote_origin: Option<WorkerOrigin>,
+    ) -> bool {
         // Serialize concurrent replacements for the same worker ID.
         // Lock is held only during the in-memory diff (no I/O, microseconds).
         let lock = self
@@ -758,6 +770,10 @@ impl WorkerRegistry {
                 .entry(*new_worker.connection_mode())
                 .or_default()
                 .push(worker_id.clone());
+        }
+
+        if let Some(origin) = promote_origin {
+            self.worker_origins.insert(worker_id.clone(), origin);
         }
 
         let _ = self.event_tx.send(WorkerEvent::Replaced {

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -627,7 +627,15 @@ impl WorkerRegistry {
 
         // URL exists with an active worker — replace it
         if let Some(existing_id) = self.url_to_id.get(worker.url()).map(|e| e.clone()) {
-            if !self.replace(&existing_id, worker) {
+            if self.replace(&existing_id, worker) {
+                // This is the "node claims this URL" path (startup workflows,
+                // K8s discovery): if a mesh import won the race for the URL,
+                // the local registration must take ownership back, else the
+                // worker is never published and a peer tombstone could delete
+                // a locally-configured worker.
+                self.worker_origins
+                    .insert(existing_id.clone(), WorkerOrigin::Local);
+            } else {
                 // replace() returned false — worker was removed concurrently.
                 // The mutation lock prevents stale indexes, so this is safe to ignore.
                 tracing::warn!(
@@ -1619,6 +1627,35 @@ mod tests {
         assert!(
             registry.get(&local_id).is_some(),
             "a locally-owned worker survives a remote tombstone"
+        );
+    }
+
+    #[test]
+    fn register_or_replace_promotes_mesh_origin_to_local() {
+        // Restart race: a mesh import wins the URL before the local
+        // workflow registers it. The local claim must take ownership back,
+        // else the node never publishes its own worker and a peer tombstone
+        // could delete it.
+        let registry = WorkerRegistry::new();
+        registry.on_remote_worker_state(&remote_state("peer-w1", "http://w:8080", true, vec![]));
+        let id = registry.get_id_by_url("http://w:8080").unwrap();
+        assert_eq!(registry.origin_of(&id), Some(WorkerOrigin::Mesh));
+
+        let local: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8080")
+                .model(ModelCard::new("llama-3"))
+                .build(),
+        );
+        let claimed_id = registry.register_or_replace(local);
+        assert_eq!(claimed_id, id, "claim reuses the adopted id");
+        assert_eq!(
+            registry.origin_of(&id),
+            Some(WorkerOrigin::Local),
+            "local registration over a mesh import takes ownership"
+        );
+        assert!(
+            registry.remove_remote(&id).is_none(),
+            "a peer tombstone can no longer delete the claimed worker"
         );
     }
 

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -1336,16 +1336,31 @@ impl WorkerRegistry {
                 .or_insert_with(|| WorkerId::from_string(state.worker_id.clone()));
         }
 
-        // New worker — build from the full WorkerSpec if available,
-        // otherwise fall back to minimal builder.
-        let worker = match bincode::deserialize::<openai_protocol::worker::WorkerSpec>(&state.spec)
-        {
-            Ok(spec) if !state.spec.is_empty() => {
-                super::builder::BasicWorkerBuilder::from_spec(spec).build()
-            }
-            _ => super::builder::BasicWorkerBuilder::new(&state.url)
+        // New worker — build from the full WorkerSpec (JSON) if available,
+        // otherwise fall back to the minimal builder.
+        let minimal = || {
+            super::builder::BasicWorkerBuilder::new(&state.url)
                 .model(ModelCard::new(&state.model_id))
-                .build(),
+                .build()
+        };
+        let mut spec_applied = false;
+        let worker = if state.spec.is_empty() {
+            minimal()
+        } else {
+            match serde_json::from_slice::<openai_protocol::worker::WorkerSpec>(&state.spec) {
+                Ok(spec) => {
+                    spec_applied = true;
+                    super::builder::BasicWorkerBuilder::from_spec(spec).build()
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        url = %state.url,
+                        %err,
+                        "undecodable WorkerSpec in mesh state; importing minimal worker"
+                    );
+                    minimal()
+                }
+            }
         };
 
         // An explicitly-unhealthy import must not be routable: the builder
@@ -1370,7 +1385,7 @@ impl WorkerRegistry {
                 url = %state.url,
                 model = %state.model_id,
                 healthy = state.health,
-                has_spec = !state.spec.is_empty(),
+                spec_applied,
                 "Registered mesh-synced worker into local registry"
             );
         }
@@ -1593,7 +1608,7 @@ mod tests {
             "peer-w1",
             "http://remote:8080",
             false,
-            bincode::serialize(&spec).unwrap(),
+            serde_json::to_vec(&spec).unwrap(),
         ));
         let worker = registry.get_by_url("http://remote:8080").expect("imported");
         assert_ne!(

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -928,6 +928,20 @@ impl WorkerRegistry {
     /// mutation lock for the whole teardown so it cannot race a
     /// concurrent `replace()`.
     pub fn remove(&self, worker_id: &WorkerId) -> Option<Arc<dyn Worker>> {
+        self.remove_inner(worker_id, None)
+    }
+
+    /// Core removal shared by [`Self::remove`] and [`Self::remove_remote`].
+    /// When `expect_origin` is set, the origin is re-checked after the
+    /// per-worker mutation lock is acquired and the removal aborts on a
+    /// mismatch — a lock-free pre-check alone races `replace_inner`'s
+    /// promotion (check Mesh, block on the lock, promotion lands, then
+    /// delete a now locally-owned worker).
+    fn remove_inner(
+        &self,
+        worker_id: &WorkerId,
+        expect_origin: Option<WorkerOrigin>,
+    ) -> Option<Arc<dyn Worker>> {
         // Acquire the same per-worker lock used by replace() to prevent
         // remove racing with a concurrent replace that has already snapshot
         // the old worker and is about to re-insert.
@@ -937,6 +951,16 @@ impl WorkerRegistry {
             .or_insert_with(|| Arc::new(parking_lot::Mutex::new(())))
             .clone();
         let _guard = lock.lock();
+
+        if let Some(expected) = expect_origin {
+            if self.origin_of(worker_id) != Some(expected) {
+                tracing::warn!(
+                    worker_id = %worker_id.as_str(),
+                    "Aborting removal: worker origin changed before the lock was acquired"
+                );
+                return None;
+            }
+        }
 
         if let Some((_, worker)) = self.workers.remove(worker_id) {
             self.url_to_id.remove(worker.url());
@@ -1008,15 +1032,17 @@ impl WorkerRegistry {
 
     /// Remove a mesh-imported worker in response to a remote tombstone.
     ///
-    /// Delegates to [`Self::remove`] only when the worker's origin is
-    /// [`WorkerOrigin::Mesh`]. A locally-owned worker is never removed by
-    /// a peer's tombstone — only the owning node retires its own key, so
-    /// a remote tombstone for a local worker is anomalous and is refused
-    /// with a warning. Returns the removed worker, or `None` if the id is
-    /// unknown or locally owned.
+    /// Removes only when the worker's origin is [`WorkerOrigin::Mesh`],
+    /// re-verified under the per-worker mutation lock so a concurrent
+    /// local claim (`register_or_replace` promoting the origin) cannot
+    /// slip between the check and the removal. A locally-owned worker is
+    /// never removed by a peer's tombstone — only the owning node retires
+    /// its own key, so a remote tombstone for a local worker is anomalous
+    /// and is refused with a warning. Returns the removed worker, or
+    /// `None` if the id is unknown or locally owned.
     pub fn remove_remote(&self, worker_id: &WorkerId) -> Option<Arc<dyn Worker>> {
         match self.origin_of(worker_id) {
-            Some(WorkerOrigin::Mesh) => self.remove(worker_id),
+            Some(WorkerOrigin::Mesh) => self.remove_inner(worker_id, Some(WorkerOrigin::Mesh)),
             Some(WorkerOrigin::Local) => {
                 tracing::warn!(
                     worker_id = %worker_id.as_str(),
@@ -1727,6 +1753,32 @@ mod tests {
         assert!(
             registry.remove_remote(&id).is_none(),
             "a peer tombstone can no longer delete the claimed worker"
+        );
+    }
+
+    #[test]
+    fn remove_inner_aborts_when_origin_changed_before_lock() {
+        // The TOCTOU guard: remove_remote's pre-check can observe Mesh,
+        // then lose the lock race to a local claim that promotes the
+        // origin. The under-lock recheck must abort the removal.
+        let registry = WorkerRegistry::new();
+        let local: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8080")
+                .model(ModelCard::new("m"))
+                .build(),
+        );
+        let id = registry.register(local).unwrap();
+
+        // Models the post-promotion state: expecting Mesh, finding Local.
+        assert!(
+            registry
+                .remove_inner(&id, Some(WorkerOrigin::Mesh))
+                .is_none(),
+            "removal must abort when the origin no longer matches"
+        );
+        assert!(
+            registry.get(&id).is_some(),
+            "the claimed worker survives the racing tombstone"
         );
     }
 


### PR DESCRIPTION
## Description

### Problem

#1626 made inbound worker sync live, but nothing publishes: a node's workers, their health transitions, and their removals are invisible to the mesh. The registry also had no notion of which workers it *owns* versus which it imported — the dead `sync_mesh` flag carried that intent but did nothing — so any naive outbound wiring would re-publish imports (a CRDT version-bump loop) and let peers mutate or delete locally-configured workers.

### Solution

Single-writer ownership, enforced end to end: each `worker:{id}` key has exactly one writer — the node that registered the worker. Everyone else is a reader.

- **`WorkerOrigin` (Local/Mesh)** recorded per worker under the per-worker mutation lock, before the worker becomes visible; promoted to Local when `register_or_replace` claims a URL a mesh import won (the rolling-restart race); cleared on removal.
- **Outbound publish loop** in `WorkerSyncAdapter::start`: Registered/Replaced/StatusChanged of locally-owned workers publish `WorkerState` (JSON `WorkerSpec` riding along); Removed tombstones the key. Mesh imports are filtered by live origin. Broadcast lag triggers a full local resync that also tombstones removals missed in the lag window.
- **Import hardening**: peers can never mutate a locally-owned worker's status; imports adopt the publisher's id so tombstones resolve; an explicitly-unhealthy import lands NotReady (the builder would otherwise default `disable_health_check` specs to Ready); mesh health hints never resurrect probe-owned `Failed`/`Draining` states.
- **Tombstone handling**: `remove_remote` removes only Mesh-origin workers; a foreign tombstone for an owned key is refused *and the key re-asserted* (the delete already propagated cluster-wide).
- **Recovery paths**: the inbound loop acts on store truth (not event snapshots), and a 30s reconcile pass repairs anything a dropped `try_send` notification missed — imports, tombstones, and lost publishes — including cold-start merge bursts larger than the subscription channel.
- **Memory**: CRDT tombstone GC is now actually driven (it existed with a 300s grace but had zero runtime callers; this branch ships the first production tombstone producer). `WorkerSpec` is JSON inside the bincode `WorkerState` envelope — bincode could not round-trip its serde-skip attributes, so every import silently downgraded to the minimal builder.

### Review hardening

Three adversarial review rounds (multi-agent) ran before this PR: a whole-branch sweep (19 confirmed findings → 6 fix commits), a memory/lifecycle audit of the new structures (leak-freedom proven; one lock-scoping bug found and fixed), and a per-commit design/complexity/perf review + final capped perf pass (tombstone-GC wiring, the Ready-flap fix, and the reconcile allocation fix came out of it).

## Changes

- `model_gateway/src/worker/registry.rs` — `WorkerOrigin` + `origin_of`/`remove_remote`; `register_inner(origin)`; `replace_inner(.., promote_origin)`; import hardening in `on_remote_worker_state`
- `model_gateway/src/mesh/adapters/worker_sync.rs` — outbound publish loop, store-truth inbound, tombstone handling, 30s reconcile, lag resync
- `model_gateway/src/worker/manager.rs` — failed mesh imports are never auto-removed (owner-managed; local removal would churn re-import/remove forever)
- `crates/mesh/src/kv.rs` + `gossip_controller.rs` — tombstone GC driven from the 60-round housekeeping tick
- `crates/mesh/src/types.rs` — spec field documented as JSON

## Known limitations (tracked follow-ups)

- **Dead-owner keys persist**: only the owner tombstones its keys, so a permanently-dead node's `worker:` keys remain cluster-wide (~0.5–2 KB/worker/node; imports stay registered, demoted by probes). Fix: dead-node key GC.
- **Crash-restart orphans**: a restart that registers locally before its old state gossips back orphans up to one store key per worker per restart. Fix: deterministic worker ids.
- **Dual-claim flap**: two gateways locally configuring the same URL both claim Local and alternate the published value (benign LWW flapping over near-identical state).
- **`api_key` never gossips** (deliberate — secrets stay on the owner): imports of auth-protected backends fail non-owner probes and sit demoted.
- **Lagged-resync burst** (~16× at 1k workers off the 64-slot broadcast) and **op-log value retention** (≤ ~15 MB at the 10k-op cap) — both bounded; mitigations tracked.

## Test Plan

- `cargo test -p smg -p smg-mesh` — full suite green post-rebase (1,550+ tests; 25 new in this branch).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.

Key regressions: `claimed_import_publishes_from_next_mutation` (restart race), `outbound_never_republishes_mesh_imported_worker` (echo), `remote_tombstone_never_removes_local_worker` (+ key re-assert), `stale_healthy_state_never_resurrects_probe_failed_import` (Ready-flap), `published_spec_round_trips_into_importing_registry` (gRPC decode worker imports faithfully), `reconcile_recovers_missed_put_and_missed_tombstone`, `rapid_put_then_delete_converges_to_absent`, `unhealthy_import_with_disabled_health_check_is_not_ready`, `failed_mesh_imported_workers_are_not_removed`, `gc_tombstones_respects_grace_through_mesh_kv`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tombstone garbage collection to reclaim old mesh metadata.
  * Mesh-origin tracking for workers and mesh-aware handling to avoid unintended removals.
  * More resilient gateway↔mesh synchronization with periodic reconciliation and backfill.

* **Bug Fixes**
  * Improved recovery of missed updates and better handling of remote tombstones and imports.
  * Prevent automatic removal of failed mesh-imported workers.

* **Tests**
  * Expanded integration and unit tests covering mesh GC, sync, imports, tombstones, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->