### PR TITLE
fix(e2e): unbreak trtllm lanes broken by mcp 2.0.0a1

### DIFF
--- a/e2e_test/infra/__init__.py
+++ b/e2e_test/infra/__init__.py
@@ -41,7 +41,6 @@ from .constants import (  # Enums; Convenience sets; Fixture parameters; Default
 from .gateway import Gateway, WorkerInfo, launch_cloud_gateway
 from .gpu_monitor import GPUMonitor
 from .gpu_monitor import should_monitor as should_monitor_gpu
-from .mock_mcp import IMAGE_GENERATION_PNG_BASE64, MockMcpServer, mock_mcp_server
 from .model_specs import (  # Default model paths; Model groups
     CHAT_MODELS,
     DEFAULT_EMBEDDING_MODEL_PATH,
@@ -161,3 +160,19 @@ __all__ = [
     # Evaluation
     "run_eval",
 ]
+
+# The mock MCP server is only used by the agentic (responses) lane and drags
+# in the `mcp` SDK at import time. Resolve its symbols lazily so infra
+# consumers that never touch it — model download, chat/router lanes — keep
+# working even when the venv's `mcp` lacks `mcp.server.fastmcp` (e.g.
+# TensorRT-LLM's `pip install --pre` resolving mcp to a 2.x pre-release,
+# which removed the module).
+_LAZY_MOCK_MCP = ("IMAGE_GENERATION_PNG_BASE64", "MockMcpServer", "mock_mcp_server")
+
+
+def __getattr__(name: str) -> object:
+    if name in _LAZY_MOCK_MCP:
+        from . import mock_mcp
+
+        return getattr(mock_mcp, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/e2e_test/pyproject.toml
+++ b/e2e_test/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
   "grpcio-health-checking",
   "httpx",
   "jinja2",
-  "mcp>=1.0",
+  # infra.mock_mcp_server needs mcp.server.fastmcp: added in 1.2, removed in 2.0
+  "mcp>=1.2,<2",
   "numpy",
   "openai",
   "pandas",


### PR DESCRIPTION
## Summary
Every trtllm e2e job has been failing at the **model-download step** (before any test runs) since the TensorRT-LLM 1.3.0rc18 bump (#1663):

```
File ".../e2e_test/infra/__init__.py", line 44, in <module>
    from .mock_mcp import ...
File ".../e2e_test/infra/mock_mcp_server.py", line 60, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

## Root cause (with receipts from job 80871944044)
1. `tensorrt-llm==1.3.0rc18` **newly depends on `mcp`** (unconstrained) — rc14 did not (`Collecting mcp (from tensorrt-llm==1.3.0rc18)`).
2. `ci_install_trtllm.sh` installs with `pip install --pre` (required for NVIDIA pre-release wheels) — which lets *every transitive dep* resolve to pre-releases → **`mcp-2.0.0a1`** (note the neighbours: `pydantic-2.14.0a1`, `lxml-7.0.0a2`).
3. mcp 2.0 **removed the legacy `mcp.server.fastmcp` module** (verified by inspecting the wheel: zero `fastmcp` entries).
4. Our floor `mcp>=1.0` treats the alpha as already satisfied (`Requirement already satisfied: mcp>=1.0 ... (2.0.0a1)`), so the e2e deps install keeps it.
5. `e2e_test/infra/__init__.py` **eagerly** imports the FastMCP-based mock — used only by the sglang-only `responses/` lane — so even `ci_download_model.sh` (which just wants model specs) crashes.

Passing rc14 runs confirm the contrast: there `mcp` came only from e2e deps and resolved to stable `mcp-1.27.2`.

## Fix
- **`mcp>=1.2,<2`** — the honest requirement (`mcp.server.fastmcp` was added in 1.2, removed in 2.0). Per PEP 440, `<2` excludes pre-releases of 2.0 (verified with `packaging`: `SpecifierSet(">=1.2,<2").contains("2.0.0a1", prereleases=True) == False`), so `pip install e2e_test/` now replaces the alpha with stable 1.x. TensorRT-LLM's own `mcp` requirement is unconstrained, so the downgrade leaves the environment consistent.
- **Lazy-load the mock MCP server** via module `__getattr__` in `infra/__init__.py` — model download and chat/router lanes no longer depend on the `mcp` SDK at all. The `responses/` consumers (`from infra import MockMcpServer`, `from infra.mock_mcp import mock_mcp_server`) are unaffected.

## Verification
- mcp 2.0.0a1 wheel inspected: no `mcp/server/fastmcp` content; specifier semantics verified with `packaging`.
- ruff check/format clean.
- This PR's own `e2e-1gpu-chat (trtllm)` lane is the live regression test — it exercises the exact failing path (engine setup → e2e deps → model download → tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MCP dependency version constraints to ensure E2E test compatibility.
  * Optimized test infrastructure module initialization with lazy loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->