### PR TITLE
refactor(protocols): move ListWorkersQuery to the protocols crate

### DIFF
--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -974,6 +974,16 @@ pub struct WorkerUpdateRequest {
     pub health: Option<HealthCheckUpdate>,
 }
 
+// ── Request types ───────────────────────────────────────────────────
+
+/// Query parameters for `GET /workers`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ListWorkersQuery {
+    /// Only return workers serving this model, e.g. `?model=moonshotai/Kimi-K2.5`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
 // ── Response types ──────────────────────────────────────────────────
 
 /// Generic API response

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -32,7 +32,9 @@ use openai_protocol::{
     responses::ResponsesRequest,
     tokenize::{AddTokenizerRequest, DetokenizeRequest, TokenizeRequest},
     validated::ValidatedJson,
-    worker::{StartProfileRequest, StopProfileRequest, WorkerSpec, WorkerUpdateRequest},
+    worker::{
+        ListWorkersQuery, StartProfileRequest, StopProfileRequest, WorkerSpec, WorkerUpdateRequest,
+    },
 };
 use rustls::crypto::ring;
 use serde::Deserialize;
@@ -618,12 +620,6 @@ async fn create_worker(
         Ok(result) => result.into_response(),
         Err(err) => err.into_response(),
     }
-}
-
-#[derive(serde::Deserialize)]
-struct ListWorkersQuery {
-    /// Only return workers serving this model, e.g. `?model=moonshotai/Kimi-K2.5`.
-    model: Option<String>,
 }
 
 async fn list_workers_rest(


### PR DESCRIPTION
## Description

Follow-up to #1672 before the v1.5.0 release: `ListWorkersQuery` (the `GET /workers?model=` query params) was defined inline in `server.rs`. All wire-protocol types belong in `crates/protocols` — moved next to the other worker API request/response types with the house derives (`Serialize`/`Deserialize`/`schemars::JsonSchema`, so it's covered by OpenAPI generation), and `server.rs` now just imports it. No behavior change.

## Test Plan

- `cargo +nightly fmt --all` clean
- `cargo clippy -p smg -p openai-protocol --all-targets --all-features -- -D warnings` clean
- `cargo test -p smg --lib worker::service` — 3/3 pass (the #1672 filter tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/workers` API endpoint now supports an optional `model` query parameter, allowing filtering of workers by model type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->