### PR TITLE
revert(ci): use NVMe storage for H100 runner workspaces

### DIFF
--- a/scripts/k8s-runner-resources/README.md
+++ b/scripts/k8s-runner-resources/README.md
@@ -119,16 +119,6 @@ kubectl get pods -n actions-runner-system
 
 Each runner set should have a listener pod in `Running` state. Runner pods will be created on-demand when workflows target the corresponding `runs-on` label (matching `runnerScaleSetName` in each values file).
 
-## H100 Runner NVMe Storage
-
-The H100 runner scale-set values mount `/raid/actions-runner` from the host into each runner pod. Workspace, cache, temp, and Docker storage paths use `subPathExpr: $(POD_NAME)/...` so concurrent pods on the same node do not share mutable state.
-
-Because Kubernetes does not garbage collect `hostPath` contents when a pod is deleted, the H100 values also mount the parent NVMe path into the dind sidecar-style init container and use a `preStop` hook to remove `/runner-nvme/${POD_NAME:?}` during normal pod termination. This cleanup is best-effort; force deletion or node failure can still leave orphaned directories. Add host-level pruning if the cluster needs stronger cleanup guarantees.
-
-Do not copy this exact `/raid/actions-runner` setup to non-H100 runner values unless the target node pool has the same NVMe layout and enough free space. During Moirai validation, A10 nodes did not safely support this path.
-
-For the legacy `actions.summerwind.dev` `RunnerDeployment` controller, the generated dind lifecycle is controller-managed, so dind `preStop` hooks from the template may not survive into pods. Use the official GitHub ARC scale-set values above for this configuration, or validate any Summerwind-specific cleanup separately.
-
 ## Upgrading
 
 To update a runner set (e.g. after changing values):

--- a/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
@@ -46,16 +46,10 @@ template:
 
     volumes:
       - name: work
-        hostPath:
-          path: /raid/actions-runner
-          type: DirectoryOrCreate
+        emptyDir: {}
       - name: model-cache
         persistentVolumeClaim:
           claimName: model-cache
-      - name: runner-nvme
-        hostPath:
-          path: /raid/actions-runner
-          type: DirectoryOrCreate
       - name: dshm
         emptyDir:
           medium: Memory
@@ -65,9 +59,7 @@ template:
       - name: dind-externals
         emptyDir: {}
       - name: docker-storage
-        hostPath:
-          path: /raid/actions-runner
-          type: DirectoryOrCreate
+        emptyDir: {}
 
     containers:
       - name: runner
@@ -79,10 +71,6 @@ template:
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
         resources:
           requests:
             cpu: "8"
@@ -96,36 +84,12 @@ template:
             mountPath: /dev/shm
           - name: work
             mountPath: /home/runner/_work
-            subPathExpr: $(POD_NAME)/_work
-          - name: runner-nvme
-            mountPath: /home/runner/.cache
-            subPathExpr: $(POD_NAME)/.cache
-          - name: runner-nvme
-            mountPath: /tmp
-            subPathExpr: $(POD_NAME)/tmp
           - name: dind-sock
             mountPath: /var/run
           - name: docker-storage
             mountPath: /var/lib/docker
-            subPathExpr: $(POD_NAME)/docker
 
     initContainers:
-      - name: prepare-runner-nvme
-        image: fra.ocir.io/idqj093njucb/docker:dind
-        command:
-          - sh
-          - -c
-          - mkdir -p /runner-nvme/${POD_NAME}/_work /runner-nvme/${POD_NAME}/.cache /runner-nvme/${POD_NAME}/tmp /runner-nvme/${POD_NAME}/docker /models/.locks /models/hub /models/hub/.locks && chown -R 1001:1001 /runner-nvme/${POD_NAME} && chown 1001:1001 /models/.locks /models/hub /models/hub/.locks && chmod 1777 /runner-nvme/${POD_NAME}/tmp /models/.locks /models/hub/.locks
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-        volumeMounts:
-          - mountPath: /runner-nvme
-            name: runner-nvme
-          - mountPath: /models
-            name: model-cache
       - name: init-dind-externals
         args:
           - '-r'
@@ -145,21 +109,10 @@ template:
         env:
           - name: DOCKER_GROUP_GID
             value: '123'
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
         image: fra.ocir.io/idqj093njucb/docker:dind
         restartPolicy: Always
         securityContext:
           privileged: true
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - sh
-                - -c
-                - rm -rf -- "/runner-nvme/${POD_NAME:?}"
         startupProbe:
           exec:
             command:
@@ -169,15 +122,11 @@ template:
           initialDelaySeconds: 0
           periodSeconds: 5
         volumeMounts:
-          - mountPath: /runner-nvme
-            name: runner-nvme
           - mountPath: /home/runner/_work
             name: work
-            subPathExpr: $(POD_NAME)/_work
           - mountPath: /var/run
             name: dind-sock
           - mountPath: /home/runner/externals
             name: dind-externals
           - name: docker-storage
             mountPath: /var/lib/docker
-            subPathExpr: $(POD_NAME)/docker

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -46,16 +46,10 @@ template:
 
     volumes:
       - name: work
-        hostPath:
-          path: /raid/actions-runner
-          type: DirectoryOrCreate
+        emptyDir: {}
       - name: model-cache
         persistentVolumeClaim:
           claimName: model-cache
-      - name: runner-nvme
-        hostPath:
-          path: /raid/actions-runner
-          type: DirectoryOrCreate
       - name: dshm
         emptyDir:
           medium: Memory
@@ -65,9 +59,7 @@ template:
       - name: dind-externals
         emptyDir: {}
       - name: docker-storage
-        hostPath:
-          path: /raid/actions-runner
-          type: DirectoryOrCreate
+        emptyDir: {}
 
     containers:
       - name: runner
@@ -79,10 +71,6 @@ template:
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
         resources:
           requests:
             cpu: "16"
@@ -96,36 +84,12 @@ template:
             mountPath: /dev/shm
           - name: work
             mountPath: /home/runner/_work
-            subPathExpr: $(POD_NAME)/_work
-          - name: runner-nvme
-            mountPath: /home/runner/.cache
-            subPathExpr: $(POD_NAME)/.cache
-          - name: runner-nvme
-            mountPath: /tmp
-            subPathExpr: $(POD_NAME)/tmp
           - name: dind-sock
             mountPath: /var/run
           - name: docker-storage
             mountPath: /var/lib/docker
-            subPathExpr: $(POD_NAME)/docker
 
     initContainers:
-      - name: prepare-runner-nvme
-        image: fra.ocir.io/idqj093njucb/docker:dind
-        command:
-          - sh
-          - -c
-          - mkdir -p /runner-nvme/${POD_NAME}/_work /runner-nvme/${POD_NAME}/.cache /runner-nvme/${POD_NAME}/tmp /runner-nvme/${POD_NAME}/docker /models/.locks /models/hub /models/hub/.locks && chown -R 1001:1001 /runner-nvme/${POD_NAME} && chown 1001:1001 /models/.locks /models/hub /models/hub/.locks && chmod 1777 /runner-nvme/${POD_NAME}/tmp /models/.locks /models/hub/.locks
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-        volumeMounts:
-          - mountPath: /runner-nvme
-            name: runner-nvme
-          - mountPath: /models
-            name: model-cache
       - name: init-dind-externals
         args:
           - '-r'
@@ -145,21 +109,10 @@ template:
         env:
           - name: DOCKER_GROUP_GID
             value: '123'
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
         image: fra.ocir.io/idqj093njucb/docker:dind
         restartPolicy: Always
         securityContext:
           privileged: true
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - sh
-                - -c
-                - rm -rf -- "/runner-nvme/${POD_NAME:?}"
         startupProbe:
           exec:
             command:
@@ -169,15 +122,11 @@ template:
           initialDelaySeconds: 0
           periodSeconds: 5
         volumeMounts:
-          - mountPath: /runner-nvme
-            name: runner-nvme
           - mountPath: /home/runner/_work
             name: work
-            subPathExpr: $(POD_NAME)/_work
           - mountPath: /var/run
             name: dind-sock
           - mountPath: /home/runner/externals
             name: dind-externals
           - name: docker-storage
             mountPath: /var/lib/docker
-            subPathExpr: $(POD_NAME)/docker

--- a/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
@@ -45,16 +45,10 @@ template:
 
     volumes:
       - name: work
-        hostPath:
-          path: /raid/actions-runner
-          type: DirectoryOrCreate
+        emptyDir: {}
       - name: model-cache
         persistentVolumeClaim:
           claimName: model-cache
-      - name: runner-nvme
-        hostPath:
-          path: /raid/actions-runner
-          type: DirectoryOrCreate
       - name: dshm
         emptyDir:
           medium: Memory
@@ -64,9 +58,7 @@ template:
       - name: dind-externals
         emptyDir: {}
       - name: docker-storage
-        hostPath:
-          path: /raid/actions-runner
-          type: DirectoryOrCreate
+        emptyDir: {}
 
     containers:
       - name: runner
@@ -78,10 +70,6 @@ template:
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
         resources:
           requests:
             cpu: "32"
@@ -95,36 +83,12 @@ template:
             mountPath: /dev/shm
           - name: work
             mountPath: /home/runner/_work
-            subPathExpr: $(POD_NAME)/_work
-          - name: runner-nvme
-            mountPath: /home/runner/.cache
-            subPathExpr: $(POD_NAME)/.cache
-          - name: runner-nvme
-            mountPath: /tmp
-            subPathExpr: $(POD_NAME)/tmp
           - name: dind-sock
             mountPath: /var/run
           - name: docker-storage
             mountPath: /var/lib/docker
-            subPathExpr: $(POD_NAME)/docker
 
     initContainers:
-      - name: prepare-runner-nvme
-        image: fra.ocir.io/idqj093njucb/docker:dind
-        command:
-          - sh
-          - -c
-          - mkdir -p /runner-nvme/${POD_NAME}/_work /runner-nvme/${POD_NAME}/.cache /runner-nvme/${POD_NAME}/tmp /runner-nvme/${POD_NAME}/docker /models/.locks /models/hub /models/hub/.locks && chown -R 1001:1001 /runner-nvme/${POD_NAME} && chown 1001:1001 /models/.locks /models/hub /models/hub/.locks && chmod 1777 /runner-nvme/${POD_NAME}/tmp /models/.locks /models/hub/.locks
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-        volumeMounts:
-          - mountPath: /runner-nvme
-            name: runner-nvme
-          - mountPath: /models
-            name: model-cache
       - name: init-dind-externals
         args:
           - '-r'
@@ -144,21 +108,10 @@ template:
         env:
           - name: DOCKER_GROUP_GID
             value: '123'
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
         image: fra.ocir.io/idqj093njucb/docker:dind
         restartPolicy: Always
         securityContext:
           privileged: true
-        lifecycle:
-          preStop:
-            exec:
-              command:
-                - sh
-                - -c
-                - rm -rf -- "/runner-nvme/${POD_NAME:?}"
         startupProbe:
           exec:
             command:
@@ -168,15 +121,11 @@ template:
           initialDelaySeconds: 0
           periodSeconds: 5
         volumeMounts:
-          - mountPath: /runner-nvme
-            name: runner-nvme
           - mountPath: /home/runner/_work
             name: work
-            subPathExpr: $(POD_NAME)/_work
           - mountPath: /var/run
             name: dind-sock
           - mountPath: /home/runner/externals
             name: dind-externals
           - name: docker-storage
             mountPath: /var/lib/docker
-            subPathExpr: $(POD_NAME)/docker


### PR DESCRIPTION
Reverts lightseekorg/smg#1627 since the boot volume extends from 100GB and 360GB which have enough runner space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed obsolete H100 NVMe storage guidance from the Kubernetes runner docs.

* **Chores**
  * Simplified GPU H100 runner storage and Docker wiring: moved to in-pod ephemeral storage, removed per-pod subpath mounts and lifecycle cleanup steps, and streamlined container mounts and env settings across runner configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->