### PR TITLE
feat(grpc): DP-aware routing for vLLM gRPC workers (rank pinning + Mooncake DP mint)

### DIFF
--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -173,6 +173,9 @@ message GenerateRequest {
   // engine (e.g. NIXL's do_remote_prefill/remote_block_ids/remote_host/...).
   // Preferred over the legacy typed kv_transfer_params field.
   optional string kv_transfer_params_json = 8;
+
+  // DP rank to pin this request to; unset lets the engine balance internally
+  optional int32 data_parallel_rank = 9;
 }
 
 // KV cache transfer parameters for Mooncake PD disaggregation
@@ -334,6 +337,8 @@ message GetServerInfoResponse {
   string kv_connector = 6;  // "MooncakeConnector", "NixlConnector", "" if not configured
   string kv_role = 7;       // "kv_producer", "kv_consumer", "kv_both", "" if not configured
   string kv_engine_id = 8;  // kv_transfer_config.engine_id, "" if not configured
+
+  int32 data_parallel_size = 9;  // parallel_config.data_parallel_size (1 when DP is off)
 }
 
 // =====================

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -144,6 +144,7 @@ impl VllmEngineClient {
             stream: body.stream,
             kv_transfer_params: None,
             kv_transfer_params_json: None,
+            data_parallel_rank: None,
             mm_inputs,
         };
 
@@ -177,6 +178,7 @@ impl VllmEngineClient {
             stream: body.stream,
             kv_transfer_params: None,
             kv_transfer_params_json: None,
+            data_parallel_rank: None,
             mm_inputs: None,
         };
 
@@ -214,6 +216,7 @@ impl VllmEngineClient {
             stream: body.stream.unwrap_or(false),
             kv_transfer_params: None,
             kv_transfer_params_json: None,
+            data_parallel_rank: None,
             mm_inputs: None,
         };
 
@@ -430,6 +433,7 @@ impl VllmEngineClient {
             stream: body.stream.unwrap_or(false),
             kv_transfer_params: None,
             kv_transfer_params_json: None,
+            data_parallel_rank: None,
             mm_inputs: multimodal_inputs,
         };
 
@@ -493,6 +497,7 @@ impl VllmEngineClient {
             stream: body.stream,
             kv_transfer_params: None,
             kv_transfer_params_json: None,
+            data_parallel_rank: None,
             mm_inputs: None,
         };
 
@@ -814,6 +819,7 @@ mod tests {
             stream: false,
             kv_transfer_params: None,
             kv_transfer_params_json: None,
+            data_parallel_rank: None,
             mm_inputs: None,
         };
 

--- a/docs/getting-started/pd-disaggregation.md
+++ b/docs/getting-started/pd-disaggregation.md
@@ -152,10 +152,14 @@ the id once at worker registration; without a pinned id, vLLM generates a new
 one per process, so a restarted prefill container would invalidate the
 registered id until the worker is re-registered.
 
-Limitation: Mooncake PD requires the prefill workers to run without vLLM data
-parallelism (`data_parallel_size = 1`). With DP active the servicer reports no
-engine id and SMG falls back to legacy host/port injection (decode recomputes
-the prompt locally).
+With vLLM data parallelism (`data_parallel_size > 1`), run SMG with
+`--dp-aware`: SMG pins each request to a DP rank and mints the decode params
+with the matching `{engine_id}_dp{rank}` engine-core id. Without `--dp-aware`,
+DP>1 prefill workers are not minted for and SMG falls back to legacy host/port
+injection (decode recomputes the prompt locally). External-LB DP
+(`--data-parallel-external-lb`, one pod per rank) is unsupported for Mooncake
+minting: every pod's engine core is `{engine_id}_dp0`, so register pods as
+plain workers and pin a distinct `engine_id` per pod.
 
 ```bash
 smg \

--- a/e2e_test/conftest.py
+++ b/e2e_test/conftest.py
@@ -5,7 +5,7 @@ Markers
 @pytest.mark.model(name)
     Specify which model to use for the test.
 
-@pytest.mark.workers(count=1, prefill=None, decode=None)
+@pytest.mark.workers(count=1, prefill=None, decode=None, gpus=None, extra_engine_args=None)
     Configure worker topology for the test.
 
 @pytest.mark.gateway(policy="round_robin", timeout=None, extra_args=None)

--- a/e2e_test/fixtures/hooks.py
+++ b/e2e_test/fixtures/hooks.py
@@ -52,7 +52,8 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     config.addinivalue_line(
         "markers",
-        "workers(count=1, prefill=None, decode=None): worker topology configuration",
+        "workers(count=1, prefill=None, decode=None, gpus=None, extra_engine_args=None): "
+        "worker topology configuration",
     )
     config.addinivalue_line(
         "markers",

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -49,7 +49,13 @@ _GW_DEFAULTS = {
     "log_dir": None,
 }
 
-_WORKER_DEFAULTS = {"count": 1, "prefill": None, "decode": None}
+_WORKER_DEFAULTS = {
+    "count": 1,
+    "prefill": None,
+    "decode": None,
+    "gpus": None,
+    "extra_engine_args": None,
+}
 
 # Track worker startup failures — fail fast after repeated failures
 _worker_start_failures: dict[str, int] = {}  # engine -> count
@@ -106,6 +112,8 @@ def setup_backend(request: pytest.FixtureRequest):
     Configuration via markers:
       - ``@pytest.mark.model("model-id")``: Override default model
       - ``@pytest.mark.workers(count=1)``: Number of regular workers
+      - ``@pytest.mark.workers(gpus=2, extra_engine_args=[...])``: Per-worker
+        GPU count and extra engine CLI args (local workers only)
       - ``@pytest.mark.workers(prefill=1, decode=1)``: PD worker counts
       - ``@pytest.mark.gateway(policy=..., timeout=..., extra_args=...)``: Gateway config
 
@@ -205,6 +213,8 @@ def _setup_local(
         mode=connection_mode,
         count=num_workers,
         log_dir=log_dir,
+        gpus=workers_config.get("gpus"),
+        extra_engine_args=workers_config.get("extra_engine_args"),
     )
     try:
         _start_gateway(

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -45,6 +45,7 @@ class Worker:
     nixl_port: int | None = None
     ib_device: str | None = None
     log_dir: str | None = None
+    extra_engine_args: list[str] | None = None
     process: subprocess.Popen | None = field(default=None, repr=False)
     _log_file: IO[Any] | None = field(default=None, repr=False)
 
@@ -176,25 +177,29 @@ class Worker:
         features = spec.get("features", [])
 
         if self.engine == "sglang":
-            return self._build_sglang_cmd(model_path, tp_size, features, spec)
+            cmd = self._build_sglang_cmd(model_path, tp_size, features, spec)
         elif self.engine == "vllm":
             if self.mode == ConnectionMode.GRPC:
-                return self._build_vllm_grpc_cmd(model_path, tp_size, spec)
+                cmd = self._build_vllm_grpc_cmd(model_path, tp_size, spec)
             else:
-                return self._build_vllm_http_cmd(model_path, tp_size, spec)
+                cmd = self._build_vllm_http_cmd(model_path, tp_size, spec)
         elif self.engine == "trtllm":
-            return self._build_trtllm_cmd(model_path, tp_size, spec)
+            cmd = self._build_trtllm_cmd(model_path, tp_size, spec)
         elif self.engine == "mlx":
-            return self._build_mlx_cmd(model_path, spec)
+            cmd = self._build_mlx_cmd(model_path, spec)
         elif self.engine == "tokenspeed":
             if self.mode != ConnectionMode.GRPC:
                 raise ValueError(
                     "TokenSpeed e2e workers only support gRPC mode; "
                     "HTTP mode would go through the existing OpenAI frontend."
                 )
-            return self._build_tokenspeed_grpc_cmd(model_path, tp_size, spec)
+            cmd = self._build_tokenspeed_grpc_cmd(model_path, tp_size, spec)
         else:
             raise ValueError(f"Unsupported engine: {self.engine}")
+
+        if self.extra_engine_args:
+            cmd.extend(self.extra_engine_args)
+        return cmd
 
     def _build_sglang_cmd(
         self, model_path: str, tp_size: int, features: list[str], spec: dict
@@ -495,6 +500,8 @@ def start_workers(
     log_dir: str | None = None,
     gpu_offset: int = 0,
     wait_ready: bool = True,
+    gpus: int | None = None,
+    extra_engine_args: list[str] | None = None,
 ) -> list[Worker]:
     """Start N workers for a model. GPU IDs assigned sequentially.
 
@@ -510,6 +517,8 @@ def start_workers(
         gpu_offset: Starting GPU index for worker assignment.
         wait_ready: If True (default), block until each worker is healthy.
             If False, spawn processes and return immediately.
+        gpus: GPUs per worker; defaults to the model spec's tp (e.g. DP needs dp*tp).
+        extra_engine_args: Extra CLI args appended to the engine launch command.
 
     Returns:
         List of started Worker instances.
@@ -521,7 +530,7 @@ def start_workers(
         engine = get_runtime()
 
     spec = get_model_spec(model_id)
-    tp = spec.get("tp", 1)
+    gpus_per_worker = gpus or spec.get("tp", 1)
     timeout = spec.get("startup_timeout", timeout)
 
     # Detect IB device for PD workers
@@ -532,8 +541,8 @@ def start_workers(
 
     try:
         for i in range(count):
-            gpu_ids = list(range(gpu_offset, gpu_offset + tp))
-            gpu_offset += tp
+            gpu_ids = list(range(gpu_offset, gpu_offset + gpus_per_worker))
+            gpu_offset += gpus_per_worker
             port = get_open_port()
             bootstrap_port = get_open_port() if worker_type == WorkerType.PREFILL else None
 
@@ -547,6 +556,7 @@ def start_workers(
                 bootstrap_port=bootstrap_port,
                 ib_device=ib_device if has_pd else None,
                 log_dir=log_dir,
+                extra_engine_args=extra_engine_args,
             )
 
             # Stagger launches to avoid resource contention

--- a/e2e_test/infra/worker_pool.py
+++ b/e2e_test/infra/worker_pool.py
@@ -33,11 +33,12 @@ from .worker import Worker, start_workers, stop_workers
 logger = logging.getLogger(__name__)
 
 
-# Key is (engine, model_id, mode, worker_type, count). ``count`` is part of
-# the key because a class asking for count=2 after a count=1 class on the
-# same backend would otherwise reuse a 1-worker entry and run with the
-# wrong topology.
-_PoolKey = tuple[str, str, ConnectionMode, WorkerType, int]
+# Key is (engine, model_id, mode, worker_type, count, gpus, extra_engine_args).
+# ``count`` is part of the key because a class asking for count=2 after a
+# count=1 class on the same backend would otherwise reuse a 1-worker entry and
+# run with the wrong topology; ``gpus``/``extra_engine_args`` likewise change
+# the launched topology (e.g. --data-parallel-size).
+_PoolKey = tuple[str, str, ConnectionMode, WorkerType, int, int | None, tuple[str, ...] | None]
 
 
 class WorkerPool:
@@ -66,6 +67,8 @@ class WorkerPool:
         timeout: int = DEFAULT_STARTUP_TIMEOUT,
         log_dir: str | None = None,
         gpu_offset: int = 0,
+        gpus: int | None = None,
+        extra_engine_args: list[str] | None = None,
     ) -> list[Worker]:
         """Return ``count`` healthy workers for the given key.
 
@@ -106,11 +109,21 @@ class WorkerPool:
                     timeout=timeout,
                     log_dir=log_dir,
                     gpu_offset=gpu_offset,
+                    gpus=gpus,
+                    extra_engine_args=extra_engine_args,
                 )
 
             # REGULAR workers always start at gpu 0; ``gpu_offset`` is only
             # meaningful for non-REGULAR (PD decode) callers.
-            key: _PoolKey = (engine, model_id, mode, worker_type, count)
+            key: _PoolKey = (
+                engine,
+                model_id,
+                mode,
+                worker_type,
+                count,
+                gpus,
+                tuple(extra_engine_args) if extra_engine_args else None,
+            )
 
             if self._key == key and all(w.is_alive() for w in self._workers):
                 logger.info(
@@ -138,6 +151,8 @@ class WorkerPool:
                 worker_type=worker_type,
                 timeout=timeout,
                 log_dir=log_dir,
+                gpus=gpus,
+                extra_engine_args=extra_engine_args,
             )
             self._key = key
             self._workers = new_workers

--- a/e2e_test/router/test_dp_routing.py
+++ b/e2e_test/router/test_dp_routing.py
@@ -1,0 +1,84 @@
+"""DP rank-pinning verification for vLLM gRPC workers (``--dp-aware``).
+
+Output correctness alone cannot catch broken pinning: when no rank reaches the
+engine, vLLM load-balances across DP ranks internally and still produces
+correct completions. This test asserts the transmitted rank instead, via the
+servicer's per-request ``dp_rank=<n>`` log line:
+
+1. Both ``dp_rank=0`` and ``dp_rank=1`` appear in the worker log — the router
+   discovered dp_size, expanded the single worker URL into one worker per
+   rank, and pinned requests to both.
+2. ``dp_rank=None`` never appears — every request carried a pinned rank
+   instead of falling back to vLLM-internal balancing.
+
+Requirements:
+    - vLLM gRPC worker launched with --data-parallel-size 2
+    - 2 GPUs (one per DP rank)
+
+Usage:
+    E2E_RUNTIME=vllm pytest e2e_test/router/test_dp_routing.py -v
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from infra.pd_logs import (
+    assert_worker_logs_captured,
+    unique_prompt,
+    wait_for_marker,
+    worker_log_dir,
+)
+
+logger = logging.getLogger(__name__)
+
+# Router logs land here via the gateway marker (rolling files named smg.YYYY-MM-DD)
+_LOG_DIR = Path(tempfile.gettempdir()) / f"smg-e2e-dp-routing-{os.getpid()}"
+
+# Scope to this test's worker — PD workers in the same CI job log dp_rank=None
+_WORKER_LOG_GLOB = "worker-meta-llama__Llama-3.2-1B-Instruct_vllm_grpc_*.log"
+
+RANK_MARKERS = ("dp_rank=0", "dp_rank=1")
+UNPINNED_MARKER = "dp_rank=None"
+
+
+@pytest.mark.engine("vllm")
+@pytest.mark.gpu(2)
+@pytest.mark.model("meta-llama/Llama-3.2-1B-Instruct")
+@pytest.mark.e2e
+@pytest.mark.gateway(log_level="debug", log_dir=str(_LOG_DIR), extra_args=["--dp-aware"])
+@pytest.mark.workers(count=1, gpus=2, extra_engine_args=["--data-parallel-size", "2"])
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestDpAwareRankPinning:
+    """Verify the router pins every request to a DP rank and covers both ranks."""
+
+    def test_requests_pinned_to_both_ranks(self, setup_backend):
+        backend, model, client, *_ = setup_backend
+
+        for _ in range(8):
+            response = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": unique_prompt()}],
+                max_tokens=16,
+                temperature=0.0,
+            )
+            assert response.choices[0].message.content, "Empty completion from DP backend"
+
+        worker_dir = worker_log_dir(_LOG_DIR)
+        wait_for_marker(worker_dir, _WORKER_LOG_GLOB, RANK_MARKERS[0])
+        worker_logs = wait_for_marker(worker_dir, _WORKER_LOG_GLOB, RANK_MARKERS[1])
+        assert_worker_logs_captured(worker_logs, "DP rank pinning")
+
+        missing = [m for m in RANK_MARKERS if m not in worker_logs]
+        assert not missing, (
+            f"Router never pinned {missing} — 8 round-robin requests across "
+            f"dp_size=2 must hit both ranks; checked {worker_dir}/{_WORKER_LOG_GLOB}"
+        )
+        assert UNPINNED_MARKER not in worker_logs, (
+            "Worker received a request without a pinned DP rank — the router "
+            f"fell back to vLLM-internal balancing; checked {worker_dir}/{_WORKER_LOG_GLOB}"
+        )

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -175,11 +175,12 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             "pixel_values"
         )
         logger.info(
-            "Generate request %s: input_type=%s, stream=%s, preprocessed_mm=%s",
+            "Generate request %s: input_type=%s, stream=%s, preprocessed_mm=%s, dp_rank=%s",
             request_id,
             input_type,
             request.stream,
             has_preprocessed_mm,
+            request.data_parallel_rank if request.HasField("data_parallel_rank") else None,
         )
 
         kv_transfer_params: dict | None = None

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -222,6 +222,9 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                 sampling_params=sampling_params,
                 request_id=request_id,
                 tokenization_kwargs=tokenization_kwargs,
+                data_parallel_rank=(
+                    request.data_parallel_rank if request.HasField("data_parallel_rank") else None
+                ),
             ):
                 engine_started = True
                 # For streaming, send chunks for EACH completion output (n outputs)
@@ -469,6 +472,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         kv_connector = ""
         kv_role = ""
         kv_engine_id = ""
+        parallel = self.engine.vllm_config.parallel_config
         kv_transfer_config = self.engine.vllm_config.kv_transfer_config
         if kv_transfer_config is not None:
             kv_connector = kv_transfer_config.kv_connector or ""
@@ -476,7 +480,6 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             # With DP active the engine cores suffix their connector engine_id
             # (base_dp{rank}) and the router cannot attribute requests to a
             # rank — report no id so it falls back to legacy injection
-            parallel = self.engine.vllm_config.parallel_config
             dp_active = (
                 parallel.data_parallel_size > 1 or getattr(parallel, "data_parallel_rank", 0) > 0
             )
@@ -487,6 +490,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             kv_connector=kv_connector,
             kv_role=kv_role,
             kv_engine_id=kv_engine_id,
+            data_parallel_size=parallel.data_parallel_size,
         )
 
     async def GetLoads(

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -477,14 +477,9 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         if kv_transfer_config is not None:
             kv_connector = kv_transfer_config.kv_connector or ""
             kv_role = kv_transfer_config.kv_role or ""
-            # With DP active the engine cores suffix their connector engine_id
-            # (base_dp{rank}) and the router cannot attribute requests to a
-            # rank — report no id so it falls back to legacy injection
-            dp_active = (
-                parallel.data_parallel_size > 1 or getattr(parallel, "data_parallel_rank", 0) > 0
-            )
-            if not dp_active:
-                kv_engine_id = getattr(kv_transfer_config, "engine_id", "") or ""
+            # Base engine_id; with DP the engine cores serve `{id}_dp{rank}` and
+            # the router derives the suffix from the rank it pins per request
+            kv_engine_id = getattr(kv_transfer_config, "engine_id", "") or ""
 
         return vllm_engine_pb2.GetServerInfoResponse(
             kv_connector=kv_connector,

--- a/grpc_servicer/tests/test_dp_proto_fields.py
+++ b/grpc_servicer/tests/test_dp_proto_fields.py
@@ -1,0 +1,37 @@
+"""Unit tests for DP-aware routing proto fields (engine-free, no vLLM required).
+
+Run with: pytest grpc_servicer/tests/test_dp_proto_fields.py
+"""
+
+import pytest
+
+pytest.importorskip("smg_grpc_proto")
+from smg_grpc_proto import vllm_engine_pb2  # noqa: E402
+
+
+class TestGenerateRequestDataParallelRank:
+    def test_unset_by_default(self):
+        request = vllm_engine_pb2.GenerateRequest()
+        assert not request.HasField("data_parallel_rank")
+
+    def test_rank_zero_is_distinguishable_from_unset(self):
+        request = vllm_engine_pb2.GenerateRequest(data_parallel_rank=0)
+        assert request.HasField("data_parallel_rank")
+        assert request.data_parallel_rank == 0
+
+    def test_set_rank_roundtrips(self):
+        request = vllm_engine_pb2.GenerateRequest(data_parallel_rank=3)
+        parsed = vllm_engine_pb2.GenerateRequest.FromString(request.SerializeToString())
+        assert parsed.HasField("data_parallel_rank")
+        assert parsed.data_parallel_rank == 3
+
+
+class TestGetServerInfoResponseDataParallelSize:
+    def test_defaults_to_zero_when_unreported(self):
+        info = vllm_engine_pb2.GetServerInfoResponse()
+        assert info.data_parallel_size == 0
+
+    def test_size_roundtrips(self):
+        info = vllm_engine_pb2.GetServerInfoResponse(data_parallel_size=4)
+        parsed = vllm_engine_pb2.GetServerInfoResponse.FromString(info.SerializeToString())
+        assert parsed.data_parallel_size == 4

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -33,7 +33,7 @@ const NIXL_PREFILL_KV_PARAMS: &str = r#"{"do_remote_decode":true,"do_remote_pref
 enum KvConnectorMode {
     /// MooncakeConnector: mint a transfer_id, tag both legs, synthesize decode
     /// params from worker metadata; legacy host/port injection when the
-    /// servicer predates kv_engine_id reporting (or DP is active).
+    /// servicer predates kv_engine_id reporting (or DP runs without a pinned rank).
     Mooncake {
         host: String,
         port: u32,
@@ -60,6 +60,22 @@ fn kv_connector_mode(
         },
         Some(NIXL_CONNECTOR) => KvConnectorMode::Nixl,
         _ => KvConnectorMode::Passthrough,
+    }
+}
+
+/// Connector id of the engine core serving the prefill leg. With DP the cores
+/// suffix the configured id as `{base}_dp{rank}`, so minting needs a pinned
+/// rank; unpinned DP>1 yields None (no mint — decode recomputes locally).
+fn effective_kv_engine_id(
+    base: Option<&str>,
+    dp_size: Option<usize>,
+    dp_rank: Option<usize>,
+) -> Option<String> {
+    let base = base.filter(|s| !s.is_empty())?;
+    if dp_size.unwrap_or(1) > 1 {
+        dp_rank.map(|rank| format!("{base}_dp{rank}"))
+    } else {
+        Some(base.to_string())
     }
 }
 
@@ -376,11 +392,18 @@ impl RequestExecutionStage {
             .prefill_worker()
             .map(|w| {
                 let meta = w.metadata();
+                // Discovered dp_size matters even without --dp-aware expansion:
+                // a DP>1 engine behind an unexpanded worker must not be minted for
+                let dp_size = w
+                    .dp_size()
+                    .or_else(|| meta.spec.labels.get("dp_size").and_then(|s| s.parse().ok()));
+                let engine_id =
+                    effective_kv_engine_id(meta.spec.kv_engine_id.as_deref(), dp_size, w.dp_rank());
                 kv_connector_mode(
                     meta.spec.kv_connector.as_deref(),
                     &meta.spec.bootstrap_host,
                     meta.spec.bootstrap_port,
-                    meta.spec.kv_engine_id.as_deref(),
+                    engine_id.as_deref(),
                 )
             })
             .unwrap_or(KvConnectorMode::Passthrough);
@@ -753,5 +776,40 @@ mod tests {
 
         let unset = ProtoGenerateComplete::Vllm(vllm::GenerateComplete::default());
         assert_eq!(unset.kv_transfer_params_json(), None);
+    }
+
+    #[test]
+    fn effective_engine_id_passthrough_when_no_dp() {
+        assert_eq!(
+            effective_kv_engine_id(Some("eng"), None, None).as_deref(),
+            Some("eng")
+        );
+        assert_eq!(
+            effective_kv_engine_id(Some("eng"), Some(1), None).as_deref(),
+            Some("eng")
+        );
+    }
+
+    #[test]
+    fn effective_engine_id_suffixes_pinned_dp_rank() {
+        assert_eq!(
+            effective_kv_engine_id(Some("eng"), Some(2), Some(1)).as_deref(),
+            Some("eng_dp1")
+        );
+        assert_eq!(
+            effective_kv_engine_id(Some("eng"), Some(2), Some(0)).as_deref(),
+            Some("eng_dp0")
+        );
+    }
+
+    #[test]
+    fn effective_engine_id_none_for_unpinned_dp() {
+        assert_eq!(effective_kv_engine_id(Some("eng"), Some(2), None), None);
+    }
+
+    #[test]
+    fn effective_engine_id_none_for_missing_or_empty_base() {
+        assert_eq!(effective_kv_engine_id(None, Some(2), Some(0)), None);
+        assert_eq!(effective_kv_engine_id(Some(""), None, None), None);
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -224,7 +224,7 @@ impl PipelineStage for RequestExecutionStage {
 impl RequestExecutionStage {
     async fn execute_single(
         &self,
-        proto_request: ProtoGenerateRequest,
+        mut proto_request: ProtoGenerateRequest,
         clients: &mut ClientSelection,
         workers: &WorkerSelection,
     ) -> Result<ExecutionResult, Response> {
@@ -238,6 +238,10 @@ impl RequestExecutionStage {
                 "Expected single client but got dual",
             )
         })?;
+
+        if let Some(rank) = workers.single().and_then(|w| w.dp_rank()) {
+            proto_request.set_data_parallel_rank(rank as i32);
+        }
 
         let result = client.generate(proto_request).await;
         workers.record_outcome(result.cb_status_code());
@@ -301,11 +305,17 @@ impl RequestExecutionStage {
             )
         })?;
 
-        let prefill_request = proto_request.clone_inner();
+        let mut prefill_request = proto_request.clone_inner();
         // Strip multimodal data from decode request — the decode worker only
         // needs the KV cache from prefill, not the pixel tensors (~40MB saved).
         let mut decode_request = proto_request;
         decode_request.clear_mm_inputs();
+        if let Some(rank) = workers.prefill_worker().and_then(|w| w.dp_rank()) {
+            prefill_request.set_data_parallel_rank(rank as i32);
+        }
+        if let Some(rank) = workers.decode_worker().and_then(|w| w.dp_rank()) {
+            decode_request.set_data_parallel_rank(rank as i32);
+        }
 
         let (prefill_result, decode_result): (StreamResult, StreamResult) = tokio::join!(
             prefill_client.generate(prefill_request),
@@ -420,6 +430,9 @@ impl RequestExecutionStage {
         let mut prefill_request = proto_request.clone_inner();
         prefill_request.sanitize_sampling_for_prefill(1);
         prefill_request.set_stream(false);
+        if let Some(rank) = workers.prefill_worker().and_then(|w| w.dp_rank()) {
+            prefill_request.set_data_parallel_rank(rank as i32);
+        }
         if mode == KvConnectorMode::Nixl {
             if relay_kv_params {
                 prefill_request.set_kv_transfer_params_json(NIXL_PREFILL_KV_PARAMS.to_string());
@@ -479,6 +492,9 @@ impl RequestExecutionStage {
         // Decode reuses proto_request as-is; same request_id as the prefill leg is
         // load-bearing for NIXL P/D correlation on vLLM < 0.13
         let mut decode_request = proto_request;
+        if let Some(rank) = workers.decode_worker().and_then(|w| w.dp_rank()) {
+            decode_request.set_data_parallel_rank(rank as i32);
+        }
         match (&mode, prefill_kv_params) {
             // Modern Mooncake: synthesized params under the minted transfer_id
             (

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -568,6 +568,15 @@ impl ProtoGenerateRequest {
         }
     }
 
+    /// Pin the request to a data-parallel rank (engines without the field ignore it).
+    pub fn set_data_parallel_rank(&mut self, rank: i32) {
+        match self {
+            Self::Vllm(req) => req.data_parallel_rank = Some(rank),
+            Self::Sglang(req) => req.data_parallel_rank = rank,
+            Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => {}
+        }
+    }
+
     /// Number of parallel samples requested (vLLM only; 1 when unset).
     pub fn sampling_n(&self) -> u32 {
         match self {
@@ -1368,5 +1377,26 @@ mod tests {
             Some(tokenspeed::tensor_data::Payload::Inline(data)) => data,
             _ => panic!("expected inline TensorData payload"),
         }
+    }
+
+    #[test]
+    fn set_data_parallel_rank_per_engine() {
+        let mut vllm_req = ProtoGenerateRequest::Vllm(Box::default());
+        vllm_req.set_data_parallel_rank(2);
+        assert!(matches!(
+            &vllm_req,
+            ProtoGenerateRequest::Vllm(req) if req.data_parallel_rank == Some(2)
+        ));
+
+        let mut sglang_req = ProtoGenerateRequest::Sglang(Box::default());
+        sglang_req.set_data_parallel_rank(3);
+        assert!(matches!(
+            &sglang_req,
+            ProtoGenerateRequest::Sglang(req) if req.data_parallel_rank == 3
+        ));
+
+        // Engines without the proto field ignore the pin
+        let mut mlx_req = ProtoGenerateRequest::Mlx(Box::default());
+        mlx_req.set_data_parallel_rank(1);
     }
 }

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -1164,7 +1164,8 @@ impl Worker for BasicWorker {
                             runtime_str,
                             self.metadata.spec.url
                         );
-                        match GrpcClient::connect(&self.metadata.spec.url, &runtime_str).await {
+                        // DP-expanded workers carry a `{base}@{rank}` URL; connect to the base
+                        match GrpcClient::connect(self.metadata.base_url(), &runtime_str).await {
                             Ok(client) => {
                                 tracing::info!(
                                     "Successfully connected gRPC client ({}) for worker: {}",

--- a/model_gateway/src/workflow/steps/local/discover_dp.rs
+++ b/model_gateway/src/workflow/steps/local/discover_dp.rs
@@ -1,5 +1,7 @@
 //! Data Parallel (DP) information discovery step.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use tracing::{debug, warn};
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
@@ -38,6 +40,32 @@ pub async fn get_dp_info(url: &str, api_key: Option<&str>) -> Result<DpInfo, Str
     Ok(DpInfo { dp_size, model_id })
 }
 
+/// Build DP info from gRPC-discovered metadata labels (`dp_size` is reported
+/// via GetServerInfo and normalized into the label set by metadata discovery).
+pub fn dp_info_from_labels(labels: &HashMap<String, String>) -> Result<DpInfo, String> {
+    let dp_size = labels
+        .get("dp_size")
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .ok_or_else(|| "no positive dp_size in discovered metadata".to_string())?;
+
+    let model_id = labels
+        .get("model_id")
+        .or_else(|| labels.get("served_model_name"))
+        .filter(|s| !s.is_empty())
+        .cloned()
+        .or_else(|| {
+            labels
+                .get("model_path")
+                .and_then(|p| p.rsplit('/').next())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| UNKNOWN_MODEL_ID.to_string());
+
+    Ok(DpInfo { dp_size, model_id })
+}
+
 /// Step 2b: Discover DP (Data Parallel) information (only for DP-aware workers).
 pub struct DiscoverDPInfoStep;
 
@@ -66,28 +94,36 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverDPInfoStep {
             return Ok(StepResult::Success);
         }
 
-        // DP discovery uses SGLang's /server_info which exposes dp_size.
-        // Only proceed for sglang HTTP workers — other runtimes don't expose DP info this way.
-        if matches!(context.data.connection_mode, Some(ConnectionMode::Http)) {
-            let runtime = context.data.detected_runtime_type.as_deref();
-            if runtime != Some("sglang") {
-                warn!(
-                    "DP discovery is not supported for {} HTTP workers ({}), skipping",
-                    runtime.unwrap_or("unknown"),
-                    config.url
-                );
-                return Ok(StepResult::Success);
-            }
-        }
-
         debug!("Discovering DP info for {} (DP-aware)", config.url);
 
-        let dp_info = get_dp_info(&config.url, config.api_key.as_deref())
-            .await
-            .map_err(|e| WorkflowError::StepFailed {
-                step_id: StepId::new("discover_dp_info"),
-                message: format!("Failed to get DP info: {e}"),
-            })?;
+        let dp_info = match context.data.connection_mode {
+            // gRPC workers report dp_size through GetServerInfo, already
+            // flattened into the discovered metadata labels
+            Some(ConnectionMode::Grpc) => dp_info_from_labels(&context.data.discovered_labels)
+                .map_err(|e| WorkflowError::StepFailed {
+                    step_id: StepId::new("discover_dp_info"),
+                    message: format!("Failed to get DP info for {}: {e}", config.url),
+                })?,
+            _ => {
+                // HTTP DP discovery uses SGLang's /server_info which exposes
+                // dp_size — other runtimes don't expose DP info this way
+                let runtime = context.data.detected_runtime_type.as_deref();
+                if runtime != Some("sglang") {
+                    warn!(
+                        "DP discovery is not supported for {} HTTP workers ({}), skipping",
+                        runtime.unwrap_or("unknown"),
+                        config.url
+                    );
+                    return Ok(StepResult::Success);
+                }
+                get_dp_info(&config.url, config.api_key.as_deref())
+                    .await
+                    .map_err(|e| WorkflowError::StepFailed {
+                        step_id: StepId::new("discover_dp_info"),
+                        message: format!("Failed to get DP info: {e}"),
+                    })?
+            }
+        };
 
         debug!(
             "Discovered DP size {} for {} (model: {})",
@@ -100,5 +136,45 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverDPInfoStep {
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn dp_info_from_labels_reads_dp_size_and_model() {
+        let info =
+            dp_info_from_labels(&labels(&[("dp_size", "4"), ("served_model_name", "m")])).unwrap();
+        assert_eq!(info.dp_size, 4);
+        assert_eq!(info.model_id, "m");
+    }
+
+    #[test]
+    fn dp_info_from_labels_model_path_fallback() {
+        let info =
+            dp_info_from_labels(&labels(&[("dp_size", "2"), ("model_path", "org/repo")])).unwrap();
+        assert_eq!(info.model_id, "repo");
+    }
+
+    #[test]
+    fn dp_info_from_labels_unknown_model_when_absent() {
+        let info = dp_info_from_labels(&labels(&[("dp_size", "2")])).unwrap();
+        assert_eq!(info.model_id, UNKNOWN_MODEL_ID);
+    }
+
+    #[test]
+    fn dp_info_from_labels_rejects_missing_or_zero_dp_size() {
+        assert!(dp_info_from_labels(&labels(&[])).is_err());
+        assert!(dp_info_from_labels(&labels(&[("dp_size", "0")])).is_err());
+        assert!(dp_info_from_labels(&labels(&[("dp_size", "abc")])).is_err());
     }
 }

--- a/model_gateway/src/workflow/steps/local/discover_dp.rs
+++ b/model_gateway/src/workflow/steps/local/discover_dp.rs
@@ -57,8 +57,7 @@ pub fn dp_info_from_labels(labels: &HashMap<String, String>) -> Result<DpInfo, S
         .or_else(|| {
             labels
                 .get("model_path")
-                .and_then(|p| p.rsplit('/').next())
-                .filter(|s| !s.is_empty())
+                .and_then(|p| p.split('/').rfind(|s| !s.is_empty()))
                 .map(str::to_string)
         })
         .unwrap_or_else(|| UNKNOWN_MODEL_ID.to_string());
@@ -162,6 +161,9 @@ mod tests {
     fn dp_info_from_labels_model_path_fallback() {
         let info =
             dp_info_from_labels(&labels(&[("dp_size", "2"), ("model_path", "org/repo")])).unwrap();
+        assert_eq!(info.model_id, "repo");
+        let info =
+            dp_info_from_labels(&labels(&[("dp_size", "2"), ("model_path", "org/repo/")])).unwrap();
         assert_eq!(info.model_id, "repo");
     }
 

--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -263,6 +263,7 @@ fn normalize_grpc_keys(labels: &mut HashMap<String, String>) {
         ("tensor_parallel_size", "tp_size"),
         ("pipeline_parallel_size", "pp_size"),
         ("context_parallel_size", "cp_size"),
+        ("data_parallel_size", "dp_size"),
     ] {
         if let Some(val) = labels.remove(from) {
             labels.entry(to.to_string()).or_insert(val);


### PR DESCRIPTION
## Description

### Problem

vLLM gRPC workers with `data_parallel_size > 1` are opaque to SMG: vLLM's internal balancer picks the rank for every request, so SMG cannot make cluster-wide placement decisions, and Mooncake PD is disabled under DP entirely — the servicer suppresses `kv_engine_id` because the engine cores serve suffixed ids (`{base}_dp{rank}`) that the router could not attribute requests to (documented limitation from #1664).

### Solution

Implement DP-aware routing for vLLM gRPC workers the way vLLM's own proxies do it: the router picks the rank per request and pins it via `AsyncLLM.generate(data_parallel_rank=N)` — verified against vLLM v0.22.1, where a pinned rank short-circuits the internal balancer (vllm/v1/engine/core_client.py `DPLBAsyncMPClient.get_core_engine_for_request`).

- **Contract**: `GenerateRequest` gains `optional int32 data_parallel_rank` (rank 0 distinguishable from unset; unset preserves vLLM internal balancing), `GetServerInfoResponse` reports `data_parallel_size`. `EmbedRequest` is left out: `AsyncLLM.encode()` has no rank parameter.
- **Routing**: with `--dp-aware`, gRPC workers get DP discovery from GetServerInfo metadata and expand into per-rank workers (same `{base}@{rank}` pattern as SGLang HTTP); the execution stage pins each leg's request to its worker's rank. The gRPC client now dials the base URL so DP-expanded worker URLs connect.
- **Mooncake under DP**: the servicer-side DP gate moves to the router, which holds the pairing information — `dp_size <= 1` mints with the base engine id as before; DP>1 with a pinned rank mints `{base}_dp{rank}` to match the engine-core suffix; DP>1 unpinned declines to mint (same safe fallback as the old gate). The discovered `dp_size` label guards unexpanded workers fronting DP>1 engines.

External-LB DP (`--data-parallel-external-lb`) needs none of this: each rank is its own server registered as a plain worker (every pod's engine core is `{base}_dp0`, so Mooncake users pin a distinct `engine_id` per pod — documented).

## Changes

- a1043f88 proto fields + servicer pass-through to `AsyncLLM.generate()` + `data_parallel_size` reporting
- accd8fee gRPC DP discovery (dp_size via metadata labels), per-rank worker expansion, per-leg rank pinning in single/PD/dual-dispatch paths, base-URL gRPC connect fix
- f9184bd5 router-side Mooncake mint gate (`effective_kv_engine_id`), servicer DP gate removal
- ee7616e2 e2e (`test_dp_routing.py`) + `extra_engine_args`/`gpus` options on the workers marker + PD docs update

## Test Plan

- Unit: proto presence semantics (rank 0 vs unset, round-trips), `dp_info_from_labels`, `set_data_parallel_rank` per engine, `effective_kv_engine_id` (passthrough / suffix / decline / empty-base). 1053 model_gateway lib tests, 60 grpc_client tests, 29 servicer pytest tests pass.
- e2e (runs in both vllm legs of `e2e-2gpu-pd`): one vLLM gRPC worker with `--data-parallel-size 2`, router with `--dp-aware`, 8 completions; asserts servicer logs show both dp_rank=0 and dp_rank=1 and never dp_rank=None. Output correctness alone cannot catch broken pinning because vLLM balances internally as a fallback — the assertion is on the transmitted rank.
- Mooncake DP>1 minting cannot be e2e-tested on the 2-GPU pods (DP=2 prefill + decode needs 3+ GPUs); covered by unit tests on the mint gate.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests can be pinned to a specific data-parallel rank; server now reports data-parallel size.
  * Worker startup accepts per-worker GPU selection and extra engine CLI arguments; cache reuse respects these.

* **Bug Fixes**
  * gRPC connections for data-parallel workers use base URLs correctly (avoid per-rank expansion).

* **Documentation**
  * Updated data-parallel deployment and backend-specific DP guidance.

* **Tests**
  * Added e2e DP routing and protobuf-field tests for DP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->