### PR TITLE
fix(grpc): classify TRT-LLM health by exact OK status, not substring

### DIFF
--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -23,6 +23,13 @@ pub struct HealthCheckResponse {
     pub message: String,
 }
 
+/// TRT-LLM reports liveness via a free-form status string whose only healthy
+/// value is `"OK"` (per `trtllm_service.proto`); anything else is an error
+/// description and must be treated as unhealthy.
+fn trtllm_status_healthy(status: &str) -> bool {
+    status.trim().eq_ignore_ascii_case("ok")
+}
+
 /// Wraps the per-backend gRPC clients. RPCs absent on a backend's wire
 /// return `Status::unimplemented`.
 #[derive(Clone)]
@@ -199,8 +206,7 @@ impl GrpcClient {
             }
             Self::Trtllm(client) => {
                 let resp = client.health_check().await?;
-                let healthy = resp.status.to_lowercase().contains("ok")
-                    || resp.status.to_lowercase().contains("healthy");
+                let healthy = trtllm_status_healthy(&resp.status);
                 Ok(HealthCheckResponse {
                     healthy,
                     message: resp.status,
@@ -883,7 +889,19 @@ mod tests {
 
     use smg_grpc_client::{sglang_proto, tokenspeed_proto};
 
-    use super::{ModelInfo, ServerInfo};
+    use super::{trtllm_status_healthy, ModelInfo, ServerInfo};
+
+    #[test]
+    fn trtllm_status_healthy_matches_ok_exactly() {
+        assert!(trtllm_status_healthy("ok"));
+        assert!(trtllm_status_healthy("OK"));
+        assert!(trtllm_status_healthy("  OK  "));
+
+        assert!(!trtllm_status_healthy("not ok"));
+        assert!(!trtllm_status_healthy("checking"));
+        assert!(!trtllm_status_healthy("degraded"));
+        assert!(!trtllm_status_healthy(""));
+    }
 
     fn string_value(s: &str) -> prost_types::Value {
         prost_types::Value {


### PR DESCRIPTION
## Description

### Problem

TRT-LLM backends report liveness through a free-form `status` string on `HealthCheckResponse`. Per `crates/grpc_client/proto/trtllm_service.proto` (`string status = 1; // "OK" or error description`), the only healthy value is the literal `"OK"`; everything else is an error description. The gateway classified health with `resp.status.to_lowercase().contains("ok") || resp.status.to_lowercase().contains("healthy")`. The substring test wrongly accepts error statuses that contain "ok" as a substring — `"not ok"`, or even words like `"broken"` — marking an unhealthy backend as healthy and leaving it in rotation.

### Solution

Classify a TRT-LLM backend as healthy only when its status equals the documented success token exactly. Extract a small pure helper `trtllm_status_healthy(status: &str) -> bool` returning `status.trim().eq_ignore_ascii_case("ok")`, and call it from the `health_check` match arm. Trimming preserves the previous acceptance of whitespace-padded `OK`; the exact match drops the buggy substring acceptance (and the undocumented `"healthy"` substring, which no contract-compliant backend emits). Extracting the pure helper is the minimal seam needed to make this deterministically testable without a live backend.

## Changes

- `model_gateway/src/routers/grpc/client.rs`: add private `trtllm_status_healthy` helper (exact, case-insensitive, trimmed match against `"ok"`) and use it in the `Self::Trtllm` arm of `health_check`, replacing the `contains("ok") || contains("healthy")` check.
- `model_gateway/src/routers/grpc/client.rs` (tests): add `trtllm_status_healthy_matches_ok_exactly`.

## Test Plan

- **`trtllm_status_healthy_matches_ok_exactly`** — asserts `"ok"`, `"OK"`, `"  OK  "` are healthy; `"not ok"`, `"checking"`, `"degraded"`, `""` are not. Fails before the fix (old substring logic returns `true` for `"not ok"`) and passes after.

Authoritative gate (sccache disabled, `RUSTC_WRAPPER=""`):

```
$ rustup run nightly cargo fmt --all -- --check
FMT CLEAN (exit 0)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile target(s) in 12.35s
exit 0

$ cargo test -p smg --lib trtllm_status_healthy
test result: ok. 1 passed; 0 failed — trtllm_status_healthy_matches_ok_exactly
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
