### PR TITLE
perf(worker): clone only matching workers in get_workers_filtered

### DIFF
--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -338,14 +338,10 @@ impl WorkerRegistry {
     /// - `runtime_type`: `Sglang` / `Vllm` / `External` / …
     /// - `healthy_only`: skip workers whose `is_healthy()` is false
     ///
-    /// **Cost note on `runtime_type`:** the registry keeps no runtime-type
-    /// index. This filter is applied in-memory after fetching by model or
-    /// iterating all workers, so the whole candidate set is cloned before
-    /// filtering. Callers on hot paths should prefer pre-filtering by
-    /// model or type when possible.
-    ///
-    /// Always returns an owned `Vec` because each call applies a unique
-    /// filter combination.
+    /// Only workers that pass every filter are cloned; the source collection
+    /// (the per-model index slice, or the worker map when `model_id` is `None`)
+    /// is iterated by reference rather than cloned wholesale first. Returns an
+    /// owned `Vec` because each call applies a unique filter combination.
     pub fn get_workers_filtered(
         &self,
         model_id: Option<&str>,
@@ -354,38 +350,42 @@ impl WorkerRegistry {
         runtime_type: Option<RuntimeType>,
         healthy_only: bool,
     ) -> Vec<Arc<dyn Worker>> {
-        // Start with the most efficient collection based on filters
-        // Use model index when possible as it's O(1) lookup
-        let workers: Vec<Arc<dyn Worker>> = if let Some(model) = model_id {
-            self.get_by_model(model).to_vec()
-        } else {
-            self.get_all()
-        };
-
-        workers
-            .into_iter()
-            .filter(|w| {
-                if let Some(ref wtype) = worker_type {
-                    if *w.worker_type() != *wtype {
-                        return false;
-                    }
-                }
-                if let Some(ref conn) = connection_mode {
-                    if w.connection_mode() != conn {
-                        return false;
-                    }
-                }
-                if let Some(ref rt) = runtime_type {
-                    if w.metadata().spec.runtime_type != *rt {
-                        return false;
-                    }
-                }
-                if healthy_only && !w.is_healthy() {
+        let matches = |w: &Arc<dyn Worker>| {
+            if let Some(ref wtype) = worker_type {
+                if *w.worker_type() != *wtype {
                     return false;
                 }
-                true
-            })
-            .collect()
+            }
+            if let Some(ref conn) = connection_mode {
+                if w.connection_mode() != conn {
+                    return false;
+                }
+            }
+            if let Some(ref rt) = runtime_type {
+                if w.metadata().spec.runtime_type != *rt {
+                    return false;
+                }
+            }
+            !healthy_only || w.is_healthy()
+        };
+
+        // Clone only the workers that pass: scope to the O(1) model index when a
+        // model is given, otherwise iterate the worker map directly. Avoids the
+        // per-request O(total workers) clone that fetching the full set first
+        // would incur.
+        if let Some(model) = model_id {
+            self.get_by_model(model)
+                .iter()
+                .filter(|w| matches(w))
+                .cloned()
+                .collect()
+        } else {
+            self.workers
+                .iter()
+                .filter(|entry| matches(entry.value()))
+                .map(|entry| entry.value().clone())
+                .collect()
+        }
     }
 
     /// Return an owned snapshot of every registered worker.


### PR DESCRIPTION
## Description

### Problem

`WorkerRegistry::get_workers_filtered` materialized the **entire** candidate set before filtering: `get_all()` (cloning every worker `Arc`) when `model_id` is `None` — which is the per-request routing path (`worker_selection.rs` `get_candidates` passes `None`) — or `get_by_model(..).to_vec()`. So the whole fleet was cloned on every routing request regardless of how many workers actually matched the filters.

### Solution

Iterate the source **by reference** — the per-model index slice (`get_by_model`), or the worker map (`self.workers`) directly when `model_id` is `None` — and clone only the workers that pass every filter. Behavior is unchanged (same set returned, still an owned `Vec`).

## Changes

- `model_gateway/src/worker/registry.rs`: rewrite `get_workers_filtered` to filter-then-clone instead of clone-then-filter; updated the doc comment.

## Test Plan

- `cargo test -p smg --lib worker::registry` → **38 passed**; gate clean (`fmt`, `clippy --all-targets -- -D warnings` exit 0, sccache off).
- **Scale A/B** (mock rig, `random`, rps 400) with the fix:

  | N | load CPU | RSS | p99 |
  |---|---|---|---|
  | 500 | ~0.5 core | 0.69 GB | 9 ms |
  | 2000 | ~1.05 cores | 2.5 GB | 10 ms |
  | 4000 | ~1.05 cores | 4.3 GB | 1045 ms |

  **Honest attribution:** on the rig's *homogeneous* fleet (all Regular/HTTP/one model) every worker matches the filter, so survivors = all and the clone count is unchanged — as expected, this fix is ~neutral there (and `Arc::clone` is a cheap atomic). Its win is on **filtered/heterogeneous** paths (PD prefill/decode, External-runtime, per-model), where it avoids cloning non-matching workers. The remaining per-request O(total workers) cost for the homogeneous high-fan-out case (candidate `Vec` materialization + `is_available` pass) is the larger lever tracked in #1692.

Refs #1692.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of worker filtering logic through more targeted candidate selection and streamlined filtering approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->