### PR TITLE
fix(tool_parser): make partial JSON consumed position a byte offset

### DIFF
--- a/crates/tool_parser/src/partial_json.rs
+++ b/crates/tool_parser/src/partial_json.rs
@@ -96,8 +96,8 @@ impl<'a> Parser<'a> {
     }
 
     fn advance(&mut self) {
-        if self.chars.next().is_some() {
-            self.position += 1;
+        if let Some(c) = self.chars.next() {
+            self.position += c.len_utf8();
         }
     }
 

--- a/crates/tool_parser/src/tests.rs
+++ b/crates/tool_parser/src/tests.rs
@@ -78,6 +78,33 @@ fn test_partial_json_parser() {
 }
 
 #[test]
+fn test_partial_json_consumed_is_byte_offset() {
+    let parser = PartialJson::default();
+
+    // Complete object with a multibyte value: consumed must be the byte length
+    // and must land on a UTF-8 char boundary so input[..consumed] is sliceable.
+    let input = r#"{"k":"é"}"#;
+    let (value, consumed) = parser.parse_value(input, true).unwrap();
+    assert_eq!(value["k"], "é");
+    assert_eq!(consumed, input.len());
+    assert!(input.is_char_boundary(consumed));
+    let _ = &input[..consumed];
+
+    // Partial object whose multibyte char is the last consumed content.
+    let input = "{\"k\":\"é";
+    let (value, consumed) = parser.parse_value(input, true).unwrap();
+    assert_eq!(value["k"], "é");
+    assert!(input.is_char_boundary(consumed));
+    let _ = &input[..consumed];
+
+    // Emoji (4-byte) value also yields a byte offset on a char boundary.
+    let input = r#"{"k":"🌍"}"#;
+    let (_value, consumed) = parser.parse_value(input, true).unwrap();
+    assert_eq!(consumed, input.len());
+    assert!(input.is_char_boundary(consumed));
+}
+
+#[test]
 fn test_partial_json_depth_limit() {
     // max_depth of 3 allows nesting up to 3 levels
     // Set allow_incomplete to false to get errors instead of partial results

--- a/crates/tool_parser/tests/tool_parser_json.rs
+++ b/crates/tool_parser/tests/tool_parser_json.rs
@@ -661,6 +661,35 @@ async fn test_json_incremental_arguments_streaming() {
 }
 
 #[tokio::test]
+async fn test_json_incremental_unicode_arguments() {
+    let tools = create_test_tools();
+    let mut parser = JsonParser::new();
+
+    // Multibyte argument value: on completion the buffer is sliced at the
+    // consumed offset, which must be a byte offset on a UTF-8 char boundary.
+    let input = r#"{"name": "search", "arguments": {"query": "Köln 世界 🌍"}}"#;
+    let chunks = streaming_helpers::create_realistic_chunks(input);
+
+    let mut tool_name_sent = false;
+    let mut streamed_args = String::new();
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(&chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if call.name.is_some() {
+                tool_name_sent = true;
+            }
+            streamed_args.push_str(&call.parameters);
+        }
+    }
+
+    assert!(tool_name_sent, "Should have sent tool name");
+    let parsed: serde_json::Value = serde_json::from_str(&streamed_args)
+        .unwrap_or_else(|e| panic!("streamed args not valid JSON: {e}; got: {streamed_args}"));
+    assert_eq!(parsed["query"], "Köln 世界 🌍");
+}
+
+#[tokio::test]
 async fn test_json_very_long_url_in_arguments() {
     let tools = create_test_tools();
     let mut parser = JsonParser::new();


### PR DESCRIPTION
## Description

### Problem

`PartialJson::parse_value` returns the internal parser `position`, which `advance()` incremented by `1` per `chars.next()` — i.e. a **character** count. But every caller treats the returned value as a **byte** offset. In particular `handle_json_tool_streaming` (`helpers.rs:374`) does `*buffer = current_text[start_idx + end_idx..].to_string();`. When tool-call arguments contain multibyte UTF-8 (CJK, accents, emoji), the char count is smaller than the byte length, so this slice starts too early — truncating/corrupting streamed tool arguments — or panics when `start_idx + end_idx` lands inside a multibyte char. The `safe_end_idx` guard at `helpers.rs:252-260` only protected the completeness check at `:261`, not the slice at `:374`.

### Solution

Change `Parser::advance()` to accumulate `c.len_utf8()` instead of `1`, making `position` (and the consumed length returned by `parse_value`) a byte offset that always lands on a char boundary. `position` is only ever used as the returned consumed-length (verified: its other uses in the file are the struct field, its zero-init, and the `+=`), so no internal slicing assumed char semantics. The existing `safe_end_idx` guard is kept as-is (now a harmless no-op safety net). For ASCII inputs byte == char count, so behavior is unchanged (the existing `test_partial_json_parser` still holds).

## Changes

- `crates/tool_parser/src/partial_json.rs`: `advance()` now does `self.position += c.len_utf8()`.
- `crates/tool_parser/src/tests.rs`: add `test_partial_json_consumed_is_byte_offset`.
- `crates/tool_parser/tests/tool_parser_json.rs`: add `test_json_incremental_unicode_arguments`.

## Test Plan

- **`test_partial_json_consumed_is_byte_offset`** — parses `{"k":"é"}`, the partial `{"k":"é`, and `{"k":"🌍"}`; asserts `consumed == input.len()` (complete cases), `input.is_char_boundary(consumed)`, and that `&input[..consumed]` slices. Before the fix `consumed` is 9 (chars) vs byte length 10.
- **`test_json_incremental_unicode_arguments`** — feeds `{"name":"search","arguments":{"query":"Köln 世界 🌍"}}` through `create_realistic_chunks`, concatenates streamed `parameters`, and asserts the result parses with `query == "Köln 世界 🌍"`. Before the fix the concatenated args were truncated mid-value and failed to parse.

Authoritative gate (sccache disabled, `RUSTC_WRAPPER=""`):

```
$ rustup run nightly cargo fmt --all -- --check
FMT CLEAN (exit 0)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile target(s) in 11.51s
exit 0

$ cargo test -p tool-parser
all tool-parser suites passed (24+27+11+13+6+29+13+38+11), 0 failed — incl. new test_partial_json_consumed_is_byte_offset and test_json_incremental_unicode_arguments
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved character boundary detection and byte-counting accuracy when processing JSON with non-ASCII characters.

* **Tests**
  * Added tests for Unicode support in JSON parsing and incremental stream processing with multibyte characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->