### PR TITLE
feat(smg): cluster-wide rate limiting via epoch-windowed mesh counters

### DIFF
--- a/model_gateway/src/mesh/adapters/rate_limit_sync.rs
+++ b/model_gateway/src/mesh/adapters/rate_limit_sync.rs
@@ -196,6 +196,29 @@ impl RateLimitSyncAdapter {
             .try_fold(0i64, |acc, s| acc.checked_add(s.count))
             .unwrap_or(i64::MAX)
     }
+
+    /// Cluster-wide aggregate for a counter at exactly `epoch`. Shards from
+    /// other epochs contribute nothing: the caller pins the window instead
+    /// of trusting the highest observed epoch, which after a window roll is
+    /// a stale window nothing has published past yet.
+    pub fn get_aggregate_at(&self, counter_name: &str, epoch: u64) -> i64 {
+        debug_assert!(
+            !counter_name.contains(':'),
+            "counter_name must not contain ':' (got {counter_name:?})",
+        );
+        let sub_prefix = format!("{counter_name}:");
+        let mut total = 0i64;
+        for key in self.rate_limits.keys(&sub_prefix) {
+            if let Some(bytes) = self.rate_limits.get(&key) {
+                if let Some(value) = decode_epoch_count(&bytes) {
+                    if value.epoch == epoch {
+                        total = total.checked_add(value.count).unwrap_or(i64::MAX);
+                    }
+                }
+            }
+        }
+        total
+    }
 }
 
 #[cfg(test)]

--- a/model_gateway/src/mesh/global_rate_limit.rs
+++ b/model_gateway/src/mesh/global_rate_limit.rs
@@ -1,0 +1,259 @@
+//! Cluster-wide rate limiting (d-3b).
+//!
+//! Each node counts the requests it admits into a wall-clock window and
+//! publishes the monotone cumulative count as its `rl:` shard; enforcement
+//! compares the epoch-aligned cluster aggregate (plus this node's unflushed
+//! delta) against the limit stored under `config:rate_limit`.
+//!
+//! The EpochMaxWins merge pins the per-shard maximum within an epoch, so a
+//! published count must never regress inside a window — the counter only
+//! ever increments, and a window roll advances the epoch so the fresh zero
+//! replaces (rather than fights) the old peak. Windows are wall-clock
+//! seconds so they align across nodes without coordination; clock skew at a
+//! boundary briefly under-counts, which the aggregate's max-epoch rule
+//! already tolerates by design.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use smg_mesh::CrdtNamespace;
+
+use super::adapters::RateLimitSyncAdapter;
+
+/// Cluster-wide rate-limit configuration, stored under
+/// [`RATE_LIMIT_CONFIG_KEY`] (LWW) and read per request — a DashMap lookup,
+/// not a network call.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct RateLimitConfig {
+    /// Maximum admitted requests per second across the whole cluster.
+    pub limit_per_second: u64,
+}
+
+/// Config key carrying a bincode-encoded [`RateLimitConfig`]. Absent or
+/// undecodable config disables cluster-wide limiting.
+pub const RATE_LIMIT_CONFIG_KEY: &str = "config:rate_limit";
+
+/// The cluster-wide counter name every node shards into.
+const GLOBAL_COUNTER: &str = "global";
+
+/// One node's view of the current window.
+struct Window {
+    /// Wall-clock second this window counts (the EpochMaxWins epoch).
+    epoch: u64,
+    /// Requests admitted this window on this node. Monotone within the
+    /// window (the d-3b constraint).
+    count: i64,
+    /// The count last published via `sync_counter`; the delta above it is
+    /// what the cluster aggregate does not see yet.
+    flushed: i64,
+}
+
+impl Window {
+    /// Roll forward when the wall clock entered a new epoch.
+    fn rotate(&mut self, now_secs: u64) {
+        if now_secs > self.epoch {
+            self.epoch = now_secs;
+            self.count = 0;
+            self.flushed = 0;
+        }
+    }
+}
+
+/// Cluster-wide request limiter. One per gateway, owned by `MeshAdapters`;
+/// the concurrency middleware consults it before the local token bucket.
+pub struct GlobalRateLimiter {
+    rate_limit: Arc<RateLimitSyncAdapter>,
+    configs: Arc<CrdtNamespace>,
+    window: Mutex<Window>,
+}
+
+impl std::fmt::Debug for GlobalRateLimiter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GlobalRateLimiter").finish_non_exhaustive()
+    }
+}
+
+impl GlobalRateLimiter {
+    pub(crate) fn new(
+        rate_limit: Arc<RateLimitSyncAdapter>,
+        configs: Arc<CrdtNamespace>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            rate_limit,
+            configs,
+            window: Mutex::new(Window {
+                epoch: 0,
+                count: 0,
+                flushed: 0,
+            }),
+        })
+    }
+
+    /// The configured cluster-wide limit, if any.
+    fn limit(&self) -> Option<u64> {
+        self.configs
+            .get(RATE_LIMIT_CONFIG_KEY)
+            .and_then(|bytes| bincode::deserialize::<RateLimitConfig>(&bytes).ok())
+            .map(|config| config.limit_per_second)
+    }
+
+    /// Admit or reject a request arriving at `now_secs`, counting it only
+    /// when admitted (rejected requests do not consume budget). The check
+    /// is the epoch-aligned cluster aggregate — which already includes this
+    /// node's last-flushed shard — plus the local delta not yet flushed.
+    pub fn try_admit(&self, now_secs: u64) -> bool {
+        let Some(limit) = self.limit() else {
+            return true;
+        };
+        let mut window = self.window.lock();
+        window.rotate(now_secs);
+        // Pinned to this window's epoch: after a roll, the stale window's
+        // shards must not gate admission (nothing would ever publish the
+        // new epoch and the cluster would reject forever).
+        let aggregate = self
+            .rate_limit
+            .get_aggregate_at(GLOBAL_COUNTER, window.epoch);
+        let unflushed = (window.count - window.flushed).max(0);
+        if aggregate.saturating_add(unflushed) >= limit as i64 {
+            return false;
+        }
+        window.count += 1;
+        true
+    }
+
+    /// Publish this node's shard when it grew. Driven once per second by
+    /// the flush task `MeshAdapters::start` spawns.
+    pub(crate) fn flush(&self, now_secs: u64) {
+        let mut window = self.window.lock();
+        window.rotate(now_secs);
+        if window.count > window.flushed {
+            self.rate_limit
+                .sync_counter(GLOBAL_COUNTER, window.epoch, window.count);
+            window.flushed = window.count;
+        }
+    }
+}
+
+/// Wall-clock seconds since the unix epoch; the cross-node window identity.
+pub(crate) fn unix_now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use smg_mesh::{MergeStrategy, MeshKV};
+
+    use super::*;
+
+    fn limiter_with(limit: Option<u64>) -> Arc<GlobalRateLimiter> {
+        let mesh = MeshKV::new("node-a".into());
+        let rl_ns = mesh.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+        let rate_limit = RateLimitSyncAdapter::new(rl_ns, "node-a".into());
+        let configs = mesh.configs();
+        if let Some(limit_per_second) = limit {
+            let config = RateLimitConfig { limit_per_second };
+            configs.put(
+                RATE_LIMIT_CONFIG_KEY,
+                bincode::serialize(&config).expect("config encodes"),
+            );
+        }
+        GlobalRateLimiter::new(rate_limit, configs)
+    }
+
+    #[test]
+    fn no_config_means_unlimited() {
+        let limiter = limiter_with(None);
+        for _ in 0..1000 {
+            assert!(limiter.try_admit(100));
+        }
+    }
+
+    #[test]
+    fn admits_up_to_the_limit_then_rejects() {
+        let limiter = limiter_with(Some(5));
+        for _ in 0..5 {
+            assert!(limiter.try_admit(100), "under the limit admits");
+        }
+        assert!(!limiter.try_admit(100), "at the limit rejects");
+        assert!(!limiter.try_admit(100), "rejections consume no budget");
+    }
+
+    #[test]
+    fn window_roll_resets_the_budget() {
+        let limiter = limiter_with(Some(2));
+        assert!(limiter.try_admit(100));
+        assert!(limiter.try_admit(100));
+        assert!(!limiter.try_admit(100));
+
+        assert!(limiter.try_admit(101), "a new window admits again");
+    }
+
+    #[test]
+    fn flush_publishes_monotone_cumulative_counts() {
+        let limiter = limiter_with(Some(100));
+        assert!(limiter.try_admit(100));
+        assert!(limiter.try_admit(100));
+        limiter.flush(100);
+        assert_eq!(
+            limiter.rate_limit.get_aggregate("global"),
+            2,
+            "the flushed shard carries the cumulative window count"
+        );
+
+        assert!(limiter.try_admit(100));
+        limiter.flush(100);
+        assert_eq!(
+            limiter.rate_limit.get_aggregate("global"),
+            3,
+            "the count grows monotonically within the window"
+        );
+    }
+
+    #[test]
+    fn enforcement_combines_aggregate_and_unflushed_delta() {
+        let limiter = limiter_with(Some(10));
+        for _ in 0..4 {
+            assert!(limiter.try_admit(100));
+        }
+        limiter.flush(100);
+
+        // The aggregate carries the flushed 4; six unflushed admits exhaust
+        // the cluster budget of 10 without double-counting the shard.
+        for _ in 0..6 {
+            assert!(limiter.try_admit(100));
+        }
+        assert!(!limiter.try_admit(100), "cluster budget exhausted");
+    }
+
+    #[test]
+    fn unflushed_delta_counts_against_the_limit() {
+        let limiter = limiter_with(Some(3));
+        assert!(limiter.try_admit(100));
+        assert!(limiter.try_admit(100));
+        assert!(limiter.try_admit(100));
+        // Nothing flushed yet: the local delta alone must enforce.
+        assert!(!limiter.try_admit(100));
+    }
+
+    #[test]
+    fn stale_epoch_shards_do_not_inflate_the_budget_check() {
+        let limiter = limiter_with(Some(2));
+        assert!(limiter.try_admit(100));
+        assert!(limiter.try_admit(100));
+        limiter.flush(100);
+        assert!(!limiter.try_admit(100), "window 100 exhausted");
+
+        // The flushed shard (epoch 100, count 2) still sits in the store,
+        // but the budget check is pinned to the rolled window's epoch — a
+        // stale window must never wedge the cluster into rejecting forever.
+        assert!(limiter.try_admit(101));
+        limiter.flush(101);
+        assert_eq!(limiter.rate_limit.get_aggregate("global"), 1);
+    }
+}

--- a/model_gateway/src/mesh/mod.rs
+++ b/model_gateway/src/mesh/mod.rs
@@ -3,7 +3,9 @@
 //! and shutdown wiring added in later steps.
 
 pub mod adapters;
+pub mod global_rate_limit;
 pub mod wiring;
 
 pub use adapters::{RateLimitSyncAdapter, TreeDelta, TreeSyncAdapter, WorkerSyncAdapter};
+pub use global_rate_limit::{GlobalRateLimiter, RateLimitConfig, RATE_LIMIT_CONFIG_KEY};
 pub use wiring::MeshAdapters;

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -11,7 +11,10 @@ use std::sync::Arc;
 
 use smg_mesh::{MergeStrategy, MeshKV};
 
-use super::adapters::{RateLimitSyncAdapter, WorkerSyncAdapter};
+use super::{
+    adapters::{RateLimitSyncAdapter, WorkerSyncAdapter},
+    global_rate_limit::{unix_now_secs, GlobalRateLimiter},
+};
 use crate::worker::WorkerRegistry;
 
 /// Owns the started mesh sync adapters. Mesh on means every adapter here is
@@ -21,6 +24,7 @@ use crate::worker::WorkerRegistry;
 pub struct MeshAdapters {
     worker: Arc<WorkerSyncAdapter>,
     rate_limit: Arc<RateLimitSyncAdapter>,
+    global_rate_limit: Arc<GlobalRateLimiter>,
 }
 
 impl MeshAdapters {
@@ -49,7 +53,24 @@ impl MeshAdapters {
         let rate_limit = RateLimitSyncAdapter::new(rl_ns, node_name);
         worker.start();
         rate_limit.start();
-        Arc::new(Self { worker, rate_limit })
+        let global_rate_limit = GlobalRateLimiter::new(rate_limit.clone(), mesh_kv.configs());
+        let flusher = global_rate_limit.clone();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "flush task runs for the adapter's lifetime, which is the process lifetime"
+        )]
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+            loop {
+                interval.tick().await;
+                flusher.flush(unix_now_secs());
+            }
+        });
+        Arc::new(Self {
+            worker,
+            rate_limit,
+            global_rate_limit,
+        })
     }
 
     /// Worker sync adapter.
@@ -60,6 +81,12 @@ impl MeshAdapters {
     /// Rate-limit sync adapter.
     pub fn rate_limit(&self) -> &Arc<RateLimitSyncAdapter> {
         &self.rate_limit
+    }
+
+    /// Cluster-wide request limiter, consulted by the concurrency
+    /// middleware before the local token bucket.
+    pub fn global_rate_limit(&self) -> &Arc<GlobalRateLimiter> {
+        &self.global_rate_limit
     }
 }
 

--- a/model_gateway/src/middleware/concurrency.rs
+++ b/model_gateway/src/middleware/concurrency.rs
@@ -28,6 +28,7 @@ use tracing::{debug, error, warn};
 
 use super::token_bucket::TokenBucket;
 use crate::{
+    mesh::global_rate_limit::unix_now_secs,
     observability::metrics::{metrics_labels, Metrics},
     server::AppState,
 };
@@ -202,11 +203,17 @@ pub async fn concurrency_limit_middleware(
     request: Request<Body>,
     next: Next,
 ) -> Response {
-    // Cluster-wide rate limiting was previously enforced via the
-    // v1 `MeshSyncManager::check_global_rate_limit` path. That hook
-    // is removed in this PR. Local per-node token-bucket rate
-    // limiting below still applies; cluster aggregation will return
-    // through the v2 `RateLimitSyncAdapter` in a follow-up PR.
+    // Cluster-wide rate limiting (d-3b): each node's admitted-request
+    // count gossips as an `rl:` shard; the limiter compares the
+    // epoch-aligned cluster aggregate against `config:rate_limit`.
+    // Absent mesh or config, this is a no-op.
+    if let Some(adapters) = &app_state.mesh_adapters {
+        if !adapters.global_rate_limit().try_admit(unix_now_secs()) {
+            debug!("Cluster-wide rate limit exceeded, returning 429");
+            Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_REJECTED);
+            return StatusCode::TOO_MANY_REQUESTS.into_response();
+        }
+    }
 
     let token_bucket = match &app_state.context.rate_limiter {
         Some(bucket) => bucket.clone(),


### PR DESCRIPTION
Restores the cluster-wide limit the v1 check_global_rate_limit hook
enforced, on the v2 path (d-3b): each node counts the requests it
admits into a wall-clock-second window and publishes the cumulative
count as its rl: shard — monotone within the window, as EpochMaxWins
requires, with the window roll advancing the epoch so a fresh zero
replaces the old peak instead of fighting it. The concurrency
middleware consults the limiter before the local token bucket and
rejects with 429 once the epoch-aligned cluster aggregate plus this
node's unflushed delta reaches config:rate_limit's limit_per_second;
absent mesh or config it is a no-op.

The budget check is pinned to the current window's epoch via the new
RateLimitSyncAdapter::get_aggregate_at: trusting the highest observed
epoch would let a stale exhausted window gate admission after a roll,
and since only admitted requests grow the counter, nothing would ever
publish the new epoch — the cluster would reject forever. A 1s flush
task publishes grown shards; wall-clock windows align across nodes
without coordination, with boundary skew briefly under-counting (the
aggregate's documented tolerance).

Signed-off-by: Chang Su <8605658+CatherineSue@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cluster-wide rate limiting capability with configuration support across all mesh nodes.
  * Implemented periodic synchronization of rate limit state across the cluster.
  * Enhanced rate limit enforcement returns proper `429 TOO_MANY_REQUESTS` responses when thresholds are exceeded.

* **Improvements**
  * Strengthened coordination of admission control decisions across distributed nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->