### PR TITLE
fix(ci): fix 2-gpu runner for RDMA

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -660,7 +660,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "2"
-      runner: 2-gpu-h100-test
+      runner: 2-gpu-h100
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/router
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -660,7 +660,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "2"
-      runner: 2-gpu-h100
+      runner: 2-gpu-h100-test
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/router
       vllm_kv_backend: ${{ matrix.kv_backend || 'nixl' }}

--- a/scripts/k8s-runner-resources/arc-runner-autoscaler.yaml
+++ b/scripts/k8s-runner-resources/arc-runner-autoscaler.yaml
@@ -80,8 +80,8 @@ spec:
     kind: RunnerDeployment
     name: arc-runner-2-gpu-h100
 
-  minReplicas: 2
-  maxReplicas: 10
+  minReplicas: 0
+  maxReplicas: 0
 
   metrics:
     - type: TotalNumberOfQueuedAndInProgressWorkflowRuns

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -6,11 +6,11 @@ githubConfigUrl: "https://github.com/lightseekorg/smg"
 githubConfigSecret: github-arc-secret
 
 ## Runner scaling configuration
-minRunners: 0
-maxRunners: 6
+minRunners: 1
+maxRunners: 1
 
 ## name of the runner scale set to create.  Defaults to the helm release name
-runnerScaleSetName: "2-gpu-h100"
+runnerScaleSetName: "2-gpu-h100-test"
 
 resourceMeta: {}
 keyVault: {}
@@ -19,6 +19,14 @@ keyVault: {}
 template:
   spec:
     terminationGracePeriodSeconds: 600
+
+    # hostNetwork puts the runner in the host netns so PD disaggregation KV
+    # transfer (NIXL/Mooncake) sees the host's populated RoCE GID tables. An
+    # overlay-CNI pod sees the mlx5 NICs as PORT_ACTIVE but with an empty GID
+    # table, so RDMA init dies at worker startup. ClusterFirstWithHostNet keeps
+    # cluster DNS working while on the host network.
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
 
     nodeSelector:
       nvidia.com/gpu: "true"
@@ -30,8 +38,11 @@ template:
         value: "true"
         effect: "NoSchedule"
 
+    # With hostNetwork the pod shares the host port space, so spread 2-gpu PD
+    # runners one-per-node to avoid host-port collisions between concurrent PD
+    # jobs (replaces the previous GPU bin-packing podAffinity).
     affinity:
-      podAffinity:
+      podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
@@ -40,8 +51,7 @@ template:
                   - key: actions.github.com/scale-set-name
                     operator: In
                     values:
-                      - 1-gpu-h100
-                      - 2-gpu-h100
+                      - 2-gpu-h100-test
               topologyKey: kubernetes.io/hostname
 
     volumes:
@@ -63,18 +73,49 @@ template:
 
     containers:
       - name: runner
-        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.2
+        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.3
         command:
           - /home/runner/run.sh
+        securityContext:
+          capabilities:
+            # RDMA verbs pin and register memory for queue pairs; without
+            # IPC_LOCK registration fails even though the GID table resolves.
+            add: ["IPC_LOCK"]
         env:
           - name: DOCKER_HOST
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
+          - name: HF_HOME
+            value: /models
+          - name: HF_TOKEN  # required: ci_download_model.sh runs `hf download` for the gated Llama model
+            valueFrom:
+              secretKeyRef:
+                key: HUGGINGFACE_API_KEY
+                name: huggingface-secret
+          - name: OPENAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: OPENAI_API_KEY
+                name: openai-api-key
+          - name: ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: ANTHROPIC_API_KEY
+                name: anthropic-api-key
+          - name: XAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: XAI_API_KEY
+                name: xai-api-key
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
         resources:
           requests:
-            cpu: "16"
-            memory: "64Gi"
+            cpu: '32'
+            memory: 128Gi
           limits:
             nvidia.com/gpu: 2
         volumeMounts:
@@ -97,7 +138,7 @@ template:
           - /home/runner/tmpDir/
         command:
           - cp
-        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.2
+        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.3
         volumeMounts:
           - mountPath: /home/runner/tmpDir
             name: dind-externals
@@ -109,10 +150,22 @@ template:
         env:
           - name: DOCKER_GROUP_GID
             value: '123'
+          # Suppress dind's default TLS TCP listener (:2376). dockerd only needs
+          # the unix socket here; under hostNetwork a TCP listener would bind a
+          # node port unnecessarily.
+          - name: DOCKER_TLS_CERTDIR
+            value: ""
         image: fra.ocir.io/idqj093njucb/docker:dind
         restartPolicy: Always
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: '2'
+            memory: 4Gi
+          requests:
+            cpu: '1'
+            memory: 2Gi
         startupProbe:
           exec:
             command:

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -6,11 +6,11 @@ githubConfigUrl: "https://github.com/lightseekorg/smg"
 githubConfigSecret: github-arc-secret
 
 ## Runner scaling configuration
-minRunners: 1
-maxRunners: 1
+minRunners: 2
+maxRunners: 8
 
 ## name of the runner scale set to create.  Defaults to the helm release name
-runnerScaleSetName: "2-gpu-h100-test"
+runnerScaleSetName: "2-gpu-h100"
 
 resourceMeta: {}
 keyVault: {}
@@ -51,7 +51,7 @@ template:
                   - key: actions.github.com/scale-set-name
                     operator: In
                     values:
-                      - 2-gpu-h100-test
+                      - 2-gpu-h100
               topologyKey: kubernetes.io/hostname
 
     volumes:

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -77,10 +77,12 @@ template:
         command:
           - /home/runner/run.sh
         securityContext:
-          capabilities:
-            # RDMA verbs pin and register memory for queue pairs; without
-            # IPC_LOCK registration fails even though the GID table resolves.
-            add: ["IPC_LOCK"]
+          # The runner runs as non-root (uid 1001), so capabilities.add:
+          # [IPC_LOCK] only reaches the bounding set (not effective) and the
+          # default 64KiB RLIMIT_MEMLOCK blocks RDMA completion-queue
+          # allocation (ibv_create_cq -> ENOMEM, e.g. sglang/Mooncake).
+          # privileged makes IPC_LOCK effective and lifts the memlock cap.
+          privileged: true
         env:
           - name: DOCKER_HOST
             value: unix:///var/run/docker.sock


### PR DESCRIPTION
## Description

### Problem

PD KV transfer (NIXL for vLLM, Mooncake for sglang) moves the KV cache over RDMA on the host mlx5 NICs. On the legacy runners the pod ran in an overlay-CNI network namespace, where the shared host NICs show PORT_ACTIVE but expose
  an all-zero GID table inside the pod — so RDMA init died at worker startup (Failed to query GID … No data available, UCX Address not valid). The summerwind RunnerDeployment CRD can't express hostNetwork, so the fix required
  migrating this tier to the gha-runner-scale-set, whose template.spec is a full PodSpec.

### Solution

Moves the 2-gpu-h100 runner — the only tier that runs PD disaggregation e2e tests — from the legacy summerwind RunnerDeployment to the GitHub gha-runner-scale-set, configured so PD KV transfer works over real RoCE RDMA. This fixes
  the frequent e2e-2gpu-pd flakiness.

## Changes

  - hostNetwork: true + dnsPolicy: ClusterFirstWithHostNet — pod runs in the host netns where the RoCE GID tables are populated.
  - privileged runner container — the runner runs as non-root (uid 1001), so capabilities.add: [IPC_LOCK] only reaches the bounding set (not effective), and the default 64 KiB RLIMIT_MEMLOCK blocks RDMA completion-queue allocation
  (ibv_create_cq → ENOMEM, hit by sglang/Mooncake). privileged makes IPC_LOCK effective and lifts the memlock cap. TODO: replace with node containerd default_ulimits memlock=-1 and drop privileged.
  - podAntiAffinity (one PD runner per node) — hostNetwork shares the host port space.
  - Env parity with the legacy runner — HF_HOME/HF_TOKEN (gated Llama download), OPENAI/ANTHROPIC/XAI_API_KEY, NODE_IP; resources cpu 32 / mem 128Gi.
  - dind DOCKER_TLS_CERTDIR="" — keeps dockerd on the unix socket (no stray :2376 host listener under hostNetwork).
  - Runner image v0.0.2 → v0.0.3 (actions/runner 2.335.1; 2.332.0 is deprecated and rejected by GitHub with a 403, causing a runner recreate loop).
  - minRunners: 2 / maxRunners: 8.

## Test Plan

Run 27438486706: all three e2e-2gpu-pd variants pass over real RDMA — vllm (NIXL), vllm-mooncake, and sglang (Mooncake). (The run's other failures — unit-tests, openai-responses — are unrelated pre-existing flakes.)

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled GPU runner autoscaler for the H100 deployment
  * Increased CPU and memory allocations for runner containers
  * Bumped runner and init images to v0.0.3
  * Enabled host networking and improved pod scheduling to avoid host-port conflicts
  * Added management of API credentials for runner environments and adjusted sidecar runtime settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->