### PR TITLE
chore: bump versions for v1.5.0 release

### DIFF
--- a/.github/workflows/nightly-engine-docker.yml
+++ b/.github/workflows/nightly-engine-docker.yml
@@ -43,14 +43,14 @@ jobs:
       matrix:
         include:
           - engine: vllm
-            base_image_ref: vllm/vllm-openai:v0.19.0
-            engine_ver: v0.19.0
+            base_image_ref: vllm/vllm-openai:v0.22.1
+            engine_ver: v0.22.1
           - engine: sglang
-            base_image_ref: lmsysorg/sglang:v0.5.10
-            engine_ver: v0.5.10
+            base_image_ref: lmsysorg/sglang:v0.5.12.post1
+            engine_ver: v0.5.12.post1
           - engine: trtllm
-            base_image_ref: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
-            engine_ver: 1.3.0rc10
+            base_image_ref: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18
+            engine_ver: 1.3.0rc18
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: ${{ matrix.engine }}

--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -2,9 +2,9 @@ name: Release SMG+SGLang Docker Image
 
 run-name: >-
   SMG+SGLang |
-  ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.10' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.10') }} |
+  ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.12.post1' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.12.post1') }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.4.1' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.5.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. lmsysorg/sglang:v0.5.10)'
-        default: 'lmsysorg/sglang:v0.5.10'
+        description: 'Base image (e.g. lmsysorg/sglang:v0.5.12.post1)'
+        default: 'lmsysorg/sglang:v0.5.12.post1'
         required: true
         type: string
       sglang_repo:
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.4.1'
+        default: 'v1.5.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.4.1-sglang-v0.5.10)'
+        description: 'Override image tag (e.g. v1.5.0-sglang-v0.5.12.post1)'
         required: false
         type: string
 
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["lmsysorg/sglang:v0.5.10"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.10')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["lmsysorg/sglang:v0.5.12.post1"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.12.post1')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: sglang
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.4.1' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.5.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -2,9 +2,9 @@ name: Release SMG+TRTLLM Docker Image
 
 run-name: >-
   SMG+TRTLLM |
-  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10') }} |
+  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18') }} |
   engine=${{ inputs.trtllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.4.1' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.5.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10). Empty = build from source.'
-        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10'
+        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18). Empty = build from source.'
+        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18'
         required: false
         type: string
       trtllm_repo:
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.4.1'
+        default: 'v1.5.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.4.1-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.5.0-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc9","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc8"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc17","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc16"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: trtllm
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.4.1' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.5.0' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
       source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -2,9 +2,9 @@ name: Release SMG+vLLM Docker Image
 
 run-name: >-
   SMG+vLLM |
-  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.19.0') }} |
+  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.22.1') }} |
   engine=${{ inputs.vllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.4.1' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.5.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. vllm/vllm-openai:v0.19.0)'
-        default: 'vllm/vllm-openai:v0.19.0'
+        description: 'Base image (e.g. vllm/vllm-openai:v0.22.1)'
+        default: 'vllm/vllm-openai:v0.22.1'
         required: true
         type: string
       vllm_repo:
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.4.1'
+        default: 'v1.5.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.4.1-vllm-v0.17.0)'
+        description: 'Override image tag (e.g. v1.5.0-vllm-v0.22.1)'
         required: false
         type: string
 
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["vllm/vllm-openai:v0.19.0","vllm/vllm-openai:v0.18.0","vllm/vllm-openai:v0.17.0"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'vllm/vllm-openai:v0.19.0')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["vllm/vllm-openai:v0.22.1","vllm/vllm-openai:v0.21.0","vllm/vllm-openai:v0.20.0"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'vllm/vllm-openai:v0.22.1')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: vllm
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.4.1' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.5.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.7.0", path = "crates/protocols" }
-reasoning-parser = { version = "1.2.3", path = "crates/reasoning_parser" }
-tool-parser = { version = "1.2.0", path = "crates/tool_parser" }
-wfaas = { version = "1.0.3", path = "crates/workflow" }
-llm-tokenizer = { version = "1.3.2", path = "crates/tokenizer" }
-smg-auth = { version = "1.1.1", path = "crates/auth" }
-smg-mcp = { version = "2.2.0", path = "crates/mcp" }
-kv-index = { version = "1.2.0", path = "crates/kv_index" }
-smg-data-connector = { version = "2.2.0", path = "crates/data_connector", package = "data-connector" }
-llm-multimodal = { version = "1.5.0", path = "crates/multimodal" }
-smg-wasm = { version = "1.1.0", path = "crates/wasm", package = "smg-wasm" }
-smg-mesh = { version = "1.3.0", path = "crates/mesh", package = "smg-mesh" }
-smg-grpc-client = { version = "1.5.1", path = "crates/grpc_client" }
+openai-protocol = { version = "1.8.0", path = "crates/protocols" }
+reasoning-parser = { version = "1.3.0", path = "crates/reasoning_parser" }
+tool-parser = { version = "1.3.0", path = "crates/tool_parser" }
+wfaas = { version = "1.0.4", path = "crates/workflow" }
+llm-tokenizer = { version = "1.4.0", path = "crates/tokenizer" }
+smg-auth = { version = "1.2.0", path = "crates/auth" }
+smg-mcp = { version = "2.3.0", path = "crates/mcp" }
+kv-index = { version = "1.3.0", path = "crates/kv_index" }
+smg-data-connector = { version = "2.3.0", path = "crates/data_connector", package = "data-connector" }
+llm-multimodal = { version = "1.6.0", path = "crates/multimodal" }
+smg-wasm = { version = "1.1.1", path = "crates/wasm", package = "smg-wasm" }
+smg-mesh = { version = "1.4.0", path = "crates/mesh", package = "smg-mesh" }
+smg-grpc-client = { version = "1.6.0", path = "crates/grpc_client" }
 smg-tui = { version = "0.1.0", path = "tui" }
 
 # Shared dependencies

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.4.1"
+version = "1.5.0"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-auth"
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 description = "Authentication and authorization for control plane APIs"
 license = "Apache-2.0"

--- a/crates/data_connector/Cargo.toml
+++ b/crates/data_connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-connector"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 description = "Storage backends for conversations and responses"
 license = "Apache-2.0"

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-grpc-client"
-version = "1.5.1"
+version = "1.6.0"
 edition = "2021"
 description = "gRPC clients for vLLM, TensorRT-LLM, MLX, TokenSpeed, and SGLang backends"
 license = "Apache-2.0"

--- a/crates/kv_index/Cargo.toml
+++ b/crates/kv_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kv-index"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "Radix tree implementations for prefix matching and cache-aware routing"
 license = "Apache-2.0"

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mcp"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) client implementation"
 license = "Apache-2.0"

--- a/crates/mesh/Cargo.toml
+++ b/crates/mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mesh"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 description = "Mesh gossip protocol and distributed state synchronization for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-multimodal"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/crates/reasoning_parser/Cargo.toml
+++ b/crates/reasoning_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasoning-parser"
-version = "1.2.3"
+version = "1.3.0"
 edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"

--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-tokenizer"
-version = "1.3.2"
+version = "1.4.0"
 edition = "2021"
 description = "LLM tokenizer library with caching and chat template support"
 license = "Apache-2.0"

--- a/crates/tool_parser/Cargo.toml
+++ b/crates/tool_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool-parser"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "Tool/function call parser for LLM model outputs"
 license = "Apache-2.0"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-wasm"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "WebAssembly runtime and module management for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/crates/workflow/Cargo.toml
+++ b/crates/workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wfaas"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 description = "Workflow-as-a-Service engine for managing multi-step operations"
 license = "Apache-2.0"

--- a/deploy/helm/smg/Chart.yaml
+++ b/deploy/helm/smg/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: smg
 description: "Shepherd Model Gateway - high-performance inference router for LLM deployments"
 type: application
-version: 1.4.1
-appVersion: "1.4.1"
+version: 1.5.0
+appVersion: "1.5.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/lightseekorg/smg
 sources:

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description

Version bumps for the **SMG v1.5.0** release, generated by `make check-versions` against tag `v1.4.1`, plus a refresh of the engine base images in the engine release/nightly Docker workflows (which `check-versions` does not cover — it only syncs the SMG version refs).

## Changes

**Workspace versions** (per `check-versions` proposed fixes, all applied):
- `smg` 1.4.1 → **1.5.0**; synced: `smg-python`, `smg-golang`, python `pyproject.toml`, helm chart, and the SMG refs in `release-{sglang,vllm,trtllm}-docker.yml`
- Minor bumps: `openai-protocol` 1.8.0, `reasoning-parser` 1.3.0, `tool-parser` 1.3.0, `llm-tokenizer` 1.4.0, `smg-auth` 1.2.0, `smg-mcp` 2.3.0, `kv-index` 1.3.0, `data-connector` 2.3.0, `llm-multimodal` 1.6.0, `smg-mesh` 1.4.0, `smg-grpc-client` 1.6.0
- Patch bumps: `wfaas` 1.0.4, `smg-wasm` 1.1.1

**Engine base images** — release workflows now build on the same engine versions CI tests against:

| Workflow | Before | After |
|---|---|---|
| `release-sglang-docker.yml` | `lmsysorg/sglang:v0.5.10` | `lmsysorg/sglang:v0.5.12.post1` (#1662) |
| `release-vllm-docker.yml` (3-version matrix) | `v0.19.0` / `v0.18.0` / `v0.17.0` | `v0.22.1` / `v0.21.0` / `v0.20.0` (#1625) |
| `release-trtllm-docker.yml` (3-version matrix) | `1.3.0rc10` / `rc9` / `rc8` | `1.3.0rc18` / `rc17` / `rc16` (#1663) |
| `nightly-engine-docker.yml` | all three of the above | updated to match, incl. `engine_ver` tags |

## Test Plan

- `make check-versions` re-run after applying: **"All versions consistent."** (14 crates + 2 Python packages reconciled, 0 issues)
- Every new base image tag verified published before pinning: `lmsysorg/sglang:v0.5.12.post1` (Docker Hub 200), `vllm/vllm-openai:{v0.22.1,v0.21.0,v0.20.0}` (Docker Hub 200), `nvcr.io/nvidia/tensorrt-llm/release:{1.3.0rc16,rc17,rc18}` (NGC tags list)
- `Cargo.lock` is gitignored in this repo (same as the v1.4.1 release PR #1080); workspace lock refresh happens at build time


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 1.5.0.
  * Updated Docker engine base images to newer releases (vLLM v0.22.1, SGLang v0.5.12.post1, TensorRT‑LLM 1.3.0rc18) and adjusted CI workflow defaults.
  * Bumped package/crate versions across bindings, crates, workspace, and Helm chart to align with the 1.5.0 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->