### PR TITLE
feat(mesh): dead-node key cleanup — replica attribution, membership removal, sweep

### DIFF
--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -127,23 +127,38 @@ fn expire_down_nodes(
     expired
 }
 
+/// A removed node's holddown record: when it was removed and the membership
+/// version it carried at removal, the freshness bar for lifting the hold.
+struct Holddown {
+    since: Instant,
+    removed_version: u64,
+}
+
 /// Removal holddown: a removed node re-offered by a slower survivor's
 /// full-state gossip is purged again each round instead of re-arming a
-/// fresh `dead_timeout` (and re-firing the sweep). A node that comes back
-/// Alive (restart, or its own SWIM refutation of the stale rumor) lifts
-/// its hold. Holds expire after `holddown`, which must exceed the slowest
-/// survivor's own removal lag.
+/// fresh `dead_timeout` (and re-firing the sweep). Only a freshness proof
+/// lifts the hold: an Alive entry whose version exceeds the removed
+/// version (a genuine return produces one via SWIM refutation, which bumps
+/// past the Down rumor). A stale Alive re-offer from a survivor that never
+/// saw the Down transition is purged like any other stale rumor. Holds
+/// expire after `holddown`, which must exceed the slowest survivor's own
+/// removal lag.
 fn purge_held_reinsertions(
-    held: &mut HashMap<String, Instant>,
+    held: &mut HashMap<String, Holddown>,
     state: &mut BTreeMap<String, NodeState>,
     holddown: Duration,
     now: Instant,
 ) {
-    held.retain(|_, since| now.saturating_duration_since(*since) < holddown);
-    held.retain(|name, _| match state.get(name) {
+    held.retain(|_, hold| now.saturating_duration_since(hold.since) < holddown);
+    held.retain(|name, hold| match state.get(name) {
         // Genuine return: lift the hold so normal tracking resumes.
-        Some(node) if node.status == NodeStatus::Alive as i32 => false,
-        // Stale re-offer: purge again quietly, keep holding.
+        Some(node)
+            if node.status == NodeStatus::Alive as i32 && node.version > hold.removed_version =>
+        {
+            false
+        }
+        // Stale re-offer (Down, or an Alive predating the removal): purge
+        // again quietly, keep holding.
         Some(_) => {
             state.remove(name);
             true
@@ -202,7 +217,7 @@ impl GossipController {
         // First moment each peer was seen Down, for dead_timeout removal.
         let mut down_since: HashMap<String, Instant> = HashMap::new();
         // Recently removed nodes, held against gossip re-insertion.
-        let mut removed_holddown: HashMap<String, Instant> = HashMap::new();
+        let mut removed_holddown: HashMap<String, Holddown> = HashMap::new();
 
         loop {
             log::info!("Round {} Status:{:?}", cnt, read_state.read());
@@ -240,10 +255,19 @@ impl GossipController {
             );
             for name in expired {
                 log::warn!("Removing node {name} after dead_timeout; sweeping its keys");
-                init_state.write().remove(&name);
+                let removed_version = init_state
+                    .write()
+                    .remove(&name)
+                    .map_or(0, |node| node.version);
                 retry_managers.remove(&name);
                 down_since.remove(&name);
-                removed_holddown.insert(name.clone(), Instant::now());
+                removed_holddown.insert(
+                    name.clone(),
+                    Holddown {
+                        since: Instant::now(),
+                        removed_version,
+                    },
+                );
                 // Reap the dead peer's stream task now rather than letting it
                 // tick into a dead channel until the idle timeout.
                 if let Some(handle) = self.sync_connections.lock().await.remove(&name) {
@@ -1065,6 +1089,20 @@ mod dead_node_tests {
 
     const TIMEOUT: Duration = Duration::from_secs(60);
 
+    fn hold(t0: Instant, removed_version: u64) -> Holddown {
+        Holddown {
+            since: t0,
+            removed_version,
+        }
+    }
+
+    fn node_v(name: &str, status: NodeStatus, version: u64) -> NodeState {
+        NodeState {
+            version,
+            ..node(name, status)
+        }
+    }
+
     #[test]
     fn down_node_expires_only_after_dead_timeout() {
         let mut down_since = HashMap::new();
@@ -1145,7 +1183,7 @@ mod dead_node_tests {
     fn holddown_purges_reinserted_down_entry_without_retracking() {
         let mut held = HashMap::new();
         let t0 = Instant::now();
-        held.insert("d".to_string(), t0);
+        held.insert("d".to_string(), hold(t0, 3));
 
         // A slower survivor's gossip re-inserted d(Down): purged, still held.
         let mut state = state_of(vec![node("d", NodeStatus::Down)]);
@@ -1155,22 +1193,38 @@ mod dead_node_tests {
     }
 
     #[test]
-    fn holddown_lifts_when_node_returns_alive() {
+    fn holddown_lifts_on_alive_newer_than_removal() {
         let mut held = HashMap::new();
         let t0 = Instant::now();
-        held.insert("d".to_string(), t0);
+        held.insert("d".to_string(), hold(t0, 3));
 
-        let mut state = state_of(vec![node("d", NodeStatus::Alive)]);
+        // A genuine return carries a refutation version past the removal.
+        let mut state = state_of(vec![node_v("d", NodeStatus::Alive, 4)]);
         purge_held_reinsertions(&mut held, &mut state, TIMEOUT, t0 + Duration::from_secs(1));
-        assert!(state.contains_key("d"), "alive return kept in membership");
-        assert!(held.is_empty(), "hold lifted on alive return");
+        assert!(state.contains_key("d"), "fresh return kept in membership");
+        assert!(held.is_empty(), "hold lifted on fresh alive return");
+    }
+
+    #[test]
+    fn holddown_keeps_holding_on_stale_alive_rumor() {
+        let mut held = HashMap::new();
+        let t0 = Instant::now();
+        held.insert("d".to_string(), hold(t0, 3));
+
+        // A survivor that never saw the Down transition re-offers a stale
+        // Alive; lifting on it would park the dead node in membership for
+        // another Suspected -> Down -> dead_timeout walk.
+        let mut state = state_of(vec![node_v("d", NodeStatus::Alive, 1)]);
+        purge_held_reinsertions(&mut held, &mut state, TIMEOUT, t0 + Duration::from_secs(1));
+        assert!(!state.contains_key("d"), "stale alive re-offer purged");
+        assert!(held.contains_key("d"), "hold persists against stale alive");
     }
 
     #[test]
     fn holddown_expires_after_window() {
         let mut held = HashMap::new();
         let t0 = Instant::now();
-        held.insert("d".to_string(), t0);
+        held.insert("d".to_string(), hold(t0, 3));
 
         let mut state = state_of(vec![node("d", NodeStatus::Down)]);
         purge_held_reinsertions(&mut held, &mut state, TIMEOUT, t0 + TIMEOUT);

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -254,11 +254,29 @@ impl GossipController {
                 Instant::now(),
             );
             for name in expired {
+                // Re-check under the write lock: `expired` came from a read
+                // snapshot, and merge_state (on a gRPC task) may have revived
+                // this peer to Alive in the gap. Remove + sweep ONLY if it is
+                // still departed — otherwise this is the destructive live-node
+                // sweep the rest of this PR exists to prevent.
+                let removed_version = {
+                    let mut state = init_state.write();
+                    match state.get(&name) {
+                        Some(node) if node.status == NodeStatus::Down as i32 => {
+                            let version = node.version;
+                            state.remove(&name);
+                            Some(version)
+                        }
+                        _ => None,
+                    }
+                };
+                let Some(removed_version) = removed_version else {
+                    // Revived or already gone: stop tracking so it re-arms
+                    // cleanly if it goes Down again.
+                    down_since.remove(&name);
+                    continue;
+                };
                 log::warn!("Removing node {name} after dead_timeout; sweeping its keys");
-                let removed_version = init_state
-                    .write()
-                    .remove(&name)
-                    .map_or(0, |node| node.version);
                 retry_managers.remove(&name);
                 down_since.remove(&name);
                 removed_holddown.insert(

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -293,6 +293,11 @@ impl GossipController {
             // Periodic retry-manager cleanup every 60 rounds (~60s).
             if cnt.is_multiple_of(60) {
                 retry_managers.retain(|peer_name, _| map.contains_key(peer_name));
+                // Owner-side replica-registry upkeep: re-assert this
+                // incarnation's entry, retire prior incarnations'.
+                if let Some(mesh_kv) = &self.mesh_kv {
+                    mesh_kv.reconcile_replica_registry();
+                }
             }
 
             // Stream round collection: drain stream namespace buffers and

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -90,6 +90,41 @@ pub struct GossipController {
     /// registry, and chunk assembler shared with the server-side
     /// SyncStream handlers.
     mesh_kv: Option<Arc<crate::kv::MeshKV>>,
+    /// How long a node may stay Down before it is removed from the
+    /// cluster and its keys are swept (SWIM §5.2).
+    dead_timeout: Duration,
+}
+
+/// SWIM §5.2 default: Down nodes are removed after 60s.
+const DEFAULT_DEAD_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Track how long each peer has been Down and return those past
+/// `dead_timeout`, due for removal. `down_since` keeps the first moment a
+/// peer was seen Down; entries are dropped when the peer revives (its next
+/// Down restarts the clock) or leaves the state map.
+fn expire_down_nodes(
+    down_since: &mut HashMap<String, Instant>,
+    state: &BTreeMap<String, NodeState>,
+    self_name: &str,
+    dead_timeout: Duration,
+    now: Instant,
+) -> Vec<String> {
+    down_since.retain(|name, _| {
+        state
+            .get(name)
+            .is_some_and(|node| node.status == NodeStatus::Down as i32)
+    });
+    let mut expired = Vec::new();
+    for (name, node) in state {
+        if name == self_name || node.status != NodeStatus::Down as i32 {
+            continue;
+        }
+        let since = down_since.entry(name.clone()).or_insert(now);
+        if now.saturating_duration_since(*since) >= dead_timeout {
+            expired.push(name.clone());
+        }
+    }
+    expired
 }
 
 impl GossipController {
@@ -109,6 +144,7 @@ impl GossipController {
             sync_connections: Arc::new(Mutex::new(HashMap::new())),
             current_stream_batch: Arc::new(RwLock::new(Arc::new(crate::kv::RoundBatch::default()))),
             mesh_kv: None,
+            dead_timeout: DEFAULT_DEAD_TIMEOUT,
         }
     }
 
@@ -138,6 +174,9 @@ impl GossipController {
         use std::collections::HashMap;
         let mut retry_managers: HashMap<String, RetryManager> = HashMap::new();
 
+        // First moment each peer was seen Down, for dead_timeout removal.
+        let mut down_since: HashMap<String, Instant> = HashMap::new();
+
         loop {
             log::info!("Round {} Status:{:?}", cnt, read_state.read());
 
@@ -155,6 +194,26 @@ impl GossipController {
                         true
                     }
                 });
+            }
+
+            // SWIM §5.2: remove nodes Down for longer than dead_timeout and
+            // sweep their keys (replica registry, registered namespaces).
+            let expired = expire_down_nodes(
+                &mut down_since,
+                &init_state.read(),
+                &self.self_name,
+                self.dead_timeout,
+                Instant::now(),
+            );
+            for name in expired {
+                log::warn!("Removing node {name} after dead_timeout; sweeping its keys");
+                init_state.write().remove(&name);
+                retry_managers.remove(&name);
+                down_since.remove(&name);
+                if let Some(mesh_kv) = &self.mesh_kv {
+                    let swept = mesh_kv.handle_node_removed(&name);
+                    log::info!("Dead-node sweep for {name} tombstoned {swept} keys");
+                }
             }
 
             // Get available peers from cluster state
@@ -939,5 +998,121 @@ mod retry_manager_tests {
     fn should_retry_before_any_attempt() {
         let mgr = RetryManager::default();
         assert!(mgr.should_retry());
+    }
+}
+
+#[cfg(test)]
+mod dead_node_tests {
+    use super::*;
+
+    fn node(name: &str, status: NodeStatus) -> NodeState {
+        NodeState {
+            name: name.to_string(),
+            address: format!("{name}:50051"),
+            status: status as i32,
+            version: 1,
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn state_of(nodes: Vec<NodeState>) -> BTreeMap<String, NodeState> {
+        nodes.into_iter().map(|n| (n.name.clone(), n)).collect()
+    }
+
+    const TIMEOUT: Duration = Duration::from_secs(60);
+
+    #[test]
+    fn down_node_expires_only_after_dead_timeout() {
+        let mut down_since = HashMap::new();
+        let state = state_of(vec![
+            node("a", NodeStatus::Alive),
+            node("b", NodeStatus::Down),
+        ]);
+        let t0 = Instant::now();
+
+        let expired = expire_down_nodes(&mut down_since, &state, "self", TIMEOUT, t0);
+        assert!(expired.is_empty(), "fresh Down node survives");
+
+        let expired = expire_down_nodes(
+            &mut down_since,
+            &state,
+            "self",
+            TIMEOUT,
+            t0 + Duration::from_secs(59),
+        );
+        assert!(expired.is_empty(), "still inside dead_timeout");
+
+        let expired = expire_down_nodes(
+            &mut down_since,
+            &state,
+            "self",
+            TIMEOUT,
+            t0 + Duration::from_secs(60),
+        );
+        assert_eq!(expired, vec!["b".to_string()], "expired at dead_timeout");
+    }
+
+    #[test]
+    fn revival_restarts_the_clock() {
+        let mut down_since = HashMap::new();
+        let down = state_of(vec![node("b", NodeStatus::Down)]);
+        let alive = state_of(vec![node("b", NodeStatus::Alive)]);
+        let t0 = Instant::now();
+
+        expire_down_nodes(&mut down_since, &down, "self", TIMEOUT, t0);
+        expire_down_nodes(
+            &mut down_since,
+            &alive,
+            "self",
+            TIMEOUT,
+            t0 + Duration::from_secs(30),
+        );
+        assert!(down_since.is_empty(), "revival clears tracking");
+
+        // Down again: the clock restarts from the new observation.
+        let expired = expire_down_nodes(
+            &mut down_since,
+            &down,
+            "self",
+            TIMEOUT,
+            t0 + Duration::from_secs(61),
+        );
+        assert!(expired.is_empty(), "second Down gets a fresh dead_timeout");
+    }
+
+    #[test]
+    fn self_is_never_expired() {
+        let mut down_since = HashMap::new();
+        let state = state_of(vec![node("self", NodeStatus::Down)]);
+        let t0 = Instant::now();
+        expire_down_nodes(&mut down_since, &state, "self", TIMEOUT, t0);
+        let expired = expire_down_nodes(
+            &mut down_since,
+            &state,
+            "self",
+            TIMEOUT,
+            t0 + Duration::from_secs(120),
+        );
+        assert!(expired.is_empty());
+        assert!(down_since.is_empty(), "self is never tracked");
+    }
+
+    #[test]
+    fn departed_node_is_dropped_from_tracking() {
+        let mut down_since = HashMap::new();
+        let down = state_of(vec![node("b", NodeStatus::Down)]);
+        let t0 = Instant::now();
+        expire_down_nodes(&mut down_since, &down, "self", TIMEOUT, t0);
+        assert_eq!(down_since.len(), 1);
+
+        let empty = state_of(vec![]);
+        expire_down_nodes(
+            &mut down_since,
+            &empty,
+            "self",
+            TIMEOUT,
+            t0 + Duration::from_secs(1),
+        );
+        assert!(down_since.is_empty(), "node gone from state is untracked");
     }
 }

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -127,6 +127,31 @@ fn expire_down_nodes(
     expired
 }
 
+/// Removal holddown: a removed node re-offered by a slower survivor's
+/// full-state gossip is purged again each round instead of re-arming a
+/// fresh `dead_timeout` (and re-firing the sweep). A node that comes back
+/// Alive (restart, or its own SWIM refutation of the stale rumor) lifts
+/// its hold. Holds expire after `holddown`, which must exceed the slowest
+/// survivor's own removal lag.
+fn purge_held_reinsertions(
+    held: &mut HashMap<String, Instant>,
+    state: &mut BTreeMap<String, NodeState>,
+    holddown: Duration,
+    now: Instant,
+) {
+    held.retain(|_, since| now.saturating_duration_since(*since) < holddown);
+    held.retain(|name, _| match state.get(name) {
+        // Genuine return: lift the hold so normal tracking resumes.
+        Some(node) if node.status == NodeStatus::Alive as i32 => false,
+        // Stale re-offer: purge again quietly, keep holding.
+        Some(_) => {
+            state.remove(name);
+            true
+        }
+        None => true,
+    });
+}
+
 impl GossipController {
     pub fn new(
         state: ClusterState,
@@ -176,6 +201,8 @@ impl GossipController {
 
         // First moment each peer was seen Down, for dead_timeout removal.
         let mut down_since: HashMap<String, Instant> = HashMap::new();
+        // Recently removed nodes, held against gossip re-insertion.
+        let mut removed_holddown: HashMap<String, Instant> = HashMap::new();
 
         loop {
             log::info!("Round {} Status:{:?}", cnt, read_state.read());
@@ -198,6 +225,12 @@ impl GossipController {
 
             // SWIM §5.2: remove nodes Down for longer than dead_timeout and
             // sweep their keys (replica registry, registered namespaces).
+            purge_held_reinsertions(
+                &mut removed_holddown,
+                &mut init_state.write(),
+                self.dead_timeout * 3,
+                Instant::now(),
+            );
             let expired = expire_down_nodes(
                 &mut down_since,
                 &init_state.read(),
@@ -210,6 +243,12 @@ impl GossipController {
                 init_state.write().remove(&name);
                 retry_managers.remove(&name);
                 down_since.remove(&name);
+                removed_holddown.insert(name.clone(), Instant::now());
+                // Reap the dead peer's stream task now rather than letting it
+                // tick into a dead channel until the idle timeout.
+                if let Some(handle) = self.sync_connections.lock().await.remove(&name) {
+                    handle.abort();
+                }
                 if let Some(mesh_kv) = &self.mesh_kv {
                     let swept = mesh_kv.handle_node_removed(&name);
                     log::info!("Dead-node sweep for {name} tombstoned {swept} keys");
@@ -1095,6 +1134,46 @@ mod dead_node_tests {
         );
         assert!(expired.is_empty());
         assert!(down_since.is_empty(), "self is never tracked");
+    }
+
+    #[test]
+    fn holddown_purges_reinserted_down_entry_without_retracking() {
+        let mut held = HashMap::new();
+        let t0 = Instant::now();
+        held.insert("d".to_string(), t0);
+
+        // A slower survivor's gossip re-inserted d(Down): purged, still held.
+        let mut state = state_of(vec![node("d", NodeStatus::Down)]);
+        purge_held_reinsertions(&mut held, &mut state, TIMEOUT, t0 + Duration::from_secs(1));
+        assert!(!state.contains_key("d"), "stale re-offer purged");
+        assert!(held.contains_key("d"), "hold persists");
+    }
+
+    #[test]
+    fn holddown_lifts_when_node_returns_alive() {
+        let mut held = HashMap::new();
+        let t0 = Instant::now();
+        held.insert("d".to_string(), t0);
+
+        let mut state = state_of(vec![node("d", NodeStatus::Alive)]);
+        purge_held_reinsertions(&mut held, &mut state, TIMEOUT, t0 + Duration::from_secs(1));
+        assert!(state.contains_key("d"), "alive return kept in membership");
+        assert!(held.is_empty(), "hold lifted on alive return");
+    }
+
+    #[test]
+    fn holddown_expires_after_window() {
+        let mut held = HashMap::new();
+        let t0 = Instant::now();
+        held.insert("d".to_string(), t0);
+
+        let mut state = state_of(vec![node("d", NodeStatus::Down)]);
+        purge_held_reinsertions(&mut held, &mut state, TIMEOUT, t0 + TIMEOUT);
+        assert!(held.is_empty(), "hold expires after the window");
+        assert!(
+            state.contains_key("d"),
+            "post-holddown re-offer re-enters normal tracking"
+        );
     }
 
     #[test]

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -196,13 +196,27 @@ impl GossipService {
             // intentional and must survive the merge.
             let failure_rumor = node.status == NodeStatus::Suspected as i32
                 || node.status == NodeStatus::Down as i32;
-            // Mid-graceful-shutdown the node IS departing: refuting a
-            // failure rumor here would override its own Leaving broadcast.
-            let self_is_leaving = node.name == self.self_name
-                && state
+            if node.name == self.self_name && failure_rumor {
+                // Mid-graceful-shutdown the node IS departing: a failure
+                // rumor about self must neither be refuted (re-asserting
+                // Alive) nor accepted (the generic merge below would let a
+                // higher-version Down overwrite the deliberate Leaving and
+                // ping_server would start advertising Down). Ignore it
+                // outright while Leaving.
+                let self_is_leaving = state
                     .get(&node.name)
                     .is_some_and(|entry| entry.status == NodeStatus::Leaving as i32);
-            if node.name == self.self_name && failure_rumor && !self_is_leaving {
+                if self_is_leaving {
+                    log::debug!(
+                        "ignoring status {} rumor about self while Leaving",
+                        node.status
+                    );
+                    continue;
+                }
+                // SWIM refutation: re-assert Alive past the rumor's version.
+                // Without this a stale Down rumor outliving a restart (its
+                // version exceeds the fresh boot's) would win every merge and
+                // the live node would be declared dead — and swept — repeatedly.
                 let refuted_version = node.version + 1;
                 log::warn!(
                     "Refuting status {} rumor about self (v{}); re-asserting Alive v{refuted_version}",
@@ -758,11 +772,12 @@ mod sender_tick_tests {
             metadata: std::collections::HashMap::new(),
         }]);
         let entry = state.read().get("self").cloned().expect("self present");
-        assert_ne!(
+        assert_eq!(
             entry.status,
-            NodeStatus::Alive as i32,
-            "a departing node never re-asserts Alive"
+            NodeStatus::Leaving as i32,
+            "a higher-version Down rumor must not overwrite the deliberate Leaving"
         );
+        assert_eq!(entry.version, 5, "the Leaving entry is left untouched");
     }
 
     #[test]

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -187,6 +187,37 @@ impl GossipService {
         let mut state = self.state.write();
         let mut updated = false;
         for node in incoming_nodes {
+            // SWIM refutation: a node hearing itself reported non-Alive
+            // re-asserts Alive past the rumor's version. Without this, a
+            // stale Down rumor outliving a restart (its version exceeds the
+            // fresh boot's) would win every merge and the live node would
+            // be declared dead — and swept — repeatedly.
+            if node.name == self.self_name && node.status != NodeStatus::Alive as i32 {
+                let refuted_version = node.version + 1;
+                log::warn!(
+                    "Refuting status {} rumor about self (v{}); re-asserting Alive v{refuted_version}",
+                    node.status,
+                    node.version
+                );
+                state
+                    .entry(node.name.clone())
+                    .and_modify(|entry| {
+                        if entry.version < refuted_version {
+                            entry.status = NodeStatus::Alive as i32;
+                            entry.version = refuted_version;
+                            updated = true;
+                        }
+                    })
+                    .or_insert_with(|| {
+                        updated = true;
+                        NodeState {
+                            status: NodeStatus::Alive as i32,
+                            version: refuted_version,
+                            ..node
+                        }
+                    });
+                continue;
+            }
             state
                 .entry(node.name.clone())
                 .and_modify(|entry| {
@@ -618,6 +649,65 @@ mod sender_tick_tests {
         let rb = round_batch_with(vec![("td:foo", b"d")], vec![]);
         let decision = plan_sender_tick(Some(&rb), &rb, Some("peer_X"));
         assert!(matches!(decision, SenderTick::SkipBatchUnchanged));
+    }
+
+    #[test]
+    fn merge_state_refutes_non_alive_rumor_about_self() {
+        let state = ClusterState::default();
+        let service = GossipService::new(
+            state.clone(),
+            "127.0.0.1:0".parse().unwrap(),
+            "127.0.0.1:0".parse().unwrap(),
+            "self",
+        );
+
+        // A stale Down rumor about self (e.g. outliving a restart) must be
+        // refuted past its version, never accepted.
+        service.merge_state(vec![NodeState {
+            name: "self".to_string(),
+            address: "127.0.0.1:50051".to_string(),
+            status: NodeStatus::Down as i32,
+            version: 3,
+            metadata: std::collections::HashMap::new(),
+        }]);
+        let entry = state.read().get("self").cloned().expect("self present");
+        assert_eq!(entry.status, NodeStatus::Alive as i32, "rumor refuted");
+        assert_eq!(entry.version, 4, "refutation beats the rumor's version");
+
+        // A rumor older than the current refutation does not regress it.
+        service.merge_state(vec![NodeState {
+            name: "self".to_string(),
+            address: "127.0.0.1:50051".to_string(),
+            status: NodeStatus::Suspected as i32,
+            version: 2,
+            metadata: std::collections::HashMap::new(),
+        }]);
+        let entry = state.read().get("self").cloned().expect("self present");
+        assert_eq!(entry.status, NodeStatus::Alive as i32);
+        assert_eq!(
+            entry.version, 4,
+            "older rumor cannot regress the refutation"
+        );
+    }
+
+    #[test]
+    fn merge_state_accepts_non_alive_rumor_about_peers() {
+        let state = ClusterState::default();
+        let service = GossipService::new(
+            state.clone(),
+            "127.0.0.1:0".parse().unwrap(),
+            "127.0.0.1:0".parse().unwrap(),
+            "self",
+        );
+        service.merge_state(vec![NodeState {
+            name: "other".to_string(),
+            address: "127.0.0.1:50052".to_string(),
+            status: NodeStatus::Down as i32,
+            version: 3,
+            metadata: std::collections::HashMap::new(),
+        }]);
+        let entry = state.read().get("other").cloned().expect("other present");
+        assert_eq!(entry.status, NodeStatus::Down as i32, "peer rumor accepted");
     }
 
     #[test]

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -187,12 +187,16 @@ impl GossipService {
         let mut state = self.state.write();
         let mut updated = false;
         for node in incoming_nodes {
-            // SWIM refutation: a node hearing itself reported non-Alive
+            // SWIM refutation: a node hearing itself reported as FAILED
             // re-asserts Alive past the rumor's version. Without this, a
             // stale Down rumor outliving a restart (its version exceeds the
             // fresh boot's) would win every merge and the live node would
-            // be declared dead — and swept — repeatedly.
-            if node.name == self.self_name && node.status != NodeStatus::Alive as i32 {
+            // be declared dead — and swept — repeatedly. Only failure states
+            // are refuted: a self-initiated Leaving echoed back by peers is
+            // intentional and must survive the merge.
+            let failure_rumor = node.status == NodeStatus::Suspected as i32
+                || node.status == NodeStatus::Down as i32;
+            if node.name == self.self_name && failure_rumor {
                 let refuted_version = node.version + 1;
                 log::warn!(
                     "Refuting status {} rumor about self (v{}); re-asserting Alive v{refuted_version}",
@@ -688,6 +692,34 @@ mod sender_tick_tests {
             entry.version, 4,
             "older rumor cannot regress the refutation"
         );
+    }
+
+    #[test]
+    fn merge_state_preserves_leaving_rumor_about_self() {
+        // Graceful shutdown broadcasts Leaving; a peer echoing it back within
+        // the propagation window must not be refuted to Alive, or the
+        // graceful leave degrades into a dead-timeout removal.
+        let state = ClusterState::default();
+        let service = GossipService::new(
+            state.clone(),
+            "127.0.0.1:0".parse().unwrap(),
+            "127.0.0.1:0".parse().unwrap(),
+            "self",
+        );
+        service.merge_state(vec![NodeState {
+            name: "self".to_string(),
+            address: "127.0.0.1:50051".to_string(),
+            status: NodeStatus::Leaving as i32,
+            version: 5,
+            metadata: std::collections::HashMap::new(),
+        }]);
+        let entry = state.read().get("self").cloned().expect("self present");
+        assert_eq!(
+            entry.status,
+            NodeStatus::Leaving as i32,
+            "intentional Leaving is not refuted"
+        );
+        assert_eq!(entry.version, 5);
     }
 
     #[test]

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -196,7 +196,13 @@ impl GossipService {
             // intentional and must survive the merge.
             let failure_rumor = node.status == NodeStatus::Suspected as i32
                 || node.status == NodeStatus::Down as i32;
-            if node.name == self.self_name && failure_rumor {
+            // Mid-graceful-shutdown the node IS departing: refuting a
+            // failure rumor here would override its own Leaving broadcast.
+            let self_is_leaving = node.name == self.self_name
+                && state
+                    .get(&node.name)
+                    .is_some_and(|entry| entry.status == NodeStatus::Leaving as i32);
+            if node.name == self.self_name && failure_rumor && !self_is_leaving {
                 let refuted_version = node.version + 1;
                 log::warn!(
                     "Refuting status {} rumor about self (v{}); re-asserting Alive v{refuted_version}",
@@ -720,6 +726,43 @@ mod sender_tick_tests {
             "intentional Leaving is not refuted"
         );
         assert_eq!(entry.version, 5);
+    }
+
+    #[test]
+    fn merge_state_does_not_refute_failure_rumors_while_leaving() {
+        // Mid-graceful-shutdown, a peer escalating this node's
+        // unresponsiveness to Suspected/Down must not be refuted to Alive —
+        // that would override the node's own Leaving broadcast.
+        let state = ClusterState::default();
+        state.write().insert(
+            "self".to_string(),
+            NodeState {
+                name: "self".to_string(),
+                address: "127.0.0.1:50051".to_string(),
+                status: NodeStatus::Leaving as i32,
+                version: 5,
+                metadata: std::collections::HashMap::new(),
+            },
+        );
+        let service = GossipService::new(
+            state.clone(),
+            "127.0.0.1:0".parse().unwrap(),
+            "127.0.0.1:0".parse().unwrap(),
+            "self",
+        );
+        service.merge_state(vec![NodeState {
+            name: "self".to_string(),
+            address: "127.0.0.1:50051".to_string(),
+            status: NodeStatus::Down as i32,
+            version: 6,
+            metadata: std::collections::HashMap::new(),
+        }]);
+        let entry = state.read().get("self").cloned().expect("self present");
+        assert_ne!(
+            entry.status,
+            NodeStatus::Alive as i32,
+            "a departing node never re-asserts Alive"
+        );
     }
 
     #[test]

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -6,7 +6,7 @@
 //!
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -20,13 +20,28 @@ use parking_lot::RwLock;
 use tokio::sync::mpsc;
 
 use crate::{
-    crdt_kv::{CrdtOrMap, MergeStrategy, Operation, OperationLog},
+    crdt_kv::{CrdtOrMap, MergeStrategy, Operation, OperationLog, ReplicaId},
     transport::chunk_assembler::ChunkAssembler,
 };
 
 // ============================================================================
 // Type Definitions
 // ============================================================================
+
+/// Key prefix of the gossiped replica registry: `replica:{replica_id}` →
+/// node name. One entry per node incarnation (replica ids are minted per
+/// boot); a dead node's entries retire with the rest of its keys.
+pub const REPLICA_PREFIX: &str = "replica:";
+
+/// How a dead node's keys are attributed during sweep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeadKeyAttribution {
+    /// The key's winning op was authored by one of the dead node's replica
+    /// ids (single-writer namespaces, e.g. `worker:`).
+    AuthorReplica,
+    /// The key's last `:`-segment is the node name (e.g. `rl:{counter}:{node}`).
+    NodeNameSuffix,
+}
 
 /// Routing mode for stream namespaces.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -475,6 +490,9 @@ pub struct MeshKV {
     server_name: String,
     /// Replica ID: hash(server_name) as u64.
     replica_id: u64,
+    /// Prefixes registered for dead-node key sweeping, with their
+    /// attribution rule.
+    dead_node_sweeps: RwLock<Vec<(String, DeadKeyAttribution)>>,
 }
 
 impl MeshKV {
@@ -494,6 +512,19 @@ impl MeshKV {
                 merge_strategy: MergeStrategy::LastWriterWins,
             },
         );
+        // Replica registry: publish this incarnation's op-author id so
+        // survivors can attribute single-writer keys after this node dies.
+        store.register_merge_strategy(REPLICA_PREFIX.to_string(), MergeStrategy::LastWriterWins);
+        configured_prefixes.insert(
+            REPLICA_PREFIX.to_string(),
+            StoreMode::Crdt {
+                merge_strategy: MergeStrategy::LastWriterWins,
+            },
+        );
+        store.insert(
+            format!("{REPLICA_PREFIX}{}", store.replica_id()),
+            server_name.clone().into_bytes(),
+        );
         let configs = Arc::new(CrdtNamespace {
             prefix: "config:".to_string(),
             store: store.clone(),
@@ -510,6 +541,7 @@ impl MeshKV {
             configs,
             server_name,
             replica_id,
+            dead_node_sweeps: RwLock::new(Vec::new()),
         }
     }
 
@@ -540,6 +572,104 @@ impl MeshKV {
     /// declared dead — so the caller must be the dead-node cleanup layer.
     pub fn gc_tombstones(&self) -> usize {
         self.store.gc_tombstones()
+    }
+
+    /// Register a prefix for dead-node key sweeping: when
+    /// [`handle_node_removed`](Self::handle_node_removed) fires, live keys
+    /// under `prefix` attributed to the dead node are tombstoned.
+    pub fn configure_dead_node_sweep(&self, prefix: &str, attribution: DeadKeyAttribution) {
+        self.dead_node_sweeps
+            .write()
+            .push((prefix.to_string(), attribution));
+    }
+
+    /// Dead-node cleanup: tombstone the node's keys in every sweep-registered
+    /// namespace, then retire its replica-registry entries. Every survivor
+    /// runs this; concurrent tombstones converge, and a live (partitioned)
+    /// owner's reconcile re-assert overrules a premature sweep. Returns the
+    /// number of keys tombstoned.
+    pub fn handle_node_removed(&self, node: &str) -> usize {
+        let replica_keys = self.replica_keys_of(node);
+        let dead_replicas: HashSet<ReplicaId> = replica_keys
+            .iter()
+            .filter_map(|key| key.strip_prefix(REPLICA_PREFIX))
+            .filter_map(|id| ReplicaId::from_string(id).ok())
+            .collect();
+        let mut swept = 0;
+        let sweeps = self.dead_node_sweeps.read().clone();
+        for (prefix, attribution) in &sweeps {
+            swept += match attribution {
+                DeadKeyAttribution::AuthorReplica => self.sweep_authored_by(prefix, &dead_replicas),
+                DeadKeyAttribution::NodeNameSuffix => self.sweep_node_suffix(prefix, node),
+            };
+        }
+        // Last so a concurrent sweep on another survivor can still attribute.
+        for key in &replica_keys {
+            self.delete_with_notify(key);
+        }
+        swept
+    }
+
+    /// Replica-registry keys mapping to `node` (one per incarnation).
+    pub(crate) fn replica_keys_of(&self, node: &str) -> Vec<String> {
+        self.store
+            .keys()
+            .into_iter()
+            .filter(|key| {
+                key.starts_with(REPLICA_PREFIX)
+                    && self.store.get(key).is_some_and(|v| v == node.as_bytes())
+            })
+            .collect()
+    }
+
+    /// Tombstone live `prefix` keys whose last `:`-segment is `node`.
+    fn sweep_node_suffix(&self, prefix: &str, node: &str) -> usize {
+        let mut swept = 0;
+        for key in self.store.keys() {
+            if key.starts_with(prefix) && key.rsplit(':').next() == Some(node) {
+                self.delete_with_notify(&key);
+                swept += 1;
+            }
+        }
+        swept
+    }
+
+    /// Tombstone live `prefix` keys whose winning op was authored by one of
+    /// `dead_replicas`. Winners come from the op-log snapshot; a live key
+    /// whose ops were shed by the out-of-spec truncation backstop is skipped
+    /// (never falsely swept).
+    fn sweep_authored_by(&self, prefix: &str, dead_replicas: &HashSet<ReplicaId>) -> usize {
+        if dead_replicas.is_empty() {
+            return 0;
+        }
+        let ops = self.store.operation_log_snapshot();
+        let mut winners: HashMap<&str, (u64, ReplicaId)> = HashMap::new();
+        for op in ops.operations() {
+            if !op.key().starts_with(prefix) {
+                continue;
+            }
+            let version = (op.timestamp(), op.replica_id());
+            winners
+                .entry(op.key())
+                .and_modify(|winner| *winner = version.max(*winner))
+                .or_insert(version);
+        }
+        let mut swept = 0;
+        for (key, (_, replica)) in winners {
+            if dead_replicas.contains(&replica) && self.store.contains_key(key) {
+                self.delete_with_notify(key);
+                swept += 1;
+            }
+        }
+        swept
+    }
+
+    /// Tombstone a key and fire subscribers with `None`, matching
+    /// [`CrdtNamespace::delete`] semantics so inbound adapters react to
+    /// sweeps like any other deletion.
+    fn delete_with_notify(&self, key: &str) {
+        self.store.remove(key);
+        self.subscriber_registry.notify(key, None);
     }
 
     /// Fire subscribers whose prefix matches `key`. Used by the gossip

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -597,6 +597,16 @@ impl MeshKV {
             .collect();
         let mut swept = 0;
         let sweeps = self.dead_node_sweeps.read().clone();
+        if dead_replicas.is_empty()
+            && sweeps
+                .iter()
+                .any(|(_, attribution)| *attribution == DeadKeyAttribution::AuthorReplica)
+        {
+            tracing::warn!(
+                node,
+                "no replica-registry entries for removed node; author-attributed sweeps skipped"
+            );
+        }
         for (prefix, attribution) in &sweeps {
             swept += match attribution {
                 DeadKeyAttribution::AuthorReplica => self.sweep_authored_by(prefix, &dead_replicas),
@@ -608,6 +618,30 @@ impl MeshKV {
             self.delete_with_notify(key);
         }
         swept
+    }
+
+    /// Owner-side replica-registry maintenance: re-assert this incarnation's
+    /// entry (healing a premature sweep, which would otherwise permanently
+    /// disarm author attribution for this node's real death) and retire
+    /// entries left by prior incarnations (bounding the registry at ~one
+    /// entry per live node across restarts). Driven at boot and on the
+    /// gossip loop's housekeeping cadence; only the owner touches entries
+    /// valued with its own name.
+    pub fn reconcile_replica_registry(&self) {
+        let own_key = format!("{REPLICA_PREFIX}{}", self.store.replica_id());
+        for key in self.replica_keys_of(&self.server_name) {
+            if key != own_key {
+                self.delete_with_notify(&key);
+            }
+        }
+        if self
+            .store
+            .get(&own_key)
+            .is_none_or(|value| value != self.server_name.as_bytes())
+        {
+            self.store
+                .insert(own_key, self.server_name.clone().into_bytes());
+        }
     }
 
     /// Replica-registry keys mapping to `node` (one per incarnation).

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -629,8 +629,20 @@ impl MeshKV {
     /// valued with its own name.
     pub fn reconcile_replica_registry(&self) {
         let own_key = format!("{REPLICA_PREFIX}{}", self.store.replica_id());
+        // A prior incarnation's entry retires only once nothing live is
+        // attributed to it (a crash-restart can leave keys whose winning op
+        // it authored): retiring earlier would orphan those keys at this
+        // node's real death, since attribution rebuilds from live entries.
+        let still_authoring = self.live_key_authors();
         for key in self.replica_keys_of(&self.server_name) {
-            if key != own_key {
+            if key == own_key {
+                continue;
+            }
+            let authoring = key
+                .strip_prefix(REPLICA_PREFIX)
+                .and_then(|id| ReplicaId::from_string(id).ok())
+                .is_some_and(|replica| still_authoring.contains(&replica));
+            if !authoring {
                 self.delete_with_notify(&key);
             }
         }
@@ -642,6 +654,38 @@ impl MeshKV {
             self.store
                 .insert(own_key, self.server_name.clone().into_bytes());
         }
+    }
+
+    /// Replica ids authoring the winning op of some live key in an
+    /// author-attributed namespace.
+    fn live_key_authors(&self) -> HashSet<ReplicaId> {
+        let prefixes: Vec<String> = self
+            .dead_node_sweeps
+            .read()
+            .iter()
+            .filter(|(_, attribution)| *attribution == DeadKeyAttribution::AuthorReplica)
+            .map(|(prefix, _)| prefix.clone())
+            .collect();
+        if prefixes.is_empty() {
+            return HashSet::new();
+        }
+        let ops = self.store.operation_log_snapshot();
+        let mut winners: HashMap<&str, (u64, ReplicaId)> = HashMap::new();
+        for op in ops.operations() {
+            if !prefixes.iter().any(|p| op.key().starts_with(p.as_str())) {
+                continue;
+            }
+            let version = (op.timestamp(), op.replica_id());
+            winners
+                .entry(op.key())
+                .and_modify(|winner| *winner = version.max(*winner))
+                .or_insert(version);
+        }
+        winners
+            .into_iter()
+            .filter(|(key, _)| self.store.contains_key(key))
+            .map(|(_, (_, replica))| replica)
+            .collect()
     }
 
     /// Replica-registry keys mapping to `node` (one per incarnation).

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -26,8 +26,8 @@ pub use crdt_kv::{
     MergeStrategy, OperationLog, EPOCH_MAX_WINS_ENCODED_LEN,
 };
 pub use kv::{
-    CrdtNamespace, DrainHandle, MeshKV, StreamConfig, StreamDrainFn, StreamNamespace,
-    StreamRouting, Subscription,
+    CrdtNamespace, DeadKeyAttribution, DrainHandle, MeshKV, StreamConfig, StreamDrainFn,
+    StreamNamespace, StreamRouting, Subscription,
 };
 pub use metrics::init_mesh_metrics;
 pub use mtls::{MTLSConfig, MTLSManager};

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -338,6 +338,38 @@ fn reconcile_retires_prior_incarnations_registry_entries() {
 }
 
 #[test]
+fn reconcile_keeps_prior_entry_while_it_still_authors_live_keys() {
+    // Crash-restart: the prior incarnation's worker key is still live and
+    // attributed to its replica id. Retiring that registry entry would
+    // orphan the key at this node's real death, so it must survive
+    // reconcile until the key is gone.
+    let prior = MeshKV::new("node-a".to_string());
+    let prior_ns = prior.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    prior_ns.put("worker:legacy", b"v1".to_vec());
+
+    let current = MeshKV::new("node-a".to_string());
+    let current_ns = current.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    current.configure_dead_node_sweep("worker:", DeadKeyAttribution::AuthorReplica);
+    deliver_crdt(&prior, &current);
+
+    current.reconcile_replica_registry();
+    assert_eq!(
+        current.replica_keys_of("node-a").len(),
+        2,
+        "entry still authoring a live key survives reconcile"
+    );
+
+    // Once the key is gone, the next reconcile retires the stale entry.
+    current_ns.delete("worker:legacy");
+    current.reconcile_replica_registry();
+    assert_eq!(
+        current.replica_keys_of("node-a").len(),
+        1,
+        "entry retires once nothing live is attributed to it"
+    );
+}
+
+#[test]
 fn reconcile_reasserts_own_registry_entry_after_premature_sweep() {
     // A partitioned-but-alive node swept by survivors must heal its own
     // registry entry, or author attribution is disarmed for its real death.

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -19,7 +19,7 @@ use crate::{
     crdt_kv::{
         decode as decode_epoch_count, encode as encode_epoch_count, CrdtWatermark, EpochCount,
     },
-    kv::MeshKV,
+    kv::{DeadKeyAttribution, MeshKV},
     transport::{
         crdt_batch::{build_crdt_batches, dispatch_crdt_batch},
         limits::MAX_STREAM_CHUNK_BYTES,
@@ -270,6 +270,93 @@ fn op_log_stays_bounded_by_live_keys() {
 }
 
 #[test]
+fn new_publishes_replica_registry_entry() {
+    // Survivors attribute a dead node's single-writer keys through the
+    // gossiped replica registry, so every node publishes its op-author id
+    // at construction.
+    let mesh = MeshKV::new("node-a".to_string());
+    assert_eq!(
+        mesh.replica_keys_of("node-a").len(),
+        1,
+        "exactly one replica-registry entry for this incarnation"
+    );
+}
+
+#[test]
+fn dead_node_sweep_tombstones_authored_keys() {
+    let dead = MeshKV::new("dead-node".to_string());
+    let dead_ns = dead.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    dead_ns.put("worker:dead-owned", b"v1".to_vec());
+
+    let survivor = MeshKV::new("survivor".to_string());
+    let survivor_ns = survivor.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    survivor.configure_dead_node_sweep("worker:", DeadKeyAttribution::AuthorReplica);
+    survivor_ns.put("worker:own", b"v2".to_vec());
+
+    deliver_crdt(&dead, &survivor);
+    assert!(survivor_ns.get("worker:dead-owned").is_some());
+
+    let swept = survivor.handle_node_removed("dead-node");
+    assert_eq!(swept, 1, "only the dead node's key is swept");
+    assert_eq!(
+        survivor_ns.get("worker:dead-owned"),
+        None,
+        "dead node's key tombstoned"
+    );
+    assert_eq!(
+        survivor_ns.get("worker:own"),
+        Some(b"v2".to_vec()),
+        "survivor-owned key kept"
+    );
+    assert!(
+        survivor.replica_keys_of("dead-node").is_empty(),
+        "dead node's replica-registry entries retired"
+    );
+    assert_eq!(
+        survivor.replica_keys_of("survivor").len(),
+        1,
+        "survivor's own registry entry kept"
+    );
+}
+
+#[test]
+fn dead_node_sweep_matches_node_suffix() {
+    let survivor = MeshKV::new("survivor".to_string());
+    let rl = survivor.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+    survivor.configure_dead_node_sweep("rl:", DeadKeyAttribution::NodeNameSuffix);
+    rl.put("rl:global:dead-node", encode_epoch_count(1, 5).to_vec());
+    rl.put("rl:global:survivor", encode_epoch_count(1, 7).to_vec());
+
+    let swept = survivor.handle_node_removed("dead-node");
+    assert_eq!(swept, 1);
+    assert_eq!(rl.get("rl:global:dead-node"), None, "dead shard swept");
+    assert!(
+        rl.get("rl:global:survivor").is_some(),
+        "survivor shard kept"
+    );
+}
+
+#[tokio::test]
+async fn dead_node_sweep_fires_subscriber_tombstones() {
+    // Inbound adapters (e.g. worker registry removal) react to sweeps via
+    // the same (key, None) notification a normal delete fires.
+    let dead = MeshKV::new("dead-node".to_string());
+    let dead_ns = dead.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    dead_ns.put("worker:w1", b"v1".to_vec());
+
+    let survivor = MeshKV::new("survivor".to_string());
+    let survivor_ns = survivor.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    survivor.configure_dead_node_sweep("worker:", DeadKeyAttribution::AuthorReplica);
+    deliver_crdt(&dead, &survivor);
+
+    let mut sub = survivor_ns.subscribe("");
+    survivor.handle_node_removed("dead-node");
+    let (key, payload) = sub.receiver.recv().await.expect("sweep fires subscriber");
+    assert_eq!(key, "worker:w1");
+    assert!(payload.is_none(), "sweep notifies a tombstone");
+}
+
+#[test]
 fn gc_tombstones_respects_grace_through_mesh_kv() {
     // The controller drives this periodically; a fresh tombstone must
     // survive the grace period (engine-level reclamation is covered by
@@ -370,13 +457,17 @@ fn dropping_one_keys_batch_does_not_strand_it() {
     // key and strand it forever. Per-key tracking resends only the dropped key.
     let sender = MeshKV::new("sender".to_string());
     let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
-    s_ns.put("worker:a", vec![0u8; 200]);
-    s_ns.put("worker:b", vec![1u8; 200]);
 
     let receiver = MeshKV::new("receiver".to_string());
     let r_ns = receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
 
+    // Flush and ack the construction-time replica-registry op so the batch
+    // split below is driven by the two worker keys alone.
     let mut acked = CrdtWatermark::new();
+    deliver_crdt_watermarked(&sender, &receiver, &mut acked);
+
+    s_ns.put("worker:a", vec![0u8; 200]);
+    s_ns.put("worker:b", vec![1u8; 200]);
     // A budget that fits one ~200-byte op per frame forces two separate batches.
     let batches = build_crdt_batches(&pending_ops(&sender, &acked), 300);
     assert!(

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -320,6 +320,47 @@ fn dead_node_sweep_tombstones_authored_keys() {
 }
 
 #[test]
+fn reconcile_retires_prior_incarnations_registry_entries() {
+    // A restarted node mints a fresh replica id; without owner-side
+    // retirement the registry would grow by one immortal key per boot.
+    let prior = MeshKV::new("node-a".to_string());
+    let current = MeshKV::new("node-a".to_string());
+    deliver_crdt(&prior, &current);
+    assert_eq!(
+        current.replica_keys_of("node-a").len(),
+        2,
+        "prior incarnation's entry arrived via gossip"
+    );
+
+    current.reconcile_replica_registry();
+    let keys = current.replica_keys_of("node-a");
+    assert_eq!(keys.len(), 1, "only the current incarnation's entry stays");
+}
+
+#[test]
+fn reconcile_reasserts_own_registry_entry_after_premature_sweep() {
+    // A partitioned-but-alive node swept by survivors must heal its own
+    // registry entry, or author attribution is disarmed for its real death.
+    let survivor = MeshKV::new("survivor".to_string());
+    let owner = MeshKV::new("node-a".to_string());
+    deliver_crdt(&owner, &survivor);
+
+    survivor.handle_node_removed("node-a");
+    deliver_crdt(&survivor, &owner);
+    assert!(
+        owner.replica_keys_of("node-a").is_empty(),
+        "the sweep tombstone reached the owner"
+    );
+
+    owner.reconcile_replica_registry();
+    assert_eq!(
+        owner.replica_keys_of("node-a").len(),
+        1,
+        "owner re-asserts its registry entry"
+    );
+}
+
+#[test]
 fn dead_node_sweep_matches_node_suffix() {
     let survivor = MeshKV::new("survivor".to_string());
     let rl = survivor.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use smg_mesh::{MergeStrategy, MeshKV};
+use smg_mesh::{DeadKeyAttribution, MergeStrategy, MeshKV};
 
 use super::adapters::{RateLimitSyncAdapter, WorkerSyncAdapter};
 use crate::worker::WorkerRegistry;
@@ -45,6 +45,11 @@ impl MeshAdapters {
     ) -> Arc<Self> {
         let worker_ns = mesh_kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
         let rl_ns = mesh_kv.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+        // Dead-node cleanup: worker keys attribute by the publisher's replica
+        // id (single-writer namespace); rl shard keys carry the node name as
+        // their last segment.
+        mesh_kv.configure_dead_node_sweep("worker:", DeadKeyAttribution::AuthorReplica);
+        mesh_kv.configure_dead_node_sweep("rl:", DeadKeyAttribution::NodeNameSuffix);
         let worker = WorkerSyncAdapter::new(worker_ns, worker_registry);
         let rate_limit = RateLimitSyncAdapter::new(rl_ns, node_name);
         worker.start();
@@ -116,6 +121,49 @@ mod tests {
         adapters.rate_limit().sync_counter("global", 2, 5);
         adapters.rate_limit().sync_counter("global", 1, 100);
         assert_eq!(adapters.rate_limit().get_aggregate("global"), 5);
+    }
+
+    #[tokio::test]
+    async fn dead_node_sweep_evicts_worker_and_rl_shard() {
+        let mesh = MeshKV::new("node-a".into());
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapters = MeshAdapters::start(&mesh, "node-a".into(), registry.clone());
+
+        adapters.rate_limit().sync_counter("global", 1, 5);
+        assert_eq!(adapters.rate_limit().get_aggregate("global"), 5);
+
+        let state = WorkerState {
+            worker_id: "w1".into(),
+            model_id: "llama-3".into(),
+            url: "http://remote:8080".into(),
+            health: true,
+            load: 0.0,
+            version: 1,
+            spec: vec![],
+        };
+        adapters.worker().on_worker_changed("w1", &state);
+        for _ in 0..100 {
+            if registry.get_by_url("http://remote:8080").is_some() {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        assert!(registry.get_by_url("http://remote:8080").is_some());
+
+        // Declare the publishing node dead. In production a survivor runs
+        // this against a dead peer's keys; the local plumbing is identical:
+        // replica-id attribution sweeps worker:w1, suffix attribution sweeps
+        // rl:global:node-a, and the worker tombstone evicts the import.
+        mesh.handle_node_removed("node-a");
+
+        assert_eq!(adapters.rate_limit().get_aggregate("global"), 0);
+        for _ in 0..100 {
+            if registry.get_by_url("http://remote:8080").is_none() {
+                return;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        panic!("swept worker tombstone did not evict the imported worker");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

A permanently-dead node's keys lived forever cluster-wide — the documented "known gap" of the worker-sync design: only the owner may tombstone its keys, and a dead owner never does. Its imported workers stayed registered on every gateway (demoted only by local health probes), its `rl:` shards accumulated, and nothing in any namespace ever cleaned up. The trigger half was also missing at the membership layer: SWIM §5.2 prescribes Down → removed after `dead_timeout`, but Down entries sat in `ClusterState` forever, only excluded from peer selection.

### Solution

One shared mechanism, per-namespace attribution:

- **Replica registry** (`replica:{replica_id}` → node name): every node publishes its per-boot op-author id at construction, giving survivors the attribution map from ops to nodes that random-per-boot replica ids otherwise destroy.
- **Trigger**: the gossip loop tracks how long each peer has been Down and, past `dead_timeout` (60s, spec default), removes it from membership/retry state, aborts its sync-stream task, and fires the sweep.
- **Executor** (`MeshKV::handle_node_removed`): tombstones the dead node's live keys in sweep-registered namespaces, then retires its registry entries. Attribution is declared per namespace in `MeshAdapters::start`: `worker:` sweeps by the key's winning-op author (single-writer namespace); `rl:` sweeps by the key's node-name suffix. Swept worker tombstones flow through the existing inbound loop, evicting the dead node's imports from every registry.
- Every survivor sweeps; concurrent tombstones converge (live-key gate bounds the storm to ~K×(N−1) payload-free Remove ops, quantified by review as fine at design scale), and a live partitioned owner's reconcile re-assert overrules a premature sweep.

**Found by adversarial review, fixed in-PR (3 confirmed must-fixes):**

- *Removal wasn't durable.* Full-state pings re-inserted removed Down entries unconditionally, so membership never converged (re-sweep every 60s forever) — and a **restarted live node lost the version race to its own circulating Down rumor and was destructively swept while serving**. Fixed at the root with SWIM-style self-refutation (`merge_state` re-asserts Alive past any non-Alive rumor about self) plus a removal holddown (stale re-offers are purged each round without re-arming the clock; an Alive return lifts the hold).
- *Registry entries were immortal across restarts of live nodes* — one leaked key per deploy, unbounded with deploy count. `reconcile_replica_registry` (boot + 60-round cadence) retires prior incarnations' entries, bounding the registry at ~one entry per live node.
- *A premature sweep permanently disarmed attribution* (the swept registry entry was never re-asserted, so the node's real death later leaked everything). The same reconcile re-asserts the owner's entry; the re-put wins once the owner's clock has observed the sweep tombstone.

### Known limitations (disclosed)

- `rl:` premature-sweep healing waits for the node's next local increment (no periodic re-publish yet — the d-3b middleware will publish on a cadence). Epoch-scoped aggregation makes the lost stale count mostly moot.
- A peer partitioned past the tombstone grace could replay swept keys after GC — prevented for now because tombstone GC is deliberately undriven; the causally-stable GC (next PR in this stack) owns that path.
- Tombstone metadata accrues per swept key until that causally-stable GC lands (documented deferral from #1661).
- Rolling upgrade: a dead old-binary node has no registry entry; author-attributed sweeps are skipped with an explicit warn (suffix sweeps still fire).
- `dead_timeout` is the spec default (60s), not yet a config knob.

## Changes

- `crates/mesh/src/kv.rs` — `REPLICA_PREFIX` registry (auto-registered LWW), `DeadKeyAttribution`, `configure_dead_node_sweep`, `handle_node_removed`, `reconcile_replica_registry`
- `crates/mesh/src/gossip_controller.rs` — `expire_down_nodes` + `dead_timeout` removal wired into the event loop; removal holddown; sync-stream abort; reconcile drive on the 60-round tick
- `crates/mesh/src/gossip_service.rs` — SWIM self-refutation in `merge_state`
- `model_gateway/src/mesh/wiring.rs` — sweep registration for `worker:`/`rl:`
- `crates/mesh/src/lib.rs` — export `DeadKeyAttribution`

## Test Plan

- `cargo test -p smg-mesh` (206) and `cargo test -p smg` green; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- New: registry publication; author-attributed sweep (dead node's key swept, survivor's kept, registry retired); suffix sweep; sweep fires `(key, None)` subscriber tombstones; gateway end-to-end (worker evicted from registry + rl shard zeroed); `expire_down_nodes` timing/revival/self/departure; holddown purge/lift/expiry; `merge_state` refutation (and non-regression for peer rumors); reconcile retires prior incarnations + re-asserts after premature sweep.
- Adversarially reviewed (correctness + memory lenses, independent refuters): 3 confirmed must-fixes fixed in-PR (above); a 4th claim (undriven tombstone GC) was refuted as the documented deferral this stack's next PR owns; remaining minors disclosed above.

> Stacked on #1671; retarget to `main` after it merges.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic dead-node expiration (default 60s) using holddown to prevent stale peer reappearance.
  * Dead-node key sweeping with configurable attribution rules to tombstone/evict data for removed nodes, plus replica-registry reconciliation to retire old incarnations.
* **Bug Fixes**
  * Self-state refutation now prevents outdated failure rumors from overriding an intentional restart (while preserving intentional “Leaving” state).
  * Removed-node cleanup more reliably clears related retry/backoff and outbound sync work.
* **Tests**
  * Added unit and end-to-end coverage for expiration/holddown, self refutation, and dead-node sweep/reconciliation behaviors (including subscriber tombstones).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->