### PR TITLE
feat(mesh): causally-stable tombstone GC driven by per-peer ack watermarks

### DIFF
--- a/crates/mesh/src/crdt_kv/crdt.rs
+++ b/crates/mesh/src/crdt_kv/crdt.rs
@@ -206,6 +206,19 @@ impl CrdtOrMap {
             .sum()
     }
 
+    /// Causally-stable tombstone GC: collect tombstones past `grace` whose
+    /// winning version `stable` confirms every live peer acked.
+    pub fn gc_stable_tombstones(
+        &self,
+        grace: Duration,
+        stable: &dyn Fn(&str, (u64, ReplicaId)) -> bool,
+    ) -> usize {
+        self.all_engines()
+            .iter()
+            .map(|e| e.gc_tombstones_where(grace, stable))
+            .sum()
+    }
+
     // ---- Replication ----
 
     /// Snapshot the operation log seen by gossip. Concatenates each engine's

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -466,7 +466,11 @@ impl NamespaceCrdtEngine for LwwEngine {
             .collect()
     }
 
-    fn gc_tombstones(&self, grace: Duration) -> usize {
+    fn gc_tombstones_where(
+        &self,
+        grace: Duration,
+        stable: &dyn Fn(&str, (u64, ReplicaId)) -> bool,
+    ) -> usize {
         let now = Instant::now();
         let mut removed = 0;
         // Collected keys' winning tombstone versions, for the log purge below.
@@ -494,6 +498,7 @@ impl NamespaceCrdtEngine for LwwEngine {
                         .is_none_or(|winner| {
                             winner.is_tombstone
                                 && now.saturating_duration_since(winner.created_at) >= grace
+                                && stable(&key, winner.version_key())
                         })
             });
             if let Some((key, versions)) = was_removed {

--- a/crates/mesh/src/crdt_kv/engine/mod.rs
+++ b/crates/mesh/src/crdt_kv/engine/mod.rs
@@ -15,7 +15,10 @@
 
 use std::{sync::Arc, time::Duration};
 
-use super::operation::{CrdtChange, Operation};
+use super::{
+    operation::{CrdtChange, Operation},
+    replica::ReplicaId,
+};
 
 mod lww;
 mod rate_limit;
@@ -92,7 +95,18 @@ pub(super) trait NamespaceCrdtEngine: Send + Sync {
     /// Garbage-collect tombstones older than `grace`, purging the collected
     /// keys' dominated ops from the operation log so log size keeps tracking
     /// the key population. Returns the number of metadata entries removed.
-    fn gc_tombstones(&self, grace: Duration) -> usize;
+    fn gc_tombstones(&self, grace: Duration) -> usize {
+        self.gc_tombstones_where(grace, &|_, _| true)
+    }
+
+    /// [`Self::gc_tombstones`] gated per tombstone: collect only when
+    /// `stable` returns true for the key and its winning version. The caller
+    /// proves causal stability — every live peer acked past the tombstone.
+    fn gc_tombstones_where(
+        &self,
+        grace: Duration,
+        stable: &dyn Fn(&str, (u64, ReplicaId)) -> bool,
+    ) -> usize;
 }
 
 /// Strategy-agnostic engine handle. Routers hold `Arc<dyn

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -450,7 +450,11 @@ impl NamespaceCrdtEngine for RateLimitEngine {
             .collect()
     }
 
-    fn gc_tombstones(&self, grace: Duration) -> usize {
+    fn gc_tombstones_where(
+        &self,
+        grace: Duration,
+        stable: &dyn Fn(&str, (u64, ReplicaId)) -> bool,
+    ) -> usize {
         let now = Instant::now();
         let candidates: Vec<String> = self
             .entries
@@ -469,11 +473,14 @@ impl NamespaceCrdtEngine for RateLimitEngine {
         let mut purged: std::collections::HashMap<String, RateLimitVersion> =
             std::collections::HashMap::new();
         for key in candidates {
-            let was_removed = self.entries.remove_if(&key, |_, entry| {
-                matches!(&entry.state, RateLimitState::Tombstone(_))
-                    && entry
+            let was_removed = self.entries.remove_if(&key, |_, entry| match &entry.state {
+                RateLimitState::Tombstone(version) => {
+                    entry
                         .tombstoned_at
                         .is_some_and(|at| now.saturating_duration_since(at) >= grace)
+                        && stable(&key, (version.timestamp, version.replica_id))
+                }
+                RateLimitState::Live(_) => false,
             });
             if let Some((key, entry)) = was_removed {
                 removed += 1;

--- a/crates/mesh/src/crdt_kv/mod.rs
+++ b/crates/mesh/src/crdt_kv/mod.rs
@@ -12,7 +12,7 @@ mod replica;
 mod watermark;
 
 // Export core types
-pub use crdt::CrdtOrMap;
+pub use crdt::{CrdtOrMap, DEFAULT_TOMBSTONE_GRACE};
 pub use epoch_max_wins::{decode, encode, EpochCount, EPOCH_MAX_WINS_ENCODED_LEN};
 pub use merge_strategy::MergeStrategy;
 pub use operation::{CrdtChange, Operation, OperationLog};

--- a/crates/mesh/src/crdt_kv/tests.rs
+++ b/crates/mesh/src/crdt_kv/tests.rs
@@ -11,6 +11,7 @@ use super::{
     merge_strategy::MergeStrategy,
     operation::{Operation, OperationLog},
     replica::ReplicaId,
+    watermark::CrdtWatermark,
 };
 static INIT: Once = Once::new();
 
@@ -1478,6 +1479,44 @@ fn test_epoch_max_wins_gc_purges_collected_keys_ops_from_log() {
             .iter()
             .any(|op| op.key() == "rl:global:node-b"),
         "live keys' ops stay"
+    );
+}
+
+#[test]
+fn test_stable_gc_blocks_uncovered_tombstones() {
+    // Causal stability: a tombstone no peer has acked must survive GC even
+    // past the grace, or a lagged peer's replayed insert resurrects the key.
+    init_test_logging();
+    let map = CrdtOrMap::new();
+    map.register_merge_strategy("rl:".to_string(), MergeStrategy::EpochMaxWins);
+
+    map.insert("key1".to_string(), b"v1".to_vec());
+    map.remove("key1");
+    map.insert("rl:global:node-a".to_string(), encode(1, 1).to_vec());
+    map.remove("rl:global:node-a");
+
+    let removed = map.gc_stable_tombstones(Duration::ZERO, &|_, _| false);
+    assert_eq!(removed, 0, "unstable tombstones survive in both engines");
+
+    let removed = map.gc_stable_tombstones(Duration::ZERO, &|_, _| true);
+    assert_eq!(removed, 2, "covered tombstones collect in both engines");
+}
+
+#[test]
+fn test_watermark_covers_acked_versions() {
+    let replica = ReplicaId::new();
+    let op = Operation::insert("k".to_string(), b"v".to_vec(), 5, replica);
+    let acked = CrdtWatermark::from_ops(std::slice::from_ref(&op));
+
+    assert!(acked.covers("k", (5, replica)), "acked version is covered");
+    assert!(acked.covers("k", (4, replica)), "older version is covered");
+    assert!(
+        !acked.covers("k", (6, replica)),
+        "newer version is not covered"
+    );
+    assert!(
+        !acked.covers("other", (1, replica)),
+        "unacked key is not covered"
     );
 }
 

--- a/crates/mesh/src/crdt_kv/tests.rs
+++ b/crates/mesh/src/crdt_kv/tests.rs
@@ -1521,6 +1521,24 @@ fn test_watermark_covers_acked_versions() {
 }
 
 #[test]
+fn test_watermark_sentinel_ack_covers_only_strictly_older() {
+    // A legacy timestamp-only ack maps to (v, ReplicaId::MAX). It proves
+    // nothing about WHICH op the peer holds at timestamp v, so a
+    // same-timestamp tombstone from another replica — which the sentinel
+    // also suppresses from ever being sent — must not count as covered.
+    let replica = ReplicaId::new();
+    let legacy = Operation::insert("k".to_string(), b"v".to_vec(), 5, ReplicaId::MAX);
+    let acked = CrdtWatermark::from_ops(std::slice::from_ref(&legacy));
+
+    assert!(acked.covers("k", (4, replica)), "strictly older is covered");
+    assert!(
+        !acked.covers("k", (5, replica)),
+        "same-timestamp is not covered by a sentinel ack"
+    );
+    assert!(!acked.covers("k", (6, replica)), "newer is not covered");
+}
+
+#[test]
 fn test_gc_tombstones_multiple_keys() {
     init_test_logging();
     let map = CrdtOrMap::new();

--- a/crates/mesh/src/crdt_kv/watermark.rs
+++ b/crates/mesh/src/crdt_kv/watermark.rs
@@ -62,6 +62,13 @@ impl CrdtWatermark {
         self.versions.get(key).copied()
     }
 
+    /// True when the peer has acked `version` or newer for `key`. The
+    /// causal-stability check for tombstone GC: a tombstone is collectible
+    /// only when every live peer covers it.
+    pub fn covers(&self, key: &str, version: CrdtVersion) -> bool {
+        self.get(key).is_some_and(|acked| acked >= version)
+    }
+
     /// Advance toward `other`, taking the per-key maximum op-id. Monotone,
     /// idempotent, and commutative, so out-of-order or duplicate acks are
     /// self-correcting.

--- a/crates/mesh/src/crdt_kv/watermark.rs
+++ b/crates/mesh/src/crdt_kv/watermark.rs
@@ -64,9 +64,19 @@ impl CrdtWatermark {
 
     /// True when the peer has acked `version` or newer for `key`. The
     /// causal-stability check for tombstone GC: a tombstone is collectible
-    /// only when every live peer covers it.
+    /// only when every live peer covers it. A legacy timestamp-only ack
+    /// (`ReplicaId::MAX` sentinel) proves coverage only for strictly older
+    /// timestamps — at the acked timestamp the acked op's author is
+    /// unknown, so a same-timestamp tombstone from a higher replica may
+    /// never have been sent (the sentinel suppresses it in [`Self::allows`]).
     pub fn covers(&self, key: &str, version: CrdtVersion) -> bool {
-        self.get(key).is_some_and(|acked| acked >= version)
+        self.get(key).is_some_and(|acked| {
+            if acked.1 == ReplicaId::MAX {
+                acked.0 > version.0
+            } else {
+                acked >= version
+            }
+        })
     }
 
     /// Advance toward `other`, taking the per-key maximum op-id. Monotone,

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -318,7 +318,7 @@ impl GossipController {
                 let removed_version = {
                     let mut state = init_state.write();
                     match state.get(&name) {
-                        Some(node) if node.status == NodeStatus::Down as i32 => {
+                        Some(node) if is_departed(node.status) => {
                             let version = node.version;
                             state.remove(&name);
                             Some(version)

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -105,13 +105,56 @@ pub struct GossipController {
 /// the causal-stability GC driver.
 pub(crate) type PeerWatermarks = Arc<DashMap<String, Arc<RwLock<CrdtWatermark>>>>;
 
+/// A stream's registration in the watermark table, deregistered on drop —
+/// but only while the table still points at this stream's watermark (a
+/// replacement stream's entry is left alone). A missing entry blocks GC
+/// conservatively until the peer reconnects, instead of a dead stream's
+/// frozen entry blocking it forever.
+pub(crate) struct WatermarkRegistration {
+    table: PeerWatermarks,
+    peer: String,
+    acked: Arc<RwLock<CrdtWatermark>>,
+}
+
+impl WatermarkRegistration {
+    pub(crate) fn new(
+        table: PeerWatermarks,
+        peer: String,
+        acked: Arc<RwLock<CrdtWatermark>>,
+    ) -> Self {
+        table.insert(peer.clone(), acked.clone());
+        Self { table, peer, acked }
+    }
+}
+
+impl Drop for WatermarkRegistration {
+    fn drop(&mut self) {
+        self.table
+            .remove_if(&self.peer, |_, acked| Arc::ptr_eq(acked, &self.acked));
+    }
+}
+
 /// SWIM §5.2 default: Down nodes are removed after 60s.
 const DEFAULT_DEAD_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Track how long each peer has been Down and return those past
+/// How long a removal stays quarantined: re-offers are purged, late keys
+/// are re-swept, registry entries are retained — and stable tombstone GC
+/// is paused, so a partitioned-but-alive node returning inside the window
+/// finds every tombstone intact and merges them instead of replaying its
+/// stale inserts around collected ones. Must exceed the tombstone grace.
+const REMOVAL_QUARANTINE: Duration = Duration::from_secs(600);
+
+/// True for membership states that lead to removal: failed (Down) or
+/// gracefully departed (Leaving). Spec §5.2 removes on either; a Leaving
+/// process has exited, so its in-memory CRDT state can never replay.
+fn is_departed(status: i32) -> bool {
+    status == NodeStatus::Down as i32 || status == NodeStatus::Leaving as i32
+}
+
+/// Track how long each peer has been Down or Leaving and return those past
 /// `dead_timeout`, due for removal. `down_since` keeps the first moment a
-/// peer was seen Down; entries are dropped when the peer revives (its next
-/// Down restarts the clock) or leaves the state map.
+/// peer was seen departed; entries are dropped when the peer revives (its
+/// next departure restarts the clock) or leaves the state map.
 fn expire_down_nodes(
     down_since: &mut HashMap<String, Instant>,
     state: &BTreeMap<String, NodeState>,
@@ -119,14 +162,10 @@ fn expire_down_nodes(
     dead_timeout: Duration,
     now: Instant,
 ) -> Vec<String> {
-    down_since.retain(|name, _| {
-        state
-            .get(name)
-            .is_some_and(|node| node.status == NodeStatus::Down as i32)
-    });
+    down_since.retain(|name, _| state.get(name).is_some_and(|node| is_departed(node.status)));
     let mut expired = Vec::new();
     for (name, node) in state {
-        if name == self_name || node.status != NodeStatus::Down as i32 {
+        if name == self_name || !is_departed(node.status) {
             continue;
         }
         let since = down_since.entry(name.clone()).or_insert(now);
@@ -255,12 +294,12 @@ impl GossipController {
                 });
             }
 
-            // SWIM §5.2: remove nodes Down for longer than dead_timeout and
-            // sweep their keys (replica registry, registered namespaces).
+            // SWIM §5.2: remove nodes Down (or Leaving) for longer than
+            // dead_timeout and sweep their keys.
             purge_held_reinsertions(
                 &mut removed_holddown,
                 &mut init_state.write(),
-                self.dead_timeout * 3,
+                REMOVAL_QUARANTINE,
                 Instant::now(),
             );
             let expired = expire_down_nodes(
@@ -375,7 +414,14 @@ impl GossipController {
                     }
                     // Causally-stable tombstone GC: collect only what every
                     // member has acked. Any member without a registered
-                    // watermark (no connection yet) blocks collection.
+                    // watermark (no connection yet) blocks collection, and
+                    // any removal still in quarantine pauses it — a
+                    // partitioned-but-alive node returning inside the window
+                    // must find tombstones intact, not replay around
+                    // collected ones. Residual risk: a live node partitioned
+                    // longer than the quarantine that then heals can still
+                    // replay; fencing that needs incarnation numbers (SWIM
+                    // hardening).
                     let peers: Vec<String> = init_state
                         .read()
                         .keys()
@@ -390,7 +436,7 @@ impl GossipController {
                                 .map(|entry| Arc::clone(entry.value()))
                         })
                         .collect();
-                    if handles.len() == peers.len() {
+                    if removed_holddown.is_empty() && handles.len() == peers.len() {
                         let stable = |key: &str, version: (u64, ReplicaId)| {
                             handles
                                 .iter()
@@ -665,10 +711,14 @@ impl GossipController {
                 // on CrdtAck and emits acks for received batches. Registered in
                 // the shared table for the causal-stability GC driver; a
                 // reconnect replaces the entry with this fresh (conservative)
-                // watermark.
+                // watermark, and the registration drops with this task.
                 let acked: Arc<RwLock<CrdtWatermark>> =
                     Arc::new(RwLock::new(CrdtWatermark::new()));
-                peer_watermarks.insert(peer_name.clone(), acked.clone());
+                let _watermark_registration = WatermarkRegistration::new(
+                    peer_watermarks,
+                    peer_name.clone(),
+                    acked.clone(),
+                );
 
                 // Send initial heartbeat
                 let heartbeat =
@@ -1245,6 +1295,22 @@ mod dead_node_tests {
             t0 + Duration::from_secs(61),
         );
         assert!(expired.is_empty(), "second Down gets a fresh dead_timeout");
+    }
+
+    #[test]
+    fn leaving_node_expires_like_down() {
+        // A gracefully departed process has exited (its in-memory CRDT
+        // state can never replay), so it must leave membership — otherwise
+        // its frozen watermark stalls stable GC forever.
+        let mut down_since = HashMap::new();
+        let state = state_of(vec![node("g", NodeStatus::Leaving)]);
+        let t0 = Instant::now();
+
+        let expired = expire_down_nodes(&mut down_since, &state, "self", TIMEOUT, t0);
+        assert!(expired.is_empty(), "fresh Leaving node survives");
+
+        let expired = expire_down_nodes(&mut down_since, &state, "self", TIMEOUT, t0 + TIMEOUT);
+        assert_eq!(expired, vec!["g".to_string()], "Leaving expires like Down");
     }
 
     #[test]

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -437,10 +437,14 @@ impl GossipController {
                         })
                         .collect();
                     if removed_holddown.is_empty() && handles.len() == peers.len() {
+                        // Snapshot each watermark once per run: the predicate
+                        // is evaluated under engine shard locks, and a clone
+                        // here means no lock acquisition per tombstone (acks
+                        // landing mid-run just defer coverage to the next run).
+                        let watermarks: Vec<CrdtWatermark> =
+                            handles.iter().map(|acked| acked.read().clone()).collect();
                         let stable = |key: &str, version: (u64, ReplicaId)| {
-                            handles
-                                .iter()
-                                .all(|acked| acked.read().covers(key, version))
+                            watermarks.iter().all(|acked| acked.covers(key, version))
                         };
                         let collected = mesh_kv.gc_stable_tombstones(&stable);
                         if collected > 0 {

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -35,6 +35,7 @@ use std::{
 };
 
 use anyhow::Result;
+use dashmap::DashMap;
 use parking_lot::RwLock;
 use rand::seq::{IndexedRandom, SliceRandom};
 use tokio::sync::{mpsc, watch, Mutex};
@@ -54,7 +55,7 @@ use super::{
     },
 };
 use crate::{
-    crdt_kv::CrdtWatermark,
+    crdt_kv::{CrdtWatermark, ReplicaId},
     metrics,
     transport::{
         crdt_batch::{
@@ -93,7 +94,16 @@ pub struct GossipController {
     /// How long a node may stay Down before it is removed from the
     /// cluster and its keys are swept (SWIM §5.2).
     dead_timeout: Duration,
+    /// Per-peer CRDT ack watermarks, registered by both sender paths and
+    /// read by the causal-stability GC driver. Entries are replaced on
+    /// reconnect and removed when the peer leaves membership.
+    peer_watermarks: PeerWatermarks,
 }
+
+/// Per-peer CRDT ack watermark table, keyed by peer name. Shared between the
+/// client-side senders here, the server-side senders in `gossip_service`, and
+/// the causal-stability GC driver.
+pub(crate) type PeerWatermarks = Arc<DashMap<String, Arc<RwLock<CrdtWatermark>>>>;
 
 /// SWIM §5.2 default: Down nodes are removed after 60s.
 const DEFAULT_DEAD_TIMEOUT: Duration = Duration::from_secs(60);
@@ -185,7 +195,14 @@ impl GossipController {
             current_stream_batch: Arc::new(RwLock::new(Arc::new(crate::kv::RoundBatch::default()))),
             mesh_kv: None,
             dead_timeout: DEFAULT_DEAD_TIMEOUT,
+            peer_watermarks: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Handle to the per-peer ack watermark table, shared with the
+    /// server-side sync_stream handlers.
+    pub(crate) fn peer_watermarks(&self) -> PeerWatermarks {
+        self.peer_watermarks.clone()
     }
 
     /// Attach the node-wide MeshKV handle. Plumbed from the server
@@ -286,6 +303,9 @@ impl GossipController {
                         removed_version,
                     },
                 );
+                // Spec step 4: drop the removed peer's ack watermark so it
+                // stops vetoing causal stability.
+                self.peer_watermarks.remove(&name);
                 // Reap the dead peer's stream task now rather than letting it
                 // tick into a dead channel until the idle timeout.
                 if let Some(handle) = self.sync_connections.lock().await.remove(&name) {
@@ -335,10 +355,52 @@ impl GossipController {
             // Periodic retry-manager cleanup every 60 rounds (~60s).
             if cnt.is_multiple_of(60) {
                 retry_managers.retain(|peer_name, _| map.contains_key(peer_name));
-                // Owner-side replica-registry upkeep: re-assert this
-                // incarnation's entry, retire prior incarnations'.
                 if let Some(mesh_kv) = &self.mesh_kv {
+                    // Owner-side replica-registry upkeep: re-assert this
+                    // incarnation's entry, retire prior incarnations'.
                     mesh_kv.reconcile_replica_registry();
+                    // Re-sweep held (recently removed) names so late-relayed
+                    // keys are tombstoned while attribution is still retained.
+                    for name in removed_holddown.keys() {
+                        mesh_kv.handle_node_removed(name);
+                    }
+                    // Retire registry entries for nodes neither in membership
+                    // nor still held (held names may yet see late keys).
+                    let mut present: std::collections::HashSet<String> =
+                        init_state.read().keys().cloned().collect();
+                    present.extend(removed_holddown.keys().cloned());
+                    let retired = mesh_kv.retire_absent_replica_entries(&present);
+                    if retired > 0 {
+                        log::info!("Retired {retired} replica-registry entries of departed nodes");
+                    }
+                    // Causally-stable tombstone GC: collect only what every
+                    // member has acked. Any member without a registered
+                    // watermark (no connection yet) blocks collection.
+                    let peers: Vec<String> = init_state
+                        .read()
+                        .keys()
+                        .filter(|name| **name != self.self_name)
+                        .cloned()
+                        .collect();
+                    let handles: Vec<_> = peers
+                        .iter()
+                        .filter_map(|peer| {
+                            self.peer_watermarks
+                                .get(peer)
+                                .map(|entry| Arc::clone(entry.value()))
+                        })
+                        .collect();
+                    if handles.len() == peers.len() {
+                        let stable = |key: &str, version: (u64, ReplicaId)| {
+                            handles
+                                .iter()
+                                .all(|acked| acked.read().covers(key, version))
+                        };
+                        let collected = mesh_kv.gc_stable_tombstones(&stable);
+                        if collected > 0 {
+                            log::info!("Causally-stable GC collected {collected} tombstones");
+                        }
+                    }
                 }
             }
 
@@ -569,6 +631,7 @@ impl GossipController {
         let sync_connections = self.sync_connections.clone();
         let current_stream_batch = self.current_stream_batch.clone();
         let mesh_kv = self.mesh_kv.clone();
+        let peer_watermarks = self.peer_watermarks.clone();
 
         // Log connection lifecycle: spawn
         log::debug!(
@@ -599,9 +662,13 @@ impl GossipController {
 
                 // Per-peer CRDT send watermark (per-key acked versions). The
                 // incremental sender filters by it; the inbound loop advances it
-                // on CrdtAck and emits acks for received batches.
+                // on CrdtAck and emits acks for received batches. Registered in
+                // the shared table for the causal-stability GC driver; a
+                // reconnect replaces the entry with this fresh (conservative)
+                // watermark.
                 let acked: Arc<RwLock<CrdtWatermark>> =
                     Arc::new(RwLock::new(CrdtWatermark::new()));
+                peer_watermarks.insert(peer_name.clone(), acked.clone());
 
                 // Send initial heartbeat
                 let heartbeat =

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -44,6 +44,7 @@ use tracing::instrument;
 
 use super::{
     crdt_kv::CrdtWatermark,
+    gossip_controller::PeerWatermarks,
     metrics::{record_ack, record_nack, record_peer_reconnect, update_peer_connections},
     mtls::MTLSManager,
     partition::PartitionDetector,
@@ -94,6 +95,10 @@ pub struct GossipService {
     /// registry, and chunk assembler shared with the client-side
     /// SyncStream handlers.
     mesh_kv: Option<Arc<crate::kv::MeshKV>>,
+    /// Shared per-peer ack watermark table (owned by the controller).
+    /// Server-side handlers register their peer's watermark once the peer
+    /// identifies, so the causal-stability GC sees both stream directions.
+    peer_watermarks: Option<PeerWatermarks>,
 }
 
 impl GossipService {
@@ -112,7 +117,15 @@ impl GossipService {
             mtls_manager: None,
             current_stream_batch: None,
             mesh_kv: None,
+            peer_watermarks: None,
         }
+    }
+
+    /// Attach the controller-owned per-peer ack watermark table so
+    /// server-side senders register their peers for causal-stability GC.
+    pub(crate) fn with_peer_watermarks(mut self, peer_watermarks: PeerWatermarks) -> Self {
+        self.peer_watermarks = Some(peer_watermarks);
+        self
     }
 
     /// Attach the shared stream RoundBatch reference. Server-side
@@ -419,6 +432,7 @@ impl Gossip for GossipService {
 
         let learned_peer_inbound = learned_peer.clone();
         let acked_inbound = acked.clone();
+        let peer_watermarks_inbound = self.peer_watermarks.clone();
         #[expect(
             clippy::disallowed_methods,
             reason = "server-side inbound handler bound to sync_stream lifetime; terminates when the stream closes"
@@ -458,6 +472,12 @@ impl Gossip for GossipService {
                         peer_id = msg.peer_id.clone();
                         update_peer_connections(&peer_id, true);
                         *learned_peer_inbound.write() = Some(peer_id.clone());
+                        // Register this stream's ack watermark for the
+                        // causal-stability GC; a reconnect replaces the
+                        // entry with this fresh (conservative) one.
+                        if let Some(watermarks) = &peer_watermarks_inbound {
+                            watermarks.insert(peer_id.clone(), acked_inbound.clone());
+                        }
                     }
                 } else if msg.peer_id != peer_id {
                     log::warn!(

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -44,7 +44,7 @@ use tracing::instrument;
 
 use super::{
     crdt_kv::CrdtWatermark,
-    gossip_controller::PeerWatermarks,
+    gossip_controller::{PeerWatermarks, WatermarkRegistration},
     metrics::{record_ack, record_nack, record_peer_reconnect, update_peer_connections},
     mtls::MTLSManager,
     partition::PartitionDetector,
@@ -444,6 +444,9 @@ impl Gossip for GossipService {
             let mut peer_id = String::new();
             update_peer_connections(&peer_id, true);
             let mut sequence: u64 = 0;
+            // Held for the stream's lifetime so its Drop deregisters on
+            // exit, unless a replacement stream already re-registered.
+            let mut _watermark_registration: Option<WatermarkRegistration> = None;
 
             loop {
                 let msg = match tokio::time::timeout(STREAM_IDLE_TIMEOUT, incoming.next()).await {
@@ -474,9 +477,14 @@ impl Gossip for GossipService {
                         *learned_peer_inbound.write() = Some(peer_id.clone());
                         // Register this stream's ack watermark for the
                         // causal-stability GC; a reconnect replaces the
-                        // entry with this fresh (conservative) one.
+                        // entry with this fresh (conservative) one, and the
+                        // registration drops with this stream.
                         if let Some(watermarks) = &peer_watermarks_inbound {
-                            watermarks.insert(peer_id.clone(), acked_inbound.clone());
+                            _watermark_registration = Some(WatermarkRegistration::new(
+                                watermarks.clone(),
+                                peer_id.clone(),
+                                acked_inbound.clone(),
+                            ));
                         }
                     }
                 } else if msg.peer_id != peer_id {

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -636,6 +636,7 @@ impl MeshKV {
     pub fn retire_absent_replica_entries(&self, present: &HashSet<String>) -> usize {
         let mut absent_keys = Vec::new();
         let mut absent_replicas: HashSet<ReplicaId> = HashSet::new();
+        let mut absent_nodes: HashSet<String> = HashSet::new();
         for key in self.store.keys() {
             if !key.starts_with(REPLICA_PREFIX) {
                 continue;
@@ -653,22 +654,34 @@ impl MeshKV {
             {
                 absent_replicas.insert(replica);
             }
+            absent_nodes.insert(node.into_owned());
             absent_keys.push(key);
         }
         if absent_keys.is_empty() {
             return 0;
         }
+        // Sweep any ghost key still attributed to the departed nodes before
+        // dropping their registry entries — this is the last pass that can
+        // attribute them. AuthorReplica keys go by op author; NodeNameSuffix
+        // keys (e.g. rl: shards) go by the node-name segment, which needs no
+        // registry entry, so they are swept here too rather than stranded.
         let sweeps = self.dead_node_sweeps.read().clone();
         for (prefix, attribution) in &sweeps {
-            if *attribution == DeadKeyAttribution::AuthorReplica {
-                let swept = self.sweep_authored_by(prefix, &absent_replicas);
-                if swept > 0 {
-                    tracing::warn!(
-                        swept,
-                        prefix = prefix.as_str(),
-                        "swept ghost keys of departed nodes at registry retirement"
-                    );
+            let swept = match attribution {
+                DeadKeyAttribution::AuthorReplica => {
+                    self.sweep_authored_by(prefix, &absent_replicas)
                 }
+                DeadKeyAttribution::NodeNameSuffix => absent_nodes
+                    .iter()
+                    .map(|node| self.sweep_node_suffix(prefix, node))
+                    .sum(),
+            };
+            if swept > 0 {
+                tracing::warn!(
+                    swept,
+                    prefix = prefix.as_str(),
+                    "swept ghost keys of departed nodes at registry retirement"
+                );
             }
         }
         for key in &absent_keys {

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -629,12 +629,13 @@ impl MeshKV {
     }
 
     /// Retire replica-registry entries for nodes in neither membership nor
-    /// the removal holddown, keeping any that still author live keys (a
-    /// late-relayed key keeps its attribution until the held-name re-sweep
-    /// tombstones it). Returns the number of entries retired.
+    /// the removal quarantine, first sweeping any live key still attributed
+    /// to them (a key relayed after the quarantine's re-sweeps would
+    /// otherwise outlive its attribution as a permanent ghost). Returns the
+    /// number of entries retired.
     pub fn retire_absent_replica_entries(&self, present: &HashSet<String>) -> usize {
-        let still_authoring = self.live_key_authors();
-        let mut retired = 0;
+        let mut absent_keys = Vec::new();
+        let mut absent_replicas: HashSet<ReplicaId> = HashSet::new();
         for key in self.store.keys() {
             if !key.starts_with(REPLICA_PREFIX) {
                 continue;
@@ -646,16 +647,34 @@ impl MeshKV {
             if node == self.server_name || present.contains(node.as_ref()) {
                 continue;
             }
-            let authoring = key
+            if let Some(replica) = key
                 .strip_prefix(REPLICA_PREFIX)
                 .and_then(|id| ReplicaId::from_string(id).ok())
-                .is_some_and(|replica| still_authoring.contains(&replica));
-            if !authoring {
-                self.delete_with_notify(&key);
-                retired += 1;
+            {
+                absent_replicas.insert(replica);
+            }
+            absent_keys.push(key);
+        }
+        if absent_keys.is_empty() {
+            return 0;
+        }
+        let sweeps = self.dead_node_sweeps.read().clone();
+        for (prefix, attribution) in &sweeps {
+            if *attribution == DeadKeyAttribution::AuthorReplica {
+                let swept = self.sweep_authored_by(prefix, &absent_replicas);
+                if swept > 0 {
+                    tracing::warn!(
+                        swept,
+                        prefix = prefix.as_str(),
+                        "swept ghost keys of departed nodes at registry retirement"
+                    );
+                }
             }
         }
-        retired
+        for key in &absent_keys {
+            self.delete_with_notify(key);
+        }
+        absent_keys.len()
     }
 
     /// Owner-side replica-registry maintenance: re-assert this incarnation's

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -567,11 +567,21 @@ impl MeshKV {
     /// A peer absent longer than the grace still holds the deleted key's
     /// older insert in its op-log and replays it on reconnect; with the
     /// tombstone metadata gone, the stale insert lands on an empty entry
-    /// and resurrects the key. Collection is only safe at causal stability
-    /// — every live peer acked past the tombstone and absent peers
-    /// declared dead — so the caller must be the dead-node cleanup layer.
+    /// and resurrects the key. The driven path is
+    /// [`gc_stable_tombstones`](Self::gc_stable_tombstones).
     pub fn gc_tombstones(&self) -> usize {
         self.store.gc_tombstones()
+    }
+
+    /// Causally-stable tombstone GC: collect tombstones past the default
+    /// grace whose winning version `stable` confirms every live peer has
+    /// acked. The gossip controller drives this with a predicate built from
+    /// the per-peer send watermarks, so a collected tombstone can never be
+    /// replayed-around: every peer that could relay the dominated insert
+    /// already holds (and has compacted against) the tombstone.
+    pub fn gc_stable_tombstones(&self, stable: &dyn Fn(&str, (u64, ReplicaId)) -> bool) -> usize {
+        self.store
+            .gc_stable_tombstones(crate::crdt_kv::DEFAULT_TOMBSTONE_GRACE, stable)
     }
 
     /// Register a prefix for dead-node key sweeping: when
@@ -584,10 +594,12 @@ impl MeshKV {
     }
 
     /// Dead-node cleanup: tombstone the node's keys in every sweep-registered
-    /// namespace, then retire its replica-registry entries. Every survivor
-    /// runs this; concurrent tombstones converge, and a live (partitioned)
-    /// owner's reconcile re-assert overrules a premature sweep. Returns the
-    /// number of keys tombstoned.
+    /// namespace. Every survivor runs this; concurrent tombstones converge,
+    /// and a live (partitioned) owner's reconcile re-assert overrules a
+    /// premature sweep. The node's replica-registry entries are deliberately
+    /// retained so re-sweeps can attribute late-relayed keys; they retire via
+    /// [`retire_absent_replica_entries`](Self::retire_absent_replica_entries).
+    /// Returns the number of keys tombstoned.
     pub fn handle_node_removed(&self, node: &str) -> usize {
         let replica_keys = self.replica_keys_of(node);
         let dead_replicas: HashSet<ReplicaId> = replica_keys
@@ -613,11 +625,37 @@ impl MeshKV {
                 DeadKeyAttribution::NodeNameSuffix => self.sweep_node_suffix(prefix, node),
             };
         }
-        // Last so a concurrent sweep on another survivor can still attribute.
-        for key in &replica_keys {
-            self.delete_with_notify(key);
-        }
         swept
+    }
+
+    /// Retire replica-registry entries for nodes in neither membership nor
+    /// the removal holddown, keeping any that still author live keys (a
+    /// late-relayed key keeps its attribution until the held-name re-sweep
+    /// tombstones it). Returns the number of entries retired.
+    pub fn retire_absent_replica_entries(&self, present: &HashSet<String>) -> usize {
+        let still_authoring = self.live_key_authors();
+        let mut retired = 0;
+        for key in self.store.keys() {
+            if !key.starts_with(REPLICA_PREFIX) {
+                continue;
+            }
+            let Some(node) = self.store.get(&key) else {
+                continue;
+            };
+            let node = String::from_utf8_lossy(&node);
+            if node == self.server_name || present.contains(node.as_ref()) {
+                continue;
+            }
+            let authoring = key
+                .strip_prefix(REPLICA_PREFIX)
+                .and_then(|id| ReplicaId::from_string(id).ok())
+                .is_some_and(|replica| still_authoring.contains(&replica));
+            if !authoring {
+                self.delete_with_notify(&key);
+                retired += 1;
+            }
+        }
+        retired
     }
 
     /// Owner-side replica-registry maintenance: re-assert this incarnation's

--- a/crates/mesh/src/service.rs
+++ b/crates/mesh/src/service.rs
@@ -324,6 +324,10 @@ impl MeshServer {
         // client-side.
         service = service.with_current_stream_batch(controller.current_stream_batch());
 
+        // Share the controller's per-peer ack watermark table so the
+        // causal-stability GC sees both stream directions.
+        service = service.with_peer_watermarks(controller.peer_watermarks());
+
         // Add mTLS support if configured
         if let Some(mtls_manager) = self.mtls_manager.clone() {
             service = service.with_mtls_manager(mtls_manager);

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -354,6 +354,31 @@ fn absent_entry_retirement_sweeps_ghost_keys_first() {
 }
 
 #[test]
+fn absent_entry_retirement_sweeps_suffix_attributed_ghosts() {
+    // A suffix-attributed (rl:) key relayed after the dead node left
+    // holddown must also be swept at retirement — it carries no registry
+    // entry, so this is the last pass that can attribute it by node name.
+    let dead = MeshKV::new("dead-node".to_string());
+    let dead_rl = dead.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+    dead_rl.put("rl:global:dead-node", encode_epoch_count(1, 5).to_vec());
+
+    let survivor = MeshKV::new("survivor".to_string());
+    let survivor_rl = survivor.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+    survivor.configure_dead_node_sweep("rl:", DeadKeyAttribution::NodeNameSuffix);
+    // The dead node also published a replica-registry entry (every node does).
+    deliver_crdt(&dead, &survivor);
+    assert!(survivor_rl.get("rl:global:dead-node").is_some());
+
+    let retired = survivor.retire_absent_replica_entries(&std::collections::HashSet::new());
+    assert_eq!(retired, 1, "absent node's registry entry retires");
+    assert_eq!(
+        survivor_rl.get("rl:global:dead-node"),
+        None,
+        "the suffix-attributed ghost shard is swept in the same pass"
+    );
+}
+
+#[test]
 fn reconcile_retires_prior_incarnations_registry_entries() {
     // A restarted node mints a fresh replica id; without owner-side
     // retirement the registry would grow by one immortal key per boot.

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -330,26 +330,27 @@ fn dead_node_sweep_tombstones_authored_keys() {
 }
 
 #[test]
-fn absent_entry_retirement_waits_for_attributed_live_keys() {
-    // A key relayed after the sweep keeps its attribution: the entry
-    // survives retirement until a re-sweep tombstones the key.
+fn absent_entry_retirement_sweeps_ghost_keys_first() {
+    // A key relayed after the quarantine's re-sweeps would outlive its
+    // attribution as a permanent ghost; retirement sweeps it in the same
+    // pass before deleting the entries.
     let dead = MeshKV::new("dead-node".to_string());
     let dead_ns = dead.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
     dead_ns.put("worker:late", b"v1".to_vec());
 
     let survivor = MeshKV::new("survivor".to_string());
-    survivor.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    let survivor_ns = survivor.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
     survivor.configure_dead_node_sweep("worker:", DeadKeyAttribution::AuthorReplica);
     deliver_crdt(&dead, &survivor);
+    assert!(survivor_ns.get("worker:late").is_some());
 
-    // The late key is live and attributed: retirement must hold off.
     let retired = survivor.retire_absent_replica_entries(&std::collections::HashSet::new());
-    assert_eq!(retired, 0, "entry kept while it authors a live key");
-
-    // The held-name re-sweep tombstones the late key; retirement follows.
-    assert_eq!(survivor.handle_node_removed("dead-node"), 1);
-    let retired = survivor.retire_absent_replica_entries(&std::collections::HashSet::new());
-    assert_eq!(retired, 1, "entry retires once the late key is swept");
+    assert_eq!(retired, 1, "absent node's entry retires");
+    assert_eq!(
+        survivor_ns.get("worker:late"),
+        None,
+        "the ghost key is swept in the same pass"
+    );
 }
 
 #[test]

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -308,6 +308,16 @@ fn dead_node_sweep_tombstones_authored_keys() {
         Some(b"v2".to_vec()),
         "survivor-owned key kept"
     );
+    assert_eq!(
+        survivor.replica_keys_of("dead-node").len(),
+        1,
+        "registry entries are retained at sweep time for late-key re-sweeps"
+    );
+
+    // Once the node is neither in membership nor held, and nothing live is
+    // attributed to it, its registry entries retire.
+    let retired = survivor.retire_absent_replica_entries(&std::collections::HashSet::new());
+    assert_eq!(retired, 1);
     assert!(
         survivor.replica_keys_of("dead-node").is_empty(),
         "dead node's replica-registry entries retired"
@@ -317,6 +327,29 @@ fn dead_node_sweep_tombstones_authored_keys() {
         1,
         "survivor's own registry entry kept"
     );
+}
+
+#[test]
+fn absent_entry_retirement_waits_for_attributed_live_keys() {
+    // A key relayed after the sweep keeps its attribution: the entry
+    // survives retirement until a re-sweep tombstones the key.
+    let dead = MeshKV::new("dead-node".to_string());
+    let dead_ns = dead.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    dead_ns.put("worker:late", b"v1".to_vec());
+
+    let survivor = MeshKV::new("survivor".to_string());
+    survivor.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    survivor.configure_dead_node_sweep("worker:", DeadKeyAttribution::AuthorReplica);
+    deliver_crdt(&dead, &survivor);
+
+    // The late key is live and attributed: retirement must hold off.
+    let retired = survivor.retire_absent_replica_entries(&std::collections::HashSet::new());
+    assert_eq!(retired, 0, "entry kept while it authors a live key");
+
+    // The held-name re-sweep tombstones the late key; retirement follows.
+    assert_eq!(survivor.handle_node_removed("dead-node"), 1);
+    let retired = survivor.retire_absent_replica_entries(&std::collections::HashSet::new());
+    assert_eq!(retired, 1, "entry retires once the late key is swept");
 }
 
 #[test]
@@ -378,10 +411,11 @@ fn reconcile_reasserts_own_registry_entry_after_premature_sweep() {
     deliver_crdt(&owner, &survivor);
 
     survivor.handle_node_removed("node-a");
+    survivor.retire_absent_replica_entries(&std::collections::HashSet::new());
     deliver_crdt(&survivor, &owner);
     assert!(
         owner.replica_keys_of("node-a").is_empty(),
-        "the sweep tombstone reached the owner"
+        "the retirement tombstone reached the owner"
     );
 
     owner.reconcile_replica_registry();


### PR DESCRIPTION
## Description

### Problem

Tombstone GC was deliberately undriven: time-based collection is unsound, because a peer absent past the grace replays its retained insert against vacant metadata and resurrects the deleted key. Without any driven GC, tombstone metadata and the Remove ops they pin accumulate forever — dead-node sweeps (#1674) made this acute by becoming the first mass-delete producer.

### Solution

Collect a tombstone only at **causal stability** — when every member has provably acked past it:

- `CrdtWatermark::covers(key, version)` turns the per-peer send watermarks (#1586) into stability proofs; engines gain `gc_tombstones_where(grace, stable)` (time-based `gc_tombstones` is the always-true special case).
- Both sender paths register their per-peer ack watermark in a controller-owned table — client-side at dial, server-side when the peer identifies. Registrations are **stream-scoped** (Drop deregisters unless a replacement stream re-registered), reconnects start fresh (conservative), removal drops the entry (spec §5.2 step 4).
- The 60-round housekeeping tick runs GC only when **every** member has a registered watermark, with `stable = all peers cover it`. A peer acked tombstone ⇒ it holds and has compacted against it ⇒ it can never relay the dominated insert.

**Found by adversarial review, fixed in-PR (3 confirmed must-fixes):**

- *Removal un-vetoed GC while the stack explicitly supports the removed node returning* (refutation + holddown lift) with its full in-memory log — after grace + collection its replay resurrected deleted keys cluster-wide, and a survivor that removed every peer degenerated to vacuously-true stability. Removals now sit in a **600s quarantine** (> grace) during which stable GC is paused entirely: a node returning inside the window finds every tombstone intact and merges them.
- *A graceful `Leaving` departure stalled GC permanently* (name stranded in membership, watermark frozen in the table). Leaving now **expires from membership like Down** — spec §5.2 removes on either, and an exited process has no in-memory state to replay, so removal + sweep is unconditionally safe.
- *Legacy timestamp-only acks (`ReplicaId::MAX` sentinel) claimed coverage of same-timestamp tombstones they also suppress from ever being sent.* Sentinel entries now prove coverage only strictly below their timestamp.

It also delivers the promise from the #1674 review threads: dead-node sweeps no longer retire replica-registry entries; quarantined names are re-swept each tick (late-relayed keys tombstoned with attribution intact), and retirement sweeps any remaining ghost keys in the same pass before deleting the entries.

### Known limitations (disclosed)

- **Residual replay window**: a live node partitioned *longer than the 600s quarantine* that then heals can still replay around collected tombstones. Fencing that requires incarnation numbers (SWIM hardening, recorded follow-up; Cassandra's `gc_grace` + rebootstrap rule is the operational precedent). Documented at the GC gate.
- A dead stream's deregistration blocks GC conservatively until reconnect (better than the prior frozen-entry permanent stall); per-key watermark entries for collected keys persist for the connection's lifetime (bounded; reset on reconnect).
- The GC-blocked regime (any member without a watermark, any quarantine active) is the exception in a healthy cluster but recurs ~10min after each removal.

## Changes

- `crates/mesh/src/crdt_kv/watermark.rs` — `covers` (sentinel-aware)
- `crates/mesh/src/crdt_kv/engine/{mod,lww,rate_limit}.rs` — `gc_tombstones_where`
- `crates/mesh/src/crdt_kv/crdt.rs`, `crates/mesh/src/kv.rs` — `gc_stable_tombstones`; retirement sweeps ghosts
- `crates/mesh/src/gossip_controller.rs` — `PeerWatermarks` table + `WatermarkRegistration`, quarantine, Leaving expiry, GC driver
- `crates/mesh/src/gossip_service.rs` — server-side registration
- `crates/mesh/src/service.rs` — table shared controller → service

## Test Plan

- `cargo test -p smg-mesh` green (214); `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- New: stable GC blocks uncovered tombstones in both engines; `covers` semantics + sentinel strictness; Leaving expires like Down; ghost-sweeping retirement; existing dead-node/holddown/refutation suites updated and green.
- Adversarially reviewed (correctness + memory lenses, independent refuters): all 3 confirmed must-fixes fixed in-PR; minors addressed (stream-scoped registrations, ghost sweep) or disclosed above.

> Stacked on #1674; retarget after it merges.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
