### PR TITLE
fix(policies): age out stale cached loads in least_load/power_of_two

### DIFF
--- a/model_gateway/src/policies/factory.rs
+++ b/model_gateway/src/policies/factory.rs
@@ -18,16 +18,19 @@ impl PolicyFactory {
         match config {
             PolicyConfig::Random => Arc::new(RandomPolicy::new()),
             PolicyConfig::RoundRobin => Arc::new(RoundRobinPolicy::new()),
-            PolicyConfig::PowerOfTwo { .. } => Arc::new(PowerOfTwoPolicy::new()),
+            PolicyConfig::PowerOfTwo {
+                load_check_interval_secs,
+            } => Arc::new(PowerOfTwoPolicy::with_config(*load_check_interval_secs)),
             PolicyConfig::LeastLoad {
+                load_check_interval_secs,
                 kv_pressure_weight,
                 mean_prefill_tokens,
                 default_throughput,
-                ..
-            } => Arc::new(LeastLoadPolicy::with_params(
+            } => Arc::new(LeastLoadPolicy::with_config(
                 *kv_pressure_weight,
                 *mean_prefill_tokens,
                 *default_throughput,
+                *load_check_interval_secs,
             )),
             PolicyConfig::CacheAware {
                 cache_threshold,

--- a/model_gateway/src/policies/least_load.rs
+++ b/model_gateway/src/policies/least_load.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
+    time::{Duration, Instant},
 };
 
 use openai_protocol::worker::WorkerLoadResponse;
@@ -22,6 +23,22 @@ pub const DEFAULT_MEAN_PREFILL_TOKENS: u32 = 1024;
 /// fleet its absolute value mainly sets the work-vs-barrier balance, so it
 /// co-tunes with `kv_pressure_weight`.
 pub const DEFAULT_THROUGHPUT: f64 = 2000.0;
+
+/// Default worker-load poll period (seconds) when the policy is built without a
+/// configured `load_check_interval_secs`, used to derive the staleness horizon.
+const DEFAULT_LOAD_CHECK_INTERVAL_SECS: u64 = 10;
+
+/// A cached load is treated as absent once it is older than this many poll
+/// intervals, so a worker whose fetch keeps failing degrades to request counts
+/// instead of routing on an indefinitely stale snapshot.
+const STALE_LOAD_INTERVALS: u32 = 3;
+
+/// Staleness horizon (a few poll intervals) past which an unrefreshed cached
+/// load is treated as absent; tolerates a couple of missed/slow polls.
+fn staleness_ttl(load_check_interval_secs: u64) -> Duration {
+    let secs = load_check_interval_secs.max(1) * u64::from(STALE_LOAD_INTERVALS);
+    Duration::from_secs(secs)
+}
 
 /// Least-(token-)work routing — route to the worker with the lowest estimated
 /// time-to-drain plus a convex KV-pressure barrier (argmin, lower is better):
@@ -79,8 +96,10 @@ pub const DEFAULT_THROUGHPUT: f64 = 2000.0;
 ///   in-flight correction absorbs staleness between polls.
 #[derive(Debug)]
 pub struct LeastLoadPolicy {
-    /// Cached load reports from the worker monitor (keyed by worker URL).
-    cached_loads: RwLock<HashMap<String, WorkerLoadResponse>>,
+    /// Cached load reports from the worker monitor (keyed by worker URL), each
+    /// stamped with the `Instant` it was last refreshed so a snapshot that stops
+    /// being refreshed (the worker's poll keeps failing) can age out.
+    cached_loads: RwLock<HashMap<String, (Instant, WorkerLoadResponse)>>,
     /// In-flight token-work dispatched per worker since its last load poll
     /// (keyed by worker URL); reset when a fresh report arrives.
     inflight_tokens: RwLock<HashMap<String, u64>>,
@@ -92,6 +111,8 @@ pub struct LeastLoadPolicy {
     /// Fallback throughput (tokens/s) for the `/throughput` term when a backend
     /// reports no live `gen_throughput`.
     default_throughput: f64,
+    /// Age past which a cached load is treated as absent (no fresh snapshot).
+    staleness_ttl: Duration,
 }
 
 impl LeastLoadPolicy {
@@ -116,6 +137,22 @@ impl LeastLoadPolicy {
         mean_prefill_tokens: u32,
         default_throughput: f64,
     ) -> Self {
+        Self::with_config(
+            kv_pressure_weight,
+            mean_prefill_tokens,
+            default_throughput,
+            DEFAULT_LOAD_CHECK_INTERVAL_SECS,
+        )
+    }
+
+    /// Build with the configured worker-load poll period, which sets the horizon
+    /// past which an unrefreshed cached load is treated as absent.
+    pub fn with_config(
+        kv_pressure_weight: f64,
+        mean_prefill_tokens: u32,
+        default_throughput: f64,
+        load_check_interval_secs: u64,
+    ) -> Self {
         Self {
             cached_loads: RwLock::new(HashMap::new()),
             inflight_tokens: RwLock::new(HashMap::new()),
@@ -130,6 +167,7 @@ impl LeastLoadPolicy {
             } else {
                 DEFAULT_THROUGHPUT
             },
+            staleness_ttl: staleness_ttl(load_check_interval_secs),
         }
     }
 
@@ -144,13 +182,13 @@ impl LeastLoadPolicy {
     fn score(
         &self,
         worker: &Arc<dyn Worker>,
-        loads: Option<&HashMap<String, WorkerLoadResponse>>,
+        loads: Option<&HashMap<&str, &WorkerLoadResponse>>,
         inflight: &HashMap<String, u64>,
         nominal_throughput: f64,
         fleet_has_loads: bool,
     ) -> f64 {
         let url = worker.url();
-        match loads.and_then(|m| m.get(url)) {
+        match loads.and_then(|m| m.get(url).copied()) {
             Some(load) => {
                 let inflight_tokens = inflight.get(url).copied().unwrap_or(0) as f64;
                 let queued_tokens = load.total_waiting_uncached_tokens() as f64;
@@ -196,7 +234,17 @@ impl LoadBalancingPolicy for LeastLoadPolicy {
         }
 
         let loads_guard = self.cached_loads.read().ok();
-        let loads = loads_guard.as_deref();
+        // A snapshot that stopped being refreshed (its worker's poll keeps
+        // failing) is dropped here, so it no longer counts as cached and that
+        // worker degrades to the request-count fallback.
+        let now = Instant::now();
+        let fresh: Option<HashMap<&str, &WorkerLoadResponse>> = loads_guard.as_ref().map(|m| {
+            m.iter()
+                .filter(|(_, (stamped, _))| now.duration_since(*stamped) <= self.staleness_ttl)
+                .map(|(url, (_, load))| (url.as_str(), load))
+                .collect()
+        });
+        let loads = fresh.as_ref();
 
         // Fleet-nominal throughput (mean of positive reports) stands in for a
         // worker missing a fresh snapshot; `fleet_has_loads` distinguishes a
@@ -204,7 +252,7 @@ impl LoadBalancingPolicy for LeastLoadPolicy {
         // from a fully dark fleet (fall back to join-shortest-queue).
         let (tp_sum, tp_count) = healthy
             .iter()
-            .filter_map(|&i| loads.and_then(|m| m.get(workers[i].url())))
+            .filter_map(|&i| loads.and_then(|m| m.get(workers[i].url()).copied()))
             .map(|l| l.total_gen_throughput())
             .filter(|t| *t > 0.0)
             .fold((0.0, 0u32), |(s, n), t| (s + t, n + 1));
@@ -267,8 +315,9 @@ impl LoadBalancingPolicy for LeastLoadPolicy {
     }
 
     fn update_loads(&self, loads: &HashMap<String, WorkerLoadResponse>) {
+        let now = Instant::now();
         if let Ok(mut cached) = self.cached_loads.write() {
-            cached.extend(loads.iter().map(|(k, v)| (k.clone(), v.clone())));
+            cached.extend(loads.iter().map(|(k, v)| (k.clone(), (now, v.clone()))));
         }
         // A fresh snapshot already reflects work up to the poll, so reset the
         // since-poll in-flight estimate for the workers it covers.
@@ -503,6 +552,48 @@ mod tests {
     fn single_worker_always_selected() {
         let policy = LeastLoadPolicy::new();
         let workers = vec![mk("http://a:8000")];
+        assert_eq!(
+            policy.select_worker(&workers, &SelectWorkerInfo::default()),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn stale_load_evicted_falls_back_to_in_flight() {
+        // poll1 reports both A and B; poll2 reports only A (B's fetch failed).
+        // B's stale report claims it is idle while its live in-flight is heavy:
+        // once the report ages past the staleness horizon B must be scored on
+        // that live in-flight, not the stale snapshot, and lose to idle A.
+        let mut policy = LeastLoadPolicy::new();
+        policy.staleness_ttl = Duration::from_millis(10);
+
+        let a = mk("http://a:8000");
+        let b = mk("http://b:8000");
+        for _ in 0..50 {
+            b.increment_load();
+        }
+        let workers = vec![a, b];
+
+        let mut poll1 = HashMap::new();
+        poll1.insert("http://a:8000".to_string(), make_load(0, 0.2, 100.0));
+        poll1.insert("http://b:8000".to_string(), make_load(0, 0.0, 100.0));
+        policy.update_loads(&poll1);
+
+        std::thread::sleep(Duration::from_millis(25));
+
+        // poll2: only A refreshed; B keeps its now-stale (idle-looking) entry.
+        let mut poll2 = HashMap::new();
+        poll2.insert("http://a:8000".to_string(), make_load(0, 0.2, 100.0));
+        policy.update_loads(&poll2);
+
+        // The stale entry is still present in the cache (merge never drops it)...
+        assert!(policy
+            .cached_loads
+            .read()
+            .unwrap()
+            .contains_key("http://b:8000"));
+        // ...but selection ignores it: B is scored on its 50 live in-flight
+        // (≈512s) and loses to the freshly-idle A (≈0.04s).
         assert_eq!(
             policy.select_worker(&workers, &SelectWorkerInfo::default()),
             Some(0)

--- a/model_gateway/src/policies/power_of_two.rs
+++ b/model_gateway/src/policies/power_of_two.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
+    time::{Duration, Instant},
 };
 
 use openai_protocol::worker::WorkerLoadResponse;
@@ -12,21 +13,61 @@ use tracing::debug;
 use super::{get_healthy_worker_indices, LoadBalancingPolicy, SelectWorkerInfo};
 use crate::worker::Worker;
 
+/// Default worker-load poll period (seconds) when the policy is built without a
+/// configured `load_check_interval_secs`, used to derive the staleness horizon.
+const DEFAULT_LOAD_CHECK_INTERVAL_SECS: u64 = 10;
+
+/// A cached load is treated as absent once it is older than this many poll
+/// intervals, so a worker whose fetch keeps failing degrades to request counts
+/// instead of being compared on an indefinitely stale snapshot.
+const STALE_LOAD_INTERVALS: u32 = 3;
+
+/// Staleness horizon (a few poll intervals) past which an unrefreshed cached
+/// load is treated as absent; tolerates a couple of missed/slow polls.
+fn staleness_ttl(load_check_interval_secs: u64) -> Duration {
+    let secs = load_check_interval_secs.max(1) * u64::from(STALE_LOAD_INTERVALS);
+    Duration::from_secs(secs)
+}
+
 /// Power-of-two choices policy
 ///
 /// Randomly selects two workers and routes to the one with lower load.
 /// This provides good load distribution with minimal coordination overhead.
 #[derive(Debug)]
 pub struct PowerOfTwoPolicy {
-    /// Cached load information from external monitoring
-    cached_loads: RwLock<HashMap<String, WorkerLoadResponse>>,
+    /// Cached load information from external monitoring, each stamped with the
+    /// `Instant` it was last refreshed so a snapshot that stops being refreshed
+    /// (the worker's poll keeps failing) can age out.
+    cached_loads: RwLock<HashMap<String, (Instant, WorkerLoadResponse)>>,
+    /// Age past which a cached load is treated as absent (no fresh snapshot).
+    staleness_ttl: Duration,
 }
 
 impl PowerOfTwoPolicy {
     pub fn new() -> Self {
+        Self::with_config(DEFAULT_LOAD_CHECK_INTERVAL_SECS)
+    }
+
+    /// Build with the configured worker-load poll period, which sets the horizon
+    /// past which an unrefreshed cached load is treated as absent.
+    pub fn with_config(load_check_interval_secs: u64) -> Self {
         Self {
             cached_loads: RwLock::new(HashMap::new()),
+            staleness_ttl: staleness_ttl(load_check_interval_secs),
         }
+    }
+
+    /// Fresh cached load for `url`, or `None` once the last refresh has aged out.
+    fn fresh_load<'a>(
+        &self,
+        cached: &'a HashMap<String, (Instant, WorkerLoadResponse)>,
+        url: &str,
+        now: Instant,
+    ) -> Option<&'a WorkerLoadResponse> {
+        cached
+            .get(url)
+            .filter(|(stamped, _)| now.duration_since(*stamped) <= self.staleness_ttl)
+            .map(|(_, load)| load)
     }
 }
 
@@ -61,9 +102,16 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
         // Access cached loads safely
         let loads_guard = self.cached_loads.read().ok();
 
-        // Try to get high-fidelity token usage for BOTH workers
-        let load1_response = loads_guard.as_ref().and_then(|m| m.get(worker1.url()));
-        let load2_response = loads_guard.as_ref().and_then(|m| m.get(worker2.url()));
+        // Try to get high-fidelity token usage for BOTH workers. A snapshot that
+        // stopped being refreshed (the worker's poll keeps failing) is treated as
+        // absent here so the pair falls back to request counts.
+        let now = Instant::now();
+        let load1_response = loads_guard
+            .as_ref()
+            .and_then(|m| self.fresh_load(m, worker1.url(), now));
+        let load2_response = loads_guard
+            .as_ref()
+            .and_then(|m| self.fresh_load(m, worker2.url(), now));
 
         // If either worker is missing token data (e.g. monitor failure),
         // we must degrade BOTH to request counts to ensure fairness.
@@ -114,8 +162,9 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
     }
 
     fn update_loads(&self, loads: &HashMap<String, WorkerLoadResponse>) {
+        let now = Instant::now();
         if let Ok(mut cached) = self.cached_loads.write() {
-            cached.extend(loads.iter().map(|(k, v)| (k.clone(), v.clone())));
+            cached.extend(loads.iter().map(|(k, v)| (k.clone(), (now, v.clone()))));
         }
     }
 
@@ -327,6 +376,58 @@ mod tests {
         assert_eq!(
             selected_idx, 0,
             "The policy failed to handle incompatible metrics. Should select idle Worker A."
+        );
+    }
+
+    #[test]
+    fn stale_load_evicted_falls_back_to_request_counts() {
+        // poll1 reports both A and B; poll2 reports only A (B's fetch failed).
+        // Once B's snapshot ages past the staleness horizon the pair must
+        // degrade to request counts instead of comparing on B's stale report.
+        let mut policy = PowerOfTwoPolicy::new();
+        policy.staleness_ttl = Duration::from_millis(10);
+
+        let worker_a = BasicWorkerBuilder::new("http://a:8000")
+            .worker_type(WorkerType::Regular)
+            .health_config(no_health_check())
+            .build();
+        let worker_b = BasicWorkerBuilder::new("http://b:8000")
+            .worker_type(WorkerType::Regular)
+            .health_config(no_health_check())
+            .build();
+        // B is busy by request count; its stale token report claims it is idle.
+        for _ in 0..5 {
+            worker_b.increment_load();
+        }
+        let workers: Vec<Arc<dyn Worker>> = vec![Arc::new(worker_a), Arc::new(worker_b)];
+
+        let mut poll1 = HashMap::new();
+        poll1.insert("http://a:8000".to_string(), make_load(0.9));
+        poll1.insert("http://b:8000".to_string(), make_load(0.1));
+        policy.update_loads(&poll1);
+        // Fresh token usage: B (0.1) beats A (0.9), so B is selected.
+        assert_eq!(
+            policy.select_worker(&workers, &SelectWorkerInfo::default()),
+            Some(1)
+        );
+
+        std::thread::sleep(Duration::from_millis(25));
+
+        // poll2: only A refreshed; B keeps its now-stale entry.
+        let mut poll2 = HashMap::new();
+        poll2.insert("http://a:8000".to_string(), make_load(0.9));
+        policy.update_loads(&poll2);
+
+        // B's stale entry is ignored, so the pair falls back to request counts:
+        // A (0 reqs) beats B (5 reqs).
+        assert!(policy
+            .cached_loads
+            .read()
+            .unwrap()
+            .contains_key("http://b:8000"));
+        assert_eq!(
+            policy.select_worker(&workers, &SelectWorkerInfo::default()),
+            Some(0)
         );
     }
 


### PR DESCRIPTION
## Description

### Problem

The `least_load` and `power_of_two` policies cache backend load reports keyed by worker URL and update that cache with `HashMap::extend` (merge-only). The worker load monitor polls every Ready worker in a group each tick and calls `update_loads` with only the workers whose fetch *succeeded* (`worker/monitor.rs`); a worker present in a prior poll but missing from the current set failed this tick. Because the policies only ever merge, that worker's **stale** entry lives forever. The documented behavior — "if a worker is missing token data (e.g. monitor failure), degrade to request counts" (power_of_two) / convert to a drain-time estimate (least_load) — never triggers for a worker whose poll keeps failing: routing keeps using its old snapshot. (The monitor already prunes stale URLs from its shared watch-channel snapshot; the policies' own caches did not mirror that.)

### Solution

Stamp each cached load entry with the `Instant` it was last refreshed, and treat an entry older than a staleness horizon as **absent** when selecting — so a worker whose fetch keeps failing ages out and selection falls back to the request-count / live-in-flight path.

A single `default_policy` instance is shared across all model groups (`policies/registry.rs`), each group's poll loop calling `update_loads` on it independently, so the cache **cannot** be replaced wholesale per poll (that would wipe other groups' just-written entries) — per-entry staleness is group-agnostic and safe. The horizon is `STALE_LOAD_INTERVALS` (3) × the configured `load_check_interval_secs`, threaded through a new `with_config` constructor wired in the factory. Existing public constructors (`new`, `with_params`) are unchanged and default the interval, so `create_by_name` and all other call sites are unaffected.

## Changes

- `least_load.rs`: `cached_loads` stores `(Instant, WorkerLoadResponse)`; selection builds a fresh-only view filtering entries older than `staleness_ttl`; `update_loads` stamps `Instant::now()`; added `with_config(.., load_check_interval_secs)` + `staleness_ttl` field; `score` takes the borrowed fresh view.
- `power_of_two.rs`: same staleness stamping; added `with_config`, `staleness_ttl`, and a `fresh_load()` helper returning `None` once an entry has aged out; `select_worker` uses it for both probed workers so a stale entry triggers the existing request-count fallback.
- `factory.rs`: pass `load_check_interval_secs` from `PolicyConfig::PowerOfTwo`/`LeastLoad` into the new constructors.
- One regression test per policy.

## Test Plan

- **power_of_two `stale_load_evicted_falls_back_to_request_counts`** (10 ms TTL) — poll1 reports A (0.9) and B (0.1); B selected on fresh usage. After a 25 ms sleep, poll2 refreshes only A; B's stale entry is confirmed still cached but ignored, and selection falls back to request counts (A=0 reqs beats B=5).
- **least_load `stale_load_evicted_falls_back_to_in_flight`** — poll1 reports A and B idle; B has 50 live in-flight. After 25 ms, poll2 refreshes only A; B is scored on its 50 in-flight (~512 s) not the stale idle report, so freshly-idle A wins.
- Both verified to **FAIL before** the fix (staleness filter disabled: "0 passed; 2 failed") and pass after.

Authoritative gate (sccache disabled, `RUSTC_WRAPPER=""`):

```
$ rustup run nightly cargo fmt --all -- --check
FMT CLEAN (exit 0)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile target(s) in 10.92s
exit 0

$ cargo test -p smg --lib stale_load
test result: ok. 2 passed; 0 failed — stale_load_evicted_falls_back_to_in_flight, stale_load_evicted_falls_back_to_request_counts
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
