### PR TITLE
fix(mock-worker): keep the fleet running when one worker exits

### DIFF
--- a/crates/mock_worker/src/main.rs
+++ b/crates/mock_worker/src/main.rs
@@ -58,19 +58,27 @@ async fn main() -> ExitCode {
 
     tracing::info!("started {} mock workers; ctrl-c to stop", workers.len());
 
-    tokio::select! {
-        Some(res) = workers.join_next() => {
-            if let Err(e) = res {
-                tracing::error!("mock worker task failed: {e}");
-            } else {
-                tracing::error!("a mock worker stopped unexpectedly");
+    // A single worker exiting (e.g. a port already in use) is logged but must
+    // not tear down the whole fleet — the remaining workers keep serving. Only
+    // ctrl-c stops the process. When the set is empty `join_next` yields None,
+    // so that select arm is disabled and we wait on the signal.
+    loop {
+        tokio::select! {
+            Some(joined) = workers.join_next() => {
+                match joined {
+                    Ok(()) => tracing::warn!(
+                        "a mock worker stopped (likely a port bind failure); others keep serving"
+                    ),
+                    Err(e) => tracing::error!("mock worker task panicked: {e}"),
+                }
             }
-        }
-        result = tokio::signal::ctrl_c() => {
-            if let Err(e) = result {
-                tracing::error!("failed to listen for ctrl-c: {e}");
+            result = tokio::signal::ctrl_c() => {
+                if let Err(e) = result {
+                    tracing::error!("failed to listen for ctrl-c: {e}");
+                }
+                tracing::info!("shutting down");
+                break;
             }
-            tracing::info!("shutting down");
         }
     }
     ExitCode::SUCCESS


### PR DESCRIPTION
## Description

### Problem

The mock-worker launcher (added in #1696) waited on a single `JoinSet::join_next()` inside `tokio::select!`. The first worker task to finish completes that arm and the process exits — so a **single** port already in use (a stale listener on one port) makes the launcher log "a mock worker stopped unexpectedly" and tear down the **entire** fleet. In practice the scale rig then registers **0** workers from a lone `:9000` collision.

### Solution

Wait in a loop: a worker exiting is logged but **non-fatal** — the remaining workers keep serving — and only ctrl-c stops the process. When the set drains, `join_next()` returns `None`, so the `Some(..) =` arm is disabled and we wait on the signal without spinning. (Workers are still spawned into a `JoinSet`, so they run across the whole runtime.)

## Changes

- `crates/mock_worker/src/main.rs`: loop over `join_next()`; treat a single worker exit as non-fatal; break only on ctrl-c.

## Test Plan

Re-ran `scripts/scale_test.sh` with a stale listener occupying `:9000`:

- **Before:** the `:9000` bind failure exited the whole fleet → `registered ~0` at every scale.
- **After:** the fleet keeps serving — `registered ~487/500`, `~1924/2000`, `~3806/4000` (only the colliding port is lost), and the gateway routes traffic normally.

Gate (sccache off):

```
$ rustup run nightly cargo fmt -p mock-worker -- --check   # clean
$ cargo clippy -p mock-worker --all-targets --all-features -- -D warnings   # exit 0
```

Refs #1696.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mock worker to continue running remaining workers when an individual worker exits; graceful shutdown via Ctrl+C remains functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->