### PR TITLE
perf(smg): mitigate the worker-sync lag-resync burst

### DIFF
--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -286,13 +286,19 @@ impl WorkerSyncAdapter {
 
     /// Re-publish every locally-owned worker and tombstone any key this
     /// loop published whose worker no longer exists. Doubles as the
-    /// bootstrap (empty prior set) and the lag-recovery path; re-publishing
-    /// identical state is harmless (peers' URL-dedupe refreshes health).
+    /// bootstrap (empty prior set) and the lag-recovery path. Workers whose
+    /// stored state is already equivalent are skipped: every re-put mints a
+    /// fresh Lamport op, invalidating each peer's send watermark for the
+    /// key, so a blanket resync of W workers would burst W ops to every
+    /// peer even when nothing changed.
     fn resync_local(&self, published: &mut HashSet<WorkerId>) {
         let mut current = HashSet::new();
         for (id, worker) in self.worker_registry.get_all_with_ids() {
             if self.worker_registry.origin_of(&id) == Some(WorkerOrigin::Local) {
-                self.on_worker_changed(id.as_str(), &worker_state_of(&id, &worker));
+                let state = worker_state_of(&id, &worker);
+                if !self.store_matches(&id, &state) {
+                    self.on_worker_changed(id.as_str(), &state);
+                }
                 current.insert(id);
             }
         }
@@ -301,6 +307,32 @@ impl WorkerSyncAdapter {
             self.on_worker_removed(stale.as_str());
         }
         *published = current;
+    }
+
+    /// True when the store already holds an equivalent state for the
+    /// worker. `load` is ignored (volatile and unread by importers) and
+    /// specs are compared as JSON values, not bytes — `WorkerSpec` holds
+    /// maps, so two encodings of identical specs can differ byte-wise.
+    fn store_matches(&self, id: &WorkerId, state: &WorkerState) -> bool {
+        let Some(bytes) = self.workers.get(&format!("{PREFIX}{}", id.as_str())) else {
+            return false;
+        };
+        let Ok(mut stored) = bincode::deserialize::<WorkerState>(&bytes) else {
+            return false;
+        };
+        let spec_equal = match (
+            serde_json::from_slice::<serde_json::Value>(&stored.spec),
+            serde_json::from_slice::<serde_json::Value>(&state.spec),
+        ) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => stored.spec == state.spec,
+        };
+        let mut fresh = state.clone();
+        stored.load = 0.0;
+        fresh.load = 0.0;
+        stored.spec = Vec::new();
+        fresh.spec = Vec::new();
+        spec_equal && stored == fresh
     }
 
     /// Publish a worker update to the cluster. Callers pass the
@@ -348,9 +380,9 @@ fn worker_state_of(worker_id: &WorkerId, worker: &Arc<dyn Worker>) -> WorkerStat
 mod tests {
     use std::time::Duration;
 
-    use openai_protocol::model_card::ModelCard;
+    use openai_protocol::{model_card::ModelCard, worker::WorkerStatus};
     use smg_mesh::{MergeStrategy, MeshKV};
-    use tokio::time::sleep;
+    use tokio::{sync::mpsc::error::TryRecvError, time::sleep};
 
     use super::*;
     use crate::worker::BasicWorkerBuilder;
@@ -775,6 +807,39 @@ mod tests {
             })
             .await,
             "claimed worker must be published with its local spec"
+        );
+    }
+
+    #[tokio::test]
+    async fn resync_skips_republish_when_state_unchanged() {
+        // Every put mints a fresh Lamport op (a watermark delta to every
+        // peer), so a lag resync must not re-put unchanged state. A put
+        // always notifies local subscribers, so an empty channel after the
+        // second resync proves the skip.
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+
+        let id = registry
+            .register(local_worker("http://local:8080"))
+            .unwrap();
+        let mut published = HashSet::new();
+        adapter.resync_local(&mut published);
+
+        let mut sub = ns.subscribe("");
+        adapter.resync_local(&mut published);
+        assert!(
+            matches!(sub.receiver.try_recv(), Err(TryRecvError::Empty)),
+            "unchanged state must not be re-put on resync"
+        );
+
+        // A real change (health flip) is still republished.
+        registry.get(&id).unwrap().set_status(WorkerStatus::Ready);
+        adapter.resync_local(&mut published);
+        assert!(
+            sub.receiver.try_recv().is_ok(),
+            "changed state must be republished on resync"
         );
     }
 

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -311,10 +311,9 @@ impl WorkerSyncAdapter {
 
     /// True when the store already holds an equivalent state for the
     /// worker. `load` is not compared (volatile and unread by importers);
-    /// specs compare as JSON values, not bytes — `WorkerSpec` holds maps,
+    /// specs compare semantically as JSON values — `WorkerSpec` holds maps,
     /// so two encodings of identical specs can differ byte-wise. Cheap
-    /// scalar fields gate the JSON parses, so changed workers skip the
-    /// expensive path.
+    /// scalar fields and a byte-equality fast path gate the JSON parses.
     fn store_matches(&self, id: &WorkerId, state: &WorkerState) -> bool {
         let Some(bytes) = self.workers.get(&format!("{PREFIX}{}", id.as_str())) else {
             return false;
@@ -330,12 +329,19 @@ impl WorkerSyncAdapter {
         {
             return false;
         }
+        // Byte equality is sufficient (not necessary): re-serialising the
+        // same spec instance is byte-stable in-process, so this skips the
+        // JSON parses in the steady state; key-order drift (e.g. across
+        // restarts) falls through to the semantic comparison.
+        if stored.spec == state.spec {
+            return true;
+        }
         match (
             serde_json::from_slice::<serde_json::Value>(&stored.spec),
             serde_json::from_slice::<serde_json::Value>(&state.spec),
         ) {
             (Ok(a), Ok(b)) => a == b,
-            _ => stored.spec == state.spec,
+            _ => false,
         }
     }
 

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -310,29 +310,33 @@ impl WorkerSyncAdapter {
     }
 
     /// True when the store already holds an equivalent state for the
-    /// worker. `load` is ignored (volatile and unread by importers) and
-    /// specs are compared as JSON values, not bytes — `WorkerSpec` holds
-    /// maps, so two encodings of identical specs can differ byte-wise.
+    /// worker. `load` is not compared (volatile and unread by importers);
+    /// specs compare as JSON values, not bytes — `WorkerSpec` holds maps,
+    /// so two encodings of identical specs can differ byte-wise. Cheap
+    /// scalar fields gate the JSON parses, so changed workers skip the
+    /// expensive path.
     fn store_matches(&self, id: &WorkerId, state: &WorkerState) -> bool {
         let Some(bytes) = self.workers.get(&format!("{PREFIX}{}", id.as_str())) else {
             return false;
         };
-        let Ok(mut stored) = bincode::deserialize::<WorkerState>(&bytes) else {
+        let Ok(stored) = bincode::deserialize::<WorkerState>(&bytes) else {
             return false;
         };
-        let spec_equal = match (
+        if stored.worker_id != state.worker_id
+            || stored.model_id != state.model_id
+            || stored.url != state.url
+            || stored.health != state.health
+            || stored.version != state.version
+        {
+            return false;
+        }
+        match (
             serde_json::from_slice::<serde_json::Value>(&stored.spec),
             serde_json::from_slice::<serde_json::Value>(&state.spec),
         ) {
             (Ok(a), Ok(b)) => a == b,
             _ => stored.spec == state.spec,
-        };
-        let mut fresh = state.clone();
-        stored.load = 0.0;
-        fresh.load = 0.0;
-        stored.spec = Vec::new();
-        fresh.spec = Vec::new();
-        spec_equal && stored == fresh
+        }
     }
 
     /// Publish a worker update to the cluster. Callers pass the

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -133,7 +133,7 @@ impl WorkerRegistry {
 
     /// Create an empty worker registry.
     ///
-    /// Initialises all indexes and a broadcast channel with capacity 64
+    /// Initialises all indexes and a broadcast channel with capacity 1024
     /// for `WorkerEvent` delivery. Holds no locks. Emits no events.
     pub fn new() -> Self {
         Self {
@@ -146,7 +146,11 @@ impl WorkerRegistry {
             worker_mutation_locks: Arc::new(DashMap::new()),
             model_retry_configs: Arc::new(DashMap::new()),
             worker_origins: Arc::new(DashMap::new()),
-            event_tx: broadcast::Sender::new(64),
+            // Sized for fleet-scale bursts (startup registration, probe
+            // storms): a lagged subscriber forces a full state resync, so
+            // the capacity should comfortably exceed realistic worker
+            // counts. ~100 B per slot; fixed cost ~100 KB.
+            event_tx: broadcast::Sender::new(1024),
         }
     }
 


### PR DESCRIPTION
## Description

### Problem

Two related burst amplifiers in the worker mesh sync, found by the #1661 perf review: (1) the registry's `WorkerEvent` broadcast had 64 slots — bulk startup registration or a probe storm lags it, and every lag forces a full mesh resync; (2) that resync (`resync_local`) re-put **every** local worker unconditionally. Each re-put mints a fresh Lamport op, which invalidates every peer's per-key send watermark — so one lag event burst W ops to N peers (~16× amplification at 1,000 workers) even when nothing had changed, and a sustained status storm could re-trigger it repeatedly.

### Solution

- **Channel sized for fleets**: 64 → 1024 slots (~98 KB fixed; verified the per-slot math, and tokio clears a consumed slot's payload on last receive, so retention is transient).
- **Resync skips unchanged workers**: `store_matches` consults the store before re-putting. Cheap scalar fields gate the comparison; `load` is not compared (volatile, unread by importers); specs compare as JSON *values* rather than bytes, since `WorkerSpec` holds maps and two encodings of an identical spec can differ byte-wise. A skipped put is a watermark delta that never ships.

Correctness containment: a lost publish or foreign tombstone leaves the store without (or with different) state, so `store_matches` returns false and the resync still re-asserts — the lag-recovery role is preserved. False negatives merely re-put (the old behavior).

## Changes

- `model_gateway/src/worker/registry.rs` — event channel capacity + sizing rationale
- `model_gateway/src/mesh/adapters/worker_sync.rs` — `store_matches` + resync gating; test via the local-subscriber observable (put ⇒ notify, skip ⇒ empty channel)

## Test Plan

- `cargo test -p smg` — suite green; new `resync_skips_republish_when_state_unchanged` asserts both directions (unchanged ⇒ skipped; health flip ⇒ republished).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- Adversarially reviewed (correctness + memory/perf lenses): zero confirmed must-fix; the comparison-ordering suggestion is folded in.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized worker state synchronization to avoid re-publishing unchanged local worker state and reduce unnecessary updates.

* **Performance Improvements**
  * Increased internal event queue capacity to better handle fleet-scale bursts of worker events.

* **Tests**
  * Added coverage to ensure resync skips redundant publishes and emits updates when state actually changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->