### PR TITLE
feat(server): optional dedicated liveness listener on its own thread+runtime

### DIFF
--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -170,6 +170,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn maybe_liveness_port(mut self, liveness_port: Option<u16>) -> Self {
+        self.config.liveness_port = liveness_port;
+        self
+    }
+
     // ==================== Request ====================
 
     pub fn max_payload_size(mut self, size: usize) -> Self {

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -121,6 +121,11 @@ pub struct RouterConfig {
     /// When set, wraps all storage backends with hook-based interceptors.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_hook_wasm_path: Option<String>,
+    /// Optional dedicated port for a minimal liveness server, served from its
+    /// own OS thread + runtime so a saturated request runtime cannot starve it.
+    /// `None` (default) keeps liveness only on the main port, unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub liveness_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -688,6 +693,7 @@ impl Default for RouterConfig {
             mcp_config: None,
             enable_wasm: false,
             storage_hook_wasm_path: None,
+            liveness_port: None,
             server_cert: None,
             server_key: None,
         }

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -476,6 +476,23 @@ impl ConfigValidator {
             });
         }
 
+        if let Some(liveness_port) = config.liveness_port {
+            if liveness_port == 0 {
+                return Err(ConfigError::InvalidValue {
+                    field: "liveness_port".to_string(),
+                    value: liveness_port.to_string(),
+                    reason: "Port must be > 0".to_string(),
+                });
+            }
+            if liveness_port == config.port {
+                return Err(ConfigError::InvalidValue {
+                    field: "liveness_port".to_string(),
+                    value: liveness_port.to_string(),
+                    reason: "Must differ from the main server port".to_string(),
+                });
+            }
+        }
+
         Ok(())
     }
 
@@ -1273,5 +1290,43 @@ mod tests {
 
         let result = ConfigValidator::validate(&config);
         assert!(result.is_err());
+    }
+
+    fn config_with_liveness_port(port: u16, liveness_port: Option<u16>) -> RouterConfig {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker1:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+        config.port = port;
+        config.liveness_port = liveness_port;
+        config
+    }
+
+    #[test]
+    fn test_liveness_port_unset_is_accepted() {
+        assert!(ConfigValidator::validate(&config_with_liveness_port(8080, None)).is_ok());
+    }
+
+    #[test]
+    fn test_liveness_port_distinct_is_accepted() {
+        assert!(ConfigValidator::validate(&config_with_liveness_port(8080, Some(8081))).is_ok());
+    }
+
+    #[test]
+    fn test_liveness_port_zero_is_rejected() {
+        assert!(matches!(
+            ConfigValidator::validate(&config_with_liveness_port(8080, Some(0))),
+            Err(ConfigError::InvalidValue { ref field, .. }) if field == "liveness_port"
+        ));
+    }
+
+    #[test]
+    fn test_liveness_port_equal_to_main_port_is_rejected() {
+        assert!(matches!(
+            ConfigValidator::validate(&config_with_liveness_port(8080, Some(8080))),
+            Err(ConfigError::InvalidValue { ref field, .. }) if field == "liveness_port"
+        ));
     }
 }

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -143,6 +143,12 @@ struct CliArgs {
     #[arg(long, default_value_t = 30000, help_heading = "Worker Configuration")]
     port: u16,
 
+    /// Optional dedicated port for a minimal liveness server. Served from its
+    /// own thread + runtime so a saturated request runtime cannot starve the
+    /// k8s liveness probe. Unset (default) keeps liveness only on `--port`.
+    #[arg(long, help_heading = "Worker Configuration")]
+    liveness_port: Option<u16>,
+
     /// List of worker URLs (supports IPv4 and IPv6)
     #[arg(long, num_args = 0.., help_heading = "Worker Configuration")]
     worker_urls: Vec<String>,
@@ -1239,6 +1245,7 @@ impl CliArgs {
             .connection_mode(connection_mode)
             .host(&self.host)
             .port(self.port)
+            .maybe_liveness_port(self.liveness_port)
             .max_payload_size(self.max_payload_size)
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)

--- a/model_gateway/src/observability/liveness_server.rs
+++ b/model_gateway/src/observability/liveness_server.rs
@@ -1,0 +1,99 @@
+//! Dedicated liveness server (optional, off by default).
+//!
+//! The main `/health` endpoint is served from the request runtime and its full
+//! middleware stack, so when worker threads are saturated with CPU-bound work
+//! the runtime cannot schedule the liveness future within the k8s probe timeout
+//! and pods get restarted under load. When `liveness_port` is configured, this
+//! module serves a minimal `GET /health` and `GET /liveness` from a dedicated OS
+//! thread running its own single-threaded tokio runtime, so the request runtime
+//! cannot starve it.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use axum::{http::StatusCode, response::IntoResponse, routing::get, Router};
+use tracing::{error, info};
+
+async fn liveness() -> impl IntoResponse {
+    (StatusCode::OK, "OK")
+}
+
+fn liveness_router() -> Router {
+    Router::new()
+        .route("/health", get(liveness))
+        .route("/liveness", get(liveness))
+}
+
+async fn serve(addr: SocketAddr) {
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(listener) => listener,
+        Err(e) => {
+            error!("Dedicated liveness server failed to bind on {addr}: {e}");
+            return;
+        }
+    };
+    info!("Dedicated liveness server listening on {addr} (/health + /liveness)");
+    if let Err(e) = axum::serve(listener, liveness_router()).await {
+        error!("Dedicated liveness server error: {e}");
+    }
+}
+
+/// Spawn the dedicated liveness server on its own OS thread + current-thread
+/// runtime so a CPU-saturated request runtime cannot starve the probe.
+pub fn spawn_liveness_server(host: &str, port: u16) {
+    let ip_addr: IpAddr = host.parse().unwrap_or_else(|e| {
+        error!("Failed to parse liveness host '{host}': {e}, falling back to 0.0.0.0");
+        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
+    });
+    let addr = SocketAddr::new(ip_addr, port);
+
+    // A dedicated OS thread + its own runtime is the whole point: it stays
+    // schedulable even when the main multi-threaded runtime is saturated.
+    let spawn_result = std::thread::Builder::new()
+        .name("liveness-server".to_string())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(e) => {
+                    error!("Failed to build liveness server runtime: {e}");
+                    return;
+                }
+            };
+            runtime.block_on(serve(addr));
+        });
+
+    if let Err(e) = spawn_result {
+        error!("Failed to spawn liveness server thread: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::Body, http::Request};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn liveness_endpoints_return_200_ok() {
+        for path in ["/health", "/liveness"] {
+            let response = liveness_router()
+                .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "path: {path}");
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(&body[..], b"OK", "path: {path}");
+        }
+    }
+
+    #[test]
+    fn spawn_with_bad_host_does_not_panic() {
+        // Unparseable host falls back to 0.0.0.0; spawning must not panic even
+        // when the dedicated thread cannot ultimately bind.
+        spawn_liveness_server("not-an-ip", 0);
+    }
+}

--- a/model_gateway/src/observability/mod.rs
+++ b/model_gateway/src/observability/mod.rs
@@ -3,6 +3,7 @@
 pub mod events;
 pub mod gauge_histogram;
 pub mod inflight_tracker;
+pub mod liveness_server;
 pub mod logging;
 pub mod metrics;
 pub mod metrics_server;

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -50,6 +50,7 @@ use crate::{
     mesh::MeshAdapters,
     middleware::{self, AuthConfig, QueuedRequest},
     observability::{
+        liveness_server,
         logging::{self, LoggingConfig},
         metrics::{self, PrometheusConfig},
         metrics_server,
@@ -1071,6 +1072,13 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         } else {
             (None, None)
         };
+
+    // Start the dedicated liveness server before the (slow) worker init path so
+    // the probe is answerable immediately and stays answerable even when the
+    // main request runtime is CPU-saturated.
+    if let Some(liveness_port) = config.router_config.liveness_port {
+        liveness_server::spawn_liveness_server(&config.host, liveness_port);
+    }
 
     // Build the mesh server if configured. Starting gossip is deferred until
     // MeshAdapters has registered the `worker:`/`rl:` CRDT namespaces below —


### PR DESCRIPTION
## Description

### Problem

`/health` is handled by a trivial `liveness()` handler, but it is served from the
same multi-threaded tokio runtime and full middleware stack as all request
traffic (`model_gateway/src/server.rs`: route registered at the `public_routes`
group, handler returns `(StatusCode::OK, "OK")`). When worker threads are
saturated with CPU-bound work, the runtime cannot schedule the liveness future
within the k8s probe timeout (empirically 2-3.3s under load at 2000-4000 workers
in our scale rig), so probes fail and pods get restarted under load.

### Solution

Add an **optional, off-by-default** dedicated liveness port. When set, spawn a
dedicated OS thread (`std::thread::spawn`) running its own
`tokio::runtime::Builder::new_current_thread().enable_all().build()` runtime that
serves a minimal `GET /health` and `GET /liveness` returning `200 OK`, outside
the main app and its middleware. Because it is a separate thread + runtime, it
stays schedulable even when the main request runtime is CPU-saturated.

The existing `/health` on the main port is unchanged. When `liveness_port` is
unset (default `None`), behavior is identical to today — zero impact on existing
deployments.

Scope is only the dedicated liveness listener; making `/readiness` O(1) is a
separate concern and is not included.

## Changes

- New `model_gateway/src/observability/liveness_server.rs`: `spawn_liveness_server(host, port)` spawns a named OS thread + current-thread runtime serving a minimal `/health` + `/liveness` router; bind/runtime failures are logged (and the thread exits) without taking down the main server.
- `model_gateway/src/server.rs`: in `startup`, spawn the dedicated liveness server before the slow worker-init path when `liveness_port` is configured, so the probe is answerable immediately.
- `model_gateway/src/config/types.rs`: add `RouterConfig.liveness_port: Option<u16>` (serde `default` + `skip_serializing_if`, default `None`).
- `model_gateway/src/config/builder.rs`: add `maybe_liveness_port` builder setter.
- `model_gateway/src/config/validation.rs`: reject `liveness_port == 0` and `liveness_port == port`.
- `model_gateway/src/main.rs`: add `--liveness-port` CLI flag, wired through `to_router_config`.

Note: the Python/Go bindings' `RouterConfig` mirror was intentionally left
unchanged to keep this a minimal single-concern change; the knob is fully
exposed via the CLI flag and via `RouterConfig` YAML/serde.

## Test Plan

Added focused tests (run via `cargo test -p smg --lib liveness`):

- `observability::liveness_server::tests::liveness_endpoints_return_200_ok` — drives `/health` and `/liveness` through the dedicated router via `tower::oneshot` and asserts `200 OK` with body `OK`.
- `observability::liveness_server::tests::spawn_with_bad_host_does_not_panic` — unparseable host falls back to `0.0.0.0`; spawning must not panic.
- `config::validation::tests::test_liveness_port_unset_is_accepted`
- `config::validation::tests::test_liveness_port_distinct_is_accepted`
- `config::validation::tests::test_liveness_port_zero_is_rejected`
- `config::validation::tests::test_liveness_port_equal_to_main_port_is_rejected`

```
running 7 tests
test config::validation::tests::test_liveness_port_distinct_is_accepted ... ok
test config::validation::tests::test_liveness_port_equal_to_main_port_is_rejected ... ok
test config::validation::tests::test_liveness_port_unset_is_accepted ... ok
test config::validation::tests::test_liveness_port_zero_is_rejected ... ok
test observability::liveness_server::tests::spawn_with_bad_host_does_not_panic ... ok
test observability::liveness_server::tests::liveness_endpoints_return_200_ok ... ok
test worker::manager::tests::test_state_machine_notready_to_failed_after_liveness_threshold ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1054 filtered out; finished in 0.00s
```

Clippy (`RUSTC_WRAPPER="" cargo clippy --workspace --all-targets --all-features -- -D warnings`):

```
    Checking smg v1.5.0 (model_gateway)
    Checking smg-golang v1.5.0 (bindings/golang)
    Checking smg-python v1.5.0 (bindings/python)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 41s
```

Format (`RUSTC_WRAPPER="" rustup run nightly cargo fmt --all`): no changes / clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

Refs #1694


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `--liveness-port` CLI option to configure a dedicated health check port.
  * Introduced a dedicated liveness server with `/health` and `/liveness` endpoints running on its own thread, ensuring probe availability even under CPU saturation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->