### PR TITLE
feat(smg): deterministic worker ids — restart-stable mesh keys

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1261,9 +1261,15 @@ impl Router {
                     // advertise address so the mesh identity — and the
                     // deterministic worker-id namespace keyed on it — survives
                     // restarts. ':' is the rl shard-key separator, hence '-'.
-                    let self_name = self.mesh_server_name.clone().unwrap_or_else(|| {
-                        format!("Mesh_{}", advertise_addr.to_string().replace(':', "-"))
-                    });
+                    let self_name = match self.mesh_server_name.clone() {
+                        Some(name) => {
+                            config::validate_mesh_server_name(&name).map_err(|e| {
+                                pyo3::exceptions::PyValueError::new_err(e.to_string())
+                            })?;
+                            name
+                        }
+                        None => format!("Mesh_{}", advertise_addr.to_string().replace(':', "-")),
+                    };
                     Some(smg_mesh::MeshServerConfig {
                         self_name,
                         bind_addr,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1228,13 +1228,6 @@ impl Router {
                     .as_ref()
                     .map(|c| c.to_auth_control_plane_config()),
                 mesh_server_config: if self.enable_mesh {
-                    let self_name = self.mesh_server_name.clone().unwrap_or_else(|| {
-                        use rand::{distr::Alphanumeric, RngExt};
-                        let random_string: String = (0..4)
-                            .map(|_| rand::rng().sample(Alphanumeric) as char)
-                            .collect();
-                        format!("Mesh_{random_string}")
-                    });
                     let peer = self
                         .mesh_peer_urls
                         .first()
@@ -1264,6 +1257,13 @@ impl Router {
                             "Invalid value for {advertise_field}='{advertise_host}': mesh advertise address cannot be unspecified; set mesh_advertise_host to a routable node IP"
                         )));
                     }
+                    // Stable default: derive from the (routable, per-node-unique)
+                    // advertise address so the mesh identity — and the
+                    // deterministic worker-id namespace keyed on it — survives
+                    // restarts. ':' is the rl shard-key separator, hence '-'.
+                    let self_name = self.mesh_server_name.clone().unwrap_or_else(|| {
+                        format!("Mesh_{}", advertise_addr.to_string().replace(':', "-"))
+                    });
                     Some(smg_mesh::MeshServerConfig {
                         self_name,
                         bind_addr,

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -61,7 +61,7 @@ reqwest = { workspace = true, features = ["stream", "blocking", "json", "rustls"
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true
-uuid = { workspace = true, features = ["serde"] }
+uuid = { workspace = true, features = ["serde", "v5"] }
 
 # Workspace crates
 openai-protocol = { workspace = true, features = ["axum"] }

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
-use rand::{distr::Alphanumeric, RngExt};
 use smg::{
     config::{
         validate_mesh_server_name, CircuitBreakerConfig, ConfigError, ConfigResult,
@@ -920,15 +919,6 @@ impl CliArgs {
             return Ok(None);
         }
 
-        let self_name = if let Some(name) = &self.mesh_server_name {
-            validate_mesh_server_name(name)?;
-            name.to_string()
-        } else {
-            let mut rng = rand::rng();
-            let random_string: String = (0..4).map(|_| rng.sample(Alphanumeric) as char).collect();
-            format!("Mesh_{random_string}")
-        };
-
         let peer = self
             .mesh_peer_urls
             .first()
@@ -960,6 +950,17 @@ impl CliArgs {
                     "mesh advertise address cannot be unspecified; set --mesh-advertise-host to a routable node IP".to_string(),
             });
         }
+
+        let self_name = if let Some(name) = &self.mesh_server_name {
+            validate_mesh_server_name(name)?;
+            name.to_string()
+        } else {
+            // Stable default: the advertise address is required, routable,
+            // and unique per node, so it yields the same identity across
+            // restarts (deterministic worker ids, no ghost member per boot).
+            // ':' is the rl shard-key separator, hence the '-'.
+            format!("Mesh_{}", advertise_addr.to_string().replace(':', "-"))
+        };
 
         Ok(Some(MeshServerConfig {
             self_name,

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -23,9 +23,7 @@
 //!
 //! Known gap: only the owner tombstones its keys, so a permanently-dead
 //! node's `worker:` keys persist cluster-wide (imports stay registered,
-//! demoted by local probes), and a crash-restart that registers locally
-//! before its old state gossips back orphans up to one store key per
-//! worker per restart. Tombstone metadata also accrues per removed
+//! demoted by local probes). Tombstone metadata also accrues per removed
 //! worker (time-based collection would resurrect deleted keys; it is
 //! only sound at causal stability). Cleanup belongs to dead-node key GC.
 

--- a/model_gateway/src/mesh/adapters/worker_sync.rs
+++ b/model_gateway/src/mesh/adapters/worker_sync.rs
@@ -26,6 +26,11 @@
 //! demoted by local probes). Tombstone metadata also accrues per removed
 //! worker (time-based collection would resurrect deleted keys; it is
 //! only sound at causal stability). Cleanup belongs to dead-node key GC.
+//!
+//! Restart-stable ids reuse keys across incarnations, so a prior
+//! incarnation's higher-timestamp ops can transiently shadow the fresh
+//! state; the reconcile pass re-asserts locally-owned state it finds
+//! mismatched, bounding the shadow to one pass.
 
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
@@ -170,13 +175,24 @@ impl WorkerSyncAdapter {
         // to test membership, and feeds the backfill below so the
         // namespace is scanned once per pass.
         let live: HashSet<String> = self.workers.keys("").into_iter().collect();
-        for (id, _) in self.worker_registry.get_all_with_ids() {
+        for (id, worker) in self.worker_registry.get_all_with_ids() {
             let key = format!("{PREFIX}{}", id.as_str());
             if !live.contains(&key) {
                 // Missing backing key: same handling as a live tombstone
                 // event — imports are removed, locally-owned state is
                 // re-asserted.
                 self.sync_key_from_store(&key, id.as_str());
+            } else if self.worker_registry.origin_of(&id) == Some(WorkerOrigin::Local) {
+                // Present but stale: with restart-stable ids, a prior
+                // incarnation's higher-timestamp ops can dominate the
+                // reused key (LWW), shadowing the live state. By now the
+                // clock has observed those timestamps via the merge, so a
+                // re-put wins and the shadow is bounded to one pass.
+                let state = worker_state_of(&id, &worker);
+                if !self.store_matches(&id, &state) {
+                    warn!(worker_id = %id.as_str(), "re-asserting locally-owned state over stale store value");
+                    self.on_worker_changed(id.as_str(), &state);
+                }
             }
         }
         self.backfill_keys(live);
@@ -711,6 +727,35 @@ mod tests {
         assert!(
             registry.get_by_url("http://remote:8080").is_none(),
             "reconcile recovers a missed tombstone"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_reasserts_local_state_over_stale_store_value() {
+        // With restart-stable ids a prior incarnation's ops can dominate
+        // the reused key; reconcile must detect the mismatch and re-put
+        // the live state.
+        let mesh = MeshKV::new("node-a".into());
+        let ns = worker_namespace(&mesh);
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapter = WorkerSyncAdapter::new(ns.clone(), registry.clone());
+
+        let id = registry
+            .register(local_worker("http://local:8080"))
+            .unwrap();
+        // A stale state (no spec) occupying the worker's own key models the
+        // prior incarnation's value winning LWW.
+        let key = format!("worker:{}", id.as_str());
+        ns.put(
+            &key,
+            bincode::serialize(&sample_state(id.as_str(), "http://local:8080")).unwrap(),
+        );
+
+        adapter.reconcile_once();
+        let stored: WorkerState = bincode::deserialize(&ns.get(&key).unwrap()).unwrap();
+        assert!(
+            !stored.spec.is_empty(),
+            "reconcile re-asserts the live local state over the stale value"
         );
     }
 

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -43,6 +43,12 @@ impl MeshAdapters {
         node_name: String,
         worker_registry: Arc<WorkerRegistry>,
     ) -> Arc<Self> {
+        // Deterministic worker ids: a restarted node republishes its
+        // workers under their previous mesh keys, so tombstones resolve
+        // and no orphan keys form. Installed here because this runs
+        // before the worker-init workflows register anything.
+        worker_registry.set_worker_id_namespace(&node_name);
+
         let worker_ns = mesh_kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
         let rl_ns = mesh_kv.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
         let worker = WorkerSyncAdapter::new(worker_ns, worker_registry);
@@ -71,6 +77,7 @@ mod tests {
     use tokio::time::sleep;
 
     use super::*;
+    use crate::worker::registry::WorkerId;
 
     fn started(mesh: &MeshKV) -> Arc<MeshAdapters> {
         MeshAdapters::start(mesh, "node-a".into(), Arc::new(WorkerRegistry::new()))
@@ -116,6 +123,20 @@ mod tests {
         adapters.rate_limit().sync_counter("global", 2, 5);
         adapters.rate_limit().sync_counter("global", 1, 100);
         assert_eq!(adapters.rate_limit().get_aggregate("global"), 5);
+    }
+
+    #[tokio::test]
+    async fn start_installs_deterministic_worker_ids() {
+        let mesh = MeshKV::new("node-a".into());
+        let registry = Arc::new(WorkerRegistry::new());
+        let _adapters = MeshAdapters::start(&mesh, "node-a".into(), registry.clone());
+
+        let id = registry.reserve_id_for_url("http://w:8080");
+        assert_eq!(
+            id,
+            WorkerId::derived("node-a", "http://w:8080"),
+            "mesh-enabled nodes mint restart-stable worker ids"
+        );
     }
 
     #[tokio::test]

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -43,6 +43,13 @@ impl MeshAdapters {
         node_name: String,
         worker_registry: Arc<WorkerRegistry>,
     ) -> Arc<Self> {
+        // Checked before the namespace install: the registry's id namespace
+        // is first-writer-wins, so a later panic must not leave a shared
+        // registry stuck with an invalid value.
+        assert!(
+            !node_name.is_empty() && !node_name.contains(':'),
+            "mesh node name must be non-empty and must not contain ':'"
+        );
         // Deterministic worker ids: a restarted node republishes its
         // workers under their previous mesh keys, so tombstones resolve
         // and no orphan keys form. Installed here because this runs

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -44,6 +44,16 @@ impl WorkerId {
         Self(Uuid::now_v7().to_string())
     }
 
+    /// Derive the stable id for `(node, url)`: the same pair always yields
+    /// the same id, so a restarted node republishes its workers under
+    /// their previous mesh keys (tombstones resolve, no orphan keys).
+    /// Chained v5 namespacing keeps the pair collision-free without a
+    /// separator convention.
+    pub fn derived(node_name: &str, url: &str) -> Self {
+        let node_ns = Uuid::new_v5(&Uuid::NAMESPACE_URL, node_name.as_bytes());
+        Self(Uuid::new_v5(&node_ns, url.as_bytes()).to_string())
+    }
+
     /// Create a worker ID from a string
     pub fn from_string(s: String) -> Self {
         Self(s)
@@ -122,6 +132,12 @@ pub struct WorkerRegistry {
     /// removed in `remove()` teardown.
     worker_origins: Arc<DashMap<WorkerId, WorkerOrigin>>,
 
+    /// Mesh node identity for deterministic worker-id minting. When set
+    /// (mesh enabled), new ids derive from `(node, url)` so a restarted
+    /// node republishes under its previous mesh keys; unset (mesh off),
+    /// ids stay random v7.
+    id_namespace: std::sync::OnceLock<String>,
+
     /// Broadcast channel for worker state change events.
     event_tx: broadcast::Sender<WorkerEvent>,
 }
@@ -146,11 +162,36 @@ impl WorkerRegistry {
             worker_mutation_locks: Arc::new(DashMap::new()),
             model_retry_configs: Arc::new(DashMap::new()),
             worker_origins: Arc::new(DashMap::new()),
+            id_namespace: std::sync::OnceLock::new(),
             // Sized for fleet-scale bursts (startup registration, probe
             // storms): a lagged subscriber forces a full state resync, so
             // the capacity should comfortably exceed realistic worker
             // counts. ~100 B per slot; fixed cost ~100 KB.
             event_tx: broadcast::Sender::new(1024),
+        }
+    }
+
+    /// Install the mesh node identity used to mint deterministic worker
+    /// ids. Must run before workers register; ids minted earlier keep
+    /// their random form. Idempotent for the same name; a different name
+    /// is refused with a warning (the first writer wins).
+    pub fn set_worker_id_namespace(&self, node_name: &str) {
+        if self.id_namespace.set(node_name.to_string()).is_err()
+            && self.id_namespace.get().map(String::as_str) != Some(node_name)
+        {
+            tracing::warn!(
+                node_name,
+                "worker id namespace already set to a different name; keeping the first"
+            );
+        }
+    }
+
+    /// Mint an id for a new registration at `url`: deterministic when the
+    /// mesh node identity is installed, random otherwise.
+    fn mint_worker_id(&self, url: &str) -> WorkerId {
+        match self.id_namespace.get() {
+            Some(node) => WorkerId::derived(node, url),
+            None => WorkerId::new(),
         }
     }
 
@@ -913,7 +954,14 @@ impl WorkerRegistry {
     /// create the worker under this ID. Idempotent — repeated calls for
     /// the same URL return the same ID. Emits no events.
     pub fn reserve_id_for_url(&self, url: &str) -> WorkerId {
-        self.url_to_id.entry(url.to_string()).or_default().clone()
+        // Minted before taking the entry so the shard guard is never held
+        // across the mint; deterministic minting keeps the reservation
+        // identical to what register_inner would derive for the URL.
+        let candidate = self.mint_worker_id(url);
+        self.url_to_id
+            .entry(url.to_string())
+            .or_insert(candidate)
+            .clone()
     }
 
     // ───────────────────────────────────────────────────────────────────
@@ -1161,13 +1209,15 @@ impl WorkerRegistry {
     fn register_inner(&self, worker: Arc<dyn Worker>, origin: WorkerOrigin) -> Option<WorkerId> {
         // Resolve (or reserve) the worker_id from url_to_id. The entry
         // API is atomic per bucket, so concurrent callers either reuse
-        // the same existing_id or serialize on vacant insertion.
+        // the same existing_id or serialize on vacant insertion. The
+        // candidate is minted before taking the entry so the shard guard
+        // is never held across the mint.
+        let candidate = self.mint_worker_id(worker.url());
         let worker_id = match self.url_to_id.entry(worker.url().to_string()) {
             Entry::Occupied(entry) => entry.get().clone(),
             Entry::Vacant(entry) => {
-                let new_id = WorkerId::new();
-                entry.insert(new_id.clone());
-                new_id
+                entry.insert(candidate.clone());
+                candidate
             }
         };
 
@@ -1567,6 +1617,68 @@ mod tests {
 
         registry.remove(&worker_id);
         assert!(registry.get(&worker_id).is_none());
+    }
+
+    #[test]
+    fn deterministic_ids_survive_reregistration() {
+        let registry = WorkerRegistry::new();
+        registry.set_worker_id_namespace("node-a");
+
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8080")
+                .model(ModelCard::new("m"))
+                .build(),
+        );
+        let first = registry.register(worker).unwrap();
+        assert_eq!(first, WorkerId::derived("node-a", "http://w:8080"));
+
+        registry.remove(&first);
+        let again: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8080")
+                .model(ModelCard::new("m"))
+                .build(),
+        );
+        let second = registry.register(again).unwrap();
+        assert_eq!(
+            first, second,
+            "the same (node, url) re-registers under the same id"
+        );
+
+        // Reservations derive identically.
+        registry.remove(&second);
+        assert_eq!(registry.reserve_id_for_url("http://w:8080"), first);
+    }
+
+    #[test]
+    fn derived_ids_differ_across_nodes_and_urls() {
+        let a = WorkerId::derived("node-a", "http://w:8080");
+        assert_ne!(a, WorkerId::derived("node-b", "http://w:8080"));
+        assert_ne!(a, WorkerId::derived("node-a", "http://w:8081"));
+        // Chained namespacing: shifting bytes between node and url must
+        // not collide.
+        assert_ne!(
+            WorkerId::derived("node-a", "x/http://w:8080"),
+            WorkerId::derived("node-a/x", "http://w:8080")
+        );
+    }
+
+    #[test]
+    fn random_ids_without_namespace() {
+        let registry = WorkerRegistry::new();
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8080")
+                .model(ModelCard::new("m"))
+                .build(),
+        );
+        let first = registry.register(worker).unwrap();
+        registry.remove(&first);
+        let again: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:8080")
+                .model(ModelCard::new("m"))
+                .build(),
+        );
+        let second = registry.register(again).unwrap();
+        assert_ne!(first, second, "mesh-off deployments keep random ids");
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

Worker ids were random UUIDv7 minted per registration, so every gateway restart re-keyed every worker: the old `worker:{id}` keys were orphaned cluster-wide (one per worker per restart, unreclaimable — only the owner may tombstone, and the owner no longer knows the id), and tombstones for the new id never resolved on peers still holding the import under the old id.

### Solution

Ids derive from `(node_name, url)` via chained UUIDv5 namespacing — the same node republishes the same keys across restarts, so tombstones resolve and no orphan keys form. `MeshAdapters::start` installs the node identity before the worker-init workflows register anything; reservations (`reserve_id_for_url`) derive identically; mesh-off deployments keep random v7 ids.

**The subtle part (found by adversarial review, fixed in-PR):** key reuse re-introduces same-key contention that random ids structurally avoided. A restarted node's Lamport clock starts fresh, so its first publish *loses LWW to its own prior incarnation's ops* once peers gossip them back — shadowing live state and resurrecting pre-restart tombstones. The reconcile pass now re-asserts locally-owned state it finds mismatched in the store; by reconcile time the clock has observed the stale timestamps via the merge, so the re-put wins and the shadow is bounded to one ~30s pass. (Builds on the `store_matches` comparison from the parent PR.)

### Known limitations (honest scoping)

- **Dual-claim is unchanged**: when two live nodes claim the same URL and one imports before registering locally, the claim keeps the *publisher's* derived id — per-(node,url) key separation only materializes when each node registers before importing. Same LWW flap as before, not a regression.
- Id reuse is API-visible: DELETE + re-ADD of the same URL (and restarts) now yield the same worker id, so clients can't distinguish worker incarnations by id.
- Derived-id distinctness rests on mesh node-name uniqueness (assumed, not enforced).

## Changes

- `model_gateway/src/worker/registry.rs` — `WorkerId::derived` (chained v5 — collision-free without separator conventions), `id_namespace: OnceLock`, `set_worker_id_namespace`, deterministic minting at both mint sites (shard guards never held across the mint)
- `model_gateway/src/mesh/wiring.rs` — namespace install in `MeshAdapters::start`
- `model_gateway/src/mesh/adapters/worker_sync.rs` — reconcile re-assert on store mismatch; module-doc gap updated
- `model_gateway/Cargo.toml` — uuid `v5` feature

## Test Plan

- `cargo test -p smg` green; `cargo clippy --all-targets --all-features -- -D warnings` clean.
- New: `deterministic_ids_survive_reregistration` (register→remove→re-register → same id; reservations agree), `derived_ids_differ_across_nodes_and_urls` (incl. the byte-shifting collision case), `random_ids_without_namespace` (mesh-off unchanged), `start_installs_deterministic_worker_ids` (wiring), `reconcile_reasserts_local_state_over_stale_store_value` (the shadow fix).
- Adversarially reviewed (correctness + design lenses): the one confirmed must-fix is fixed in-PR; both minors are disclosed above.

> Stacked on #1667 (uses its `store_matches`); retarget to `main` after it merges.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic mesh server identity derived from the advertised address when no name is provided.
  * Added deterministic worker ID derivation from the node name and worker URL to keep reserved IDs stable across restarts.
* **Improvements**
  * Mesh startup now initializes a worker ID namespace before adapter initialization to ensure consistent identity.
* **Bug Fixes**
  * Reconciliation now detects divergence for locally owned workers and re-asserts the live local state when the stored value is stale.
* **Tests**
  * Added coverage for stale local worker re-assertion and deterministic worker ID reservation/re-registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->