### PR TITLE
perf(grpc): offload tokenizer.encode to spawn_blocking

### DIFF
--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -131,7 +131,13 @@ impl ChatPreparationStage {
         };
 
         // Step 3: Tokenize the processed text (no special tokens - chat template already handles them)
-        let encoding = match tokenizer.encode(&processed_messages.text, false) {
+        let encoding = match utils::encode_blocking(
+            tokenizer.clone(),
+            processed_messages.text.clone(),
+            false,
+        )
+        .await
+        {
             Ok(encoding) => encoding,
             Err(e) => {
                 error!(function = "ChatPreparationStage::execute", error = %e, "Tokenization failed");

--- a/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
@@ -39,14 +39,16 @@ impl PipelineStage for CompletionPreparationStage {
             }
         };
 
-        let encoding = tokenizer.encode(&prompt_text, false).map_err(|e| {
-            error!(
-                function = "CompletionPreparationStage::execute",
-                error = %e,
-                "Tokenization failed"
-            );
-            error::bad_request("tokenization_failed", format!("Tokenization failed: {e}"))
-        })?;
+        let encoding = utils::encode_blocking(tokenizer.clone(), prompt_text.clone(), false)
+            .await
+            .map_err(|e| {
+                error!(
+                    function = "CompletionPreparationStage::execute",
+                    error = %e,
+                    "Tokenization failed"
+                );
+                error::bad_request("tokenization_failed", format!("Tokenization failed: {e}"))
+            })?;
 
         let stop_decoder = utils::create_stop_decoder(
             &tokenizer,

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
@@ -53,8 +53,8 @@ impl PipelineStage for EmbeddingPreparationStage {
 
         // Tokenize with special tokens (BOS/EOS) for embeddings
         // This matches Python's transformers behavior which reads add_bos_token/add_eos_token from tokenizer_config.json
-        let token_ids = tokenizer
-            .encode(&text, true)
+        let token_ids = utils::encode_blocking(tokenizer.clone(), text.clone(), true)
+            .await
             .map_err(|e| {
                 error!(
                     function = "EmbeddingPreparationStage::execute",

--- a/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -27,7 +27,7 @@ pub(crate) struct GeneratePreparationStage;
 impl PipelineStage for GeneratePreparationStage {
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
         let request = ctx.generate_request_arc();
-        self.prepare_generate(ctx, &request)?;
+        self.prepare_generate(ctx, &request).await?;
         Ok(None)
     }
 
@@ -37,11 +37,7 @@ impl PipelineStage for GeneratePreparationStage {
 }
 
 impl GeneratePreparationStage {
-    #[expect(
-        clippy::result_large_err,
-        reason = "Response is the standard error type in the pipeline stage pattern"
-    )]
-    fn prepare_generate(
+    async fn prepare_generate(
         &self,
         ctx: &mut RequestContext,
         request: &GenerateRequest,
@@ -50,7 +46,10 @@ impl GeneratePreparationStage {
         let tokenizer = utils::resolve_tokenizer(ctx, "GeneratePreparationStage::prepare_generate")
             .map_err(|e| *e)?;
 
-        let (original_text, token_ids) = match self.resolve_generate_input(request, &tokenizer) {
+        let (original_text, token_ids) = match self
+            .resolve_generate_input(request, &tokenizer)
+            .await
+        {
             Ok(res) => res,
             Err(msg) => {
                 error!(function = "GeneratePreparationStage::execute", error = %msg, "Failed to resolve generate input");
@@ -80,7 +79,7 @@ impl GeneratePreparationStage {
         Ok(())
     }
 
-    fn resolve_generate_input(
+    async fn resolve_generate_input(
         &self,
         request: &GenerateRequest,
         tokenizer: &Arc<dyn Tokenizer>,
@@ -88,6 +87,7 @@ impl GeneratePreparationStage {
         if let Some(text) = &request.text {
             return self
                 .tokenize_single_text(tokenizer, text)
+                .await
                 .map(|(original, ids)| (Some(original), ids));
         }
 
@@ -109,18 +109,14 @@ impl GeneratePreparationStage {
         Err("Either `text` or `input_ids` must be provided".to_string())
     }
 
-    #[expect(
-        clippy::unused_self,
-        reason = "method on stage struct for consistency with resolve_generate_input"
-    )]
-    fn tokenize_single_text(
+    async fn tokenize_single_text(
         &self,
         tokenizer: &Arc<dyn Tokenizer>,
         text: &str,
     ) -> Result<(String, Vec<u32>), String> {
         // Don't add special tokens - raw text generation uses text as-is
-        let encoding = tokenizer
-            .encode(text, false)
+        let encoding = utils::encode_blocking(tokenizer.clone(), text.to_string(), false)
+            .await
             .map_err(|e| format!("Tokenization failed: {e}"))?;
         Ok((text.to_string(), encoding.token_ids().to_vec()))
     }

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -154,7 +154,13 @@ impl MessagePreparationStage {
         };
 
         // Step 3: Tokenize the processed text
-        let encoding = match tokenizer.encode(&processed_messages.text, false) {
+        let encoding = match utils::encode_blocking(
+            tokenizer.clone(),
+            processed_messages.text.clone(),
+            false,
+        )
+        .await
+        {
             Ok(encoding) => encoding,
             Err(e) => {
                 error!(function = "MessagePreparationStage::execute", error = %e, "Tokenization failed");

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -2,12 +2,13 @@
 
 use std::{collections::HashMap, io, sync::Arc};
 
+use anyhow::anyhow;
 use axum::response::Response;
 use bytes::Bytes;
 use llm_tokenizer::{
     chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
     stop::StopSequenceDecoderBuilder,
-    traits::Tokenizer,
+    traits::{Encoding, Tokenizer},
     StopSequenceDecoder,
 };
 use openai_protocol::{
@@ -78,6 +79,17 @@ pub(crate) fn resolve_tokenizer(
     ctx.state.tokenizer = Some(tokenizer.clone());
 
     Ok(tokenizer)
+}
+
+/// Tokenize on the blocking pool so CPU-bound `encode` does not stall async worker threads.
+pub(crate) async fn encode_blocking(
+    tokenizer: Arc<dyn Tokenizer>,
+    text: String,
+    add_special_tokens: bool,
+) -> anyhow::Result<Encoding> {
+    tokio::task::spawn_blocking(move || tokenizer.encode(&text, add_special_tokens))
+        .await
+        .map_err(|e| anyhow!("tokenization task failed: {e}"))?
 }
 
 /// Process tool call arguments in messages

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -10,9 +10,9 @@ pub(crate) mod tonic_ext;
 // Re-export all public items so consumer imports stay unchanged.
 pub use chat_utils::{create_stop_decoder, process_chat_messages};
 pub(crate) use chat_utils::{
-    filter_chat_request_by_tool_choice, filter_tools_by_tool_choice, generate_tool_call_id,
-    get_history_tool_calls_count, parse_finish_reason, parse_json_schema_response,
-    resolve_tokenizer, send_error_sse,
+    encode_blocking, filter_chat_request_by_tool_choice, filter_tools_by_tool_choice,
+    generate_tool_call_id, get_history_tool_calls_count, parse_finish_reason,
+    parse_json_schema_response, resolve_tokenizer, send_error_sse,
 };
 pub(crate) use logprobs::{
     convert_generate_input_logprobs, convert_generate_output_logprobs, convert_proto_logprobs,

--- a/model_gateway/src/routers/tokenize/handlers.rs
+++ b/model_gateway/src/routers/tokenize/handlers.rs
@@ -20,6 +20,7 @@ use tracing::{debug, error, warn};
 
 use crate::{
     app_context::AppContext,
+    routers::grpc::utils::encode_blocking,
     worker::UNKNOWN_MODEL_ID,
     workflow::{Job, TokenizerConfigRequest},
 };
@@ -98,7 +99,7 @@ pub async fn tokenize(registry: &Arc<TokenizerRegistry>, request: TokenizeReques
 
     for text in texts {
         // Don't add special tokens for tokenize API (matches Python behavior)
-        let encoding = match tokenizer.encode(text, false) {
+        let encoding = match encode_blocking(tokenizer.clone(), text.to_string(), false).await {
             Ok(enc) => enc,
             Err(e) => {
                 error!("Tokenization failed: {}", e);


### PR DESCRIPTION
## Description

### Problem

For gRPC workers the gateway tokenizes requests itself, and `tokenizer.encode(...)` ran INLINE on the tokio async worker threads. Tokenization is CPU-bound with no `.await` yield point, so a large prompt's `encode()` occupies an async worker thread for the full duration. Under load this starves request IO and the `/health` endpoint, because the async runtime cannot make progress on other tasks while a worker is pinned to tokenizing.

### Solution

Offload tokenization to the blocking pool with `tokio::task::spawn_blocking` so the async runtime stays responsive. A single shared helper, `encode_blocking`, is added next to `resolve_tokenizer` in `grpc/utils/chat_utils.rs`:

```rust
pub(crate) async fn encode_blocking(
    tokenizer: Arc<dyn Tokenizer>,
    text: String,
    add_special_tokens: bool,
) -> anyhow::Result<Encoding> {
    tokio::task::spawn_blocking(move || tokenizer.encode(&text, add_special_tokens))
        .await
        .map_err(|e| anyhow!("tokenization task failed: {e}"))?
}
```

The `tokenizer` is `Arc<dyn Tokenizer>` (`Send + Sync + 'static`) and is already held across `.await` in these stages, so cloning it into the closure is safe. `spawn_blocking` is the sanctioned offload primitive here (only the bare `tokio::task::spawn` is on the repo's disallowed-methods list).

Every gateway-side `encode` call site is routed through the helper. Tokenization behavior is unchanged — same inputs produce the same `Encoding` — and each site keeps its existing, distinct error mapping. No size threshold is added (kept intentionally simple).

The generate preparation stage required a small async lift: `prepare_generate`, `resolve_generate_input`, and `tokenize_single_text` become `async` so the offload `.await` can reach the call site, mirroring the already-async chat and messages stages. Two `#[expect(...)]` attributes on those methods (`clippy::result_large_err`, `clippy::unused_self`) were removed because making the methods `async` makes those lints no longer fire, so the expectations became unfulfilled.

## Changes

- `model_gateway/src/routers/grpc/utils/chat_utils.rs` — add `encode_blocking` helper; import `Encoding` and `anyhow::anyhow`.
- `model_gateway/src/routers/grpc/utils/mod.rs` — re-export `encode_blocking`.
- `model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs` — offload tokenization (add_special_tokens=false).
- `model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs` — offload tokenization (false).
- `model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs` — offload tokenization (false).
- `model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs` — offload tokenization (false); make the three private helpers `async`; drop two now-unfulfilled `#[expect]` attributes.
- `model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs` — offload tokenization (add_special_tokens=true).
- `model_gateway/src/routers/tokenize/handlers.rs` — offload `/v1/tokenize` per-text encode (false).

## Test Plan

### Scenario 1: workspace lint gate (clippy, warnings as errors)

```
$ RUSTC_WRAPPER="" cargo clippy --workspace --all-targets --all-features -- -D warnings
    Checking smg v1.5.0 (.../model_gateway)
    Checking smg-golang v1.5.0 (.../bindings/golang)
    Checking smg-python v1.5.0 (.../bindings/python)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 40s
```

Zero warnings/errors from the changed code. (The only stderr is pre-existing workspace `profiles`/`multiple build targets` notes present on a clean baseline.)

### Scenario 2: formatting

```
$ RUSTC_WRAPPER="" rustup run nightly cargo fmt --all
(no changes reported)
```

### Scenario 3: targeted unit tests

```
$ RUSTC_WRAPPER="" cargo test -p smg --lib routers::tokenize
running 1 test
test routers::tokenize::handlers::tests::test_get_tokenizer_empty_registry ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1054 filtered out; finished in 0.00s

$ RUSTC_WRAPPER="" cargo test -p smg --lib routers::grpc::regular::stages
running 7 tests
test routers::grpc::regular::stages::classify::response_processing::tests::test_argmax ... ok
test routers::grpc::regular::stages::classify::response_processing::tests::test_get_label_with_mapping ... ok
test routers::grpc::regular::stages::classify::response_processing::tests::test_get_label_without_mapping ... ok
test routers::grpc::regular::stages::classify::response_processing::tests::test_softmax_basic ... ok
test routers::grpc::regular::stages::classify::response_processing::tests::test_softmax_empty ... ok
test routers::grpc::regular::stages::classify::response_processing::tests::test_softmax_numerical_stability ... ok
test routers::grpc::regular::stages::classify::response_processing::tests::test_softmax_single ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1048 filtered out; finished in 0.00s

$ RUSTC_WRAPPER="" cargo test -p smg --lib routers::grpc::utils
running 16 tests
test routers::grpc::utils::chat_utils::tests::test_transform_messages_empty_text_parts ... ok
... (16 total) ...
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 1039 filtered out; finished in 0.00s
```

### A/B note

A clean throughput A/B (showing async-runtime responsiveness recovering under load) requires gateway-side tokenization — i.e. gRPC worker mode, or `cache_aware` routing with a real tokenizer loaded — which is a heavier setup (real model tokenizer + load generator). This PR is validated by build/clippy/tests; the throughput A/B is a follow-up.

Refs #1693

## Checklist

- [x] Code compiles without errors or warnings (`cargo clippy --workspace --all-targets --all-features -- -D warnings`)
- [x] Code is formatted (`cargo fmt --all`)
- [x] Relevant unit tests pass (`cargo test -p smg`)
- [x] No change to tokenization behavior (same inputs, same `Encoding`)
- [x] Commit is signed off (DCO)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal tokenization handling across chat, completion, embedding, and message processing stages to enhance system performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->