### PR TITLE
fix(docker): shadow distro-owned PyYAML on TRT-LLM bases before smg install

### DIFF
--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -56,6 +56,16 @@ COPY --from=sources /opt/engine-src   /opt/engine-src
 COPY --from=sources /tmp/smg-src      /opt/smg-src
 COPY --from=sources /tmp/scripts/     /tmp/scripts/
 
+# NGC TRT-LLM bases (1.3.0rc18) ship a debian-owned PyYAML with no pip RECORD
+# file, which pip refuses to uninstall when install-smg.sh resolves smg's
+# pyyaml dependency ("uninstall-no-record-file"). Shadow it with a pip-managed
+# copy (--ignore-installed leaves the distro files alone); the smg install can
+# then upgrade pyyaml normally. Scoped to trtllm so the other engine bases
+# keep their exact pip behavior.
+RUN if [ "${ENGINE}" = "trtllm" ]; then \
+      pip install --no-cache-dir --ignore-installed pyyaml; \
+    fi
+
 RUN bash /tmp/scripts/install-smg.sh /opt/smg-src
 
 RUN case "${ENGINE}" in \


### PR DESCRIPTION
## Description

The `build (nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18)` dry-run on #1665 fails in `install-smg.sh`:

```
Attempting uninstall: pyyaml
  Found existing installation: PyYAML 6.0.1
error: uninstall-no-record-file
× Cannot uninstall PyYAML 6.0.1
╰─> The package's contents are unknown: no RECORD file was found for PyYAML.
hint: The package was installed by debian.
```

The rc18 NGC base ships a debian-owned PyYAML (rc10 did not). The smg wheel install uses `--force-reinstall`, which reinstalls the dependency set including pyyaml, and pip cannot uninstall a RECORD-less distro package.

## Changes

One conditional step in `docker/engine.Dockerfile`, **scoped to `ENGINE=trtllm`**, before `install-smg.sh`: `pip install --ignore-installed pyyaml` installs a pip-managed copy that shadows the distro one on sys.path and in pip's metadata view, so the smg install can then upgrade pyyaml through its normal uninstall/reinstall path.

Deliberately NOT a blanket `--ignore-installed` in the shared `install-smg.sh`: that would make pip blind to every installed distribution on all engine bases and risks hybrid installs / stomping engine-pinned deps on the sglang/vllm images that build fine today.

## Test Plan

- This PR's own trtllm dry-run still builds on the rc10 base (main's pin), so it proves no regression but not the fix itself.
- The fix is proven by rebasing #1665 (which moves the base to rc18) on top of this once merged — its `build (…rc18)` dry-run should go green.
- sglang/vllm/tgl build paths are untouched (conditional is trtllm-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Docker build failures for specific engine configurations by improving package dependency handling during container initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->