### PR TITLE
fix(reasoning-parser): hold back split think_end_token across streaming chunks

### DIFF
--- a/crates/reasoning_parser/src/parsers/base.rs
+++ b/crates/reasoning_parser/src/parsers/base.rs
@@ -41,6 +41,22 @@ impl BaseReasoningParser {
             || (self.config.think_end_token.starts_with(text)
                 && self.config.think_end_token != text)
     }
+
+    /// Byte length of the longest trailing suffix of `text` that is a non-empty
+    /// proper prefix of `think_end_token`, so a split end token survives flushing.
+    fn trailing_end_token_prefix_len(&self, text: &str) -> usize {
+        let end = &self.config.think_end_token;
+        for (start, _) in text.char_indices() {
+            if start == 0 {
+                continue;
+            }
+            let suffix = &text[start..];
+            if end.starts_with(suffix) {
+                return suffix.len();
+            }
+        }
+        0
+    }
 }
 
 impl ReasoningParser for BaseReasoningParser {
@@ -127,9 +143,11 @@ impl ReasoningParser for BaseReasoningParser {
 
         // Continue with reasoning content
         if self.in_reasoning && self.config.stream_reasoning {
-            // Stream the content immediately
-            let reasoning_text = current_text;
-            self.buffer.clear();
+            // Hold back any trailing partial end token so a split token is not lost.
+            let hold = self.trailing_end_token_prefix_len(&current_text);
+            let split = current_text.len() - hold;
+            let reasoning_text = current_text[..split].to_string();
+            self.buffer = current_text[split..].to_string();
             Ok(ParserResult::reasoning(reasoning_text))
         } else if !self.in_reasoning {
             // If we're not in a reasoning block, return as normal text
@@ -324,6 +342,54 @@ mod tests {
             .unwrap();
         assert_eq!(result3.normal_text, " normal");
         assert_eq!(result3.reasoning_text, "more");
+    }
+
+    #[test]
+    fn test_streaming_split_think_end_token() {
+        let mut parser = create_test_parser(true, true);
+
+        // Chunk ends mid end-token: emit "abc" as reasoning, buffer "</thi".
+        let result1 = parser
+            .parse_reasoning_streaming_incremental("abc</thi")
+            .unwrap();
+        assert_eq!(result1.reasoning_text, "abc");
+        assert_eq!(result1.normal_text, "");
+        assert!(parser.is_in_reasoning());
+
+        // Next chunk completes the token: reasoning ends, "xyz" is normal text.
+        let result2 = parser
+            .parse_reasoning_streaming_incremental("nk>xyz")
+            .unwrap();
+        assert_eq!(result2.reasoning_text, "");
+        assert_eq!(result2.normal_text, "xyz");
+        assert!(!parser.is_in_reasoning());
+    }
+
+    #[test]
+    fn test_streaming_split_unicode_think_end_token() {
+        let config = ParserConfig {
+            think_start_token: "◁think▷".to_string(),
+            think_end_token: "◁/think▷".to_string(),
+            stream_reasoning: true,
+            max_buffer_size: DEFAULT_MAX_BUFFER_SIZE,
+            always_in_reasoning: true,
+        };
+        let mut parser = BaseReasoningParser::new(config);
+
+        // Split the multi-byte end token on a char boundary.
+        let result1 = parser
+            .parse_reasoning_streaming_incremental("abc◁/")
+            .unwrap();
+        assert_eq!(result1.reasoning_text, "abc");
+        assert_eq!(result1.normal_text, "");
+        assert!(parser.is_in_reasoning());
+
+        let result2 = parser
+            .parse_reasoning_streaming_incremental("think▷xyz")
+            .unwrap();
+        assert_eq!(result2.reasoning_text, "");
+        assert_eq!(result2.normal_text, "xyz");
+        assert!(!parser.is_in_reasoning());
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

The streaming reasoning parser could lose a `think_end_token` (e.g. `</think>`) split across two chunks. In `parse_reasoning_streaming_incremental`, the `in_reasoning && stream_reasoning` branch emitted the entire accumulated buffer as reasoning and cleared it. When a chunk ended mid-token (buffer `abc</thi`), the trailing `</thi` was streamed out as reasoning and discarded; the next chunk (`nk>…`) could never combine with `</thi` to form `</think>`, so the end token was never detected, reasoning never terminated, and the fragment leaked into the reasoning text. The existing `is_partial_token` guard only handled the case where the *entire* buffer was a token prefix, not when reasoning content precedes the partial token.

### Solution

Before flushing buffered reasoning in the streaming path, hold back the longest trailing suffix of the current text that is a non-empty proper prefix of `think_end_token`. That suffix stays in the buffer (instead of being cleared) and only the preceding text is emitted as reasoning. On the next chunk the fragment is reassembled and the complete end token is detected, terminating reasoning and routing the remainder to normal text; if the continuation does not complete the token it is naturally flushed as reasoning on the following call. The suffix length is computed over `char_indices()`, so it is correct for multi-byte end tokens (e.g. Kimi's `◁/think▷`). The fix lives in `BaseReasoningParser`, which every concrete parser delegates to.

## Changes

- Add private helper `BaseReasoningParser::trailing_end_token_prefix_len` (byte length of the longest trailing suffix that is a non-empty proper prefix of `think_end_token`, respecting char boundaries).
- In `parse_reasoning_streaming_incremental`, the `in_reasoning && stream_reasoning` branch holds that suffix in the buffer and emits only the preceding text, instead of emitting the whole buffer and clearing.
- Add regression tests `test_streaming_split_think_end_token` (ASCII `</think>`) and `test_streaming_split_unicode_think_end_token` (multi-byte `◁/think▷`).

## Test Plan

- **`test_streaming_split_think_end_token`** — `think_end_token="</think>"`, `stream_reasoning=true`. Feed `"abc</thi"` → reasoning `"abc"`, normal `""`, still in reasoning (`</thi` buffered, not leaked); then `"nk>xyz"` → reasoning `""`, normal `"xyz"`, reasoning ended.
- **`test_streaming_split_unicode_think_end_token`** — same with `"◁/think▷"`: `"abc◁/"` → reasoning `"abc"`, buffered `"◁/"`; `"think▷xyz"` → reasoning ends, normal `"xyz"`.
- Both fail before the change (reasoning is `"abc</thi"` / `"abc◁/"`) and pass after.

Authoritative gate (sccache disabled, `RUSTC_WRAPPER=""`):

```
$ rustup run nightly cargo fmt --all -- --check
FMT CLEAN (exit 0)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile target(s) in 11.08s
exit 0

$ cargo test -p reasoning-parser
test result: ok. 77 passed; 0 failed — incl. test_streaming_split_think_end_token and test_streaming_split_unicode_think_end_token
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a streaming parser bug where content could be lost when end tokens are split across chunk boundaries, including improved handling of multi-byte and unicode characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->