### PR TITLE
perf(runtime): make tokio worker-thread count configurable

### DIFF
--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+use clap::{builder::RangedU64ValueParser, ArgAction, Parser, Subcommand, ValueEnum};
 use rand::{distr::Alphanumeric, Rng};
 use smg::{
     config::{
@@ -20,6 +20,7 @@ use smg::{
 };
 use smg_auth::{ApiKeyEntry, ControlPlaneAuthConfig, JwtConfig, Role};
 use smg_mesh::MeshServerConfig;
+use tokio::runtime::{Builder, Runtime};
 fn parse_prefill_args() -> Vec<(String, Option<u16>)> {
     let args: Vec<String> = std::env::args().collect();
     let mut prefill_entries = Vec::new();
@@ -730,6 +731,18 @@ struct CliArgs {
     /// Defaults to `stun.l.google.com:19302`. Set to "none" to disable.
     #[arg(long, help_heading = "WebRTC")]
     webrtc_stun_server: Option<String>,
+
+    // ==================== Runtime ====================
+    /// Number of tokio worker threads. Falls back to `TOKIO_WORKER_THREADS`,
+    /// then tokio's default (number of CPU cores) when unset. Right-size this
+    /// to the core count for CPU-bound workloads to avoid scheduler thrash.
+    #[arg(long, help_heading = "Runtime", value_parser = RangedU64ValueParser::<usize>::new().range(1..))]
+    worker_threads: Option<usize>,
+
+    /// Maximum number of tokio blocking threads. Falls back to tokio's default
+    /// (512) when unset.
+    #[arg(long, help_heading = "Runtime", value_parser = RangedU64ValueParser::<usize>::new().range(1..))]
+    max_blocking_threads: Option<usize>,
 }
 
 enum OracleConnectSource {
@@ -1418,6 +1431,31 @@ impl CliArgs {
     }
 }
 
+/// Overrides `worker_threads` only when set (CLI flag, then `TOKIO_WORKER_THREADS`)
+/// so the unset default stays tokio's `num_cpus`; returns the effective count, if any.
+fn build_runtime(
+    worker_threads: Option<usize>,
+    max_blocking_threads: Option<usize>,
+) -> Result<(Runtime, Option<usize>), Box<dyn std::error::Error>> {
+    let worker_threads = worker_threads.or_else(|| {
+        std::env::var("TOKIO_WORKER_THREADS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+    });
+
+    let mut builder = Builder::new_multi_thread();
+    builder.enable_all();
+    if let Some(n) = worker_threads {
+        builder.worker_threads(n);
+    }
+    if let Some(n) = max_blocking_threads {
+        builder.max_blocking_threads(n);
+    }
+
+    Ok((builder.build()?, worker_threads))
+}
+
 #[expect(
     clippy::print_stdout,
     reason = "pre-logger startup output and version display"
@@ -1500,10 +1538,62 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     router_config.validate()?;
 
     let server_config = cli_args.to_server_config(router_config)?;
-    let runtime = tokio::runtime::Runtime::new()?;
+
+    let (runtime, worker_threads) =
+        build_runtime(cli_args.worker_threads, cli_args.max_blocking_threads)?;
+    match worker_threads {
+        Some(n) => println!("Tokio worker threads: {n}"),
+        None => {
+            let cpus = std::thread::available_parallelism()
+                .map_or_else(|_| "num_cpus".to_string(), |n| n.get().to_string());
+            println!("Tokio worker threads: {cpus} (default)");
+        }
+    }
     runtime.block_on(Box::pin(server::startup(server_config)))?;
     if is_otel_enabled() {
         shutdown_otel();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod runtime_tests {
+    use super::*;
+
+    #[test]
+    fn worker_threads_flag_parses() {
+        let cli = Cli::try_parse_from(["smg", "--worker-threads", "4"]).expect("valid flag");
+        assert_eq!(cli.router_args.worker_threads, Some(4));
+        assert_eq!(cli.router_args.max_blocking_threads, None);
+    }
+
+    #[test]
+    fn worker_threads_defaults_to_none() {
+        let cli = Cli::try_parse_from(["smg"]).expect("no flag");
+        assert_eq!(cli.router_args.worker_threads, None);
+    }
+
+    #[test]
+    fn worker_threads_rejects_zero() {
+        assert!(Cli::try_parse_from(["smg", "--worker-threads", "0"]).is_err());
+        assert!(Cli::try_parse_from(["smg", "--max-blocking-threads", "0"]).is_err());
+    }
+
+    #[test]
+    fn build_runtime_honors_explicit_count() {
+        let (runtime, effective) = build_runtime(Some(2), Some(8)).expect("runtime builds");
+        assert_eq!(effective, Some(2));
+        runtime.block_on(async {});
+    }
+
+    #[test]
+    fn build_runtime_unset_builds_usable_default() {
+        // No explicit count and no env override: tokio's default is in effect,
+        // so the reported effective count is None and the runtime still works.
+        if std::env::var_os("TOKIO_WORKER_THREADS").is_none() {
+            let (runtime, effective) = build_runtime(None, None).expect("runtime builds");
+            assert_eq!(effective, None);
+            runtime.block_on(async {});
+        }
+    }
 }


### PR DESCRIPTION
## Description

### Problem

The server built its tokio runtime with `tokio::runtime::Runtime::new()`, whose
worker-thread count defaults to `num_cpus` and is overridable only through the
`TOKIO_WORKER_THREADS` environment variable. There was no first-class, discoverable
way to size the runtime. For a workload that runs CPU-bound work on the async worker
threads, oversubscribing worker threads relative to physical cores (e.g. 32 worker
threads on a ~12-core box) increases scheduler thrash and scheduling latency rather
than throughput.

### Solution

Build the runtime with `tokio::runtime::Builder::new_multi_thread().enable_all()` and
add CLI flags to size it. The worker-thread count must be known before the runtime
exists, so the flags are read synchronously from the parsed `Cli` in `main()` (they
do not — and cannot — flow through the async `RouterConfig`). The default is
preserved: `worker_threads` is overridden only when the user provides a value (CLI
flag, falling back to `TOKIO_WORKER_THREADS`); when unset, tokio's `num_cpus` default
stands. The effective worker-thread count is logged at startup.

## Changes

- `model_gateway/src/main.rs`:
  - Replace `Runtime::new()` with a `build_runtime()` helper using
    `Builder::new_multi_thread().enable_all()`, applying `worker_threads` /
    `max_blocking_threads` only when set.
  - Add `--worker-threads` and `--max-blocking-threads` CLI flags under a new
    "Runtime" help heading. Both validate `>= 1` at the CLI boundary (a zero
    `worker_threads` would otherwise panic tokio).
  - Resolve `worker_threads` as CLI flag -> `TOKIO_WORKER_THREADS` -> tokio default,
    and log the effective count at startup.
  - Add `runtime_tests` covering flag parsing, the unset-default, zero rejection, and
    `build_runtime` behavior.

## Test Plan

Scenarios (all in `runtime_tests` in `model_gateway/src/main.rs`):

- `worker_threads_flag_parses` — `--worker-threads 4` parses to `Some(4)`; the
  parser downcasts to `usize` (regression guard: `value_parser = 1..` silently
  stores `i64` and panics on access).
- `worker_threads_defaults_to_none` — no flag leaves the field `None` (tokio default
  preserved).
- `worker_threads_rejects_zero` — `--worker-threads 0` and `--max-blocking-threads 0`
  are rejected by clap.
- `build_runtime_honors_explicit_count` — explicit count is applied and reported; the
  built runtime runs a task.
- `build_runtime_unset_builds_usable_default` — with no flag/env override the reported
  effective count is `None` and the runtime still runs a task.

```
$ cargo test -p smg --bin smg runtime_tests
running 5 tests
test runtime_tests::build_runtime_honors_explicit_count ... ok
test runtime_tests::worker_threads_defaults_to_none ... ok
test runtime_tests::worker_threads_flag_parses ... ok
test runtime_tests::worker_threads_rejects_zero ... ok
test runtime_tests::build_runtime_unset_builds_usable_default ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

```
$ cargo clippy --workspace --all-targets --all-features -- -D warnings
    Checking smg v1.5.0 (model_gateway)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 08s
```

```
$ rustup run nightly cargo fmt --all   # idempotent; re-run produces no diff
(no output)
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

Refs #1695


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--worker-threads` and `--max-blocking-threads` CLI flags for runtime performance tuning
  * Supports `TOKIO_WORKER_THREADS` environment variable fallback
  * Validates thread counts are positive integers
  * Displays effective worker thread count at startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->