### PR TITLE
test(mock-worker): add multi-port mock HTTP/gRPC worker and scale-test rig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui"]
+members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui", "crates/mock_worker"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/crates/mock_worker/Cargo.toml
+++ b/crates/mock_worker/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mock-worker"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Multi-port mock HTTP/gRPC inference worker for SMG gateway scale testing"
+
+[[bin]]
+name = "mock-worker"
+path = "src/main.rs"
+
+[dependencies]
+smg-grpc-client.workspace = true
+tokio = { workspace = true, features = ["full"] }
+tonic.workspace = true
+axum.workspace = true
+serde_json.workspace = true
+futures.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/mock_worker/README.md
+++ b/crates/mock_worker/README.md
@@ -1,0 +1,45 @@
+# mock-worker
+
+Multi-port mock HTTP/gRPC inference workers for scale-testing the SMG gateway's
+routing and async-runtime behavior. One process hosts many protocol-accurate
+stand-ins for vLLM/SGLang engines; all responses are canned (no real model).
+
+## What it implements
+
+**HTTP** (vLLM/SGLang HTTP surface the gateway probes and routes to):
+- `GET /health` → `200 OK` (gates registration + health promotion)
+- `GET /v1/models` → one model, `owned_by: sglang` (backend/model detection)
+- `POST /v1/chat/completions` · `/v1/completions` · `/generate` — non-stream JSON
+  or SSE (`data: {chunk}\n\n … data: [DONE]\n\n`)
+- `GET /v1/loads?include=core` → `WorkerLoadResponse` (load-aware policies)
+
+**gRPC** (TokenSpeed scheduler — the gateway tokenizes, the worker speaks token
+ids): `HealthCheck`, `GetModelInfo`, `GetServerInfo`, `Generate` (streamed
+chunks + complete), `GetLoads`, `Abort`; admin RPCs return `unimplemented`.
+
+## Run
+
+```bash
+cargo run --release -p mock-worker -- \
+  --http-base-port 9000 --http-count 2000 \
+  --grpc-base-port 19000 --grpc-count 0 \
+  --model mock-model --gen-ms 5
+```
+
+Each worker is one port. Register them against an IGW gateway with
+`POST /workers` (`{"url":"http://127.0.0.1:9000"}`, or `grpc://…` with
+`connection_mode`/`runtime`/`models` for gRPC).
+
+## Scale-test rig
+
+`scripts/scale_test.sh` launches an IGW gateway, starts the mock fleet,
+REST-registers it, and samples the gateway PID's CPU + `/health` latency at idle
+and under load (`scripts/scale_load.py`):
+
+```bash
+scripts/scale_test.sh --http 2000 --policy cache_aware --rps 500 --duration 30
+scripts/scale_test.sh --grpc 1000 --policy least_load
+```
+
+gRPC runs use `--disable-tokenizer-autoload` so registration/routing can be
+measured without a real tokenizer (generation itself is not exercised).

--- a/crates/mock_worker/src/config.rs
+++ b/crates/mock_worker/src/config.rs
@@ -1,0 +1,101 @@
+//! Runtime configuration for the mock worker fleet, parsed from CLI flags.
+
+use std::time::Duration;
+
+/// Configuration shared by every mocked HTTP and gRPC worker in the process.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Bind address for every listener.
+    pub host: String,
+    /// First HTTP port; `http_count` workers bind `[http_base_port, +count)`.
+    pub http_base_port: u16,
+    /// Number of HTTP workers to start.
+    pub http_count: u16,
+    /// First gRPC port; `grpc_count` workers bind `[grpc_base_port, +count)`.
+    pub grpc_base_port: u16,
+    /// Number of gRPC workers to start.
+    pub grpc_count: u16,
+    /// Model id advertised by every worker (one model, many replicas).
+    pub model_id: String,
+    /// Tokenizer path advertised by gRPC workers (for gateway autoload).
+    pub tokenizer_path: String,
+    /// Simulated per-request generation latency.
+    pub gen_delay: Duration,
+    /// Number of canned output tokens per generation.
+    pub output_tokens: u32,
+}
+
+impl Config {
+    /// Parse the configuration from `std::env::args`, falling back to defaults.
+    pub fn from_args() -> Result<Self, String> {
+        let mut cfg = Self {
+            host: "127.0.0.1".to_string(),
+            http_base_port: 9000,
+            http_count: 0,
+            grpc_base_port: 0,
+            grpc_count: 0,
+            model_id: "mock-model".to_string(),
+            tokenizer_path: String::new(),
+            gen_delay: Duration::from_millis(0),
+            output_tokens: 8,
+        };
+
+        let mut args = std::env::args().skip(1);
+        while let Some(flag) = args.next() {
+            match flag.as_str() {
+                "--host" => cfg.host = value(&mut args, &flag)?,
+                "--http-base-port" => cfg.http_base_port = parse(value(&mut args, &flag)?, &flag)?,
+                "--http-count" => cfg.http_count = parse(value(&mut args, &flag)?, &flag)?,
+                "--grpc-base-port" => cfg.grpc_base_port = parse(value(&mut args, &flag)?, &flag)?,
+                "--grpc-count" => cfg.grpc_count = parse(value(&mut args, &flag)?, &flag)?,
+                "--model" => cfg.model_id = value(&mut args, &flag)?,
+                "--tokenizer" => cfg.tokenizer_path = value(&mut args, &flag)?,
+                "--gen-ms" => {
+                    cfg.gen_delay = Duration::from_millis(parse(value(&mut args, &flag)?, &flag)?);
+                }
+                "--output-tokens" => cfg.output_tokens = parse(value(&mut args, &flag)?, &flag)?,
+                "-h" | "--help" => return Err(usage()),
+                other => return Err(format!("unknown flag: {other}\n\n{}", usage())),
+            }
+        }
+
+        if cfg.tokenizer_path.is_empty() {
+            cfg.tokenizer_path = cfg.model_id.clone();
+        }
+        if cfg.http_count == 0 && cfg.grpc_count == 0 {
+            return Err(format!(
+                "nothing to do: pass --http-count and/or --grpc-count\n\n{}",
+                usage()
+            ));
+        }
+        if cfg.grpc_count > 0 && cfg.grpc_base_port == 0 {
+            return Err("--grpc-base-port is required when --grpc-count > 0".to_string());
+        }
+        Ok(cfg)
+    }
+}
+
+fn value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String, String> {
+    args.next()
+        .ok_or_else(|| format!("missing value for {flag}"))
+}
+
+fn parse<T: std::str::FromStr>(raw: String, flag: &str) -> Result<T, String> {
+    raw.parse()
+        .map_err(|_| format!("invalid value for {flag}: {raw}"))
+}
+
+fn usage() -> String {
+    "mock-worker — multi-port mock HTTP/gRPC inference workers for SMG scale testing\n\n\
+     Flags:\n\
+       --host <addr>            bind address (default 127.0.0.1)\n\
+       --http-base-port <port>  first HTTP port (default 9000)\n\
+       --http-count <n>         number of HTTP workers (default 0)\n\
+       --grpc-base-port <port>  first gRPC port (required if --grpc-count > 0)\n\
+       --grpc-count <n>         number of gRPC workers (default 0)\n\
+       --model <id>             advertised model id (default mock-model)\n\
+       --tokenizer <path>       tokenizer path for gRPC autoload (default = model)\n\
+       --gen-ms <ms>            simulated generation latency (default 0)\n\
+       --output-tokens <n>      canned output tokens per request (default 8)"
+        .to_string()
+}

--- a/crates/mock_worker/src/grpc.rs
+++ b/crates/mock_worker/src/grpc.rs
@@ -1,7 +1,11 @@
 //! Mock gRPC worker implementing the TokenSpeed scheduler service. The gateway
 //! tokenizes and sends token ids; this service streams back canned token ids.
 
-use std::{pin::Pin, sync::Arc};
+use std::{
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+};
 
 use futures::{stream, Stream};
 use smg_grpc_client::{common_proto as common, tokenspeed_scheduler::tokenspeed_proto as ts};
@@ -15,13 +19,14 @@ use crate::config::Config;
 
 /// Serve the mock TokenSpeed gRPC service on `port` until the process exits.
 pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
-    let addr = match format!("{host}:{port}").parse() {
-        Ok(addr) => addr,
+    let ip = match host.parse::<IpAddr>() {
+        Ok(ip) => ip,
         Err(e) => {
-            tracing::error!("grpc worker addr {host}:{port} invalid: {e}");
+            tracing::error!("grpc worker host {host} invalid: {e}");
             return;
         }
     };
+    let addr = SocketAddr::new(ip, port);
     let service = MockScheduler { cfg };
     if let Err(e) = Server::builder()
         .add_service(TokenSpeedSchedulerServer::new(service))
@@ -48,6 +53,9 @@ impl TokenSpeedScheduler for MockScheduler {
         request: Request<ts::GenerateRequest>,
     ) -> Result<Response<Self::GenerateStream>, Status> {
         let request_id = request.into_inner().request_id;
+        if !self.cfg.gen_delay.is_zero() {
+            tokio::time::sleep(self.cfg.gen_delay).await;
+        }
         let ids: Vec<u32> = (0..self.cfg.output_tokens).map(|i| 100 + i).collect();
 
         let mut items: Vec<Result<ts::GenerateResponse, Status>> = Vec::new();

--- a/crates/mock_worker/src/grpc.rs
+++ b/crates/mock_worker/src/grpc.rs
@@ -1,0 +1,189 @@
+//! Mock gRPC worker implementing the TokenSpeed scheduler service. The gateway
+//! tokenizes and sends token ids; this service streams back canned token ids.
+
+use std::{pin::Pin, sync::Arc};
+
+use futures::{stream, Stream};
+use smg_grpc_client::{common_proto as common, tokenspeed_scheduler::tokenspeed_proto as ts};
+use tonic::{transport::Server, Request, Response, Status};
+use ts::{
+    generate_response::Response as GenResp,
+    token_speed_scheduler_server::{TokenSpeedScheduler, TokenSpeedSchedulerServer},
+};
+
+use crate::config::Config;
+
+/// Serve the mock TokenSpeed gRPC service on `port` until the process exits.
+pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
+    let addr = match format!("{host}:{port}").parse() {
+        Ok(addr) => addr,
+        Err(e) => {
+            tracing::error!("grpc worker addr {host}:{port} invalid: {e}");
+            return;
+        }
+    };
+    let service = MockScheduler { cfg };
+    if let Err(e) = Server::builder()
+        .add_service(TokenSpeedSchedulerServer::new(service))
+        .serve(addr)
+        .await
+    {
+        tracing::error!("grpc worker {port} stopped: {e}");
+    }
+}
+
+#[derive(Clone)]
+struct MockScheduler {
+    cfg: Arc<Config>,
+}
+
+type GenStream = Pin<Box<dyn Stream<Item = Result<ts::GenerateResponse, Status>> + Send>>;
+
+#[tonic::async_trait]
+impl TokenSpeedScheduler for MockScheduler {
+    type GenerateStream = GenStream;
+
+    async fn generate(
+        &self,
+        request: Request<ts::GenerateRequest>,
+    ) -> Result<Response<Self::GenerateStream>, Status> {
+        let request_id = request.into_inner().request_id;
+        let ids: Vec<u32> = (0..self.cfg.output_tokens).map(|i| 100 + i).collect();
+
+        let mut items: Vec<Result<ts::GenerateResponse, Status>> = Vec::new();
+        for id in &ids {
+            items.push(Ok(ts::GenerateResponse {
+                request_id: request_id.clone(),
+                response: Some(GenResp::Chunk(ts::GenerateStreamChunk {
+                    token_ids: vec![*id],
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    cached_tokens: 0,
+                    output_logprobs: None,
+                    index: 0,
+                })),
+            }));
+        }
+        items.push(Ok(ts::GenerateResponse {
+            request_id,
+            response: Some(GenResp::Complete(ts::GenerateComplete {
+                output_ids: ids,
+                finish_reason: "stop".to_string(),
+                prompt_tokens: 1,
+                completion_tokens: self.cfg.output_tokens,
+                cached_tokens: 0,
+                output_logprobs: None,
+                matched_stop: None,
+                index: 0,
+            })),
+        }));
+
+        Ok(Response::new(Box::pin(stream::iter(items))))
+    }
+
+    async fn health_check(
+        &self,
+        _request: Request<ts::HealthCheckRequest>,
+    ) -> Result<Response<ts::HealthCheckResponse>, Status> {
+        Ok(Response::new(ts::HealthCheckResponse {
+            healthy: true,
+            message: "ok".to_string(),
+        }))
+    }
+
+    async fn abort(
+        &self,
+        _request: Request<ts::AbortRequest>,
+    ) -> Result<Response<ts::AbortResponse>, Status> {
+        Ok(Response::new(ts::AbortResponse {
+            success: true,
+            message: String::new(),
+        }))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<ts::GetModelInfoRequest>,
+    ) -> Result<Response<ts::GetModelInfoResponse>, Status> {
+        Ok(Response::new(ts::GetModelInfoResponse {
+            model_path: self.cfg.model_id.clone(),
+            tokenizer_path: self.cfg.tokenizer_path.clone(),
+            served_model_name: self.cfg.model_id.clone(),
+            model_type: "mock".to_string(),
+            architectures: vec!["MockForCausalLM".to_string()],
+            max_context_length: 32768,
+            max_req_input_len: 32768,
+            vocab_size: 32000,
+            eos_token_ids: vec![2],
+            pad_token_id: 0,
+            bos_token_id: 1,
+            weight_version: "mock".to_string(),
+            default_sampling_params_json: String::new(),
+            supports_vision: false,
+        }))
+    }
+
+    async fn get_server_info(
+        &self,
+        _request: Request<ts::GetServerInfoRequest>,
+    ) -> Result<Response<ts::GetServerInfoResponse>, Status> {
+        Ok(Response::new(ts::GetServerInfoResponse {
+            server_args: None,
+            scheduler_info: None,
+            active_requests: 0,
+            is_paused: false,
+            uptime_seconds: 0.0,
+            max_total_num_tokens: 1_000_000,
+            tokenspeed_version: "mock".to_string(),
+            start_time: None,
+        }))
+    }
+
+    async fn get_loads(
+        &self,
+        _request: Request<ts::GetLoadsRequest>,
+    ) -> Result<Response<ts::GetLoadsResponse>, Status> {
+        Ok(Response::new(ts::GetLoadsResponse {
+            timestamp: String::new(),
+            version: "mock".to_string(),
+            dp_rank_count: 1,
+            loads: vec![ts::SchedulerLoad {
+                dp_rank: 0,
+                num_running_reqs: 0,
+                num_waiting_reqs: 0,
+                num_total_reqs: 0,
+                num_used_tokens: 0,
+                max_total_num_tokens: 1_000_000,
+                max_running_requests: 0,
+                token_usage: 0.0,
+                gen_throughput: 0.0,
+                cache_hit_rate: 0.0,
+                utilization: 0.0,
+                memory: None,
+                queues: None,
+            }],
+            aggregate: None,
+        }))
+    }
+
+    async fn flush_cache(
+        &self,
+        _request: Request<common::FlushCacheRequest>,
+    ) -> Result<Response<common::FlushCacheResponse>, Status> {
+        Err(Status::unimplemented("mock-worker"))
+    }
+
+    async fn start_profile(
+        &self,
+        _request: Request<common::StartProfileRequest>,
+    ) -> Result<Response<common::ProfileResponse>, Status> {
+        Err(Status::unimplemented("mock-worker"))
+    }
+
+    async fn stop_profile(
+        &self,
+        _request: Request<common::StopProfileRequest>,
+    ) -> Result<Response<common::ProfileResponse>, Status> {
+        Err(Status::unimplemented("mock-worker"))
+    }
+}

--- a/crates/mock_worker/src/http.rs
+++ b/crates/mock_worker/src/http.rs
@@ -1,0 +1,143 @@
+//! Mock HTTP worker endpoints — the vLLM/SGLang-compatible surface the SMG
+//! gateway probes and routes to. Every response is canned; no real model.
+
+use std::{convert::Infallible, sync::Arc};
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    response::{
+        sse::{Event, Sse},
+        IntoResponse, Response,
+    },
+    routing::{get, post},
+    Json, Router,
+};
+use futures::{stream, Stream};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+
+use crate::config::Config;
+
+/// Build the router serving the mock HTTP worker contract.
+pub fn router(cfg: Arc<Config>) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/v1/models", get(models))
+        .route("/v1/chat/completions", post(chat))
+        .route("/v1/completions", post(chat))
+        .route("/generate", post(chat))
+        .route("/v1/loads", get(loads))
+        .with_state(cfg)
+}
+
+/// Serve the mock HTTP worker contract on `port` until the process exits.
+pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
+    let listener = match TcpListener::bind((host.as_str(), port)).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            tracing::error!("http worker bind {host}:{port} failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = axum::serve(listener, router(cfg)).await {
+        tracing::error!("http worker {port} stopped: {e}");
+    }
+}
+
+async fn health() -> &'static str {
+    "OK"
+}
+
+async fn models(State(cfg): State<Arc<Config>>) -> Response {
+    Json(json!({
+        "object": "list",
+        "data": [{
+            "id": cfg.model_id,
+            "object": "model",
+            "created": 0,
+            "owned_by": "sglang",
+            "root": cfg.model_id,
+            "max_model_len": 32768,
+        }],
+    }))
+    .into_response()
+}
+
+async fn loads() -> Response {
+    Json(json!({
+        "timestamp": "",
+        "dp_rank_count": 1,
+        "loads": [{
+            "dp_rank": 0,
+            "num_running_reqs": 0,
+            "num_waiting_reqs": 0,
+            "num_waiting_uncached_tokens": 0,
+            "num_total_reqs": 0,
+            "num_used_tokens": 0,
+            "max_total_num_tokens": 1_000_000,
+            "token_usage": 0.0,
+            "gen_throughput": 0.0,
+            "cache_hit_rate": 0.0,
+            "utilization": 0.0,
+            "max_running_requests": 0,
+        }],
+    }))
+    .into_response()
+}
+
+async fn chat(State(cfg): State<Arc<Config>>, body: Bytes) -> Response {
+    let stream_requested = serde_json::from_slice::<Value>(&body)
+        .ok()
+        .and_then(|v| v.get("stream").and_then(Value::as_bool))
+        .unwrap_or(false);
+
+    if !cfg.gen_delay.is_zero() {
+        tokio::time::sleep(cfg.gen_delay).await;
+    }
+
+    if stream_requested {
+        stream_chat(&cfg).into_response()
+    } else {
+        Json(completion(&cfg)).into_response()
+    }
+}
+
+fn completion(cfg: &Config) -> Value {
+    json!({
+        "id": "chatcmpl-mock",
+        "object": "chat.completion",
+        "created": 0,
+        "model": cfg.model_id,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "mock"},
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": 1,
+            "completion_tokens": cfg.output_tokens,
+            "total_tokens": u64::from(cfg.output_tokens) + 1,
+        },
+    })
+}
+
+fn stream_chat(cfg: &Config) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let mut events: Vec<Result<Event, Infallible>> = Vec::new();
+    for _ in 0..cfg.output_tokens {
+        let frame = json!({
+            "id": "chatcmpl-mock",
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": {"content": "x"}, "finish_reason": null}],
+        });
+        events.push(Ok(Event::default().data(frame.to_string())));
+    }
+    let final_frame = json!({
+        "id": "chatcmpl-mock",
+        "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+    });
+    events.push(Ok(Event::default().data(final_frame.to_string())));
+    events.push(Ok(Event::default().data("[DONE]")));
+    Sse::new(stream::iter(events))
+}

--- a/crates/mock_worker/src/main.rs
+++ b/crates/mock_worker/src/main.rs
@@ -10,13 +10,9 @@ mod config;
 mod grpc;
 mod http;
 
-use std::{future::Future, pin::Pin, process::ExitCode, sync::Arc};
-
-use futures::future::join_all;
+use std::{process::ExitCode, sync::Arc};
 
 use crate::config::Config;
-
-type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -41,26 +37,35 @@ async fn main() -> ExitCode {
         cfg.model_id,
     );
 
-    let mut servers: Vec<BoxFuture> = Vec::new();
+    // Spawn each worker as its own task so they run across the whole runtime
+    // (join_all would poll them all on a single task) and an unexpected exit is
+    // surfaced instead of silently masked.
+    let mut workers = tokio::task::JoinSet::new();
     for i in 0..cfg.http_count {
         let Some(port) = cfg.http_base_port.checked_add(i) else {
             tracing::warn!("http port range overflowed u16 at offset {i}; stopping early");
             break;
         };
-        servers.push(Box::pin(http::serve(cfg.clone(), cfg.host.clone(), port)));
+        workers.spawn(http::serve(cfg.clone(), cfg.host.clone(), port));
     }
     for i in 0..cfg.grpc_count {
         let Some(port) = cfg.grpc_base_port.checked_add(i) else {
             tracing::warn!("grpc port range overflowed u16 at offset {i}; stopping early");
             break;
         };
-        servers.push(Box::pin(grpc::serve(cfg.clone(), cfg.host.clone(), port)));
+        workers.spawn(grpc::serve(cfg.clone(), cfg.host.clone(), port));
     }
 
-    tracing::info!("started {} mock workers; ctrl-c to stop", servers.len());
+    tracing::info!("started {} mock workers; ctrl-c to stop", workers.len());
 
     tokio::select! {
-        _ = join_all(servers) => {}
+        Some(res) = workers.join_next() => {
+            if let Err(e) = res {
+                tracing::error!("mock worker task failed: {e}");
+            } else {
+                tracing::error!("a mock worker stopped unexpectedly");
+            }
+        }
         result = tokio::signal::ctrl_c() => {
             if let Err(e) = result {
                 tracing::error!("failed to listen for ctrl-c: {e}");

--- a/crates/mock_worker/src/main.rs
+++ b/crates/mock_worker/src/main.rs
@@ -1,0 +1,72 @@
+//! mock-worker: spin up many mock HTTP and/or gRPC inference workers in one
+//! process to scale-test the SMG gateway's routing and runtime behavior.
+//!
+//! Workers are protocol-accurate stand-ins for vLLM/SGLang engines: HTTP
+//! workers answer the probe + chat/generate surface; gRPC workers implement the
+//! TokenSpeed scheduler service (the gateway tokenizes and speaks token ids).
+//! All responses are canned — there is no real model.
+
+mod config;
+mod grpc;
+mod http;
+
+use std::{future::Future, pin::Pin, process::ExitCode, sync::Arc};
+
+use futures::future::join_all;
+
+use crate::config::Config;
+
+type BoxFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    let cfg = match Config::from_args() {
+        Ok(cfg) => Arc::new(cfg),
+        Err(message) => {
+            eprintln!("{message}");
+            return ExitCode::from(2);
+        }
+    };
+
+    tracing::info!(
+        "mock-worker: {} http from :{}, {} grpc from :{}, model={}",
+        cfg.http_count,
+        cfg.http_base_port,
+        cfg.grpc_count,
+        cfg.grpc_base_port,
+        cfg.model_id,
+    );
+
+    let mut servers: Vec<BoxFuture> = Vec::new();
+    for i in 0..cfg.http_count {
+        let Some(port) = cfg.http_base_port.checked_add(i) else {
+            tracing::warn!("http port range overflowed u16 at offset {i}; stopping early");
+            break;
+        };
+        servers.push(Box::pin(http::serve(cfg.clone(), cfg.host.clone(), port)));
+    }
+    for i in 0..cfg.grpc_count {
+        let Some(port) = cfg.grpc_base_port.checked_add(i) else {
+            tracing::warn!("grpc port range overflowed u16 at offset {i}; stopping early");
+            break;
+        };
+        servers.push(Box::pin(grpc::serve(cfg.clone(), cfg.host.clone(), port)));
+    }
+
+    tracing::info!("started {} mock workers; ctrl-c to stop", servers.len());
+
+    tokio::select! {
+        _ = join_all(servers) => {}
+        result = tokio::signal::ctrl_c() => {
+            if let Err(e) = result {
+                tracing::error!("failed to listen for ctrl-c: {e}");
+            }
+            tracing::info!("shutting down");
+        }
+    }
+    ExitCode::SUCCESS
+}

--- a/scripts/scale_load.py
+++ b/scripts/scale_load.py
@@ -27,9 +27,7 @@ def send_one(url: str, model: str, prompt: str) -> float | None:
             "max_tokens": 8,
         }
     ).encode()
-    req = urllib.request.Request(
-        url, data=body, headers={"content-type": "application/json"}
-    )
+    req = urllib.request.Request(url, data=body, headers={"content-type": "application/json"})
     start = time.perf_counter()
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
@@ -95,8 +93,7 @@ def main() -> None:
         p50 = statistics.median(lat)
         p99 = lat[min(len(lat) - 1, int(len(lat) * 0.99))]
         print(
-            f"load: achieved_rps={ok / elapsed:.0f} "
-            f"p50={p50 * 1000:.0f}ms p99={p99 * 1000:.0f}ms"
+            f"load: achieved_rps={ok / elapsed:.0f} p50={p50 * 1000:.0f}ms p99={p99 * 1000:.0f}ms"
         )
 
 

--- a/scripts/scale_load.py
+++ b/scripts/scale_load.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Minimal stdlib load generator for the SMG scale-test rig.
+
+Sends chat-completion requests at a target rate with varied prompts (so
+cache-aware routing branches its radix tree), and reports achieved RPS plus
+latency percentiles. No third-party deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import threading
+import time
+import urllib.error
+import urllib.request
+
+
+def send_one(url: str, model: str, prompt: str) -> float | None:
+    """Send one request; return latency in seconds, or None on error."""
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            "max_tokens": 8,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        url, data=body, headers={"content-type": "application/json"}
+    )
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+        return time.perf_counter() - start
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required=True)
+    ap.add_argument("--model", default="mock-model")
+    ap.add_argument("--rps", type=int, default=200)
+    ap.add_argument("--duration", type=int, default=20)
+    ap.add_argument("--concurrency", type=int, default=0)
+    args = ap.parse_args()
+
+    concurrency = args.concurrency or min(512, max(8, args.rps))
+    deadline = time.monotonic() + args.duration
+    interval = 1.0 / args.rps if args.rps > 0 else 0.0
+
+    lat: list[float] = []
+    sent = ok = 0
+    lock = threading.Lock()
+    next_slot = time.monotonic()
+    slot_lock = threading.Lock()
+
+    def worker(wid: int) -> None:
+        nonlocal sent, ok, next_slot
+        i = 0
+        while time.monotonic() < deadline:
+            # Global pacing to approximate the target RPS.
+            if interval:
+                with slot_lock:
+                    now = time.monotonic()
+                    if next_slot < now:
+                        next_slot = now
+                    wait = next_slot - now
+                    next_slot += interval
+                if wait > 0:
+                    time.sleep(wait)
+            prompt = f"worker {wid} request {i}: summarize topic {(wid * 7 + i) % 997}"
+            i += 1
+            dt = send_one(args.url, args.model, prompt)
+            with lock:
+                sent += 1
+                if dt is not None:
+                    ok += 1
+                    lat.append(dt)
+
+    threads = [threading.Thread(target=worker, args=(w,)) for w in range(concurrency)]
+    t0 = time.monotonic()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    elapsed = time.monotonic() - t0
+
+    print(f"load: sent={sent} ok={ok} err={sent - ok} elapsed={elapsed:.1f}s")
+    if lat:
+        lat.sort()
+        p50 = statistics.median(lat)
+        p99 = lat[min(len(lat) - 1, int(len(lat) * 0.99))]
+        print(
+            f"load: achieved_rps={ok / elapsed:.0f} "
+            f"p50={p50 * 1000:.0f}ms p99={p99 * 1000:.0f}ms"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scale_load.py
+++ b/scripts/scale_load.py
@@ -91,7 +91,7 @@ def main() -> None:
     if lat:
         lat.sort()
         p50 = statistics.median(lat)
-        p99 = lat[min(len(lat) - 1, int(len(lat) * 0.99))]
+        p99 = lat[int((len(lat) - 1) * 0.99)]
         print(
             f"load: achieved_rps={ok / elapsed:.0f} p50={p50 * 1000:.0f}ms p99={p99 * 1000:.0f}ms"
         )

--- a/scripts/scale_test.sh
+++ b/scripts/scale_test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Scale-test rig for the SMG gateway using mock workers (crates/mock_worker).
+#
+# Launches one IGW gateway, starts N mock HTTP and/or gRPC workers in a single
+# mock-worker process, REST-registers them, then samples the GATEWAY process's
+# CPU and /health latency at idle and (optionally) under load. Per-PID sampling
+# isolates the gateway so the mock's own CPU does not confound the measurement.
+#
+# Usage:
+#   scripts/scale_test.sh [--http N] [--grpc N] [--policy P] [--rps R]
+#                         [--duration S] [--gen-ms MS] [--no-build]
+#
+# Examples:
+#   scripts/scale_test.sh --http 2000 --policy cache_aware --rps 500 --duration 30
+#   scripts/scale_test.sh --grpc 1000 --policy least_load
+set -euo pipefail
+
+# ---- defaults ----
+HTTP=0
+GRPC=0
+POLICY="cache_aware"
+RPS=0
+DURATION=20
+GEN_MS=5
+GW_PORT=30000
+HTTP_BASE=9000
+GRPC_BASE=19000
+MODEL="mock-model"
+BUILD=1
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --http) HTTP="$2"; shift 2 ;;
+    --grpc) GRPC="$2"; shift 2 ;;
+    --policy) POLICY="$2"; shift 2 ;;
+    --rps) RPS="$2"; shift 2 ;;
+    --duration) DURATION="$2"; shift 2 ;;
+    --gen-ms) GEN_MS="$2"; shift 2 ;;
+    --gw-port) GW_PORT="$2"; shift 2 ;;
+    --no-build) BUILD=0; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ "$HTTP" -eq 0 && "$GRPC" -eq 0 ]]; then
+  echo "pass --http N and/or --grpc N" >&2; exit 2
+fi
+
+GW_PID=""; MOCK_PID=""
+cleanup() {
+  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null || true
+  [[ -n "$GW_PID" ]] && kill "$GW_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+if [[ "$BUILD" -eq 1 ]]; then
+  echo "==> building smg + mock-worker (release, sccache off)"
+  RUSTC_WRAPPER="" cargo build --release -p smg -p mock-worker
+fi
+# Resolve the real target dir (it may be redirected via CARGO_TARGET_DIR or a
+# global cargo config, so it is not necessarily ./target).
+TARGET_DIR=$(cargo metadata --format-version 1 --no-deps \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')
+SMG="$TARGET_DIR/release/smg"
+MOCK="$TARGET_DIR/release/mock-worker"
+
+# ---- start mock workers (one process, many ports) ----
+echo "==> starting mock workers: $HTTP http, $GRPC grpc"
+MOCK_ARGS=(--model "$MODEL" --gen-ms "$GEN_MS")
+[[ "$HTTP" -gt 0 ]] && MOCK_ARGS+=(--http-base-port "$HTTP_BASE" --http-count "$HTTP")
+[[ "$GRPC" -gt 0 ]] && MOCK_ARGS+=(--grpc-base-port "$GRPC_BASE" --grpc-count "$GRPC")
+"$MOCK" "${MOCK_ARGS[@]}" &
+MOCK_PID=$!
+sleep 2
+
+# ---- start gateway in IGW mode ----
+echo "==> starting gateway on :$GW_PORT (policy=$POLICY, IGW)"
+GW_ARGS=(--host 127.0.0.1 --port "$GW_PORT" --enable-igw --policy "$POLICY")
+# gRPC workers need a tokenizer; skip autoload so registration/routing can be
+# measured without a real tokenizer (generation itself is not exercised here).
+[[ "$GRPC" -gt 0 ]] && GW_ARGS+=(--disable-tokenizer-autoload)
+"$SMG" "${GW_ARGS[@]}" &
+GW_PID=$!
+
+echo "==> waiting for gateway /health"
+for _ in $(seq 1 60); do
+  curl -sf "http://127.0.0.1:$GW_PORT/health" >/dev/null 2>&1 && break
+  sleep 1
+done
+
+# ---- register workers via REST, in parallel ----
+echo "==> registering workers via POST /workers"
+register() {
+  local url="$1" body
+  if [[ "$url" == grpc://* ]]; then
+    body="{\"url\":\"$url\",\"connection_mode\":\"grpc\",\"runtime\":\"tokenspeed\",\"models\":[{\"id\":\"$MODEL\"}]}"
+  else
+    body="{\"url\":\"$url\",\"connection_mode\":\"http\",\"runtime\":\"sglang\",\"models\":[{\"id\":\"$MODEL\"}]}"
+  fi
+  curl -sf -X POST "http://127.0.0.1:$GW_PORT/workers" \
+    -H 'content-type: application/json' -d "$body" >/dev/null 2>&1 || true
+}
+export -f register
+export GW_PORT MODEL
+{
+  for ((p = HTTP_BASE; p < HTTP_BASE + HTTP; p++)); do echo "http://127.0.0.1:$p"; done
+  for ((p = GRPC_BASE; p < GRPC_BASE + GRPC; p++)); do echo "grpc://127.0.0.1:$p"; done
+} | xargs -P 32 -I {} bash -c 'register "$@"' _ {}
+
+echo "==> waiting for workers to become Ready"
+EXPECT=$((HTTP + GRPC))
+n=0
+for _ in $(seq 1 120); do
+  body=$(curl -sf "http://127.0.0.1:$GW_PORT/workers" 2>/dev/null || true)
+  n=$(printf '%s' "$body" | grep -o '"url"' | wc -l | tr -d ' ')
+  [[ "${n:-0}" -ge "$EXPECT" ]] && break
+  sleep 1
+done
+echo "    registered ~${n:-0} / $EXPECT workers"
+
+# ---- sample gateway CPU + /health latency ----
+sample() {
+  local label="$1" secs="$2"
+  echo "==> [$label] sampling gateway PID $GW_PID for ${secs}s"
+  for _ in $(seq 1 "$secs"); do
+    cpu=$(ps -o %cpu= -p "$GW_PID" 2>/dev/null | tr -d ' ')
+    rss=$(ps -o rss= -p "$GW_PID" 2>/dev/null | tr -d ' ')
+    hl=$(curl -so /dev/null -w '%{time_total}' "http://127.0.0.1:$GW_PORT/health" 2>/dev/null || echo NA)
+    echo "    [$label] cpu=${cpu}% rss_kb=${rss} health_s=${hl}"
+    sleep 1
+  done
+}
+
+sample "idle" 5
+
+# ---- optional load phase ----
+if [[ "$RPS" -gt 0 ]]; then
+  echo "==> load: ${RPS} rps for ${DURATION}s against /v1/chat/completions"
+  python3 "$ROOT/scripts/scale_load.py" \
+    --url "http://127.0.0.1:$GW_PORT/v1/chat/completions" \
+    --model "$MODEL" --rps "$RPS" --duration "$DURATION" &
+  LOAD_PID=$!
+  sample "load" "$DURATION"
+  wait "$LOAD_PID" 2>/dev/null || true
+fi
+
+echo "==> done (gateway pid $GW_PID, mock pid $MOCK_PID); tearing down"

--- a/scripts/scale_test.sh
+++ b/scripts/scale_test.sh
@@ -47,6 +47,14 @@ if [[ "$HTTP" -eq 0 && "$GRPC" -eq 0 ]]; then
   echo "pass --http N and/or --grpc N" >&2; exit 2
 fi
 
+# Thousands of mock ports + gateway connections need plenty of file descriptors.
+ulimit -n "$(ulimit -Hn)" 2>/dev/null || true
+
+# Kill leftovers from prior runs so mock ports are free to bind.
+pkill -9 -x mock-worker 2>/dev/null || true
+pkill -9 -x smg 2>/dev/null || true
+sleep 2
+
 GW_PID=""; MOCK_PID=""
 cleanup() {
   [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null || true
@@ -54,23 +62,36 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+# Pin the target dir so `cargo build` and binary resolution always agree. The
+# environment may otherwise redirect the target dir to a hash that is not stable
+# across invocations (causing cold rebuilds + wrong paths). Override by exporting
+# CARGO_TARGET_DIR before running this script (e.g. point it at a warm dir).
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT/target}"
 if [[ "$BUILD" -eq 1 ]]; then
-  echo "==> building smg + mock-worker (release, sccache off)"
+  echo "==> building smg + mock-worker (release, sccache off) into $CARGO_TARGET_DIR"
   RUSTC_WRAPPER="" cargo build --release -p smg -p mock-worker
 fi
-# Resolve the real target dir (it may be redirected via CARGO_TARGET_DIR or a
-# global cargo config, so it is not necessarily ./target).
-TARGET_DIR=$(cargo metadata --format-version 1 --no-deps \
-  | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')
-SMG="$TARGET_DIR/release/smg"
-MOCK="$TARGET_DIR/release/mock-worker"
+SMG="$CARGO_TARGET_DIR/release/smg"
+MOCK="$CARGO_TARGET_DIR/release/mock-worker"
+if [[ ! -x "$SMG" || ! -x "$MOCK" ]]; then
+  echo "binaries not found in $CARGO_TARGET_DIR/release (run without --no-build)" >&2
+  exit 1
+fi
+echo "    smg=$SMG"
+
+# Redirect both processes to log files. If they inherited this script's stdout
+# (often an unread pipe), their heavy logging would fill the pipe buffer and
+# block the process — stalling the gateway before it serves.
+LOGDIR="${TMPDIR:-/tmp}/smg-scale"
+mkdir -p "$LOGDIR"
+echo "==> logs: $LOGDIR/{mock,gateway}.log"
 
 # ---- start mock workers (one process, many ports) ----
 echo "==> starting mock workers: $HTTP http, $GRPC grpc"
 MOCK_ARGS=(--model "$MODEL" --gen-ms "$GEN_MS")
 [[ "$HTTP" -gt 0 ]] && MOCK_ARGS+=(--http-base-port "$HTTP_BASE" --http-count "$HTTP")
 [[ "$GRPC" -gt 0 ]] && MOCK_ARGS+=(--grpc-base-port "$GRPC_BASE" --grpc-count "$GRPC")
-"$MOCK" "${MOCK_ARGS[@]}" &
+"$MOCK" "${MOCK_ARGS[@]}" >"$LOGDIR/mock.log" 2>&1 &
 MOCK_PID=$!
 sleep 2
 
@@ -80,7 +101,7 @@ GW_ARGS=(--host 127.0.0.1 --port "$GW_PORT" --enable-igw --policy "$POLICY")
 # gRPC workers need a tokenizer; skip autoload so registration/routing can be
 # measured without a real tokenizer (generation itself is not exercised here).
 [[ "$GRPC" -gt 0 ]] && GW_ARGS+=(--disable-tokenizer-autoload)
-"$SMG" "${GW_ARGS[@]}" &
+"$SMG" "${GW_ARGS[@]}" >"$LOGDIR/gateway.log" 2>&1 &
 GW_PID=$!
 
 echo "==> waiting for gateway /health"
@@ -90,31 +111,33 @@ for _ in $(seq 1 60); do
 done
 
 # ---- register workers via REST, in parallel ----
+# Health disabled so workers are instantly Ready/routable — isolates routing
+# cost from the per-worker health-probe loop (and avoids the 60s promote wait).
+# Direct curl per port ({} = port via xargs); model/mode pinned so routing has a
+# concrete model (bare-URL auto-detect leaves model_id "unknown" -> 404 on route).
 echo "==> registering workers via POST /workers"
-register() {
-  local url="$1" body
-  if [[ "$url" == grpc://* ]]; then
-    body="{\"url\":\"$url\",\"connection_mode\":\"grpc\",\"runtime\":\"tokenspeed\",\"models\":[{\"id\":\"$MODEL\"}]}"
-  else
-    body="{\"url\":\"$url\",\"connection_mode\":\"http\",\"runtime\":\"sglang\",\"models\":[{\"id\":\"$MODEL\"}]}"
-  fi
-  curl -sf -X POST "http://127.0.0.1:$GW_PORT/workers" \
-    -H 'content-type: application/json' -d "$body" >/dev/null 2>&1 || true
-}
-export -f register
-export GW_PORT MODEL
-{
-  for ((p = HTTP_BASE; p < HTTP_BASE + HTTP; p++)); do echo "http://127.0.0.1:$p"; done
-  for ((p = GRPC_BASE; p < GRPC_BASE + GRPC; p++)); do echo "grpc://127.0.0.1:$p"; done
-} | xargs -P 32 -I {} bash -c 'register "$@"' _ {}
+H='"health":{"disable_health_check":true}'
+W="http://127.0.0.1:$GW_PORT/workers"
+if [[ "$HTTP" -gt 0 ]]; then
+  seq "$HTTP_BASE" $((HTTP_BASE + HTTP - 1)) | xargs -P 32 -I{} \
+    curl -s -o /dev/null --max-time 15 -X POST "$W" -H 'content-type: application/json' \
+    -d "{\"url\":\"http://127.0.0.1:{}\",\"connection_mode\":\"http\",\"runtime\":\"sglang\",\"models\":[{\"id\":\"$MODEL\"}],$H}" || true
+fi
+if [[ "$GRPC" -gt 0 ]]; then
+  seq "$GRPC_BASE" $((GRPC_BASE + GRPC - 1)) | xargs -P 32 -I{} \
+    curl -s -o /dev/null --max-time 15 -X POST "$W" -H 'content-type: application/json' \
+    -d "{\"url\":\"grpc://127.0.0.1:{}\",\"connection_mode\":\"grpc\",\"runtime\":\"tokenspeed\",\"models\":[{\"id\":\"$MODEL\"}],$H}" || true
+fi
 
 echo "==> waiting for workers to become Ready"
 EXPECT=$((HTTP + GRPC))
 n=0
 for _ in $(seq 1 120); do
-  body=$(curl -sf "http://127.0.0.1:$GW_PORT/workers" 2>/dev/null || true)
-  n=$(printf '%s' "$body" | grep -o '"url"' | wc -l | tr -d ' ')
-  [[ "${n:-0}" -ge "$EXPECT" ]] && break
+  body=$(curl -sf --max-time 20 "http://127.0.0.1:$GW_PORT/workers" 2>/dev/null || true)
+  n=$(printf '%s' "$body" | grep -o '"url"' | wc -l | tr -d ' ' || true)
+  n=${n:-0}
+  # Accept ~95%: a few ports may collide and a couple of workflows lag.
+  [[ "$n" -ge $((EXPECT * 95 / 100)) ]] && break
   sleep 1
 done
 echo "    registered ~${n:-0} / $EXPECT workers"
@@ -124,10 +147,10 @@ sample() {
   local label="$1" secs="$2"
   echo "==> [$label] sampling gateway PID $GW_PID for ${secs}s"
   for _ in $(seq 1 "$secs"); do
-    cpu=$(ps -o %cpu= -p "$GW_PID" 2>/dev/null | tr -d ' ')
-    rss=$(ps -o rss= -p "$GW_PID" 2>/dev/null | tr -d ' ')
+    cpu=$(ps -p "$GW_PID" -o pcpu= 2>/dev/null | tr -d ' ' || true)
+    rss=$(ps -p "$GW_PID" -o rss= 2>/dev/null | tr -d ' ' || true)
     hl=$(curl -so /dev/null -w '%{time_total}' "http://127.0.0.1:$GW_PORT/health" 2>/dev/null || echo NA)
-    echo "    [$label] cpu=${cpu}% rss_kb=${rss} health_s=${hl}"
+    echo "    [$label] cpu=${cpu:-NA}% rss_kb=${rss:-NA} health_s=${hl}"
     sleep 1
   done
 }


### PR DESCRIPTION
## Description

### Problem

We have no GPU-free way to reproduce or measure the gateway's behavior with a large worker fleet (routing cost, async-runtime saturation, `/health` latency). #1685 reports the gateway becoming unstable and failing `/health` probes above 2–3 cores with ~4500 workers, but there was no rig to reproduce it or to validate fixes.

### Solution

Add `crates/mock_worker` — a single Rust binary that starts many protocol-accurate mock **HTTP** and **gRPC** inference workers (stand-ins for vLLM/SGLang) on distinct ports in one process — plus a scale-test harness (`scripts/scale_test.sh`, `scripts/scale_load.py`) that launches an IGW gateway, REST-registers N workers, and samples the **gateway process CPU + `/health` latency** at idle and under load (per-PID sampling isolates the gateway from the mock's own CPU).

- **HTTP** workers answer the probe + chat/generate + loads surface (`/health`, `/v1/models`, `/v1/chat/completions` non-stream + SSE, `/v1/loads`).
- **gRPC** workers implement the TokenSpeed scheduler service (`HealthCheck`, `GetModelInfo`, `GetServerInfo`, `Generate` streaming, `GetLoads`, `Abort`) and stream canned token ids — the gateway tokenizes and speaks token ids.

This is test/dev infrastructure only — a new workspace member and two scripts; no production code is changed.

## Changes

- `crates/mock_worker/` — `config.rs` (CLI), `http.rs` (HTTP worker), `grpc.rs` (TokenSpeed worker), `main.rs` (multi-port launcher), `README.md`.
- `scripts/scale_test.sh` — launch gateway + mock fleet, REST-register, sample CPU/`/health`.
- `scripts/scale_load.py` — stdlib load generator (varied prompts to branch cache-aware routing).
- `Cargo.toml` — add the workspace member.

## Test Plan

**Functional (small scale):** registered workers `202`, `model_id` pinned, gateway lists the model, and both **non-streaming and streaming** chat route to mocks → `200`.

**Scale baseline** (`random` policy; `scripts/scale_test.sh --http N --rps 400`) — the rig works and reproduces #1685:

| Workers | Registered | Gateway CPU | RSS | `/health` spike | Load p50 / p99 |
|---|---|---|---|---|---|
| 500 | 499 | ~0.8 core | 0.78 GB | 0.7 ms | 7 / 9 ms |
| 2000 | 1902 | ~1.18 cores | 2.5 GB | **3.32 s** | 8 / 11 ms |
| 4000 | 3807 | ~1.15 cores | 4.1 GB | **2.30 s** | 9 / **850 ms** |

→ `/health` starvation (2–3.3 s), CPU plateau (~1.2 cores) with p99 blowup (serialization ceiling), ~1.1 MB/worker memory. This data backs the follow-up issues #1692, #1693, #1694, #1695.

Authoritative gate (sccache disabled, `RUSTC_WRAPPER=""`):

```
$ rustup run nightly cargo fmt --all -- --check
FMT CLEAN (exit 0)

$ cargo clippy --workspace --all-targets --all-features -- -D warnings
Finished `dev` profile target(s) in 2m 41s
exit 0
```

Refs #1685. Surfaces #1692, #1693, #1694, #1695.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mock-worker binary that launches many mock HTTP and gRPC inference endpoints (including streaming and non-streaming completions) for large-scale gateway testing.
  * Added a Python load generator to drive chat-completion requests at configurable RPS, concurrency and duration.
  * Added an end-to-end scale test script to start workers, register them with a gateway, sample metrics, and run load.

* **Documentation**
  * Added user docs explaining run/config options and registration/scale-test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->