### PR TITLE
fix(model_gateway): emit valid-JSON SSE error frame on PD streaming decode error

### DIFF
--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -511,8 +511,8 @@ impl PDRouter {
             };
 
             let sse_data = format!(
-                "data: {{'error': {}}}",
-                serde_json::to_string(&error_payload).unwrap_or_default()
+                "data: {}\n\n",
+                serde_json::to_string(&json!({ "error": error_payload })).unwrap_or_default()
             );
             let error_stream = tokio_stream::once(Ok(axum::body::Bytes::from(sse_data)));
 
@@ -1552,6 +1552,58 @@ mod tests {
 
         assert_eq!(prefill_worker.load(), 0);
         assert_eq!(decode_worker.load(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_streaming_decode_error_emits_valid_json_sse() {
+        let router = create_test_pd_router();
+
+        let prefill: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://prefill".to_string(),
+            WorkerType::Prefill,
+            true,
+        ));
+        let decode: Arc<dyn Worker> = Arc::from(create_test_worker(
+            "http://decode".to_string(),
+            WorkerType::Decode,
+            true,
+        ));
+
+        let upstream = http::Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(r#"{"error":"boom \"quoted\""}"#)
+            .unwrap();
+        let decode_response = reqwest::Response::from(upstream);
+
+        let context = PDRequestContext {
+            route: "/v1/chat/completions",
+            batch_size: None,
+            is_stream: true,
+            return_logprob: false,
+            request_text: None,
+            model_id: UNKNOWN_MODEL_ID,
+            headers: None,
+        };
+
+        let response = router
+            .handle_decode_error_response(decode_response, &context, prefill, decode)
+            .await;
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let frame = std::str::from_utf8(&body).unwrap();
+
+        let payload = frame
+            .strip_prefix("data: ")
+            .expect("SSE frame must start with `data: `")
+            .trim_end();
+        let parsed: Value =
+            serde_json::from_str(payload).expect("bytes after `data: ` must be valid JSON");
+        assert!(
+            parsed.get("error").is_some(),
+            "parsed SSE payload must contain an `error` field: {parsed}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

On a disaggregated (PD) streaming request, when the decode worker returns a non-success status, `PDRouter::handle_decode_error_response` emits a terminal SSE error frame built as `format!("data: {{'error': {}}}", serde_json::to_string(&error_payload)…)`. Two defects make the body invalid JSON:

1. `'error'` is a single-quoted key — JSON requires double-quoted keys, so the structure is not parseable.
2. `error_payload` is already a `serde_json::Value`; serializing it to a string and splicing it into hand-written braces double-encodes it.

A client parsing the bytes after `data: ` gets a hard parse failure (`serde_json: "key must be a string"`). The frame was also missing the `\n\n` SSE record terminator that every other frame producer in the gateway emits.

### Solution

Build the frame with serde: `format!("data: {}\n\n", serde_json::to_string(&json!({ "error": error_payload }))…)`. This wraps the existing `error_payload` (already carrying `message` and `status`) under an `error` key and serializes the whole object, guaranteeing valid JSON with proper escaping, and appends the `\n\n` terminator. The shape mirrors the serde-based SSE helpers already used elsewhere (`grpc/utils/chat_utils.rs::send_error_sse`, `grpc/common/responses/streaming.rs::emit_error`, and `merge_streaming_logprobs` in this same file).

## Changes

- `model_gateway/src/routers/http/pd_router.rs`: in the streaming branch of `handle_decode_error_response`, build the terminal SSE error frame with `serde_json` (payload under an `error` key) and add the `\n\n` terminator.
- `model_gateway/src/routers/http/pd_router.rs` (tests): add `test_streaming_decode_error_emits_valid_json_sse`.

## Test Plan

- **`test_streaming_decode_error_emits_valid_json_sse`** — constructs a `reqwest::Response` (status 500, body `{"error":"boom \"quoted\""}` to exercise escaping), calls `handle_decode_error_response` with `is_stream = true`, collects the streamed body, strips `data: `, and `serde_json::from_str` the remainder; asserts it parses as valid JSON containing an `error` field. Fails before the fix (`serde_json: "key must be a string"`), passes after.

Authoritative gate (sccache disabled, `RUSTC_WRAPPER=""`):

```
$ rustup run nightly cargo fmt --all -- --check
FMT CLEAN (exit 0)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile target(s) in 11.00s
exit 0

$ cargo test -p smg --lib streaming_decode_error
test result: ok. 1 passed; 0 failed — test_streaming_decode_error_emits_valid_json_sse
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
