### PR TITLE
fix(messages): Anthropic messages API, preserve system "text" and unknown fields

### DIFF
--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use validator::Validate;
 
 use crate::{common::GenerationRequest, validated::Normalizable};
@@ -73,6 +73,11 @@ pub struct CreateMessageRequest {
 
     /// MCP servers to be utilized in this request (beta).
     pub mcp_servers: Option<Vec<McpServerConfig>>,
+
+    /// Additional fields not explicitly defined above (e.g. beta features like
+    /// context_management, output_config). Captured and forwarded to backends.
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 impl Normalizable for CreateMessageRequest {
@@ -134,7 +139,8 @@ impl GenerationRequest for CreateMessageRequest {
                 SystemContent::String(s) => push(s, &mut has_content, &mut buffer),
                 SystemContent::Blocks(blocks) => {
                     for block in blocks {
-                        push(&block.text, &mut has_content, &mut buffer);
+                        let SystemContentBlock::Text(text_block) = block;
+                        push(&text_block.text, &mut has_content, &mut buffer);
                     }
                 }
             }
@@ -246,7 +252,15 @@ pub enum ServiceTier {
 #[serde(untagged)]
 pub enum SystemContent {
     String(String),
-    Blocks(Vec<TextBlock>),
+    Blocks(Vec<SystemContentBlock>),
+}
+
+/// System content block — wraps TextBlock with the required `type` discriminator
+/// so it round-trips correctly through serialization.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SystemContentBlock {
+    Text(TextBlock),
 }
 
 /// A single input message in a conversation
@@ -1886,9 +1900,90 @@ pub enum ServerToolCaller {
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
+    use serde_json::{self, json};
 
     use super::*;
+
+    #[test]
+    fn test_system_blocks_preserve_type_field() {
+        let input = json!({
+            "model": "test",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "system": [
+                {"type": "text", "text": "system prompt", "cache_control": {"type": "ephemeral"}}
+            ]
+        });
+
+        let req: CreateMessageRequest = serde_json::from_value(input).expect("should deserialize");
+        let reserialized = serde_json::to_value(&req).expect("should serialize");
+
+        let system_blocks = reserialized.get("system").unwrap().as_array().unwrap();
+        let first_block = &system_blocks[0];
+        assert_eq!(
+            first_block.get("type").and_then(|v| v.as_str()),
+            Some("text"),
+            "system block must retain 'type' field after round-trip: got {first_block:?}",
+        );
+    }
+
+    #[test]
+    fn test_message_content_blocks_preserve_type_field() {
+        let input = json!({
+            "model": "test",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}}
+                ]
+            }],
+            "max_tokens": 100
+        });
+
+        let req: CreateMessageRequest = serde_json::from_value(input).expect("should deserialize");
+        let reserialized = serde_json::to_value(&req).expect("should serialize");
+
+        let msg = &reserialized["messages"][0];
+        let content_blocks = msg["content"].as_array().unwrap();
+        let first_block = &content_blocks[0];
+        assert_eq!(
+            first_block.get("type").and_then(|v| v.as_str()),
+            Some("text"),
+            "content block must retain 'type' field: got {first_block:?}",
+        );
+    }
+
+    #[test]
+    fn test_unknown_fields_preserved_via_flatten() {
+        let input = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 100,
+            "thinking": {"type": "adaptive"},
+            "context_management": {"edits": [{"type": "clear_thinking", "keep": "all"}]},
+            "output_config": {"effort": "high"},
+            "stream": true
+        });
+
+        let req: CreateMessageRequest =
+            serde_json::from_value(input.clone()).expect("should deserialize");
+        assert!(matches!(
+            req.thinking,
+            Some(ThinkingConfig::Adaptive { .. })
+        ));
+
+        let reserialized = serde_json::to_value(&req).expect("should serialize");
+        assert_eq!(
+            reserialized.get("context_management"),
+            input.get("context_management"),
+            "context_management must survive round-trip"
+        );
+        assert_eq!(
+            reserialized.get("output_config"),
+            input.get("output_config"),
+            "output_config must survive round-trip"
+        );
+    }
 
     fn base_request() -> CreateMessageRequest {
         CreateMessageRequest {
@@ -1911,6 +2006,7 @@ mod tests {
             top_p: None,
             container: None,
             mcp_servers: None,
+            other: Map::new(),
         }
     }
 

--- a/model_gateway/src/routers/grpc/utils/message_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/message_utils.rs
@@ -50,7 +50,10 @@ pub fn process_messages(
             SystemContent::String(s) => s.clone(),
             SystemContent::Blocks(blocks) => blocks
                 .iter()
-                .map(|b| b.text.as_str())
+                .map(|b| {
+                    let messages::SystemContentBlock::Text(tb) = b;
+                    tb.text.as_str()
+                })
                 .collect::<Vec<_>>()
                 .join("\n"),
         };
@@ -649,6 +652,7 @@ mod tests {
             top_p: None,
             container: None,
             mcp_servers: None,
+            other: serde_json::Map::new(),
         };
         assert_eq!(get_history_tool_calls_count_messages(&request), 0);
 
@@ -697,6 +701,7 @@ mod tests {
             top_p: None,
             container: None,
             mcp_servers: None,
+            other: serde_json::Map::new(),
         };
         assert_eq!(get_history_tool_calls_count_messages(&request), 2);
     }


### PR DESCRIPTION
## Description

### Problem

When smg proxies /v1/messages requests, it deserializes then re-serializes the body. Two issues caused the re-serialized payload to diverge from the original:

1. System content blocks lost their `type: "text"` discriminator because `SystemContent::Blocks` used `Vec<TextBlock>` directly and `TextBlock` has no `type` field. Backends (e.g. sglang) that validate the discriminator rejected the forwarded request. Fix: wrap `TextBlock` in a new `SystemContentBlock` tagged enum so `type` is emitted on serialization.

2. Unknown/beta Anthropic API fields (`context_management`, `output_config`, etc.) were silently dropped because `CreateMessageRequest` lacked a `#[serde(flatten)]` catch-all. Fix: add `other: Map<String, Value>` with flatten, matching the existing pattern in `ChatCompletionRequest`.

### Solution

This fixes the round-trip for those fields and adds tests.

## Changes

- Added `text` to round-trip of system content block so the type field is not dropped.
- Added a catch-all for unknown fields that aren't handled yet, so they can be forwarded safely to the HTTP backend.
- Ran `cargo +nightly fmt` and `cargo clippy --all-targets`

## Test Plan

- Added tests for both behaviors (regression tests)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and preservation of system content blocks during message processing and serialization round-trips.
  * Enhanced system prompt extraction logic to properly support typed content blocks.

* **Tests**
  * Expanded test coverage to verify preservation of content type information across serialization cycles and proper handling of message fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->