### PR TITLE
fix(tool_parser): iterate char boundaries in ends_with_partial_token

### DIFF
--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -77,7 +77,11 @@ pub fn ends_with_partial_token(buffer: &str, token: &str) -> Option<usize> {
         return None;
     }
 
-    (1..token.len()).find(|&i| buffer.ends_with(&token[..i]))
+    token
+        .char_indices()
+        .skip(1)
+        .map(|(i, _)| i)
+        .find(|&i| buffer.ends_with(&token[..i]))
 }
 
 /// Reset state for the current tool being parsed (used when skipping invalid tools).
@@ -391,6 +395,30 @@ mod tests {
         assert!(ends_with_partial_token("hello <|python_tag|>", "<|python_tag|>").is_none());
         assert!(ends_with_partial_token("", "<|python_tag|>").is_none());
         assert!(ends_with_partial_token("hello world", "<|python_tag|>").is_none());
+    }
+
+    #[test]
+    fn test_ends_with_partial_token_multibyte() {
+        // U+FF5C "｜" is 3 bytes, so token[..i] must only be sliced at char boundaries.
+        let token = "<｜tool_calls_begin｜>";
+
+        // Buffer not ending in '<' must not panic and yields no partial match.
+        assert_eq!(
+            ends_with_partial_token("some plain ascii text", token),
+            None
+        );
+
+        // Ending in '<' matches a 1-byte prefix.
+        assert_eq!(ends_with_partial_token("hello <", token), Some(1));
+
+        // Ending in "<｜" matches the prefix up to the next char boundary (1 + 3 bytes).
+        assert_eq!(ends_with_partial_token("hello <｜", token), Some(4));
+
+        // A complete token at the end is not a partial match.
+        assert_eq!(
+            ends_with_partial_token("x <｜tool_calls_begin｜>", token),
+            None
+        );
     }
 
     #[test]

--- a/crates/tool_parser/tests/tool_parser_step3.rs
+++ b/crates/tool_parser/tests/tool_parser_step3.rs
@@ -105,6 +105,28 @@ async fn test_step3_streaming() {
     assert!(found_complete);
 }
 
+#[tokio::test]
+async fn test_step3_streaming_plain_text_no_panic() {
+    let mut parser = Step3Parser::new();
+    let tools = create_test_tools();
+
+    // Plain ASCII text with no tool markers must be returned as normal text without
+    // panicking on the multi-byte bot_token "<｜tool_calls_begin｜>".
+    let chunks = vec!["some plain ascii text", " without any markers", " at all"];
+    let mut normal_text = String::new();
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        normal_text.push_str(&result.normal_text);
+        assert!(result.calls.is_empty());
+    }
+
+    assert_eq!(
+        normal_text,
+        "some plain ascii text without any markers at all"
+    );
+}
+
 #[test]
 fn test_step3_format_detection() {
     let parser = Step3Parser::new();


### PR DESCRIPTION
## Description

### Problem

`tool_parser::parsers::helpers::ends_with_partial_token` panics when the token contains multi-byte UTF-8 characters near its start. The body was:

```rust
(1..token.len()).find(|&i| buffer.ends_with(&token[..i]))
```

`token.len()` is a byte count, so `&token[..i]` slices at byte offset `i`. When `i` is not a char boundary the slice panics — and the slice is evaluated before `ends_with` inspects the buffer, so the panic fires for **any** non-empty buffer, not just buffers sharing a prefix with the token.

The Step3 parser's `bot_token` is `"<｜tool_calls_begin｜>"`, where `｜` is U+FF5C (3 bytes). The second char spans bytes 1..4, so `&token[..2]` and `&token[..3]` fall inside it. `Step3Parser::parse_incremental` calls `ends_with_partial_token(&self.buffer, self.bot_token)` on arbitrary buffered text before any tool block is seen, so streaming ordinary text through the Step3 parser panics the worker thread.

### Solution

Iterate only over valid UTF-8 char-boundary offsets instead of every byte index:

```rust
token
    .char_indices()
    .skip(1)
    .map(|(i, _)| i)
    .find(|&i| buffer.ends_with(&token[..i]))
```

`char_indices()` yields the starting byte offset of each char; `.skip(1)` drops offset 0, preserving the original "second char onward, proper prefixes only" semantics (which also excludes a full-token match). For ASCII tokens this is byte-identical to the old `1..token.len()`. The return contract is unchanged: `Some(byte_length_of_matched_prefix)` or `None`. All 8 call sites remain correct — seven use `.is_some()`/`.is_none()`; the only numeric consumer (`qwen.rs` `split_point = buffer.len() - partial_match_len`) slices on a char boundary because the returned offset is a char boundary within `token` and the buffer ends with that exact prefix.

## Changes

- `crates/tool_parser/src/parsers/helpers.rs`: `ends_with_partial_token` iterates `token.char_indices().skip(1)` instead of `1..token.len()`, so it never slices inside a multi-byte char.
- `crates/tool_parser/src/parsers/helpers.rs`: added unit test `test_ends_with_partial_token_multibyte`.
- `crates/tool_parser/tests/tool_parser_step3.rs`: added streaming integration test `test_step3_streaming_plain_text_no_panic` (previously panicked).

## Test Plan

- **`test_ends_with_partial_token_multibyte`** — token `"<｜tool_calls_begin｜>"`: buffer `"some plain ascii text"` (no `<`) returns `None` without panicking; buffer ending in `<` → `Some(1)`; ending in `<｜` → `Some(4)`; a complete token at the end → `None`. The existing ASCII test still passes.
- **`test_step3_streaming_plain_text_no_panic`** — streams `["some plain ascii text", " without any markers", " at all"]` through `Step3Parser::parse_incremental`; asserts no panic, no tool calls, and reassembled text. Confirmed to panic (`end byte index 2 is not a char boundary; it is inside '｜'`) before the fix and pass after.

Authoritative gate (sccache disabled, `RUSTC_WRAPPER=""`):

```
$ rustup run nightly cargo fmt --all -- --check
FMT CLEAN (exit 0)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 32s
exit 0

$ cargo test -p tool-parser
test result: ok. (tool_parser_step3: 12 passed, 0 failed; lib + other suites: 0 failed)
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTF-8 boundary handling in token parsing to ensure correct processing of multibyte characters.

* **Tests**
  * Added incremental parsing test coverage for plain text input without tool markers, enhancing test suite reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->