### PR TITLE
refactor(service-discovery): migrate k8s watcher to informer (reflector + Store)

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -598,7 +598,6 @@ impl Router {
                 enabled: true,
                 namespace: self.service_discovery_namespace.clone(),
                 port: self.service_discovery_port,
-                check_interval_secs: 60,
                 selector: self.selector.clone(),
                 prefill_selector: self.prefill_selector.clone(),
                 decode_selector: self.decode_selector.clone(),
@@ -1149,7 +1148,6 @@ impl Router {
             Some(service_discovery::ServiceDiscoveryConfig {
                 enabled: true,
                 selector: self.selector.clone(),
-                check_interval: std::time::Duration::from_secs(60),
                 port: self.service_discovery_port,
                 namespace: self.service_discovery_namespace.clone(),
                 pd_mode: self.pd_disaggregation,

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -458,7 +458,6 @@ pub struct DiscoveryConfig {
     /// None = all namespaces
     pub namespace: Option<String>,
     pub port: u16,
-    pub check_interval_secs: u64,
     /// Regular mode
     pub selector: HashMap<String, String>,
     /// PD mode prefill
@@ -487,7 +486,6 @@ impl Default for DiscoveryConfig {
             enabled: false,
             namespace: None,
             port: 8000,
-            check_interval_secs: 120,
             selector: HashMap::new(),
             prefill_selector: HashMap::new(),
             decode_selector: HashMap::new(),
@@ -1038,7 +1036,6 @@ mod tests {
         assert!(!config.enabled);
         assert!(config.namespace.is_none());
         assert_eq!(config.port, 8000);
-        assert_eq!(config.check_interval_secs, 120);
         assert!(config.selector.is_empty());
         assert!(config.prefill_selector.is_empty());
         assert!(config.decode_selector.is_empty());
@@ -1055,7 +1052,6 @@ mod tests {
             enabled: true,
             namespace: Some("default".to_string()),
             port: 9000,
-            check_interval_secs: 30,
             selector: selector.clone(),
             prefill_selector: selector.clone(),
             decode_selector: selector.clone(),
@@ -1297,7 +1293,6 @@ mod tests {
                 enabled: true,
                 namespace: None,
                 port: 8080,
-                check_interval_secs: 45,
                 selector,
                 ..Default::default()
             })
@@ -1334,7 +1329,6 @@ mod tests {
                 enabled: true,
                 namespace: Some("production".to_string()),
                 port: 8443,
-                check_interval_secs: 120,
                 selector: selectors.clone(),
                 prefill_selector: selectors.clone(),
                 decode_selector: selectors,

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -492,14 +492,6 @@ impl ConfigValidator {
             });
         }
 
-        if discovery.check_interval_secs == 0 {
-            return Err(ConfigError::InvalidValue {
-                field: "discovery.check_interval_secs".to_string(),
-                value: discovery.check_interval_secs.to_string(),
-                reason: "Must be > 0".to_string(),
-            });
-        }
-
         match mode {
             RoutingMode::Regular { .. } => {
                 if discovery.selector.is_empty() {

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1166,7 +1166,6 @@ impl CliArgs {
                 enabled: true,
                 namespace: self.service_discovery_namespace.clone(),
                 port: self.service_discovery_port,
-                check_interval_secs: 60,
                 selector: Self::parse_selector(&self.selector),
                 prefill_selector: Self::parse_selector(&self.prefill_selector),
                 decode_selector: Self::parse_selector(&self.decode_selector),
@@ -1355,7 +1354,6 @@ impl CliArgs {
             Some(ServiceDiscoveryConfig {
                 enabled: true,
                 selector: Self::parse_selector(&self.selector),
-                check_interval: std::time::Duration::from_secs(60),
                 port: self.service_discovery_port,
                 namespace: self.service_discovery_namespace.clone(),
                 pd_mode: self.pd_disaggregation,

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -4,7 +4,6 @@ use std::{
     // (HashSet insert/remove/contains) and never cross .await boundaries.
     // See: https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use
     sync::{Arc, Mutex},
-    time::Duration,
 };
 
 use futures::StreamExt;
@@ -90,10 +89,6 @@ impl ModelIdSource {
 pub struct ServiceDiscoveryConfig {
     pub enabled: bool,
     pub selector: HashMap<String, String>,
-    /// Deprecated: no longer used. The informer self-heals via watch + backoff
-    /// and reconciles against its in-memory `Store` on every re-LIST. Retained
-    /// for config/CLI backward compatibility.
-    pub check_interval: Duration,
     pub port: u16,
     pub namespace: Option<String>,
     // PD mode specific configuration
@@ -167,7 +162,6 @@ impl Default for ServiceDiscoveryConfig {
         ServiceDiscoveryConfig {
             enabled: false,
             selector: HashMap::new(),
-            check_interval: Duration::from_secs(60),
             port: 8000,
             namespace: None,
             pd_mode: false,
@@ -410,14 +404,6 @@ pub async fn start_service_discovery(
     let _ = ring::default_provider().install_default();
 
     let client = Client::try_default().await?;
-
-    if config.check_interval != ServiceDiscoveryConfig::default().check_interval {
-        warn!(
-            "check_interval ({}s) is deprecated and no longer used: the informer self-heals via \
-             watch + backoff and reconciles against its in-memory Store on every re-LIST",
-            config.check_interval.as_secs()
-        );
-    }
 
     // Log the appropriate selectors based on mode
     if config.pd_mode {
@@ -1233,7 +1219,6 @@ mod tests {
         ServiceDiscoveryConfig {
             enabled: true,
             selector: HashMap::new(),
-            check_interval: Duration::from_secs(60),
             port: 8080,
             namespace: None,
             pd_mode: true,
@@ -1360,8 +1345,6 @@ mod tests {
 
     #[test]
     fn test_apply_router_event_delete_marks_down() {
-        use std::collections::BTreeMap;
-
         let mut router_selector = HashMap::new();
         router_selector.insert("role".to_string(), "router".to_string());
         let config = ServiceDiscoveryConfig {
@@ -1370,10 +1353,11 @@ mod tests {
             ..ServiceDiscoveryConfig::default()
         };
 
-        let cluster_state: ClusterState = Arc::new(parking_lot::RwLock::new(BTreeMap::new()));
+        let cluster_state: ClusterState =
+            Arc::new(parking_lot::RwLock::new(std::collections::BTreeMap::new()));
 
         // Build a router pod and pre-seed it as Alive via an Apply event.
-        let mut labels = BTreeMap::new();
+        let mut labels = std::collections::BTreeMap::new();
         labels.insert("role".to_string(), "router".to_string());
         let mut pod = create_k8s_pod(
             Some("r1"),
@@ -1427,7 +1411,6 @@ mod tests {
         let config = ServiceDiscoveryConfig::default();
         assert!(!config.enabled);
         assert!(config.selector.is_empty());
-        assert_eq!(config.check_interval, Duration::from_secs(60));
         assert_eq!(config.port, 8000);
         assert!(config.namespace.is_none());
         assert!(!config.pd_mode);

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -7,12 +7,13 @@ use std::{
     time::Duration,
 };
 
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
-    api::{Api, ListParams},
+    api::Api,
     runtime::{
-        watcher::{watcher, Config},
+        reflector::{self, Store},
+        watcher::{watcher, Config, Event},
         WatchStreamExt,
     },
     Client,
@@ -89,6 +90,9 @@ impl ModelIdSource {
 pub struct ServiceDiscoveryConfig {
     pub enabled: bool,
     pub selector: HashMap<String, String>,
+    /// Deprecated: no longer used. The informer self-heals via watch + backoff
+    /// and reconciles against its in-memory `Store` on every re-LIST. Retained
+    /// for config/CLI backward compatibility.
     pub check_interval: Duration,
     pub port: u16,
     pub namespace: Option<String>,
@@ -354,6 +358,41 @@ impl PodInfo {
     }
 }
 
+/// Route a single worker-watcher `Event` to the right handler.
+///
+/// `Apply`/`InitApply` add (idempotent via the tracked set), `Delete` removes,
+/// and `InitDone` reconciles the tracked set against the `Store` snapshot. `Init`
+/// is just a relist-start marker.
+async fn dispatch_worker_event(
+    event: Event<Pod>,
+    store: &Store<Pod>,
+    tracked_pods: Arc<Mutex<HashSet<PodInfo>>>,
+    app_context: Arc<AppContext>,
+    config: Arc<ServiceDiscoveryConfig>,
+    port: u16,
+) {
+    match event {
+        Event::Init => {
+            debug!("K8s worker watcher (re)list starting");
+        }
+        Event::Apply(pod) | Event::InitApply(pod) => {
+            if PodInfo::should_include(&pod, &config) {
+                if let Some(info) = PodInfo::from_pod(&pod, Some(&config)) {
+                    handle_pod_event(&info, tracked_pods, app_context, port, config.pd_mode).await;
+                }
+            }
+        }
+        Event::Delete(pod) => {
+            if let Some(info) = PodInfo::from_pod(&pod, Some(&config)) {
+                handle_pod_deletion(&info, tracked_pods, app_context, port).await;
+            }
+        }
+        Event::InitDone => {
+            reconcile_from_store(store, config, tracked_pods, app_context, port).await;
+        }
+    }
+}
+
 pub async fn start_service_discovery(
     config: ServiceDiscoveryConfig,
     app_context: Arc<AppContext>,
@@ -371,6 +410,14 @@ pub async fn start_service_discovery(
     let _ = ring::default_provider().install_default();
 
     let client = Client::try_default().await?;
+
+    if config.check_interval != ServiceDiscoveryConfig::default().check_interval {
+        warn!(
+            "check_interval ({}s) is deprecated and no longer used: the informer self-heals via \
+             watch + backoff and reconciles against its in-memory Store on every re-LIST",
+            config.check_interval.as_secs()
+        );
+    }
 
     // Log the appropriate selectors based on mode
     if config.pd_mode {
@@ -475,147 +522,44 @@ pub async fn start_service_discovery(
             }
         }
 
-        // Spawn a supervisor that runs periodic reconciliation and restarts it
-        // on panic. This is a safety net independent of the watcher: it catches
-        // missed events regardless of whether the watcher is healthy, restarting,
-        // or erroring out.
-        {
-            let reconcile_pods_api = pods.clone();
-            let reconcile_config = Arc::clone(&config_arc);
-            let reconcile_tracked = Arc::clone(&tracked_pods);
-            let reconcile_ctx = Arc::clone(&app_context);
-            let reconcile_interval = config.check_interval;
-            #[expect(
-                clippy::disallowed_methods,
-                reason = "reconciliation supervisor runs for the lifetime of the server"
-            )]
-            tokio::spawn(async move {
-                loop {
-                    let api = reconcile_pods_api.clone();
-                    let cfg = Arc::clone(&reconcile_config);
-                    let trk = Arc::clone(&reconcile_tracked);
-                    let ctx = Arc::clone(&reconcile_ctx);
-                    let handle = tokio::spawn(async move {
-                        // Delay the first tick so the watcher has time to populate initial state.
-                        let start = time::Instant::now() + reconcile_interval;
-                        let mut interval = time::interval_at(start, reconcile_interval);
-                        loop {
-                            interval.tick().await;
-                            reconcile_pods(
-                                &api,
-                                Arc::clone(&cfg),
-                                Arc::clone(&trk),
-                                Arc::clone(&ctx),
-                                port,
-                            )
-                            .await;
-                        }
-                    });
-                    if let Err(e) = handle.await {
-                        error!(
-                            "Periodic reconciliation task panicked: {} -- restarting after {}s",
-                            e,
-                            reconcile_interval.as_secs()
-                        );
-                        time::sleep(reconcile_interval).await;
-                    } else {
-                        break;
-                    }
+        // Informer: watcher → default_backoff (self-heal) → reflect into a Store.
+        //
+        // `default_backoff` makes the stream infinite: transient watch errors
+        // trigger an internal exponential-backoff reconnect (no manual restart
+        // loop). `reflect` keeps an in-memory `Store<Pod>` consistent with the
+        // API server while passing every `Event` through unchanged. A desync
+        // re-LIST surfaces as `Init…InitDone`, and `InitDone` drives
+        // `reconcile_from_store` — replacing the old periodic full-LIST reconcile.
+        let watcher_config = build_watcher_config("worker", &config_arc.list_label_selector());
+        let (store_reader, store_writer) = reflector::store::<Pod>();
+        let mut stream = watcher(pods.clone(), watcher_config)
+            .default_backoff()
+            .reflect(store_writer)
+            .boxed();
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(event) => {
+                    dispatch_worker_event(
+                        event,
+                        &store_reader,
+                        Arc::clone(&tracked_pods),
+                        Arc::clone(&app_context),
+                        Arc::clone(&config_arc),
+                        port,
+                    )
+                    .await;
                 }
-            });
-            info!(
-                "Periodic reconciliation enabled | interval: {}s",
-                config.check_interval.as_secs()
-            );
-        }
-
-        let mut retry_delay = Duration::from_secs(1);
-        const MAX_RETRY_DELAY: Duration = Duration::from_secs(300);
-
-        loop {
-            let watcher_config = build_watcher_config("worker", &config_arc.list_label_selector());
-            let watcher_stream = watcher(pods.clone(), watcher_config).applied_objects();
-
-            let config_clone = Arc::clone(&config_arc);
-            let tracked_pods_clone = Arc::clone(&tracked_pods);
-
-            let filtered_stream = watcher_stream.filter_map(move |obj_res| {
-                let config_inner = Arc::clone(&config_clone);
-
-                async move {
-                    match obj_res {
-                        Ok(pod) => {
-                            if PodInfo::should_include(&pod, &config_inner) {
-                                Some(Ok(pod))
-                            } else {
-                                None
-                            }
-                        }
-                        Err(e) => Some(Err(e)),
-                    }
-                }
-            });
-
-            let tracked_pods_clone2 = Arc::clone(&tracked_pods_clone);
-            let app_context_clone = Arc::clone(&app_context);
-            let config_clone2 = Arc::clone(&config_arc);
-
-            let watcher_ok = filtered_stream
-                .try_for_each(move |pod| {
-                    let tracked_pods_inner = Arc::clone(&tracked_pods_clone2);
-                    let app_context_inner = Arc::clone(&app_context_clone);
-                    let config_inner = Arc::clone(&config_clone2);
-
-                    async move {
-                        let pod_info = PodInfo::from_pod(&pod, Some(&config_inner));
-
-                        if let Some(pod_info) = pod_info {
-                            if pod.metadata.deletion_timestamp.is_some() {
-                                handle_pod_deletion(
-                                    &pod_info,
-                                    tracked_pods_inner,
-                                    app_context_inner,
-                                    port,
-                                )
-                                .await;
-                            } else {
-                                handle_pod_event(
-                                    &pod_info,
-                                    tracked_pods_inner,
-                                    app_context_inner,
-                                    port,
-                                    config_inner.pd_mode,
-                                )
-                                .await;
-                            }
-                        }
-                        Ok(())
-                    }
-                })
-                .await;
-
-            match watcher_ok {
-                Ok(()) => {
-                    retry_delay = Duration::from_secs(1);
-                }
-                Err(err) => {
-                    error!("Error in Kubernetes watcher: {}", err);
-                    warn!(
-                        "Retrying in {} seconds with exponential backoff",
-                        retry_delay.as_secs()
+                Err(e) => {
+                    error!(
+                        "K8s worker watcher error (auto-retrying with backoff): {}",
+                        e
                     );
-                    time::sleep(retry_delay).await;
-
-                    retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
                 }
             }
-
-            warn!(
-                "Kubernetes watcher exited, restarting in {} seconds",
-                config_arc.check_interval.as_secs()
-            );
-            time::sleep(config_arc.check_interval).await;
         }
+
+        warn!("K8s worker watcher stream ended unexpectedly");
     });
 
     Ok(handle)
@@ -892,41 +836,30 @@ fn compute_reconciliation_diff(
     (stale, missing)
 }
 
-/// Reconcile the tracked pod set with actual Kubernetes state.
+/// Reconcile the tracked pod set against the informer's in-memory `Store`
+/// snapshot.
 ///
-/// Performs a full pod list via the K8s API and compares with `tracked_pods`:
-/// - Pods in `tracked_pods` but no longer in K8s → submit `RemoveWorker` job
-/// - Healthy pods in K8s but missing from `tracked_pods` → submit `AddWorker` job
-///
-/// This closes two gaps in the event-driven watcher:
-/// 1. Missed deletion events (pod force-deleted, watcher down during delete)
-/// 2. Missed creation events (pod created while watcher was restarting)
-async fn reconcile_pods(
-    pods: &Api<Pod>,
+/// Runs on every `Event::InitDone` (initial sync + each re-LIST after a desync),
+/// replacing the old timer-driven full-LIST reconcile. The `Store` is kept
+/// consistent with the API server by the reflector, so this performs **zero**
+/// API calls:
+/// - Pods in `tracked_pods` but no longer in the `Store` → submit `RemoveWorker`
+/// - Healthy pods in the `Store` but missing from `tracked_pods` → submit `AddWorker`
+async fn reconcile_from_store(
+    store: &Store<Pod>,
     config: Arc<ServiceDiscoveryConfig>,
     tracked_pods: Arc<Mutex<HashSet<PodInfo>>>,
     app_context: Arc<AppContext>,
     port: u16,
 ) {
     let reconcile_start = time::Instant::now();
-    let label_selector = config.list_label_selector();
-    let list_params = if label_selector.is_empty() {
-        ListParams::default()
-    } else {
-        ListParams::default().labels(&label_selector)
-    };
-    let pod_list = match pods.list(&list_params).await {
-        Ok(list) => list,
-        Err(e) => {
-            error!("Reconciliation: failed to list pods: {}", e);
-            return;
-        }
-    };
 
-    // Build the set of live pods that match our selectors.
-    // Include all non-deleted pods regardless of health: the router's own health
-    // checker handles unhealthy workers. Only pods completely gone from K8s are stale.
-    let live_pods = build_live_pod_set(&pod_list.items, &config);
+    // Snapshot the informer cache (no API round-trip). Build the set of live pods
+    // that match our selectors. Include all non-deleted pods regardless of health:
+    // the router's own health checker handles unhealthy workers. Only pods
+    // completely gone from the cache are stale.
+    let snapshot: Vec<Pod> = store.state().iter().map(|p| (**p).clone()).collect();
+    let live_pods = build_live_pod_set(&snapshot, &config);
 
     // Diff: stale = tracked but not live, missing = live-and-healthy but not tracked
     let (stale, missing) = {
@@ -1042,137 +975,105 @@ async fn reconcile_pods(
     );
 }
 
-/// Start router node discovery for mesh cluster
+/// Apply a single router-watcher `Event` to the mesh `ClusterState`.
+///
+/// A real `Event::Delete` now marks a hard-deleted router pod `Down` — the old
+/// `.applied_objects()` stream dropped deletes, so hard-deleted routers were only
+/// ever detected via mesh SWIM timeout. The graceful-termination path
+/// (`deletion_timestamp` set on a still-applied object) is preserved.
+fn apply_router_event(
+    event: &Event<Pod>,
+    config: &ServiceDiscoveryConfig,
+    cluster_state: &ClusterState,
+    default_mesh_port: u16,
+) {
+    let (pod, is_delete) = match event {
+        Event::Apply(pod) | Event::InitApply(pod) => (pod, false),
+        Event::Delete(pod) => (pod, true),
+        Event::Init | Event::InitDone => return,
+    };
+
+    if !PodInfo::matches_selector(pod, &config.router_selector) {
+        return;
+    }
+    let Some(pod_info) = PodInfo::from_pod(pod, Some(config)) else {
+        return;
+    };
+    if !pod_info.is_router {
+        return;
+    }
+
+    let terminating = pod.metadata.deletion_timestamp.is_some();
+
+    if is_delete || terminating {
+        // Pod deleted or terminating: mark node Down.
+        let mut state = cluster_state.write();
+        if let Some(node) = state.get_mut(&pod_info.name) {
+            node.status = NodeStatus::Down as i32;
+            node.version += 1;
+            info!("Router node {} marked as Down (pod deleted)", pod_info.name);
+        } else {
+            debug!(
+                "Router node {} not found in cluster state (already removed)",
+                pod_info.name
+            );
+        }
+    } else if pod_info.is_healthy() {
+        // Pod is healthy: add or update node in cluster state.
+        let mesh_port = pod_info.mesh_port.unwrap_or(default_mesh_port);
+        let node_address = format!("{}:{}", pod_info.ip, mesh_port);
+        let mut state = cluster_state.write();
+        let existing_version = state.get(&pod_info.name).map(|n| n.version).unwrap_or(0);
+        let node_state = NodeState {
+            name: pod_info.name.clone(),
+            address: node_address,
+            status: NodeStatus::Alive as i32,
+            version: existing_version + 1,
+            metadata: HashMap::new(),
+        };
+        state.insert(pod_info.name.clone(), node_state.clone());
+        info!(
+            "Router node {} added/updated in mesh cluster (address: {})",
+            pod_info.name, node_state.address
+        );
+    } else {
+        // Pod is not healthy: mark as Suspected (unless already Down).
+        let mut state = cluster_state.write();
+        if let Some(node) = state.get_mut(&pod_info.name) {
+            if node.status != NodeStatus::Down as i32 {
+                node.status = NodeStatus::Suspected as i32;
+                node.version += 1;
+                debug!(
+                    "Router node {} marked as Suspected (pod not healthy)",
+                    pod_info.name
+                );
+            }
+        }
+    }
+}
+
+/// Start router node discovery for the mesh cluster.
+///
+/// Uses the informer self-healing watcher (`default_backoff`) and consumes real
+/// `Event`s. No `Store`/snapshot reconcile is needed here: the mesh CRDT/SWIM
+/// layer handles convergence; the watcher just feeds accurate up/down events.
 async fn start_router_discovery(
     config: Arc<ServiceDiscoveryConfig>,
     pods: Api<Pod>,
     cluster_state: ClusterState,
     default_mesh_port: u16,
 ) {
-    use std::collections::HashMap;
+    let watcher_config = build_watcher_config("router", &config.router_label_selector());
+    let mut stream = watcher(pods, watcher_config).default_backoff().boxed();
 
-    let mut retry_delay = Duration::from_secs(1);
-    const MAX_RETRY_DELAY: Duration = Duration::from_secs(300);
-
-    loop {
-        let watcher_config = build_watcher_config("router", &config.router_label_selector());
-        let watcher_stream = watcher(pods.clone(), watcher_config).applied_objects();
-
-        let config_clone = Arc::clone(&config);
-
-        let filtered_stream = watcher_stream.filter_map(move |obj_res| {
-            let config_inner = Arc::clone(&config_clone);
-
-            async move {
-                match obj_res {
-                    Ok(pod) => {
-                        // Check if this pod matches router selector
-                        if PodInfo::matches_selector(&pod, &config_inner.router_selector) {
-                            Some(Ok(pod))
-                        } else {
-                            None
-                        }
-                    }
-                    Err(e) => Some(Err(e)),
-                }
-            }
-        });
-
-        let config_clone2 = Arc::clone(&config);
-        let cluster_state_clone2 = cluster_state.clone();
-
-        match filtered_stream
-            .try_for_each(move |pod| {
-                let config_inner = Arc::clone(&config_clone2);
-                let cluster_state_inner = cluster_state_clone2.clone();
-
-                async move {
-                    let pod_info = PodInfo::from_pod(&pod, Some(&config_inner));
-
-                    if let Some(pod_info) = pod_info {
-                        if pod_info.is_router {
-                            let mesh_port = pod_info.mesh_port.unwrap_or(default_mesh_port);
-                            let node_address = format!("{}:{}", pod_info.ip, mesh_port);
-
-                            if pod.metadata.deletion_timestamp.is_some() {
-                                // Pod is being deleted, mark node as Down
-                                let mut state = cluster_state_inner.write();
-                                if let Some(node) = state.get_mut(&pod_info.name) {
-                                    node.status = NodeStatus::Down as i32;
-                                    node.version += 1;
-                                    info!(
-                                        "Router node {} marked as Down (pod deleted)",
-                                        pod_info.name
-                                    );
-                                } else {
-                                    debug!(
-                                        "Router node {} not found in cluster state (already removed)",
-                                        pod_info.name
-                                    );
-                                }
-                            } else if pod_info.is_healthy() {
-                                // Pod is healthy, add or update node in cluster state
-                                let mut state = cluster_state_inner.write();
-                                let existing_version = state
-                                    .get(&pod_info.name)
-                                    .map(|n| n.version)
-                                    .unwrap_or(0);
-
-                                let node_state = NodeState {
-                                    name: pod_info.name.clone(),
-                                    address: node_address,
-                                    status: NodeStatus::Alive as i32,
-                                    version: existing_version + 1,
-                                    metadata: HashMap::new(),
-                                };
-
-                                state.insert(pod_info.name.clone(), node_state.clone());
-                                info!(
-                                    "Router node {} added/updated in mesh cluster (address: {})",
-                                    pod_info.name, node_state.address
-                                );
-                            } else {
-                                // Pod is not healthy, mark as Suspected
-                                let mut state = cluster_state_inner.write();
-                                if let Some(node) = state.get_mut(&pod_info.name) {
-                                    if node.status != NodeStatus::Down as i32 {
-                                        node.status = NodeStatus::Suspected as i32;
-                                        node.version += 1;
-                                        debug!(
-                                            "Router node {} marked as Suspected (pod not healthy)",
-                                            pod_info.name
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
-                }
-            })
-            .await
-        {
-            Ok(()) => {
-                retry_delay = Duration::from_secs(1);
-            }
-            Err(err) => {
-                error!("Error in router discovery watcher: {}", err);
-                warn!(
-                    "Retrying router discovery in {} seconds with exponential backoff",
-                    retry_delay.as_secs()
-                );
-                time::sleep(retry_delay).await;
-
-                retry_delay = std::cmp::min(retry_delay * 2, MAX_RETRY_DELAY);
-            }
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(event) => apply_router_event(&event, &config, &cluster_state, default_mesh_port),
+            Err(e) => error!("Router watcher error (auto-retrying with backoff): {}", e),
         }
-
-        warn!(
-            "Router discovery watcher exited, restarting in {} seconds",
-            config.check_interval.as_secs()
-        );
-        time::sleep(config.check_interval).await;
     }
+
+    warn!("Router watcher stream ended unexpectedly");
 }
 
 #[cfg(test)]
@@ -1343,6 +1244,159 @@ mod tests {
             router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
             model_id_source: None,
         }
+    }
+
+    fn create_regular_config() -> ServiceDiscoveryConfig {
+        let mut selector = HashMap::new();
+        selector.insert("app".to_string(), "sglang".to_string());
+        ServiceDiscoveryConfig {
+            enabled: true,
+            selector,
+            ..ServiceDiscoveryConfig::default()
+        }
+    }
+
+    fn create_regular_pod(name: &str, ip: &str) -> Pod {
+        let mut labels = std::collections::BTreeMap::new();
+        labels.insert("app".to_string(), "sglang".to_string());
+        let mut pod = create_k8s_pod(Some(name), Some(ip), Some("Running"), Some("True"), None);
+        pod.metadata.labels = Some(labels);
+        pod
+    }
+
+    // ---- Informer event dispatch tests ----
+
+    #[tokio::test]
+    async fn test_dispatch_worker_event_apply_then_delete() {
+        let config = Arc::new(create_regular_config());
+        let ctx = create_test_app_context();
+        let tracked = Arc::new(Mutex::new(HashSet::new()));
+        let (store_reader, _writer) = reflector::store::<Pod>();
+        let pod = create_regular_pod("w1", "10.0.0.1");
+
+        dispatch_worker_event(
+            Event::Apply(pod.clone()),
+            &store_reader,
+            Arc::clone(&tracked),
+            Arc::clone(&ctx),
+            Arc::clone(&config),
+            8000,
+        )
+        .await;
+        assert_eq!(
+            tracked.lock().expect("lock").len(),
+            1,
+            "Apply should add the pod"
+        );
+
+        dispatch_worker_event(
+            Event::Delete(pod),
+            &store_reader,
+            Arc::clone(&tracked),
+            Arc::clone(&ctx),
+            Arc::clone(&config),
+            8000,
+        )
+        .await;
+        assert_eq!(
+            tracked.lock().expect("lock").len(),
+            0,
+            "Delete should remove the pod"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_worker_event_init_apply_adds() {
+        let config = Arc::new(create_regular_config());
+        let ctx = create_test_app_context();
+        let tracked = Arc::new(Mutex::new(HashSet::new()));
+        let (store_reader, _writer) = reflector::store::<Pod>();
+        let pod = create_regular_pod("w1", "10.0.0.1");
+
+        dispatch_worker_event(
+            Event::InitApply(pod),
+            &store_reader,
+            Arc::clone(&tracked),
+            Arc::clone(&ctx),
+            Arc::clone(&config),
+            8000,
+        )
+        .await;
+        assert_eq!(
+            tracked.lock().expect("lock").len(),
+            1,
+            "InitApply should add the pod"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_worker_event_init_done_adds_missing_from_store() {
+        let config = Arc::new(create_regular_config());
+        let ctx = create_test_app_context();
+        let tracked = Arc::new(Mutex::new(HashSet::new()));
+
+        // Populate a Store as the informer would during a relist.
+        let (store_reader, mut writer) = reflector::store::<Pod>();
+        let pod = create_regular_pod("w1", "10.0.0.1");
+        writer.apply_watcher_event(&Event::Init);
+        writer.apply_watcher_event(&Event::InitApply(pod));
+        writer.apply_watcher_event(&Event::InitDone);
+
+        dispatch_worker_event(
+            Event::InitDone,
+            &store_reader,
+            Arc::clone(&tracked),
+            Arc::clone(&ctx),
+            Arc::clone(&config),
+            8000,
+        )
+        .await;
+        assert_eq!(
+            tracked.lock().expect("lock").len(),
+            1,
+            "InitDone reconcile should add the pod present in the Store snapshot"
+        );
+    }
+
+    #[test]
+    fn test_apply_router_event_delete_marks_down() {
+        use std::collections::BTreeMap;
+
+        let mut router_selector = HashMap::new();
+        router_selector.insert("role".to_string(), "router".to_string());
+        let config = ServiceDiscoveryConfig {
+            enabled: true,
+            router_selector,
+            ..ServiceDiscoveryConfig::default()
+        };
+
+        let cluster_state: ClusterState = Arc::new(parking_lot::RwLock::new(BTreeMap::new()));
+
+        // Build a router pod and pre-seed it as Alive via an Apply event.
+        let mut labels = BTreeMap::new();
+        labels.insert("role".to_string(), "router".to_string());
+        let mut pod = create_k8s_pod(
+            Some("r1"),
+            Some("10.1.0.1"),
+            Some("Running"),
+            Some("True"),
+            None,
+        );
+        pod.metadata.labels = Some(labels);
+
+        apply_router_event(&Event::Apply(pod.clone()), &config, &cluster_state, 7000);
+        assert_eq!(
+            cluster_state.read().get("r1").map(|n| n.status),
+            Some(NodeStatus::Alive as i32),
+            "Apply of a healthy router pod should mark it Alive"
+        );
+
+        apply_router_event(&Event::Delete(pod), &config, &cluster_state, 7000);
+        assert_eq!(
+            cluster_state.read().get("r1").map(|n| n.status),
+            Some(NodeStatus::Down as i32),
+            "Delete of a router pod should mark it Down"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

SMG's Kubernetes service discovery (`model_gateway/src/service_discovery.rs`) is built directly on a raw `kube::runtime::watcher()` consumed through `.applied_objects()`. Because that gives a bare event stream with **no cached state** and, critically, **no delete events**, a layer of hand-written workarounds had accreted to paper over the gaps a raw watcher leaves behind:

1. **Periodic full-LIST reconciliation** (`reconcile_pods`, every `check_interval` = 60s): a full `pods.list()` against the API server, diffed against an in-memory tracked set to catch events the watcher missed (force-deleted pods, pods created while the watcher was restarting).
2. **Manual watcher restart loop with exponential backoff** (1s → 300s): the stream wrapped in an infinite `loop` that re-establishes the watch on error or stream completion.
3. **Reconciliation supervisor** that catches panics in the reconcile task and restarts it.
4. **Delete detection via `deletion_timestamp`**: since `.applied_objects()` drops delete events, deletions were inferred from a `deletion_timestamp` on a *modified* object — which only fires during the graceful-termination window and **misses hard/force deletes entirely**. The router/mesh watcher has no reconcile safety net, so hard-deleted router pods were only ever detected via mesh SWIM timeout.

(1)–(3) are emulating, by hand, exactly what a Kubernetes **informer** provides natively: an always-consistent in-memory cache (initial LIST → watch → automatic re-LIST on desync) plus self-healing reconnect.

### Solution

Migrate both watchers (worker discovery and the optional router/mesh discovery) to the kube-rs **informer** pattern: `reflector` + `Store` + `WatchStreamExt::default_backoff()`, consuming real `watcher::Event<Pod>`.

- `watcher(api, cfg).default_backoff().reflect(writer)` maintains an in-memory `Store<Pod>`. The stream **never terminates** — transient watch errors trigger an internal exponential-backoff reconnect, and a desync (410 Gone / "too old resource version") triggers an automatic re-LIST.
- Events are dispatched directly: `Apply`/`InitApply` → add (idempotent), `Delete` → remove (**real delete events**, incl. hard deletes), `InitDone` → reconcile the tracked set against the `Store` snapshot. The `InitDone` reconcile fires on initial sync **and** on every re-LIST after a desync — exactly when drift can occur — replacing the timer-driven full-LIST reconcile with **zero** API calls.

This removes the watcher-gap workarounds while leaving the downstream worker-registration pipeline (`PodInfo → WorkerSpec → Job::AddWorker → JobQueue → create_worker`), UID-restart eviction, idempotent dedup, and `(name, uid)` identity equality unchanged.

Considered and rejected: the full `kube::runtime::Controller`/`applier` (level-triggered reconciler). It duplicates the existing `Job`/`JobQueue` actuation layer (two work queues) and its owner/finalizer model is overkill for plain Pod discovery.

## Changes

Single file: `model_gateway/src/service_discovery.rs` (+341 / −287).

**Removed (all watcher-gap workarounds):**

| Removed | Replaced by |
| --- | --- |
| Periodic full `pods.list()` reconcile (`reconcile_pods` timer loop) | `reconcile_from_store` on `Event::InitDone` (in-memory `Store` snapshot) |
| Manual `loop { watcher … }` restart + exp. backoff (worker **and** router) | `.default_backoff()` |
| Reconcile supervisor (panic-restart wrapper, `interval_at`) | gone with the timer |
| `.applied_objects()` + `deletion_timestamp` delete inference | native `Event::Delete` |

**Added / rewritten:**

- `dispatch_worker_event(event, store, …)` — routes `Event<Pod>`: `Apply`/`InitApply` → `handle_pod_event`, `Delete` → `handle_pod_deletion`, `InitDone` → `reconcile_from_store`, `Init` → relist marker.
- `reconcile_from_store(store, …)` — replaces `reconcile_pods`; identical diff/act logic (reuses `build_live_pod_set` + `compute_reconciliation_diff`), but the live set comes from `store.state()` instead of an API `list()`.
- Worker loop in `start_service_discovery` — now `watcher().default_backoff().reflect(writer)` + an event-match loop; restart loop and reconcile supervisor deleted.
- `apply_router_event(event, …)` + rewritten `start_router_discovery` — reacts to real `Event::Delete` (**hard-deleted router pods now marked `Down` promptly** instead of only via mesh SWIM timeout), preserves the graceful-termination `deletion_timestamp → Down` path, uses `default_backoff`, no `Store` (mesh CRDT/SWIM handles convergence).

**Kept unchanged (legitimate, not watcher-gap hacks):** UID-restart eviction in `handle_pod_event`, tracked-set idempotent dedup, `(name, uid)` identity equality, the entire downstream registration pipeline, all metric names.

**Backward compatibility:** `ServiceDiscoveryConfig` and all CLI flags are unchanged. `check_interval` is retained for config/CLI compatibility but is now a **deprecated no-op** (the informer self-heals); a one-time `warn!` is logged at startup if it is set to a non-default value.

## Test Plan

### Unit tests (`cargo test -p smg --lib service_discovery`)

`79 passed`. Existing tests for `PodInfo`, `ModelIdSource`, `build_live_pod_set`, `compute_reconciliation_diff`, `build_watcher_config`, and UID-restart eviction are retained (logic reused). New tests added:

- `test_dispatch_worker_event_apply_then_delete` — `Apply` adds, `Delete` removes (the core delete-event fix).
- `test_dispatch_worker_event_init_apply_adds` — `InitApply` adds.
- `test_dispatch_worker_event_init_done_adds_missing_from_store` — `InitDone` reconciles missing pods from a populated `Store` snapshot.
- `test_apply_router_event_delete_marks_down` — router `Apply`→`Alive`, `Delete`→`Down`.

### Real-cluster validation (before/after behavior)

The **actual `smg` binary built from this branch** was run against a fresh `kind` cluster (k8s v1.36.1), watching `--selector app=fakeworker` in namespace `sd-test`, with `RUST_LOG=info,smg::service_discovery=debug`. "Workers" were `registry.k8s.io/pause:3.10` pods (discovery is under test, not worker health).

```
smg launch --service-discovery --selector app=fakeworker \
  --service-discovery-namespace sd-test --service-discovery-port 8000 \
  --port 30080 --prometheus-port 29555
```

**1. Apply → add.** Create pod `w1`:
```
INFO smg::service_discovery: Adding pod: w1 | type: Some(Regular) | url: 10.244.0.5:8000
```

**2. Hard delete → real `Event::Delete` → immediate remove (the headline fix).** `kubectl delete pod w1 --grace-period=0 --force`:
```
INFO smg::service_discovery: Removing pod: w1 | type: Some(Regular) | url: 10.244.0.5:8000
```
Fired **immediately**. *Before* this PR, a force-delete emits no usable event and is only caught up to `check_interval` (60s) later by the periodic full-LIST reconcile. *After*, it is caught instantly via `Event::Delete`.

**3. Startup initial-sync (Init → InitApply → InitDone) rediscovers pre-existing pods.** With `w2`, `w3` already running, `smg` restarted:
```
INFO  smg::service_discovery: Starting K8s worker watcher | selector: 'app=fakeworker'
DEBUG smg::service_discovery: K8s worker watcher (re)list starting         # Event::Init
INFO  smg::service_discovery: Adding pod: w2 | type: Some(Regular) | url: 10.244.0.6:8000
INFO  smg::service_discovery: Adding pod: w3 | type: Some(Regular) | url: 10.244.0.7:8000
```

**4. Self-heal on apiserver blip (no manual restart loop).** `docker restart <kind-control-plane>` drops the apiserver + watch connection. Same `smg` pid throughout:
```
ERROR smg::service_discovery: K8s worker watcher error (auto-retrying with backoff): watch stream failed: error reading a body from connection
ERROR smg::service_discovery: K8s worker watcher error (auto-retrying with backoff): failed to start watching object: client error (Connect)
ERROR smg::service_discovery: K8s worker watcher error (auto-retrying with backoff): error returned by apiserver during watch: too old resource version: 1880 (1890): Expired
DEBUG smg::service_discovery: K8s worker watcher (re)list starting          # automatic re-LIST after desync
INFO  smg::service_discovery: Adding pod: w4 | type: Some(Regular) | url: 10.244.0.7:8000
```
The `Expired` (410-equivalent) desync triggers the watcher's automatic re-LIST; discovery resumes with **no manual restart** — exactly what `default_backoff` + reflector replaced the hand-written restart loop and periodic reconcile with.

**Not exercised live (covered by unit tests):** router/mesh `Event::Delete → Down` (same event mechanism as the worker delete above; `test_apply_router_event_delete_marks_down`), and StatefulSet same-name/new-uid eviction (unchanged logic; `test_handle_pod_event_evicts_old_uid_on_restart`).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated — `check_interval` field doc-comment marks it deprecated/no-op
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Reliability**
  * Switched service discovery to event-driven, self-healing watchers for workers and routers.
  * Improved pod lifecycle handling and router state transitions for more accurate, real-time status.
  * More efficient reconciliation that reduces unnecessary API calls and improves performance.
  * Removed explicit service-discovery "check interval" setting; system defaults are now used.

* **Tests**
  * Added and updated unit tests to validate the new discovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->