### PR TITLE
ci(trtllm): bump CI wheel to TensorRT-LLM 1.3.0rc18

### DIFF
--- a/scripts/ci_install_trtllm.sh
+++ b/scripts/ci_install_trtllm.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Install TensorRT-LLM pre-release wheel from PyPI for CI.
 #
-# As of 1.3.0rc14 (released 2026-05-07), the gRPC serve command from PR #11037
-# and the Harmony parser fixes (#12045, #12467) referenced by SMG #801 are all
-# included in the published pre-release wheel. We install it directly from PyPI
-# instead of building TensorRT-LLM from source, which saves ~30 min of CMake
-# compile time per CI run. See git history for the previous source-build logic.
+# The gRPC serve command from PR #11037 and the Harmony parser fixes (#12045,
+# #12467) referenced by SMG #801 first shipped in 1.3.0rc14 (released
+# 2026-05-07) and remain included in the pinned 1.3.0rc18 pre-release wheel.
+# We install it directly from PyPI instead of building TensorRT-LLM from
+# source, which saves ~30 min of CMake compile time per CI run. See git
+# history for the previous source-build logic.
 #
 # Prerequisites (expected on k8s-runner-gpu nodes):
 #   - NVIDIA driver 580+ (CUDA 13)
@@ -16,7 +17,7 @@
 
 set -euo pipefail
 
-TRTLLM_VERSION="1.3.0rc14"
+TRTLLM_VERSION="1.3.0rc18"
 NCCL_VERSION_CONSTRAINT="nvidia-nccl-cu13>=2.28.9,<=2.29.2"
 
 # Activate venv if it exists


### PR DESCRIPTION
## Description

CI-only bump of the TensorRT-LLM e2e wheel from 1.3.0rc14 to **1.3.0rc18**. The Docker release pipelines (`release-trtllm-docker.yml`, `nightly-engine-docker.yml`) are untouched and keep their rc10 base images.

## Changes (`scripts/ci_install_trtllm.sh` only)

- `TRTLLM_VERSION="1.3.0rc14"` → `"1.3.0rc18"`
- Header comment reworded so the rc14 feature provenance (gRPC serve from PR #11037, Harmony parser fixes #12045/#12467 for SMG #801) reads correctly against the new pin.
- `NCCL_VERSION_CONSTRAINT` deliberately unchanged: upstream `requirements.txt` at tag v1.3.0rc18 pins the identical `nvidia-nccl-cu13>=2.28.9,<=2.29.2` (and the same `torch>=2.10.0,<=2.11.0a0`, `cuda-python>=13`).

## Test Plan

- `bash -n scripts/ci_install_trtllm.sh` — clean.
- Verified `tensorrt_llm-1.3.0rc18-cp312-cp312-manylinux_2_28_x86_64.whl` is published on pypi.nvidia.com (public PyPI stops at rc15; the script already resolves via `--pre --extra-index-url https://pypi.nvidia.com`, so the pin is installable as-is).
- Real gate: this PR's trtllm GPU e2e jobs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI installation to use TensorRT-LLM pre-release version 1.3.0rc18, which includes gRPC serve and Harmony parser improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->