### PR TITLE
feat(gateway): Filter /workers by model

### DIFF
--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -620,8 +620,21 @@ async fn create_worker(
     }
 }
 
-async fn list_workers_rest(State(state): State<Arc<AppState>>) -> Response {
-    state.context.worker_service.list_workers().into_response()
+#[derive(serde::Deserialize)]
+struct ListWorkersQuery {
+    /// Only return workers serving this model, e.g. `?model=moonshotai/Kimi-K2.5`.
+    model: Option<String>,
+}
+
+async fn list_workers_rest(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ListWorkersQuery>,
+) -> Response {
+    state
+        .context
+        .worker_service
+        .list_workers(query.model.as_deref())
+        .into_response()
 }
 
 async fn get_worker(

--- a/model_gateway/src/worker/service.rs
+++ b/model_gateway/src/worker/service.rs
@@ -17,7 +17,7 @@ use tracing::warn;
 
 use crate::{
     config::RouterConfig,
-    worker::{registry::WorkerId, worker::worker_to_info, WorkerRegistry},
+    worker::{registry::WorkerId, worker::worker_to_info, WorkerRegistry, WorkerType},
     workflow::{Job, JobQueue},
 };
 
@@ -337,28 +337,40 @@ impl WorkerService {
         Ok(UpdateWorkerResult { worker_id, url })
     }
 
-    /// List all workers with their info. Building each `WorkerInfo` is cheap:
-    /// `WorkerSpec` is shared via `Arc`, so there is no per-worker spec deep
-    /// clone on this path.
-    pub fn list_workers(&self) -> ListWorkersResult {
-        let workers = self.worker_registry.get_all_with_ids();
-        let worker_infos: Vec<WorkerInfo> = workers
-            .iter()
-            .map(|(worker_id, worker)| {
-                let mut info = worker_to_info(worker);
-                info.id = worker_id.as_str().to_string();
-                info
-            })
-            .collect();
+    /// List all workers with their info, optionally filtered to workers
+    /// serving `model`. Building each `WorkerInfo` is cheap: `WorkerSpec`
+    /// is shared via `Arc`, so there is no per-worker spec deep clone.
+    ///
+    /// The counts reflect the returned (filtered) list, not the whole
+    /// registry.
+    pub fn list_workers(&self, model: Option<&str>) -> ListWorkersResult {
+        let mut worker_infos = Vec::new();
+        let mut prefill_count = 0;
+        let mut decode_count = 0;
+        let mut regular_count = 0;
 
-        let stats = self.worker_registry.stats();
+        for (worker_id, worker) in self.worker_registry.get_all_with_ids() {
+            if let Some(model) = model {
+                if !worker.supports_model(model) {
+                    continue;
+                }
+            }
+            match worker.worker_type() {
+                WorkerType::Prefill => prefill_count += 1,
+                WorkerType::Decode => decode_count += 1,
+                WorkerType::Regular => regular_count += 1,
+            }
+            let mut info = worker_to_info(&worker);
+            info.id = worker_id.as_str().to_string();
+            worker_infos.push(info);
+        }
 
         ListWorkersResult {
+            total: worker_infos.len(),
             workers: worker_infos,
-            total: stats.total_workers,
-            prefill_count: stats.prefill_workers,
-            decode_count: stats.decode_workers,
-            regular_count: stats.regular_workers,
+            prefill_count,
+            decode_count,
+            regular_count,
         }
     }
 
@@ -446,5 +458,83 @@ impl WorkerService {
             .map_err(|e| WorkerServiceError::QueueSubmitFailed { message: e })?;
 
         Ok(UpdateWorkerResult { worker_id, url })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::model_card::ModelCard;
+
+    use super::*;
+    use crate::worker::{BasicWorkerBuilder, WorkerType};
+
+    fn make_service(registry: Arc<WorkerRegistry>) -> WorkerService {
+        WorkerService::new(
+            registry,
+            Arc::new(std::sync::OnceLock::new()),
+            RouterConfig::default(),
+        )
+    }
+
+    fn register_worker(registry: &WorkerRegistry, url: &str, model: Option<&str>) {
+        let mut builder = BasicWorkerBuilder::new(url).worker_type(WorkerType::Regular);
+        if let Some(model) = model {
+            builder = builder.model(ModelCard::new(model));
+        }
+        registry.register(Arc::new(builder.build())).unwrap();
+    }
+
+    #[test]
+    fn test_list_workers_unfiltered_returns_all() {
+        let registry = Arc::new(WorkerRegistry::new());
+        register_worker(&registry, "http://kimi:30000", Some("moonshotai/Kimi-K2.5"));
+        register_worker(
+            &registry,
+            "http://llama:30000",
+            Some("meta-llama/Llama-3.1-8B"),
+        );
+        let service = make_service(registry);
+
+        let result = service.list_workers(None);
+        assert_eq!(result.workers.len(), 2);
+        assert_eq!(result.total, 2);
+        assert_eq!(result.regular_count, 2);
+    }
+
+    #[test]
+    fn test_list_workers_filters_by_model() {
+        let registry = Arc::new(WorkerRegistry::new());
+        register_worker(&registry, "http://kimi:30000", Some("moonshotai/Kimi-K2.5"));
+        register_worker(
+            &registry,
+            "http://llama:30000",
+            Some("meta-llama/Llama-3.1-8B"),
+        );
+        let service = make_service(registry);
+
+        let result = service.list_workers(Some("moonshotai/Kimi-K2.5"));
+        assert_eq!(result.workers.len(), 1);
+        assert_eq!(
+            result.workers[0].model_id.as_deref(),
+            Some("moonshotai/Kimi-K2.5")
+        );
+        assert_eq!(result.total, 1);
+        assert_eq!(result.regular_count, 1);
+
+        let result = service.list_workers(Some("no-such-model"));
+        assert!(result.workers.is_empty());
+        assert_eq!(result.total, 0);
+        assert_eq!(result.regular_count, 0);
+    }
+
+    #[test]
+    fn test_list_workers_wildcard_worker_matches_any_model() {
+        let registry = Arc::new(WorkerRegistry::new());
+        register_worker(&registry, "http://wildcard:30000", None);
+        let service = make_service(registry);
+
+        let result = service.list_workers(Some("moonshotai/Kimi-K2.5"));
+        assert_eq!(result.workers.len(), 1);
+        assert_eq!(result.total, 1);
     }
 }


### PR DESCRIPTION

## Description

### Problem

This allows you to filter the `GET /workers` by model ID, improving performance / reducing CPU overhead in gateways that serve many workers (~10 thousand with DP-aware) spread across ~100 models.


### Solution

`/workers` now takes a `?model=` query parameter that filters by workers. The output response schema is exactly the same as before, just filtered now. No performance impact as it's just a cheap check while iterating the list to construct the `Vec<WorkerInfo>` (already done)

## Changes

- Added filter to `/workers` endpoint
- Added tests

## Test Plan

- Added tests for existing `/workers` endpoint
- Added tests for filtering
- fmt and clippy run

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The /workers endpoint now supports an optional model query parameter so clients can request only workers that support a specific model, improving targeted discovery and reducing result noise.

* **Tests**
  * Added unit tests covering model-based filtering, wildcard worker matching, and unfiltered listing to ensure reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->