### PR TITLE
feat(grpc): drive vLLM MooncakeConnector PD with router-minted kv_transfer_params

### DIFF
--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -44,6 +44,11 @@ on:
         type: boolean
         default: false
         description: "Set up Oracle DB and Brave MCP for agentic tests"
+      vllm_kv_backend:
+        required: false
+        type: string
+        default: "nixl"
+        description: "KV transfer backend for vLLM PD workers: nixl or mooncake"
 
 jobs:
   run:
@@ -55,6 +60,7 @@ jobs:
       E2E_ENGINE: ${{ inputs.engine }}
       E2E_RUNTIME: ${{ inputs.engine }}
       E2E_GPU_TIER: ${{ inputs.gpu_tier }}
+      E2E_VLLM_KV_BACKEND: ${{ inputs.vllm_kv_backend }}
       ROUTER_LOCAL_MODEL_PATH: /models
     steps:
       - name: Checkout code
@@ -141,16 +147,21 @@ jobs:
         if: failure() || cancelled()
         run: |
           LABEL=$(echo '${{ inputs.test_dirs }}' | tr '/' '-')
-          ARTIFACT="e2e-worker-logs-${{ inputs.engine }}-gpu${{ inputs.gpu_tier }}-${LABEL}"
+          # vLLM legs can differ only by KV backend; disambiguate the artifact
+          SUFFIX=""
+          if [ "${{ inputs.engine }}" = "vllm" ]; then
+            SUFFIX="-${{ inputs.vllm_kv_backend }}"
+          fi
+          ARTIFACT="e2e-worker-logs-${{ inputs.engine }}-gpu${{ inputs.gpu_tier }}-${LABEL}${SUFFIX}"
           bash scripts/ci_dump_worker_logs.sh e2e-logs "$ARTIFACT"
-          echo "label=${LABEL}" >> "$GITHUB_OUTPUT"
+          echo "artifact=${ARTIFACT}" >> "$GITHUB_OUTPUT"
         id: log-snapshot
 
       - name: Upload worker logs
         if: failure() || cancelled()
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-worker-logs-${{ inputs.engine }}-gpu${{ inputs.gpu_tier }}-${{ steps.log-snapshot.outputs.label }}
+          name: ${{ steps.log-snapshot.outputs.artifact }}
           path: e2e-logs/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -618,7 +618,7 @@ jobs:
     secrets: inherit
 
   e2e-2gpu-pd:
-    name: e2e-2gpu-pd (${{ matrix.engine }})
+    name: e2e-2gpu-pd (${{ matrix.engine }}${{ matrix.kv_backend && format('-{0}', matrix.kv_backend) || '' }})
     needs: [e2e-1gpu-gateway, detect-changes]
     if: >-
       always()
@@ -636,6 +636,9 @@ jobs:
             timeout: 30
           - engine: vllm
             timeout: 30
+          - engine: vllm
+            kv_backend: mooncake
+            timeout: 30
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -643,6 +646,7 @@ jobs:
       runner: 2-gpu-h100
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/router
+      vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}
     secrets: inherit
 
   # === 4 GPU ===

--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -333,6 +333,7 @@ message GetServerInfoResponse {
   // KV transfer config (for PD disaggregation)
   string kv_connector = 6;  // "MooncakeConnector", "NixlConnector", "" if not configured
   string kv_role = 7;       // "kv_producer", "kv_consumer", "kv_both", "" if not configured
+  string kv_engine_id = 8;  // kv_transfer_config.engine_id, "" if not configured
 }
 
 // =====================

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.9"
+version = "0.4.10"
 description = "SMG gRPC proto definitions for vLLM, TRT-LLM, MLX, TokenSpeed, and SGLang"
 requires-python = ">=3.10"
 dependencies = [

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -627,6 +627,10 @@ pub struct WorkerSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kv_role: Option<String>,
 
+    /// KV transfer engine id (vLLM `kv_transfer_config.engine_id`; Mooncake PD).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kv_engine_id: Option<String>,
+
     /// KV cache block size (tokens per block) for event-driven routing.
     /// When set, overrides the router-level default for this worker's model.
     /// Typically matches the backend engine's page size (e.g. 16 for SGLang).
@@ -677,6 +681,7 @@ impl WorkerSpec {
             dp_size: None,
             kv_connector: None,
             kv_role: None,
+            kv_engine_id: None,
             kv_block_size: None,
             health: HealthCheckUpdate::default(),
             http_pool: HttpPoolConfig::default(),

--- a/docs/concepts/routing/pd-disaggregation.md
+++ b/docs/concepts/routing/pd-disaggregation.md
@@ -308,7 +308,7 @@ The KV cache is transferred between workers using the backend's native mechanism
 **vLLM**: SMG uses the standard proxy pattern — sends `max_tokens=1` to prefill to trigger KV cache computation, then relays the engine's KV-transfer metadata to the decode request:
 
 - **NIXL**: SMG tags the prefill request with `do_remote_decode=true`; the engine holds its KV blocks and returns handoff params (e.g. `remote_engine_id`, `remote_request_id`, `remote_block_ids`, `remote_host`/`remote_port`, `tp_size`) that SMG forwards verbatim with the decode request, which pulls the blocks over RDMA
-- **Mooncake**: SMG injects the prefill worker's bootstrap host/port; workers coordinate via P2P handshake (no external metadata server required)
+- **Mooncake**: push-based — the engine returns no handoff, so SMG mints a shared `transfer_id`, tags the prefill request, and synthesizes the decode params (`remote_engine_id` from worker registration via GetServerInfo, `remote_bootstrap_addr` = `http://bootstrap_host:bootstrap_port`); workers coordinate via P2P handshake (no external metadata server required). Falls back to legacy host/port injection when the servicer predates `kv_engine_id` reporting
 
 **SGLang**: SMG injects bootstrap metadata (`DisaggregatedParams`) into requests, enabling workers to coordinate KV transfer through a shared "room".
 

--- a/docs/getting-started/pd-disaggregation.md
+++ b/docs/getting-started/pd-disaggregation.md
@@ -82,7 +82,7 @@ smg \
 SMG sends to prefill first with `max_tokens=1`, then sends the original request to decode, relaying KV-transfer metadata between the two legs:
 
 - **NIXL**: SMG tags the prefill request with `do_remote_decode=true`, harvests the `kv_transfer_params` the prefill engine returns (engine id, request id, block ids, side-channel address, TP size), and forwards them verbatim with the decode request so decode pulls the KV cache over NIXL.
-- **Mooncake**: SMG injects the prefill worker's bootstrap host/port into the decode request.
+- **Mooncake**: the connector is push-based and returns nothing, so SMG mints a shared `transfer_id`, tags the prefill request with it, and synthesizes the decode params (`remote_engine_id` discovered from the worker at registration, `remote_bootstrap_addr` from the worker's bootstrap host/port). With an older servicer that doesn't report `kv_engine_id`, SMG falls back to legacy host/port injection.
 
 ### Start vLLM Workers with NIXL
 
@@ -138,7 +138,7 @@ VLLM_MOONCAKE_BOOTSTRAP_PORT=8998 \
 python -m vllm.entrypoints.grpc_server \
   --model /path/to/model \
   --port 50051 \
-  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer"}'
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer","engine_id":"prefill-0"}'
 
 # Decode worker
 python -m vllm.entrypoints.grpc_server \
@@ -146,6 +146,16 @@ python -m vllm.entrypoints.grpc_server \
   --port 50052 \
   --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer"}'
 ```
+
+Set an explicit `engine_id` on each prefill worker in production. SMG discovers
+the id once at worker registration; without a pinned id, vLLM generates a new
+one per process, so a restarted prefill container would invalidate the
+registered id until the worker is re-registered.
+
+Limitation: Mooncake PD requires the prefill workers to run without vLLM data
+parallelism (`data_parallel_size = 1`). With DP active the servicer reports no
+engine id and SMG falls back to legacy host/port injection (decode recomputes
+the prompt locally).
 
 ```bash
 smg \

--- a/e2e_test/infra/constants.py
+++ b/e2e_test/infra/constants.py
@@ -124,6 +124,14 @@ def is_tokenspeed() -> bool:
     return get_runtime() == "tokenspeed"
 
 
+ENV_VLLM_KV_BACKEND = "E2E_VLLM_KV_BACKEND"
+
+
+def vllm_kv_backend() -> str:
+    """KV transfer backend for vLLM PD workers: "nixl" (default) or "mooncake"."""
+    return os.environ.get(ENV_VLLM_KV_BACKEND, "nixl").lower()
+
+
 # Runtime display labels
 RUNTIME_LABELS = {
     "sglang": "SGLang",

--- a/e2e_test/infra/pd_logs.py
+++ b/e2e_test/infra/pd_logs.py
@@ -1,0 +1,78 @@
+"""Log-scraping helpers shared by the PD KV-transfer e2e tests."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+LOG_FLUSH_TIMEOUT_S = 15.0
+
+
+def assert_worker_logs_captured(worker_logs: str, what: str) -> None:
+    """Empty worker logs are a broken-capture signal in CI, a skip locally.
+
+    CI always writes worker log files (SHOW_WORKER_LOGS=0 + E2E_LOG_DIR), so a
+    silent skip there would disable the transfer assertion exactly when log
+    routing is broken.
+    """
+    if worker_logs:
+        return
+    msg = f"No worker log files captured (SHOW_WORKER_LOGS=1?); cannot assert on {what}"
+    if os.environ.get("CI") == "true":
+        pytest.fail(msg)
+    pytest.skip(msg)
+
+
+def worker_log_dir(default: Path) -> Path:
+    """Worker logs go to E2E_LOG_DIR when set (CI); otherwise the gateway dir."""
+    return Path(os.environ.get("E2E_LOG_DIR") or default)
+
+
+def read_logs(log_dir: Path, pattern: str) -> str:
+    return "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in sorted(log_dir.glob(pattern))
+        if path.is_file()
+    )
+
+
+def wait_for_marker(log_dir: Path, pattern: str, marker: str | tuple[str, ...]) -> str:
+    # Both the router file appender and worker pipes flush asynchronously
+    markers = (marker,) if isinstance(marker, str) else marker
+    deadline = time.monotonic() + LOG_FLUSH_TIMEOUT_S
+    logs = ""
+    while time.monotonic() < deadline:
+        logs = read_logs(log_dir, pattern)
+        if any(m in logs for m in markers):
+            return logs
+        time.sleep(0.5)
+    return logs
+
+
+def wait_for_pattern(log_dir: Path, pattern: str, regex: re.Pattern[str]) -> str:
+    # Like wait_for_marker, but for assertions that need more than a substring
+    # (e.g. a positive counter value)
+    deadline = time.monotonic() + LOG_FLUSH_TIMEOUT_S
+    logs = ""
+    while time.monotonic() < deadline:
+        logs = read_logs(log_dir, pattern)
+        if regex.search(logs):
+            return logs
+        time.sleep(0.5)
+    return logs
+
+
+def unique_prompt() -> str:
+    # Unique filler defeats prefix caching so every request exercises a fresh
+    # prefill -> transfer -> decode cycle
+    filler = " ".join(uuid.uuid4().hex for _ in range(24))
+    return (
+        f"Session token: {filler}\n"
+        "Ignoring the session token above, explain in two sentences why the "
+        "sky appears blue during the day."
+    )

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -23,6 +23,7 @@ from .constants import (
     ConnectionMode,
     WorkerType,
     get_runtime,
+    vllm_kv_backend,
 )
 from .model_specs import get_model_spec
 from .process_utils import detect_ib_device, get_open_port, wait_for_health
@@ -271,15 +272,19 @@ class Worker:
             "0.9",
         ]
 
-        # PD disaggregation: NIXL KV transfer roles
+        # PD disaggregation: KV transfer roles (backend via E2E_VLLM_KV_BACKEND)
         if self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE):
             kv_role = "kv_producer" if self.worker_type == WorkerType.PREFILL else "kv_consumer"
-            cmd.extend(
-                [
-                    "--kv-transfer-config",
-                    json.dumps({"kv_connector": "NixlConnector", "kv_role": kv_role}),
-                ]
-            )
+            if vllm_kv_backend() == "mooncake":
+                # tcp keeps the transfer off RDMA, which is flaky on shared CI nodes
+                config = {
+                    "kv_connector": "MooncakeConnector",
+                    "kv_role": kv_role,
+                    "kv_connector_extra_config": {"mooncake_protocol": "tcp"},
+                }
+            else:
+                config = {"kv_connector": "NixlConnector", "kv_role": kv_role}
+            cmd.extend(["--kv-transfer-config", json.dumps(config)])
 
         extra = spec.get("vllm_args", [])
         if extra:
@@ -381,10 +386,16 @@ class Worker:
         env.setdefault("PYTHONUNBUFFERED", "1")
         env["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, self.gpu_ids))
 
-        # vLLM PD workers need a unique NIXL side-channel port per worker
+        # vLLM PD workers need per-worker side-channel ports for their KV backend
         if self.engine == "vllm" and self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE):
-            self.nixl_port = get_open_port()
-            env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(self.nixl_port)
+            if vllm_kv_backend() == "mooncake":
+                # The producer's bootstrap server must listen on the port the
+                # gateway advertises in remote_bootstrap_addr
+                if self.bootstrap_port is not None:
+                    env["VLLM_MOONCAKE_BOOTSTRAP_PORT"] = str(self.bootstrap_port)
+            else:
+                self.nixl_port = get_open_port()
+                env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(self.nixl_port)
 
         # TRT-LLM multi-GPU needs NCCL tuning for CI compatibility
         if self.engine == "trtllm" and len(self.gpu_ids) > 1:

--- a/e2e_test/router/test_pd_mooncake.py
+++ b/e2e_test/router/test_pd_mooncake.py
@@ -1,0 +1,95 @@
+"""Mooncake KV-transfer verification for vLLM PD disaggregation (gRPC mode).
+
+The MooncakeConnector is push-based: the prefill engine returns no
+kv_transfer_params, so the router mints a transfer_id, tags the prefill
+request, and synthesizes the decode params (remote_engine_id discovered via
+GetServerInfo, remote_bootstrap_addr from worker metadata). This test asserts:
+
+1. The router injected minted kv_transfer_params into the decode request
+   (router debug log).
+2. The workers actually transferred KV blocks ("KV Transfer metrics" with
+   successful transfers in the worker logs).
+
+Runs only on the mooncake leg of e2e-2gpu-pd (E2E_VLLM_KV_BACKEND=mooncake).
+
+Usage:
+    E2E_RUNTIME=vllm E2E_VLLM_KV_BACKEND=mooncake \
+        pytest e2e_test/router/test_pd_mooncake.py -v
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+
+import pytest
+from infra.constants import vllm_kv_backend
+from infra.pd_logs import (
+    assert_worker_logs_captured,
+    unique_prompt,
+    wait_for_marker,
+    wait_for_pattern,
+    worker_log_dir,
+)
+
+logger = logging.getLogger(__name__)
+
+# Router logs land here via the gateway marker (rolling files named smg.YYYY-MM-DD)
+_LOG_DIR = Path(tempfile.gettempdir()) / f"smg-e2e-pd-mooncake-{os.getpid()}"
+
+MINT_MARKER = "vLLM PD (Mooncake): injecting minted kv_transfer_params"
+# Periodic connector metrics line; a positive count is required — the line is
+# also printed with "Num successful transfers=0" when every transfer failed
+TRANSFER_SUCCESS_RE = re.compile(r"Num successful transfers=([1-9]\d*)")
+
+
+@pytest.mark.skipif(vllm_kv_backend() != "mooncake", reason="mooncake PD leg only")
+@pytest.mark.engine("vllm")
+@pytest.mark.gpu(2)
+@pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
+@pytest.mark.e2e
+@pytest.mark.gateway(log_level="debug", log_dir=str(_LOG_DIR))
+@pytest.mark.parametrize("setup_backend", ["pd_grpc"], indirect=True)
+class TestPDMooncakeKvTransfer:
+    """Verify KV cache actually moves from prefill to decode over Mooncake."""
+
+    def test_minted_params_injected(self, setup_backend):
+        backend, model, client, *_ = setup_backend
+
+        for _ in range(3):
+            response = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": unique_prompt()}],
+                max_tokens=64,
+                temperature=0.0,
+            )
+            assert response.choices[0].message.content, "Empty completion from PD pipeline"
+
+        router_logs = wait_for_marker(_LOG_DIR, "smg*", MINT_MARKER)
+        assert MINT_MARKER in router_logs, (
+            "Router never injected minted Mooncake kv_transfer_params — "
+            f"engine_id discovery or minting is broken; checked logs under {_LOG_DIR}"
+        )
+
+    def test_workers_transferred_kv(self, setup_backend):
+        backend, model, client, *_ = setup_backend
+
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": unique_prompt()}],
+            max_tokens=32,
+            temperature=0.0,
+        )
+        assert response.choices[0].message.content
+
+        worker_dir = worker_log_dir(_LOG_DIR)
+        worker_logs = wait_for_pattern(worker_dir, "worker-*.log", TRANSFER_SUCCESS_RE)
+        assert_worker_logs_captured(worker_logs, "Mooncake transfer")
+        assert TRANSFER_SUCCESS_RE.search(worker_logs), (
+            "No successful Mooncake KV transfer in worker logs (zero-success "
+            "metrics mean decode recomputed locally); checked "
+            f"{worker_dir}/worker-*.log for {TRANSFER_SUCCESS_RE.pattern}"
+        )

--- a/e2e_test/router/test_pd_nixl.py
+++ b/e2e_test/router/test_pd_nixl.py
@@ -23,16 +23,20 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
-import time
-import uuid
 from pathlib import Path
 
 import pytest
+from infra.constants import vllm_kv_backend
+from infra.pd_logs import (
+    assert_worker_logs_captured,
+    unique_prompt,
+    wait_for_marker,
+    worker_log_dir,
+)
 
 logger = logging.getLogger(__name__)
 
-# Router logs land here via the gateway marker (rolling files named smg.YYYY-MM-DD).
-# Worker logs go to E2E_LOG_DIR when set (CI), otherwise setup_backend reuses this dir.
+# Router logs land here via the gateway marker (rolling files named smg.YYYY-MM-DD)
 _LOG_DIR = Path(tempfile.gettempdir()) / f"smg-e2e-pd-nixl-{os.getpid()}"
 
 RELAY_MARKER = "relaying prefill kv_transfer_params"
@@ -46,45 +50,8 @@ HANDSHAKE_MARKERS = (
     "Registering remote agent",
 )
 
-_LOG_FLUSH_TIMEOUT_S = 15.0
 
-
-def _worker_log_dir() -> Path:
-    return Path(os.environ.get("E2E_LOG_DIR") or _LOG_DIR)
-
-
-def _read_logs(log_dir: Path, pattern: str) -> str:
-    return "\n".join(
-        path.read_text(encoding="utf-8", errors="replace")
-        for path in sorted(log_dir.glob(pattern))
-        if path.is_file()
-    )
-
-
-def _wait_for_marker(log_dir: Path, pattern: str, marker: str | tuple[str, ...]) -> str:
-    # Both the router file appender and worker pipes flush asynchronously
-    markers = (marker,) if isinstance(marker, str) else marker
-    deadline = time.monotonic() + _LOG_FLUSH_TIMEOUT_S
-    logs = ""
-    while time.monotonic() < deadline:
-        logs = _read_logs(log_dir, pattern)
-        if any(m in logs for m in markers):
-            return logs
-        time.sleep(0.5)
-    return logs
-
-
-def _unique_prompt() -> str:
-    # Unique filler defeats prefix caching so every request exercises a fresh
-    # prefill -> transfer -> decode cycle
-    filler = " ".join(uuid.uuid4().hex for _ in range(24))
-    return (
-        f"Session token: {filler}\n"
-        "Ignoring the session token above, explain in two sentences why the "
-        "sky appears blue during the day."
-    )
-
-
+@pytest.mark.skipif(vllm_kv_backend() != "nixl", reason="nixl PD leg only")
 @pytest.mark.engine("vllm")
 @pytest.mark.gpu(2)
 @pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
@@ -100,14 +67,14 @@ class TestPDNixlKvTransfer:
         for _ in range(3):
             response = client.chat.completions.create(
                 model=model,
-                messages=[{"role": "user", "content": _unique_prompt()}],
+                messages=[{"role": "user", "content": unique_prompt()}],
                 max_tokens=64,
                 temperature=0.0,
             )
             choice = response.choices[0]
             assert choice.message.content, "Empty completion from PD pipeline"
 
-        router_logs = _wait_for_marker(_LOG_DIR, "smg*", RELAY_MARKER)
+        router_logs = wait_for_marker(_LOG_DIR, "smg*", RELAY_MARKER)
         assert NO_PARAMS_MARKER not in router_logs, (
             "Router reported prefill returned no kv_transfer_params — "
             "NIXL handoff is broken (decode recomputed the prefill)"
@@ -121,19 +88,15 @@ class TestPDNixlKvTransfer:
 
         response = client.chat.completions.create(
             model=model,
-            messages=[{"role": "user", "content": _unique_prompt()}],
+            messages=[{"role": "user", "content": unique_prompt()}],
             max_tokens=32,
             temperature=0.0,
         )
         assert response.choices[0].message.content
 
-        worker_dir = _worker_log_dir()
-        worker_logs = _wait_for_marker(worker_dir, "worker-*.log", HANDSHAKE_MARKERS)
-        if not worker_logs:
-            pytest.skip(
-                "No worker log files captured (SHOW_WORKER_LOGS=1?); "
-                "cannot assert on NIXL handshake"
-            )
+        worker_dir = worker_log_dir(_LOG_DIR)
+        worker_logs = wait_for_marker(worker_dir, "worker-*.log", HANDSHAKE_MARKERS)
+        assert_worker_logs_captured(worker_logs, "NIXL handshake")
         assert any(marker in worker_logs for marker in HANDSHAKE_MARKERS), (
             "No NIXL handshake found in worker logs — the decode worker never "
             f"pulled KV from prefill; checked {worker_dir}/worker-*.log for "

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-servicer"
-version = "0.5.4"
+version = "0.5.5"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, MLX, TokenSpeed, SGLang)"
 requires-python = ">=3.10"
 dependencies = [
-    "smg-grpc-proto>=0.4.9",
+    "smg-grpc-proto>=0.4.10",
     "grpcio>=1.78.0",
     "grpcio-reflection>=1.78.0",
     "grpcio-health-checking>=1.78.0",

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -455,14 +455,25 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         """
         kv_connector = ""
         kv_role = ""
+        kv_engine_id = ""
         kv_transfer_config = self.engine.vllm_config.kv_transfer_config
         if kv_transfer_config is not None:
             kv_connector = kv_transfer_config.kv_connector or ""
             kv_role = kv_transfer_config.kv_role or ""
+            # With DP active the engine cores suffix their connector engine_id
+            # (base_dp{rank}) and the router cannot attribute requests to a
+            # rank — report no id so it falls back to legacy injection
+            parallel = self.engine.vllm_config.parallel_config
+            dp_active = (
+                parallel.data_parallel_size > 1 or getattr(parallel, "data_parallel_rank", 0) > 0
+            )
+            if not dp_active:
+                kv_engine_id = getattr(kv_transfer_config, "engine_id", "") or ""
 
         return vllm_engine_pb2.GetServerInfoResponse(
             kv_connector=kv_connector,
             kv_role=kv_role,
+            kv_engine_id=kv_engine_id,
         )
 
     async def GetLoads(

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -31,8 +31,14 @@ const NIXL_PREFILL_KV_PARAMS: &str = r#"{"do_remote_decode":true,"do_remote_pref
 /// PD KV-transfer behavior derived from prefill worker metadata.
 #[derive(Debug, Clone, PartialEq)]
 enum KvConnectorMode {
-    /// MooncakeConnector: inject bootstrap host/port into the decode request.
-    Mooncake { host: String, port: u32 },
+    /// MooncakeConnector: mint a transfer_id, tag both legs, synthesize decode
+    /// params from worker metadata; legacy host/port injection when the
+    /// servicer predates kv_engine_id reporting (or DP is active).
+    Mooncake {
+        host: String,
+        port: u32,
+        engine_id: Option<String>,
+    },
     /// NixlConnector: tag prefill with do_remote_decode, relay returned params to decode.
     Nixl,
     /// Unknown/absent connector: relay returned params opportunistically.
@@ -43,15 +49,41 @@ fn kv_connector_mode(
     kv_connector: Option<&str>,
     bootstrap_host: &str,
     bootstrap_port: Option<u16>,
+    kv_engine_id: Option<&str>,
 ) -> KvConnectorMode {
     match kv_connector {
         Some(MOONCAKE_CONNECTOR) => KvConnectorMode::Mooncake {
             host: bootstrap_host.to_string(),
             port: u32::from(bootstrap_port.unwrap_or(DEFAULT_BOOTSTRAP_PORT)),
+            // Empty means unknown (forces the legacy fallback)
+            engine_id: kv_engine_id.filter(|s| !s.is_empty()).map(str::to_string),
         },
         Some(NIXL_CONNECTOR) => KvConnectorMode::Nixl,
         _ => KvConnectorMode::Passthrough,
     }
+}
+
+/// Prefill-leg params for Mooncake: the engine pins blocks under the minted id.
+fn mooncake_prefill_params(transfer_id: &str) -> String {
+    serde_json::json!({
+        "do_remote_decode": true,
+        "do_remote_prefill": false,
+        "transfer_id": transfer_id,
+    })
+    .to_string()
+}
+
+/// Decode-leg params for Mooncake, synthesized from prefill worker metadata
+/// (the engine returns nothing to relay; the connector is push-based).
+fn mooncake_decode_params(transfer_id: &str, engine_id: &str, host: &str, port: u32) -> String {
+    serde_json::json!({
+        "do_remote_decode": false,
+        "do_remote_prefill": true,
+        "transfer_id": transfer_id,
+        "remote_engine_id": engine_id,
+        "remote_bootstrap_addr": format!("http://{host}:{port}"),
+    })
+    .to_string()
 }
 
 /// Request execution stage: Execute gRPC requests (single or dual dispatch)
@@ -338,14 +370,20 @@ impl RequestExecutionStage {
                     meta.spec.kv_connector.as_deref(),
                     &meta.spec.bootstrap_host,
                     meta.spec.bootstrap_port,
+                    meta.spec.kv_engine_id.as_deref(),
                 )
             })
             .unwrap_or(KvConnectorMode::Passthrough);
 
         match &mode {
-            KvConnectorMode::Mooncake { host, port } => debug!(
+            KvConnectorMode::Mooncake {
+                host,
+                port,
+                engine_id,
+            } => debug!(
                 bootstrap_host = %host,
                 bootstrap_port = port,
+                engine_id_known = engine_id.is_some(),
                 "vLLM PD (Mooncake): will inject kv_transfer_params into decode request"
             ),
             KvConnectorMode::Nixl => debug!(
@@ -364,9 +402,19 @@ impl RequestExecutionStage {
             }
         }
 
-        // NIXL handoff is single-consumer: with n>1 each fan-out child on decode would
-        // pull, and the first completion frees the prefill blocks under its siblings
+        // The KV handoff is single-consumer: with n>1 each fan-out child on decode
+        // would pull, and the first completion frees the prefill blocks under its
+        // siblings (same hazard for NIXL and Mooncake)
         let relay_kv_params = proto_request.sampling_n() <= 1;
+
+        // Mooncake is push-based: the engine returns nothing, so the router mints
+        // the transfer correlation id and synthesizes decode params from metadata
+        let mooncake_transfer_id = match &mode {
+            KvConnectorMode::Mooncake {
+                engine_id: Some(_), ..
+            } if relay_kv_params => Some(format!("xfer-{}", uuid::Uuid::now_v7())),
+            _ => None,
+        };
 
         // Clone request and sanitize sampling (max_tokens=1, n=1), stream=false for prefill
         let mut prefill_request = proto_request.clone_inner();
@@ -382,6 +430,9 @@ impl RequestExecutionStage {
                      (decode recomputes the prompt locally)"
                 );
             }
+        }
+        if let Some(ref transfer_id) = mooncake_transfer_id {
+            prefill_request.set_kv_transfer_params_json(mooncake_prefill_params(transfer_id));
         }
 
         debug!(
@@ -429,8 +480,30 @@ impl RequestExecutionStage {
         // load-bearing for NIXL P/D correlation on vLLM < 0.13
         let mut decode_request = proto_request;
         match (&mode, prefill_kv_params) {
-            // Mooncake is n>1-safe: host/port is connection info, not a single-consumer handoff
-            (KvConnectorMode::Mooncake { host, port }, _) => {
+            // Modern Mooncake: synthesized params under the minted transfer_id
+            (
+                KvConnectorMode::Mooncake {
+                    host,
+                    port,
+                    engine_id: Some(engine_id),
+                },
+                _,
+            ) if mooncake_transfer_id.is_some() => {
+                let transfer_id = mooncake_transfer_id.as_deref().unwrap_or_default();
+                debug!(
+                    request_id = %decode_request.request_id(),
+                    transfer_id = %transfer_id,
+                    "vLLM PD (Mooncake): injecting minted kv_transfer_params into decode request"
+                );
+                decode_request.set_kv_transfer_params_json(mooncake_decode_params(
+                    transfer_id,
+                    engine_id,
+                    host,
+                    *port,
+                ));
+            }
+            // Legacy Mooncake (no engine_id discovered, or n>1): typed host/port injection
+            (KvConnectorMode::Mooncake { host, port, .. }, _) => {
                 debug!(
                     remote_host = %host,
                     remote_port = port,
@@ -485,24 +558,44 @@ mod tests {
 
     #[test]
     fn kv_connector_mode_mooncake_uses_bootstrap_metadata() {
-        let mode = kv_connector_mode(Some(MOONCAKE_CONNECTOR), "prefill-host", Some(9090));
+        let mode = kv_connector_mode(
+            Some(MOONCAKE_CONNECTOR),
+            "prefill-host",
+            Some(9090),
+            Some("engine-1"),
+        );
         assert_eq!(
             mode,
             KvConnectorMode::Mooncake {
                 host: "prefill-host".to_string(),
                 port: 9090,
+                engine_id: Some("engine-1".to_string()),
             }
         );
     }
 
     #[test]
-    fn kv_connector_mode_mooncake_defaults_port() {
-        let mode = kv_connector_mode(Some(MOONCAKE_CONNECTOR), "prefill-host", None);
+    fn kv_connector_mode_mooncake_defaults_port_and_tolerates_missing_engine_id() {
+        let mode = kv_connector_mode(Some(MOONCAKE_CONNECTOR), "prefill-host", None, None);
         assert_eq!(
             mode,
             KvConnectorMode::Mooncake {
                 host: "prefill-host".to_string(),
                 port: u32::from(DEFAULT_BOOTSTRAP_PORT),
+                engine_id: None,
+            }
+        );
+    }
+
+    #[test]
+    fn kv_connector_mode_mooncake_empty_engine_id_means_legacy() {
+        let mode = kv_connector_mode(Some(MOONCAKE_CONNECTOR), "host", Some(9090), Some(""));
+        assert_eq!(
+            mode,
+            KvConnectorMode::Mooncake {
+                host: "host".to_string(),
+                port: 9090,
+                engine_id: None,
             }
         );
     }
@@ -510,7 +603,7 @@ mod tests {
     #[test]
     fn kv_connector_mode_nixl() {
         assert_eq!(
-            kv_connector_mode(Some(NIXL_CONNECTOR), "ignored", Some(9090)),
+            kv_connector_mode(Some(NIXL_CONNECTOR), "ignored", Some(9090), None),
             KvConnectorMode::Nixl
         );
     }
@@ -518,13 +611,37 @@ mod tests {
     #[test]
     fn kv_connector_mode_unknown_or_missing_is_passthrough() {
         assert_eq!(
-            kv_connector_mode(Some("LMCacheConnector"), "host", None),
+            kv_connector_mode(Some("LMCacheConnector"), "host", None, None),
             KvConnectorMode::Passthrough
         );
         assert_eq!(
-            kv_connector_mode(None, "host", None),
+            kv_connector_mode(None, "host", None, None),
             KvConnectorMode::Passthrough
         );
+    }
+
+    #[test]
+    fn mooncake_prefill_params_carry_transfer_id() {
+        let value: serde_json::Value =
+            serde_json::from_str(&mooncake_prefill_params("xfer-abc")).unwrap();
+        assert_eq!(value["do_remote_decode"], true);
+        assert_eq!(value["do_remote_prefill"], false);
+        assert_eq!(value["transfer_id"], "xfer-abc");
+        assert_eq!(value.as_object().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn mooncake_decode_params_synthesize_full_handoff() {
+        let value: serde_json::Value = serde_json::from_str(&mooncake_decode_params(
+            "xfer-abc", "engine-1", "10.0.0.1", 8998,
+        ))
+        .unwrap();
+        assert_eq!(value["do_remote_decode"], false);
+        assert_eq!(value["do_remote_prefill"], true);
+        assert_eq!(value["transfer_id"], "xfer-abc");
+        assert_eq!(value["remote_engine_id"], "engine-1");
+        assert_eq!(value["remote_bootstrap_addr"], "http://10.0.0.1:8998");
+        assert_eq!(value.as_object().unwrap().len(), 5);
     }
 
     #[test]

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -190,6 +190,12 @@ impl BasicWorkerBuilder {
         self
     }
 
+    /// Set KV transfer engine id (vLLM `kv_transfer_config.engine_id`)
+    pub fn kv_engine_id(mut self, engine_id: impl Into<String>) -> Self {
+        self.spec.kv_engine_id = Some(engine_id.into());
+        self
+    }
+
     /// Set worker priority (higher value = higher priority)
     pub fn priority(mut self, priority: u32) -> Self {
         self.spec.priority = priority;

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -61,6 +61,7 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
         // Extract KV transfer config (dedicated metadata fields, not labels)
         let kv_connector = labels.remove("kv_connector");
         let kv_role = labels.remove("kv_role");
+        let kv_engine_id = labels.remove("kv_engine_id").filter(|s| !s.is_empty());
 
         // Determine model_id: config.models > discovered labels > UNKNOWN_MODEL_ID
         let model_id = config
@@ -167,6 +168,9 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
                 }
                 if let Some(ref r) = kv_role {
                     builder = builder.kv_role(r);
+                }
+                if let Some(ref e) = kv_engine_id {
+                    builder = builder.kv_engine_id(e);
                 }
 
                 // Builder sets initial status: Pending if health-checked, Ready if not.

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -44,6 +44,26 @@ rm -rf "${SITE_PACKAGES}/nixl_ep"
 python3 -c "import torch, nixl"
 echo "nixl import canary OK"
 
+# Mooncake transfer engine, only on the MooncakeConnector PD leg so a broken
+# wheel cannot fail the unrelated vLLM jobs
+if [ "${E2E_VLLM_KV_BACKEND:-nixl}" = "mooncake" ]; then
+    echo "Installing mooncake-transfer-engine..."
+    uv pip install "mooncake-transfer-engine>=0.3.8"
+
+    # The mooncake wheel links libcudart.so.12 regardless of the torch CUDA
+    # flavor; provide it from the cu12 runtime wheel (venv + job env only —
+    # the wheel ships no unversioned libcudart.so, so cu13 lookups are unaffected)
+    uv pip install nvidia-cuda-runtime-cu12
+    CUDART12_DIR=$(python3 -c "import glob, sysconfig; print(glob.glob(sysconfig.get_paths()['platlib'] + '/nvidia/cuda_runtime/lib/libcudart.so.12')[0].rsplit('/', 1)[0])")
+    export LD_LIBRARY_PATH="${CUDART12_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "${GITHUB_ENV:-/dev/null}"
+
+    # Import canary: fail here (not mid-e2e) if the mooncake install is broken —
+    # vLLM swallows this ImportError at module load (torch first for CUDA libs)
+    python3 -c "import torch; from mooncake.engine import TransferEngine"
+    echo "mooncake import canary OK"
+fi
+
 # FlashInfer JIT cache: vLLM JIT-compiles flashinfer kernels at engine startup
 # and the pods have no CUDA toolchain — install the precompiled cache instead,
 # same recipe as vLLM's own Dockerfile.

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -47,16 +47,18 @@ echo "nixl import canary OK"
 # Mooncake transfer engine, only on the MooncakeConnector PD leg so a broken
 # wheel cannot fail the unrelated vLLM jobs
 if [ "${E2E_VLLM_KV_BACKEND:-nixl}" = "mooncake" ]; then
-    echo "Installing mooncake-transfer-engine..."
-    uv pip install "mooncake-transfer-engine>=0.3.8"
+    # Mooncake's native extension links libibverbs/libnuma at load time even
+    # when the transfer protocol is tcp — without these the import fails with
+    # "libibverbs.so.1: cannot open shared object file".
+    echo "Installing mooncake system dependencies..."
+    sudo apt-get install -y --no-install-recommends libnuma1 libibverbs1 ibverbs-providers
 
-    # The mooncake wheel links libcudart.so.12 regardless of the torch CUDA
-    # flavor; provide it from the cu12 runtime wheel (venv + job env only —
-    # the wheel ships no unversioned libcudart.so, so cu13 lookups are unaffected)
-    uv pip install nvidia-cuda-runtime-cu12
-    CUDART12_DIR=$(python3 -c "import glob, sysconfig; print(glob.glob(sysconfig.get_paths()['platlib'] + '/nvidia/cuda_runtime/lib/libcudart.so.12')[0].rsplit('/', 1)[0])")
-    export LD_LIBRARY_PATH="${CUDART12_DIR}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-    echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "${GITHUB_ENV:-/dev/null}"
+    # The cuda13 wheel variant matches vLLM's cu130 torch stack, so no
+    # libcudart.so.12 shim is needed (torch's bundled CUDA 13 runtime
+    # satisfies it once torch is imported first). Pinned — floating mooncake
+    # resolves have broken CI before.
+    echo "Installing mooncake-transfer-engine (cuda13)..."
+    uv pip install "mooncake-transfer-engine-cuda13==0.3.11.post1"
 
     # Import canary: fail here (not mid-e2e) if the mooncake install is broken —
     # vLLM swallows this ImportError at module load (torch first for CUDA libs)


### PR DESCRIPTION
## Description

### Problem

SMG's vLLM PD Mooncake path injects only `remote_host`/`remote_port` into the decode request. The modern in-tree `MooncakeConnector` (vLLM ≥ 0.20-era) ignores those keys entirely: it is push-based, requires `do_remote_decode` + a `transfer_id` on the prefill request (else it pins nothing and warns "Missing transfer_id in kv_transfer_params from router!"), and requires `remote_engine_id`/`remote_bootstrap_addr`/`transfer_id` on the decode request. Unlike NIXL, `request_finished()` returns no params — there is nothing to harvest from the prefill response — so the relay flow shipped in #1622 cannot drive it. Net effect: against upstream vLLM, Mooncake PD is a silent no-op (decode recomputes the prompt), the same bug class #1622 fixed for NIXL. There is also no CI coverage for vLLM-Mooncake PD.

### Solution

Implement the contract the ecosystem converged on — verified against four independent implementations (vLLM's own example proxy at the v0.22.1 tag, vllm-project/router, NVIDIA Dynamo PR #9414, llm-d's routing sidecar), all of which mint and synthesize the params outside the engine:

1. **Discovery**: the servicer reports `kv_transfer_config.engine_id` via a new `GetServerInfoResponse.kv_engine_id` field, stored in worker metadata at registration alongside `kv_connector`/`kv_role` (smg-grpc-proto 0.4.10, smg-grpc-servicer 0.5.5).
2. **Router**: in Mooncake mode the router mints a per-attempt `transfer_id`, tags the prefill request `{do_remote_decode: true, transfer_id}`, and synthesizes the decode params `{do_remote_prefill: true, transfer_id, remote_engine_id, remote_bootstrap_addr: "http://bootstrap_host:bootstrap_port"}`. The NIXL relay path and the n=1 guard are unchanged; legacy typed host/port injection remains the fallback whenever `engine_id` is unknown.
3. **Safety gates** (from adversarial review): the servicer reports no engine id when vLLM data parallelism is active (the engine cores suffix their connector ids per rank, so a minted id would make decode hang instead of degrade) — DP-aware rank pinning is a documented follow-up; empty-string `kv_engine_id` overrides force the legacy fallback instead of synthesizing broken params.
4. **CI**: new `e2e-2gpu-pd (vllm-mooncake)` matrix leg (`E2E_VLLM_KV_BACKEND` parametrization, tcp transport to stay off the flaky shared-node RDMA path, producer bootstrap server on the advertised port). `test_pd_mooncake.py` asserts the router injected minted params and the workers logged a **positive** successful-transfer count (the metrics line also prints at zero when every transfer fails). A fatal import canary catches broken `mooncake-transfer-engine` installs at setup instead of mid-e2e, and failure artifacts are disambiguated per KV backend.

Operational notes (documented): pin a stable `engine_id` in the prefill worker's `--kv-transfer-config` — SMG discovers the id once at registration, and vLLM generates a fresh uuid per process, so an unpinned restarted container invalidates the registered id. Metadata refresh on worker recovery (useful beyond Mooncake) and DP-aware routing are planned as separate follow-up PRs.

## Changes

- `crates/grpc_client/proto/vllm_engine.proto`: `GetServerInfoResponse.kv_engine_id = 8`; smg-grpc-proto → 0.4.10.
- `grpc_servicer`: report `kv_engine_id` (empty when DP is active); smg-grpc-servicer → 0.5.5.
- `crates/protocols` + `model_gateway` worker/discovery: `WorkerSpec.kv_engine_id` plumbed from discovery labels (empty-string filtered).
- `model_gateway` router: Mooncake mint/tag/synthesize with legacy fallback; unit tests for mode mapping, param shapes, and the empty-id fallback.
- `e2e_test`: KV-backend parametrization in worker launch, shared `infra/pd_logs.py` helpers, `test_pd_mooncake.py`, backend skip-gates on the NIXL test.
- `.github/workflows` + `scripts/ci_install_vllm.sh`: vllm-mooncake PD matrix leg, `mooncake-transfer-engine` install + import canary, per-backend artifact names.
- `docs`: Mooncake flow description, `engine_id` pinning guidance, DP limitation.

## Test Plan

- `cargo clippy --all-targets` clean; `cargo test -p smg --lib`: 1015 passed (new tests: Mooncake mode mapping incl. empty/missing engine_id fallbacks, prefill/decode param JSON shapes).
- `pytest grpc_servicer/tests`: 20 passed.
- New `e2e-2gpu-pd (vllm-mooncake)` job on this PR: asserts minted-param injection in router logs and `Num successful transfers=[1-9]` in worker logs — the assertion fails if decode silently recomputes.
- Existing `e2e-2gpu-pd (vllm)` NIXL leg guards the unchanged relay path; `(sglang)` leg unaffected.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mooncake KV-transfer support for vLLM PD with runtime backend selection; router can mint/inject transfer params and expose worker engine IDs.

* **Documentation**
  * Expanded PD disaggregation guides covering Mooncake flow, engine_id pinning, DP limitations, and fallback behavior.

* **Tests**
  * New/updated e2e tests for Mooncake and Nixl paths; shared log utilities and log-based assertions added.

* **Chores**
  * CI/workflow and package metadata updates; CI can optionally install Mooncake runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->