### PR TITLE
ci(sglang): bump CI install to sglang 0.5.12.post1 (cu13 stack)

### DIFF
--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -21,34 +21,36 @@ echo "Using uv version: $(uv --version)"
 # Install CUDA toolkit (nvcc) — required for SGLang JIT kernel compilation.
 # SGLang >= 0.5.9 JIT-compiles CUDA kernels (RoPE, etc.) at runtime via tvm_ffi,
 # which invokes nvcc. The CI runners have CUDA runtime (driver) but not the compiler.
+# sglang 0.5.12 pins torch==2.11.0, whose default PyPI wheels are CUDA 13, so the
+# compiler must be nvcc 13 to match the runtime headers (a 12.x nvcc is replaced).
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
-if [ ! -x "${CUDA_HOME}/bin/nvcc" ]; then
-    echo "Installing CUDA toolkit (nvcc not found at ${CUDA_HOME}/bin/nvcc)..."
+if [ ! -x "${CUDA_HOME}/bin/nvcc" ] || ! "${CUDA_HOME}/bin/nvcc" --version | grep -q "release 13\."; then
+    echo "Installing CUDA 13 toolkit (nvcc 13 not found at ${CUDA_HOME}/bin/nvcc)..."
     curl -fsSL -o /tmp/cuda-keyring.deb \
         https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
     sudo dpkg -i /tmp/cuda-keyring.deb
     rm /tmp/cuda-keyring.deb
     sudo apt-get update -qq
-    sudo apt-get install -y --no-install-recommends cuda-nvcc-12-9 cuda-cudart-dev-12-9
+    sudo apt-get install -y --no-install-recommends cuda-nvcc-13-0 cuda-cudart-dev-13-0
     # Ensure CUDA_HOME points to the installed toolkit
-    if [ ! -d "${CUDA_HOME}/bin" ] && [ -d "/usr/local/cuda-12.9/bin" ]; then
-        sudo ln -sfn /usr/local/cuda-12.9 "${CUDA_HOME}"
+    if [ ! -d "${CUDA_HOME}/bin" ] && [ -d "/usr/local/cuda-13.0/bin" ]; then
+        sudo ln -sfn /usr/local/cuda-13.0 "${CUDA_HOME}"
     fi
     echo "nvcc installed: $(${CUDA_HOME}/bin/nvcc --version | tail -1)"
 else
-    echo "nvcc already available: $(${CUDA_HOME}/bin/nvcc --version | tail -1)"
+    echo "nvcc 13 already available: $(${CUDA_HOME}/bin/nvcc --version | tail -1)"
 fi
 
 # Install SGLang with all dependencies
 echo "Installing SGLang..."
-uv pip install --prerelease=allow "sglang[all]==0.5.10"
+uv pip install --prerelease=allow "sglang[all]==0.5.12.post1"
 
 # Install flashinfer-jit-cache: sglang bundles flashinfer_python but only for attention ops.
 # Multi-GPU models need trtllm_comm kernels (fused allreduce + layernorm) which FlashInfer
 # JIT-compiles at runtime requiring nvcc. The jit-cache provides these pre-compiled.
 # Version must match flashinfer_python from sglang.
 FLASHINFER_VERSION=$(uv pip show flashinfer-python 2>/dev/null | grep "^Version:" | awk '{print $2}')
-CU_VERSION=$(python3 -c "import torch; print('cu' + torch.version.cuda.replace('.', ''))" 2>/dev/null || echo "cu129")
+CU_VERSION=$(python3 -c "import torch; print('cu' + torch.version.cuda.replace('.', ''))" 2>/dev/null || echo "cu130")
 if [ -n "$FLASHINFER_VERSION" ]; then
     echo "Installing flashinfer-jit-cache==${FLASHINFER_VERSION} (${CU_VERSION})..."
     uv pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
@@ -59,11 +61,13 @@ fi
 
 # Install mooncake for SGLang PD disaggregation (KV transfer)
 # Mooncake's native transfer engine requires InfiniBand/RDMA libraries at runtime.
-# See: https://github.com/sgl-project/sglang/blob/main/scripts/ci/cuda/ci_install_dependency.sh
+# Package and pin track upstream sglang v0.5.12.post1 CI on the cu13 stack
+# (cuda13 wheel variant + nvrtc, since torch 2.11 defaults to CUDA 13):
+# https://github.com/sgl-project/sglang/blob/v0.5.12.post1/scripts/ci/cuda/ci_install_dependency.sh
 echo "Installing mooncake system dependencies..."
 sudo apt-get install -y --no-install-recommends libnuma-dev libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils
 echo "Installing mooncake..."
-uv pip install mooncake-transfer-engine==0.3.8.post1
+uv pip install mooncake-transfer-engine-cuda13==0.3.10.post2 nvidia-cuda-nvrtc
 
 # Install gRPC packages from source (not PyPI) so PR changes are always tested
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."

--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -45,6 +45,14 @@ fi
 echo "Installing SGLang..."
 uv pip install --prerelease=allow "sglang[all]==0.5.12.post1"
 
+# sglang 0.5.12.post1 leaves its `kernels` dependency unpinned, so the resolver
+# picks kernels >=0.15, which requires LayerRepository(revision=/version=) —
+# an argument the transformers 5.6.0 hub_kernels integration (pinned by sglang)
+# does not pass. `import sglang` then dies at module load with
+# "ValueError: Either a revision or a version must be specified."
+# Pin to the band sglang upstream main now uses; drop once a release carries it.
+uv pip install "kernels>=0.14.1,<0.15"
+
 # Install flashinfer-jit-cache: sglang bundles flashinfer_python but only for attention ops.
 # Multi-GPU models need trtllm_comm kernels (fused allreduce + layernorm) which FlashInfer
 # JIT-compiles at runtime requiring nvcc. The jit-cache provides these pre-compiled.


### PR DESCRIPTION
## Description

CI-only bump of the sglang e2e stack from 0.5.10 to **0.5.12.post1** (current latest on PyPI). The Docker release pipelines (`release-sglang-docker.yml`, `nightly-engine-docker.yml`) are untouched and keep their `lmsysorg/sglang:v0.5.10` base image.

sglang 0.5.12.post1 pins `torch==2.11.0`, whose default PyPI wheels are **CUDA 13** (`nvidia-nccl-cu13` in requires_dist), so the install script moves to the cu13 stack coherently rather than bumping the version pin alone:

## Changes (`scripts/ci_install_sglang.sh` only)

- `sglang[all]==0.5.10` → `sglang[all]==0.5.12.post1`
- nvcc for JIT kernel compilation: `cuda-nvcc-12-9` → `cuda-nvcc-13-0` (+ matching cudart-dev, `/usr/local/cuda-13.0` symlink). The guard now also checks the nvcc major (`release 13.`) so a stale 12.x compiler on a runner is replaced instead of silently mismatching torch's CUDA 13 headers.
- mooncake: `mooncake-transfer-engine==0.3.8.post1` → `mooncake-transfer-engine-cuda13==0.3.10.post2` + `nvidia-cuda-nvrtc`, tracking upstream sglang v0.5.12.post1 CI's cu13 branch ([`ci_install_dependency.sh`](https://github.com/sgl-project/sglang/blob/v0.5.12.post1/scripts/ci/cuda/ci_install_dependency.sh)).
- flashinfer-jit-cache fallback index `cu129` → `cu130` (the normal path derives the index from `torch.version.cuda`; `flashinfer-jit-cache==0.6.11.post1` wheels verified present on flashinfer.ai for both cu129 and cu130).

## Test Plan

- `bash -n scripts/ci_install_sglang.sh` — clean.
- Verified upstream facts: sglang 0.5.12.post1 on PyPI (latest); its `requires_dist` pins `flashinfer_python==0.6.11.post1` and `torch==2.11.0`; torch 2.11.0 default wheel is cu13; `mooncake-transfer-engine-cuda13==0.3.10.post2` exists on PyPI.
- Real gate: this PR's GPU e2e jobs. First-run watch item: the `Installing flashinfer-jit-cache==... (cuXXX)` log line should report `cu130`.

Note: `e2e-2gpu-pd` is currently red on main for an infra reason unrelated to this bump — the GPU nodes rotated on Jun 10 now inject RDMA devices into runner pods with a 64KB memlock limit, breaking Mooncake/NIXL init. Judge this PR by the non-PD e2e jobs until that is resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensured CI uses CUDA 13 toolchain and updated related runtime packages.
  * Upgraded SGLang dependency to 0.5.12.post1 (allows prereleases) and added pinning to prevent version-resolution conflicts.
  * Updated mooncake transfer engine for CUDA 13 compatibility and added NVIDIA CUDA runtime support.
  * Adjusted GPU wheel selection default from cu129 to cu130 for JIT/cache installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->