### PR TITLE
fix(e2e): TCP fallback for PD KV transfer when RoCE GIDs are unavailable

### DIFF
--- a/e2e_test/infra/process_utils.py
+++ b/e2e_test/infra/process_utils.py
@@ -185,36 +185,70 @@ def wait_for_workers_ready(
     )
 
 
-def detect_ib_device() -> str | None:
-    """Detect first active InfiniBand device (e.g., mlx5_0).
+# RoCE GIDs are programmed per network namespace from the bound netdev's IPs.
+# A pod with its own netns (no hostNetwork / SR-IOV) sees the shared host mlx5
+# devices as PORT_ACTIVE but with an all-zero GID table, so ibv_query_gid()
+# returns ENODATA and NIXL(UCX)/Mooncake RDMA init dies during worker startup.
+# Treat such a device as unusable so PD falls back to TCP: Mooncake auto-falls
+# back when no --disaggregation-ib-device is forced, and NIXL is pinned off
+# RDMA via UCX_TLS (see Worker._build_env).
+_IB_SYSFS_ROOT = "/sys/class/infiniband"
+_ZERO_GID = "0000:0000:0000:0000:0000:0000:0000:0000"
 
-    Returns:
-        Device name if found (e.g., "mlx5_0"), None otherwise.
+
+def _port_has_usable_gid(port_dir: str) -> bool:
+    """True if an RDMA port exposes at least one non-zero GID in this netns."""
+    gids_dir = os.path.join(port_dir, "gids")
+    try:
+        names = os.listdir(gids_dir)
+    except OSError:
+        return False
+    for name in names:
+        try:
+            with open(os.path.join(gids_dir, name), encoding="ascii") as fh:
+                gid = fh.read().strip()
+        except OSError:
+            continue
+        if gid and gid != _ZERO_GID:
+            return True
+    return False
+
+
+def detect_ib_device() -> str | None:
+    """Detect an RDMA device usable for PD KV transfer in this netns.
+
+    Returns a device name (e.g. "mlx5_0") only when it has an ACTIVE port whose
+    GID table is populated. Returns None when no device is usable — e.g. on CI
+    runner pods where the shared NICs are ACTIVE but expose an empty GID table
+    inside the pod network namespace — so callers skip RDMA and let PD fall
+    back to TCP/cuda_ipc instead of dying in transfer-engine init.
     """
     try:
-        subprocess.run(
-            ["ibv_devinfo", "-l"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=1,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+        devices = sorted(os.listdir(_IB_SYSFS_ROOT))
+    except OSError:
         return None
 
-    for i in range(12):
-        dev = f"mlx5_{i}"
+    for dev in devices:
+        ports_dir = os.path.join(_IB_SYSFS_ROOT, dev, "ports")
         try:
-            res = subprocess.run(
-                ["ibv_devinfo", dev],
-                capture_output=True,
-                text=True,
-                timeout=2,
-            )
-            if res.returncode == 0 and "state:" in res.stdout:
-                for line in res.stdout.splitlines():
-                    if "state:" in line and "PORT_ACTIVE" in line:
-                        logger.info("Detected IB device: %s", dev)
-                        return dev
-        except Exception:
-            pass
+            ports = sorted(os.listdir(ports_dir))
+        except OSError:
+            continue
+        for port in ports:
+            port_dir = os.path.join(ports_dir, port)
+            try:
+                with open(os.path.join(port_dir, "state"), encoding="ascii") as fh:
+                    state = fh.read()
+            except OSError:
+                continue
+            if "ACTIVE" not in state:
+                continue
+            if _port_has_usable_gid(port_dir):
+                logger.info("Detected usable RDMA device: %s (port %s)", dev, port)
+                return dev
+
+    logger.info(
+        "No RDMA device with a usable GID in this netns; PD KV transfer will "
+        "fall back to TCP/cuda_ipc instead of RDMA"
+    )
     return None

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -397,6 +397,16 @@ class Worker:
                 self.nixl_port = get_open_port()
                 env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(self.nixl_port)
 
+                # NIXL drives UCX, which auto-probes RDMA verbs (rc/ud) at
+                # engine startup. Without a usable RoCE GID (ib_device is None)
+                # that probe hard-fails ("Failed to create UCX worker: Address
+                # not valid") and kills the worker. Pin UCX to non-RDMA
+                # transports so KV moves over cuda_ipc (same-node GPU<->GPU) /
+                # shared-mem / TCP. Presetting UCX_TLS overrides this (e.g. to
+                # force RDMA on a properly provisioned node).
+                if self.ib_device is None and "UCX_TLS" not in env:
+                    env["UCX_TLS"] = "cuda_ipc,cuda_copy,tcp,sm,self"
+
         # TRT-LLM multi-GPU needs NCCL tuning for CI compatibility
         if self.engine == "trtllm" and len(self.gpu_ids) > 1:
             env["NCCL_DEBUG"] = "WARN"


### PR DESCRIPTION
## Problem

`e2e-2gpu-pd` frequently fails (both `sglang` and `vllm`/`nixl` variants) with the PD worker dying during startup:

- **sglang/Mooncake:** `rdma_context.cpp:450 Failed to query GID … on mlx5_0/: No data available [61]` → `Mooncake Transfer Engine initialization failed`
- **vLLM/NIXL (UCX):** `uct_iface_open(rc_verbs/mlx5_2:1) failed: Address not valid` → `Failed to create UCX worker` → `EngineCore failed to start`

## Root cause

The KV cache is moved prefill→decode over **RDMA (RoCEv2)** on the host `mlx5` NICs. RoCE GIDs are programmed *per network namespace* from the netdev's IPs. The CI runner pods run in their **own overlay-CNI netns** (not `hostNetwork`, no SR-IOV, no RDMA device plugin), so the shared host NICs show `PORT_ACTIVE` but an **all-zero GID table inside the pod** — verified on a live runner: all 18 `mlx5` devices ACTIVE, 0 non-zero GIDs. `ibv_query_gid` returns ENODATA and RDMA init dies.

"Passing" runs were never real RDMA — they were the cases where the engine swallowed the failure and fell back to a non-RDMA transport (or, for the MMLU test, decode silently recomputed prefill). The flakiness is which of those happens.

In the PD e2e tests both workers run in **one pod on one node** (loopback), so RDMA buys nothing here — `cuda_ipc` does direct same-node GPU↔GPU.

## Fix

- **`detect_ib_device()`** now requires a *usable (non-zero) GID* (sysfs) rather than just a `PORT_ACTIVE` port → returns `None` on these pods, so sglang omits `--disaggregation-ib-device` and Mooncake re-enables its built-in **TCP auto-fallback**. Also drops the `ibv_devinfo` dependency (the real reason sglang flip-flopped — it depends on whether `ibverbs-utils` is installed) and scans all devices (old loop stopped at `mlx5_11`).
- **`_build_env()`** pins `UCX_TLS=cuda_ipc,cuda_copy,tcp,sm,self` for the vLLM **NIXL** path when no usable RoCE device is present (vLLM never consumed the detected device; its failure was UCX auto-probing `rc_verbs`). A preset `UCX_TLS` still overrides.

On a properly provisioned node (populated GID table) `detect_ib_device()` returns the device and UCX is left alone → **production RDMA unchanged**. The vLLM-Mooncake path already forces `mooncake_protocol=tcp` (#1664).

## Verification done
- `py_compile` + `ruff` clean.
- Unit-tested `detect_ib_device()` against: no sysfs → None; ACTIVE+empty-GID → None (the CI case); one usable GID → returns it; ACTIVE GID but port DOWN → None.

## To confirm in CI (needs GPU — please review first)
1. PD jobs go green deterministically.
2. `test_pd_nixl.py` handshake markers (`Transfer plan`, `NIXL compatibility check passed`, `Registering remote agent`) still appear over the TCP/`cuda_ipc` path — i.e. KV is still genuinely transferred, not recomputed.

> Does not address the separate `pypi.org` install-timeout failures (Family B) — that's an egress/caching issue, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)