### PR TITLE
fix(tokenizer): encode L1 cache suffix without special tokens

### DIFF
--- a/crates/tokenizer/src/cache/mod.rs
+++ b/crates/tokenizer/src/cache/mod.rs
@@ -184,7 +184,9 @@ impl Encoder for CachedTokenizer {
             {
                 let suffix = &input[prefix_len..];
                 if !suffix.is_empty() {
-                    let suffix_encoding = self.inner.encode(suffix, add_special_tokens)?;
+                    // The cached prefix already carries any leading special tokens,
+                    // so the suffix must never re-add them (it is never segment 0).
+                    let suffix_encoding = self.inner.encode(suffix, false)?;
 
                     let mut merged_tokens = prefix_tokens;
                     merged_tokens.extend_from_slice(suffix_encoding.token_ids());
@@ -295,6 +297,113 @@ impl Tokenizer for CachedTokenizer {
 #[cfg(test)]
 mod tests {
     use crate::{mock::MockTokenizer, *};
+
+    /// Tokenizer that prepends a sentinel BOS when `add_special_tokens` is set,
+    /// so duplicated specials across a prefix/suffix merge are observable.
+    struct BosTokenizer {
+        special_tokens: SpecialTokens,
+    }
+
+    const BOS_ID: TokenIdType = 99;
+
+    impl BosTokenizer {
+        fn new() -> Self {
+            Self {
+                special_tokens: SpecialTokens {
+                    bos_token: Some("<bos>".to_string()),
+                    additional_special_tokens: vec![
+                        "<|im_start|>".to_string(),
+                        "<|im_end|>".to_string(),
+                    ],
+                    ..Default::default()
+                },
+            }
+        }
+    }
+
+    impl Encoder for BosTokenizer {
+        fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Encoding> {
+            let mut ids: Vec<TokenIdType> = Vec::new();
+            if add_special_tokens {
+                ids.push(BOS_ID);
+            }
+            ids.extend(input.bytes().map(TokenIdType::from));
+            Ok(Encoding::Plain(ids))
+        }
+
+        fn encode_batch(&self, inputs: &[&str], add_special_tokens: bool) -> Result<Vec<Encoding>> {
+            inputs
+                .iter()
+                .map(|i| self.encode(i, add_special_tokens))
+                .collect()
+        }
+    }
+
+    impl Decoder for BosTokenizer {
+        fn decode(&self, _token_ids: &[TokenIdType], _skip_special_tokens: bool) -> Result<String> {
+            Ok(String::new())
+        }
+    }
+
+    impl traits::Tokenizer for BosTokenizer {
+        fn vocab_size(&self) -> usize {
+            256
+        }
+        fn get_special_tokens(&self) -> &SpecialTokens {
+            &self.special_tokens
+        }
+        fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
+            None
+        }
+        fn id_to_token(&self, _id: TokenIdType) -> Option<String> {
+            None
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[test]
+    fn test_l1_hit_does_not_duplicate_special_tokens() {
+        let tokenizer = Arc::new(BosTokenizer::new());
+        let config = CacheConfig {
+            enable_l0: false,
+            l0_max_entries: 0,
+            enable_l1: true,
+            l1_max_memory: 1024 * 1024,
+        };
+        let cached = CachedTokenizer::new(tokenizer, config);
+
+        let input = "<|im_start|>system\nhi<|im_end|><|im_start|>user\nquery<|im_end|>";
+
+        // First call warms the L1 cache at special-token boundaries.
+        let first = cached.encode(input, true).unwrap();
+        // Second call hits the warm L1 cache and merges prefix + suffix.
+        let second = cached.encode(input, true).unwrap();
+
+        // The merged result must match a fresh, uncached encode: a single BOS at
+        // the start, none duplicated mid-sequence and none dropped.
+        let fresh = CachedTokenizer::new(
+            Arc::new(BosTokenizer::new()),
+            CacheConfig {
+                enable_l0: false,
+                l0_max_entries: 0,
+                enable_l1: false,
+                l1_max_memory: 0,
+            },
+        )
+        .encode(input, true)
+        .unwrap();
+
+        assert_eq!(first.token_ids(), fresh.token_ids());
+        assert_eq!(second.token_ids(), fresh.token_ids());
+        assert_eq!(
+            second.token_ids().iter().filter(|&&t| t == BOS_ID).count(),
+            1,
+            "exactly one BOS expected, got tokens: {:?}",
+            second.token_ids()
+        );
+    }
 
     #[test]
     fn test_cache_hit() {


### PR DESCRIPTION
## Description

### Problem

When the L1 prefix cache is enabled, `CachedTokenizer::encode` could duplicate leading special tokens (e.g. BOS) on a cache hit. The cached prefix already carries any leading special tokens because `L1Cache::insert_at_boundaries` only sets `add_special_tokens` for the first segment (`(i == 0) && add_special_tokens`). But on a hit, the remaining suffix was re-encoded with the caller's `add_special_tokens` flag (`cache/mod.rs:187`). With `add_special_tokens=true`, the tokenizer re-added the BOS/special token in the middle of the merged token stream — producing a different (corrupt) tokenization than an uncached encode. This only manifests once the L1 cache is warm, making it an intermittent correctness bug for requests with `add_special_tokens=true`.

### Solution

Encode the suffix with `add_special_tokens=false` on the L1-hit merge path. The suffix is by definition never the first segment (it follows a cached prefix that already contains any leading special tokens), so it must not re-add them. This makes the merged `prefix + suffix` tokenization identical to a fresh, uncached encode, and mirrors the already-correct insert path (`L1Cache::insert_at_boundaries`).

## Changes

- `crates/tokenizer/src/cache/mod.rs`: on an L1 prefix-cache hit, encode the suffix with `add_special_tokens=false` instead of the caller's flag (one-line fix + a one-line invariant comment).
- `crates/tokenizer/src/cache/mod.rs` (tests): add `test_l1_hit_does_not_duplicate_special_tokens`, backed by a small BOS-prepending test tokenizer.

## Test Plan

- **`test_l1_hit_does_not_duplicate_special_tokens`** — build a `CachedTokenizer` over a tokenizer that prepends a sentinel BOS when `add_special_tokens=true`, L0 disabled, L1 enabled. Encode `"<|im_start|>system\nhi<|im_end|><|im_start|>user\nquery<|im_end|>"` with `add_special_tokens=true` twice (the second hits the warm L1 cache, exercising the prefix+suffix merge). Assert both results equal a fresh encode from a cache-disabled tokenizer, and that exactly one BOS is present.
- **Fail-before / pass-after independently verified**: with the suffix re-encoded using the caller's flag, an extra BOS appears mid-sequence right after the `<|im_end|>` boundary and the test fails; with `add_special_tokens=false` it passes.

Authoritative gate (sccache disabled, `RUSTC_WRAPPER=""`):

```
$ rustup run nightly cargo fmt --all -- --check
FMT CLEAN (exit 0)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile target(s) in 12.64s
exit 0

$ cargo test -p llm-tokenizer --lib cache
test result: ok. 27 passed; 0 failed — incl. test_l1_hit_does_not_duplicate_special_tokens
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
