### PR TITLE
perf(mesh): bound op-log memory at O(live keys) and share round snapshots

### DIFF
--- a/crates/mesh/src/crdt_kv/crdt.rs
+++ b/crates/mesh/src/crdt_kv/crdt.rs
@@ -225,11 +225,14 @@ impl CrdtOrMap {
     /// the cached snapshot newer than its key, forcing one extra rebuild —
     /// never a stale serve, since every mutation strictly increases the sum.
     pub fn operation_log_snapshot(&self) -> Arc<OperationLog> {
-        let generation: u64 = self
-            .all_engines()
+        // Sum over the engine table directly: `all_engines` would allocate a
+        // Vec of handles on every 1 Hz round just to read the counters.
+        let engines = self.engines_snapshot();
+        let generation: u64 = engines
             .iter()
-            .map(|engine| engine.op_generation())
-            .sum();
+            .map(|(_, engine)| engine.op_generation())
+            .sum::<u64>()
+            + self.default_engine.op_generation();
         if let Some((cached_gen, snapshot)) = self.op_snapshot.read().as_ref() {
             if *cached_gen == generation {
                 return Arc::clone(snapshot);

--- a/crates/mesh/src/crdt_kv/crdt.rs
+++ b/crates/mesh/src/crdt_kv/crdt.rs
@@ -48,7 +48,14 @@ pub struct CrdtOrMap {
     /// two op-id-colliding ops into one engine deduplicates them.
     clock: Arc<LamportClock>,
     replica_id: ReplicaId,
+    /// Cached gossip snapshot keyed by the sum of engine op-generations.
+    /// Rounds with no log mutations share one `Arc` instead of deep-cloning
+    /// every op (the log carries full values) once per second.
+    op_snapshot: OpSnapshotCache,
 }
+
+/// `(generation, snapshot)` cache slot for [`CrdtOrMap::operation_log_snapshot`].
+type OpSnapshotCache = Arc<RwLock<Option<(u64, Arc<OperationLog>)>>>;
 
 impl CrdtOrMap {
     pub fn new() -> Self {
@@ -63,6 +70,7 @@ impl CrdtOrMap {
             default_engine: Arc::new(LwwEngine::new(replica_id, Arc::clone(&clock))),
             clock,
             replica_id,
+            op_snapshot: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -208,6 +216,28 @@ impl CrdtOrMap {
             ops.extend(engine.export_ops());
         }
         OperationLog::from_operations(ops)
+    }
+
+    /// Shared gossip snapshot of the operation log. Rebuilt only when some
+    /// engine's log mutated since the cached build; unchanged rounds return
+    /// the same `Arc` (an idle node's 1 Hz round clones nothing). A racing
+    /// mutation between the generation read and the rebuild can only make
+    /// the cached snapshot newer than its key, forcing one extra rebuild —
+    /// never a stale serve, since every mutation strictly increases the sum.
+    pub fn operation_log_snapshot(&self) -> Arc<OperationLog> {
+        let generation: u64 = self
+            .all_engines()
+            .iter()
+            .map(|engine| engine.op_generation())
+            .sum();
+        if let Some((cached_gen, snapshot)) = self.op_snapshot.read().as_ref() {
+            if *cached_gen == generation {
+                return Arc::clone(snapshot);
+            }
+        }
+        let fresh = Arc::new(self.get_operation_log());
+        *self.op_snapshot.write() = Some((generation, Arc::clone(&fresh)));
+        fresh
     }
 
     /// Merge an incoming operation log. Groups ops by destination engine

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -12,7 +12,10 @@
 //! - an [`OperationLog`] for replication
 
 use std::{
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -88,6 +91,9 @@ pub(crate) struct LwwEngine {
     metadata: Arc<DashMap<String, Vec<ValueMetadata>>>,
     key_locks: Arc<DashMap<String, Arc<Mutex<()>>>>,
     log: Arc<RwLock<OperationLog>>,
+    /// Bumped on every log mutation (including relay-only appends);
+    /// invalidation key for shared op-log snapshots.
+    op_generation: Arc<AtomicU64>,
     clock: Arc<LamportClock>,
     replica_id: ReplicaId,
 }
@@ -99,9 +105,17 @@ impl LwwEngine {
             metadata: Arc::new(DashMap::new()),
             key_locks: Arc::new(DashMap::new()),
             log: Arc::new(RwLock::new(OperationLog::new())),
+            op_generation: Arc::new(AtomicU64::new(0)),
             clock,
             replica_id,
         }
+    }
+
+    /// Compact once the log carries more than twice the live key count
+    /// (min 64): a compacted log holds one op per key, so this bounds
+    /// resident log memory at O(keys) while amortizing the fold.
+    fn compact_trigger(&self) -> usize {
+        (self.metadata.len() * 2).max(64)
     }
 
     fn key_lock_for(&self, key: &str) -> Arc<Mutex<()>> {
@@ -233,7 +247,8 @@ impl LwwEngine {
     fn append_op(&self, op: Operation) {
         let mut log = self.log.write();
         log.append(op);
-        if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
+        self.op_generation.fetch_add(1, Ordering::Release);
+        if log.len() > self.compact_trigger() {
             Self::compact_log(&mut log);
             // Local-write path only: dropping oldest on the remote-merge path
             // would shed remotely-learned keys (see the helper's docs).
@@ -335,6 +350,10 @@ impl NamespaceCrdtEngine for LwwEngine {
         self.store.generation()
     }
 
+    fn op_generation(&self) -> u64 {
+        self.op_generation.load(Ordering::Acquire)
+    }
+
     fn export_ops(&self) -> Vec<Operation> {
         self.log.read().operations().to_vec()
     }
@@ -393,6 +412,7 @@ impl NamespaceCrdtEngine for LwwEngine {
                 log.append(op.clone());
             }
             Self::compact_log(&mut log);
+            self.op_generation.fetch_add(1, Ordering::Release);
         }
 
         // Snapshot the observable value of every key this batch touches before

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -467,6 +467,9 @@ impl NamespaceCrdtEngine for LwwEngine {
     fn gc_tombstones(&self, grace: Duration) -> usize {
         let now = Instant::now();
         let mut removed = 0;
+        // Collected keys' winning tombstone versions, for the log purge below.
+        let mut purged: std::collections::HashMap<String, (u64, ReplicaId)> =
+            std::collections::HashMap::new();
         let keys_to_check: Vec<String> = self
             .metadata
             .iter()
@@ -491,9 +494,25 @@ impl NamespaceCrdtEngine for LwwEngine {
                                 && now.saturating_duration_since(winner.created_at) >= grace
                         })
             });
-            if was_removed.is_some() {
+            if let Some((key, versions)) = was_removed {
                 removed += 1;
+                if let Some(winner) = versions.iter().max_by_key(|v| v.version_key()) {
+                    purged.insert(key, winner.version_key());
+                }
             }
+        }
+        if !purged.is_empty() {
+            // Purge the collected keys' dominated ops so log size keeps
+            // tracking metadata (the compaction trigger) and dead tombstones
+            // stop gossiping. Newer concurrent ops for a reused key survive
+            // the version filter.
+            let mut log = self.log.write();
+            log.retain_ops(|op| {
+                purged
+                    .get(op.key())
+                    .is_none_or(|gc_version| (op.timestamp(), op.replica_id()) > *gc_version)
+            });
+            self.op_generation.fetch_add(1, Ordering::Release);
         }
         removed
     }

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -248,7 +248,9 @@ impl LwwEngine {
         let mut log = self.log.write();
         log.append(op);
         self.op_generation.fetch_add(1, Ordering::Release);
-        if log.len() > self.compact_trigger() {
+        // The trigger floor is 64, so a short log skips the DashMap len()
+        // (an O(shards) scan) on this per-write path.
+        if log.len() > 64 && log.len() > self.compact_trigger() {
             Self::compact_log(&mut log);
             // Local-write path only: dropping oldest on the remote-merge path
             // would shed remotely-learned keys (see the helper's docs).

--- a/crates/mesh/src/crdt_kv/engine/mod.rs
+++ b/crates/mesh/src/crdt_kv/engine/mod.rs
@@ -89,8 +89,9 @@ pub(super) trait NamespaceCrdtEngine: Send + Sync {
 
     // ---- Maintenance ----
 
-    /// Garbage-collect tombstones older than `grace`. Returns the number of
-    /// metadata entries removed.
+    /// Garbage-collect tombstones older than `grace`, purging the collected
+    /// keys' dominated ops from the operation log so log size keeps tracking
+    /// the key population. Returns the number of metadata entries removed.
     fn gc_tombstones(&self, grace: Duration) -> usize;
 }
 

--- a/crates/mesh/src/crdt_kv/engine/mod.rs
+++ b/crates/mesh/src/crdt_kv/engine/mod.rs
@@ -58,6 +58,12 @@ pub(super) trait NamespaceCrdtEngine: Send + Sync {
     /// local or remote write that changes live state.
     fn generation(&self) -> u64;
 
+    /// Monotonically increasing op-log mutation counter. Unlike
+    /// [`Self::generation`], this also covers log-only mutations (a losing
+    /// remote op is appended for relay without changing live state), so it
+    /// is the correct invalidation key for shared op-log snapshots.
+    fn op_generation(&self) -> u64;
+
     // ---- Replication ----
 
     /// Snapshot every operation this engine has retained, in deterministic

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -391,6 +391,7 @@ impl NamespaceCrdtEngine for RateLimitEngine {
                 log.append(op.clone());
             }
             Self::compact_log(&mut log);
+            self.op_generation.fetch_add(1, Ordering::Release);
         }
 
         // Snapshot the observable (encoded-live) value of every key this batch

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -76,7 +76,9 @@ impl RateLimitEngine {
         let mut log = self.log.write();
         log.append(op);
         self.op_generation.fetch_add(1, Ordering::Release);
-        if log.len() > self.compact_trigger() {
+        // The trigger floor is 64, so a short log skips the DashMap len()
+        // (an O(shards) scan) on this per-write path.
+        if log.len() > 64 && log.len() > self.compact_trigger() {
             Self::compact_log(&mut log);
             // Local-write path only: dropping oldest on the remote-merge path
             // would shed remotely-learned shards (see the helper's docs).

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -48,6 +48,9 @@ pub(crate) struct RateLimitEngine {
     clock: Arc<LamportClock>,
     replica_id: ReplicaId,
     generation: AtomicU64,
+    /// Bumped on every log mutation; invalidation key for shared op-log
+    /// snapshots.
+    op_generation: AtomicU64,
 }
 
 impl RateLimitEngine {
@@ -58,13 +61,22 @@ impl RateLimitEngine {
             clock,
             replica_id,
             generation: AtomicU64::new(0),
+            op_generation: AtomicU64::new(0),
         }
+    }
+
+    /// Compact once the log carries more than twice the shard count
+    /// (min 64): a compacted log holds one op per key, so this bounds
+    /// resident log memory at O(keys) while amortizing the fold.
+    fn compact_trigger(&self) -> usize {
+        (self.entries.len() * 2).max(64)
     }
 
     fn append_op(&self, op: Operation) {
         let mut log = self.log.write();
         log.append(op);
-        if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
+        self.op_generation.fetch_add(1, Ordering::Release);
+        if log.len() > self.compact_trigger() {
             Self::compact_log(&mut log);
             // Local-write path only: dropping oldest on the remote-merge path
             // would shed remotely-learned shards (see the helper's docs).
@@ -340,6 +352,10 @@ impl NamespaceCrdtEngine for RateLimitEngine {
 
     fn generation(&self) -> u64 {
         self.generation.load(Ordering::Acquire)
+    }
+
+    fn op_generation(&self) -> u64 {
+        self.op_generation.load(Ordering::Acquire)
     }
 
     fn export_ops(&self) -> Vec<Operation> {

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -462,6 +462,9 @@ impl NamespaceCrdtEngine for RateLimitEngine {
             .collect();
 
         let mut removed = 0;
+        // Collected keys' winning tombstone versions, for the log purge below.
+        let mut purged: std::collections::HashMap<String, RateLimitVersion> =
+            std::collections::HashMap::new();
         for key in candidates {
             let was_removed = self.entries.remove_if(&key, |_, entry| {
                 matches!(&entry.state, RateLimitState::Tombstone(_))
@@ -469,9 +472,25 @@ impl NamespaceCrdtEngine for RateLimitEngine {
                         .tombstoned_at
                         .is_some_and(|at| now.saturating_duration_since(at) >= grace)
             });
-            if was_removed.is_some() {
+            if let Some((key, entry)) = was_removed {
                 removed += 1;
+                if let RateLimitState::Tombstone(version) = entry.state {
+                    purged.insert(key, version);
+                }
             }
+        }
+        if !purged.is_empty() {
+            // Purge the collected keys' dominated ops so log size keeps
+            // tracking the entry count (the compaction trigger) and dead
+            // tombstones stop gossiping. Newer concurrent ops for a reused
+            // key survive the version filter.
+            let mut log = self.log.write();
+            log.retain_ops(|op| {
+                purged.get(op.key()).is_none_or(|tombstone| {
+                    RateLimitVersion::new(op.timestamp(), op.replica_id()) > *tombstone
+                })
+            });
+            self.op_generation.fetch_add(1, Ordering::Release);
         }
         removed
     }

--- a/crates/mesh/src/crdt_kv/operation.rs
+++ b/crates/mesh/src/crdt_kv/operation.rs
@@ -154,6 +154,12 @@ impl OperationLog {
         drain_count
     }
 
+    /// Drop every operation for which `keep` returns `false`. Used by
+    /// tombstone GC to purge collected keys' dominated ops from the log.
+    pub(super) fn retain_ops(&mut self, keep: impl FnMut(&Operation) -> bool) {
+        self.operations.retain(keep);
+    }
+
     /// Serialize to bincode bytes.
     pub fn to_bytes(&self) -> Result<Vec<u8>, Box<bincode::ErrorKind>> {
         bincode::serialize(self)

--- a/crates/mesh/src/crdt_kv/tests.rs
+++ b/crates/mesh/src/crdt_kv/tests.rs
@@ -1430,6 +1430,58 @@ fn test_gc_tombstones_does_not_remove_live_keys() {
 }
 
 #[test]
+fn test_gc_purges_collected_keys_ops_from_log() {
+    // GC must reclaim the log too: leaving the collected keys' Remove ops
+    // behind would let dead tombstones gossip forever and let the compacted
+    // log sit permanently above the size-tracking compaction trigger.
+    init_test_logging();
+    let map = CrdtOrMap::new();
+
+    map.insert("key1".to_string(), b"v1".to_vec());
+    map.insert("key2".to_string(), b"v2".to_vec());
+    map.remove("key1");
+
+    let removed = map.gc_tombstones_with_grace(Duration::ZERO);
+    assert_eq!(removed, 1);
+    let log = map.get_operation_log();
+    assert!(
+        log.operations().iter().all(|op| op.key() != "key1"),
+        "GC'd key's ops must leave the log"
+    );
+    assert!(
+        log.operations().iter().any(|op| op.key() == "key2"),
+        "live keys' ops stay"
+    );
+}
+
+#[test]
+fn test_epoch_max_wins_gc_purges_collected_keys_ops_from_log() {
+    init_test_logging();
+    let replica = CrdtOrMap::new();
+    replica.register_merge_strategy("rl:".to_string(), MergeStrategy::EpochMaxWins);
+
+    replica.insert("rl:global:node-a".to_string(), encode(1, 1).to_vec());
+    replica.insert("rl:global:node-b".to_string(), encode(1, 2).to_vec());
+    replica.remove("rl:global:node-a");
+
+    let removed = replica.gc_tombstones_with_grace(Duration::ZERO);
+    assert_eq!(removed, 1);
+    let log = replica.get_operation_log();
+    assert!(
+        log.operations()
+            .iter()
+            .all(|op| op.key() != "rl:global:node-a"),
+        "GC'd key's ops must leave the log"
+    );
+    assert!(
+        log.operations()
+            .iter()
+            .any(|op| op.key() == "rl:global:node-b"),
+        "live keys' ops stay"
+    );
+}
+
+#[test]
 fn test_gc_tombstones_multiple_keys() {
     init_test_logging();
     let map = CrdtOrMap::new();

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -538,6 +538,7 @@ impl GossipController {
                                 let acked = acked_incremental.read();
                                 stream_batch
                                     .crdt_ops
+                                    .operations()
                                     .iter()
                                     .filter(|op| acked.allows(op))
                                     .cloned()

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -338,6 +338,7 @@ impl Gossip for GossipService {
                         let acked = acked_sender.read();
                         stream_batch
                             .crdt_ops
+                            .operations()
                             .iter()
                             .filter(|op| acked.allows(op))
                             .cloned()
@@ -546,7 +547,7 @@ mod sender_tick_tests {
                 .into_iter()
                 .map(|(t, k, v)| (t.to_string(), k.to_string(), Bytes::copy_from_slice(v)))
                 .collect(),
-            crdt_ops: Vec::new(),
+            crdt_ops: Arc::default(),
         })
     }
 

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -434,10 +434,11 @@ pub struct RoundBatch {
     /// Values are `Bytes` so per-peer senders clone by Arc-refcount bump when
     /// fanning out, not by a full heap copy per peer.
     pub drain_entries: Vec<(String, Bytes)>,
-    /// Snapshot of the CRDT operation log for this round. Broadcast in full to
-    /// every peer; merge is idempotent by op-id so re-sending seen ops is a
-    /// no-op. Per-peer watermark filtering is a follow-up.
-    pub crdt_ops: Vec<Operation>,
+    /// Shared snapshot of the CRDT operation log for this round. The `Arc`
+    /// is reused across rounds while no engine's log mutates, so idle
+    /// rounds clone no op data; per-peer senders filter it through their
+    /// send watermarks. Merge is idempotent by op-id.
+    pub crdt_ops: Arc<OperationLog>,
 }
 
 /// Generic, application-agnostic mesh transport. Provides explicit namespace
@@ -654,9 +655,9 @@ impl MeshKV {
         // Broadcast traffic (td:*) flows through this path.
         let drain_entries = self.drain_registry.drain_all();
 
-        // Snapshot the CRDT op-log so the per-peer senders can broadcast it
-        // alongside the stream traffic this round.
-        let crdt_ops = self.store.get_operation_log().operations().to_vec();
+        // Shared CRDT op-log snapshot for the per-peer senders; reused
+        // across rounds while no engine's log mutates.
+        let crdt_ops = self.store.operation_log_snapshot();
 
         RoundBatch {
             targeted_entries,

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -10,6 +10,8 @@
 //! we bypass prost and route the ops directly, matching the chunking
 //! integration tests.
 
+use std::sync::Arc;
+
 use bytes::Bytes;
 use tokio::sync::mpsc::error::TryRecvError;
 
@@ -29,7 +31,7 @@ use crate::{
 /// encode it into size-bounded batches, and dispatch each into the receiver.
 fn deliver_crdt(sender: &MeshKV, receiver: &MeshKV) {
     let ops = sender.collect_round_batch().crdt_ops;
-    for batch in build_crdt_batches(&ops, MAX_STREAM_CHUNK_BYTES) {
+    for batch in build_crdt_batches(ops.operations(), MAX_STREAM_CHUNK_BYTES) {
         dispatch_crdt_batch(receiver, batch);
     }
 }
@@ -40,8 +42,10 @@ fn pending_ops(sender: &MeshKV, acked: &CrdtWatermark) -> Vec<crate::crdt_kv::Op
     sender
         .collect_round_batch()
         .crdt_ops
-        .into_iter()
+        .operations()
+        .iter()
         .filter(|op| acked.allows(op))
+        .cloned()
         .collect()
 }
 
@@ -187,6 +191,53 @@ async fn remote_tombstone_after_insert_notifies_none() {
     assert_eq!(key, "worker:a");
     assert!(payload.is_none(), "tombstone notifies None");
     assert_eq!(r_ns.get("worker:a"), None);
+}
+
+#[test]
+fn round_batch_snapshot_is_shared_until_write() {
+    // Idle rounds must not deep-clone the op log: the same Arc is served
+    // until some engine's log mutates.
+    let mesh = MeshKV::new("node-a".to_string());
+    let ns = mesh.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    ns.put("worker:a", b"v1".to_vec());
+
+    let first = mesh.collect_round_batch().crdt_ops;
+    let second = mesh.collect_round_batch().crdt_ops;
+    assert!(
+        Arc::ptr_eq(&first, &second),
+        "no writes between rounds: the snapshot Arc is reused"
+    );
+
+    ns.put("worker:b", b"v2".to_vec());
+    let third = mesh.collect_round_batch().crdt_ops;
+    assert!(
+        !Arc::ptr_eq(&second, &third),
+        "a write invalidates the cached snapshot"
+    );
+    assert!(third.operations().iter().any(|op| op.key() == "worker:b"));
+}
+
+#[test]
+fn op_log_stays_bounded_by_live_keys() {
+    // 500 updates to one key previously accumulated 500 ops (full values)
+    // until the flat 10k threshold; the adaptive trigger folds the log so
+    // resident size tracks live keys, not write count.
+    let mesh = MeshKV::new("node-a".to_string());
+    let ns = mesh.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    for i in 0..500u32 {
+        ns.put("worker:hot", i.to_be_bytes().to_vec());
+    }
+    let ops = mesh.collect_round_batch().crdt_ops;
+    assert!(
+        ops.operations().len() <= 65,
+        "log must stay bounded by live keys, got {}",
+        ops.operations().len()
+    );
+    assert_eq!(
+        ns.get("worker:hot"),
+        Some(499u32.to_be_bytes().to_vec()),
+        "compaction keeps the latest value"
+    );
 }
 
 #[test]

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -218,6 +218,35 @@ fn round_batch_snapshot_is_shared_until_write() {
 }
 
 #[test]
+fn relayed_rl_merge_invalidates_round_batch_snapshot() {
+    // A relay node with no local writes must still re-gossip remotely merged
+    // rl ops: the remote merge bumps op_generation, invalidating the cached
+    // snapshot so the next round's batch carries the learned ops.
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+
+    let relay = MeshKV::new("relay".to_string());
+    relay.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+
+    let before = relay.collect_round_batch().crdt_ops;
+    s_ns.put("rl:global:node-a", encode_epoch_count(1, 5).to_vec());
+    deliver_crdt(&sender, &relay);
+
+    let after = relay.collect_round_batch().crdt_ops;
+    assert!(
+        !Arc::ptr_eq(&before, &after),
+        "a remote rl merge invalidates the cached snapshot"
+    );
+    assert!(
+        after
+            .operations()
+            .iter()
+            .any(|op| op.key() == "rl:global:node-a"),
+        "the relay's outgoing batch carries the merged rl op"
+    );
+}
+
+#[test]
 fn op_log_stays_bounded_by_live_keys() {
     // 500 updates to one key previously accumulated 500 ops (full values)
     // until the flat 10k threshold; the adaptive trigger folds the log so

--- a/crates/mesh/src/transport/sync_stream.rs
+++ b/crates/mesh/src/transport/sync_stream.rs
@@ -163,7 +163,7 @@ mod tests {
                 .into_iter()
                 .map(|(t, k, v)| (t.to_string(), k.to_string(), Bytes::copy_from_slice(v)))
                 .collect(),
-            crdt_ops: Vec::new(),
+            crdt_ops: Default::default(),
         }
     }
 


### PR DESCRIPTION
## Description

### Problem

The CRDT op-log retained full values with only a flat 10k-op truncation backstop, and every 1s gossip round deep-cloned the entire log (`operations().to_vec()`) even when idle. At 1k workers × ~1.5KB states that is a log peaking at ~15MB and ~15MB/s of steady-state allocation churn (with the previous round's clone still pinned by per-peer senders, ~30–45MB transient) — on a path whose contract is bounded memory.

### Solution

Two halves, one per concern:

**Adaptive compaction (resident log is O(live keys)).** Each engine tracks a per-engine `op_generation` counter and compacts once the log exceeds `2 × key-count` (floor 64). A compacted log holds one op per key, so resident size tracks the key population instead of the write count; the 10k truncate-oldest backstop is unchanged. Hot-key math: M uniform keys compact every ~M writes over an ~2M-op log — amortized O(log M) comparisons and ~2 op-clones per write.

**Arc-cached round snapshots (idle rounds clone nothing).** `CrdtOrMap::operation_log_snapshot()` caches an `Arc<OperationLog>` keyed on the summed engine `op_generation`s; `RoundBatch.crdt_ops` becomes an `Arc`. An idle round costs one RwLock read + per-engine atomic loads + an Arc clone. The cache-rebuild race can only key a *newer* snapshot under an older generation (one redundant rebuild, never a stale serve).

**Found by adversarial review, fixed in-PR:**
- `RateLimitEngine::apply_remote_ops` mutated the log without bumping `op_generation`, so a relay node with no local writes served its stale cached snapshot forever — never re-gossiping merged rl ops and stalling transitive EpochMaxWins propagation through quiet nodes.
- Tombstone GC removed keys from metadata while leaving their Remove ops in the log, so the compacted log could sit permanently above the now-map-sized trigger (full-log fold on every local append) and dead tombstones gossiped forever. GC now purges each collected key's ops at or below its winning tombstone version — sound under GC's documented causal-stability precondition, and newer ops for a reused key survive the filter.

### Known limitations (disclosed by review, accepted)

- The snapshot cache slot is never cleared: resident op-log memory is engine logs + one cached snapshot (~2× the compacted log, ~+1.5–3MB at the 1k-worker scale; ~3× transiently during a rebuild). Bounded, and strictly less retention than the per-round clones it replaces.
- Pre-existing (not introduced here): EpochMaxWins compaction can rewrite a folded payload at an unchanged op-id, which the per-key ack watermark then filters — only reachable via encoded-shard `put_local` payloads no production code writes today.

## Changes

- `crates/mesh/src/crdt_kv/engine/mod.rs` — trait gains `op_generation()`; `gc_tombstones` contract now includes the log purge
- `crates/mesh/src/crdt_kv/engine/lww.rs`, `engine/rate_limit.rs` — adaptive `compact_trigger`, `op_generation` bumps on every log mutation (local append, remote merge, GC purge), GC log purge
- `crates/mesh/src/crdt_kv/operation.rs` — `retain_ops` helper
- `crates/mesh/src/crdt_kv/crdt.rs` — generation-keyed `Arc<OperationLog>` snapshot cache
- `crates/mesh/src/kv.rs` — `RoundBatch.crdt_ops: Arc<OperationLog>`; round collection uses the cached snapshot
- `crates/mesh/src/gossip_controller.rs`, `gossip_service.rs`, `transport/sync_stream.rs` — consume the shared snapshot

## Test Plan

- `cargo test -p smg-mesh` green (191 tests); `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- New: `op_log_stays_bounded_by_live_keys` (500 hot-key writes → ≤65 resident ops, latest value kept), `round_batch_snapshot_is_shared_until_write` (idle rounds reuse the Arc; a write invalidates), `relayed_rl_merge_invalidates_round_batch_snapshot` (the relay-staleness regression), `test_gc_purges_collected_keys_ops_from_log` + EpochMaxWins twin (GC reclaims the log, live keys' ops stay), `gc_tombstones_respects_grace_through_mesh_kv`.
- Adversarially reviewed (correctness + memory/perf lenses, independent refuters): both confirmed must-fixes are fixed in-PR; the review's quantified memory model (before ~15MB + per-round clones → after ~1.5–3MB with sender retention bounded at #peers + 2 snapshots) is reflected above.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Operation-log snapshot caching to reduce per-round work and lower gossip sync overhead
  * Dynamic compaction thresholds that adapt to metadata size for improved resource efficiency
  * Enhanced tombstone garbage collection that purges dominated operations to shrink logs and memory usage
* **Tests**
  * New regression tests verifying snapshot reuse, invalidation, and GC behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->