### PR TITLE
perf(tokenizer): share L1 prefix on hit and fuse miss-path tokenization

### DIFF
--- a/crates/tokenizer/src/cache/l1.rs
+++ b/crates/tokenizer/src/cache/l1.rs
@@ -30,10 +30,28 @@ use std::{
 use blake3;
 use dashmap::DashMap;
 
-use crate::traits::TokenIdType;
+use crate::traits::{Encoder, Encoding, TokenIdType};
 
 /// Hash type for cache keys
 type Blake3Hash = [u8; 32];
+
+/// `(boundary byte offset, blake3 digest of add_special_tokens || input[..boundary])`
+/// pairs computed while scanning an input — produced once per lookup and reusable by
+/// the insert side, so a miss neither re-scans for boundaries nor re-hashes prefixes.
+pub(super) type PrefixSeeds = Vec<(usize, Blake3Hash)>;
+
+/// Outcome of [`L1Cache::lookup_with_seeds`].
+pub(super) enum PrefixLookup {
+    /// Longest cached prefix: the shared token allocation plus the byte length of the
+    /// matched prefix. The tokens are returned as `Arc<[TokenIdType]>` so a hit does
+    /// not copy the (large) cached prefix; the caller splices the suffix into an
+    /// exact-capacity buffer.
+    Hit(Arc<[TokenIdType]>, usize),
+    /// No cached prefix. Carries the `(boundary, digest)` pairs the failed search
+    /// computed (empty when the input has no special-token boundaries) so the miss
+    /// path can seed entries without recomputing them.
+    Miss(PrefixSeeds),
+}
 
 /// Number of shards for concurrent access
 const NUM_SHARDS: usize = 16;
@@ -124,40 +142,70 @@ impl L1Cache {
         }
     }
 
+    /// Compute the `(boundary, digest)` seed list for `input`: the blake3 digest of
+    /// `add_special_tokens || input[..boundary]` at every special token boundary,
+    /// built with one incremental O(N) hashing pass.
+    ///
+    /// Seeding with `add_special_tokens` maps prefixes tokenized with/without a
+    /// leading BOS to distinct keys (the first segment honors this flag).
+    fn boundary_seeds(
+        input: &str,
+        special_tokens: &[&str],
+        add_special_tokens: bool,
+    ) -> PrefixSeeds {
+        let boundaries = find_special_token_boundaries(input, special_tokens);
+
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&[add_special_tokens as u8]);
+        let mut seeds = Vec::with_capacity(boundaries.len());
+        let mut last_pos = 0;
+        let bytes = input.as_bytes();
+        for &boundary_pos in &boundaries {
+            hasher.update(&bytes[last_pos..boundary_pos]);
+            // `finalize(&self)` borrows — no need to clone the hasher to keep updating it.
+            seeds.push((boundary_pos, *hasher.finalize().as_bytes()));
+            last_pos = boundary_pos;
+        }
+        seeds
+    }
+
     /// Try to find the longest prefix match at special token boundaries
     /// Returns (cached_tokens, byte_offset) if found
     ///
     /// Uses pre-computed tokens cached during insertion.
-    /// Returns Vec<TokenIdType> as the caller needs to extend it with suffix tokens.
+    /// Returns the shared `Arc<[TokenIdType]>` directly — the caller splices suffix
+    /// tokens into an exact-capacity buffer instead of cloning the cached prefix.
     pub fn longest_prefix_match(
         &self,
         input: &str,
         special_tokens: &[&str],
         add_special_tokens: bool,
-    ) -> Option<(Vec<TokenIdType>, usize)> {
-        let boundaries = find_special_token_boundaries(input, special_tokens);
-
-        if boundaries.is_empty() {
-            self.misses.fetch_add(1, Ordering::Relaxed);
-            return None;
+    ) -> Option<(Arc<[TokenIdType]>, usize)> {
+        match self.lookup_with_seeds(input, special_tokens, add_special_tokens) {
+            PrefixLookup::Hit(tokens, boundary_pos) => Some((tokens, boundary_pos)),
+            PrefixLookup::Miss(_) => None,
         }
+    }
 
-        // Build all prefix hashes incrementally O(N).
-        // Seed with add_special_tokens so prefixes tokenized with/without a
-        // leading BOS map to distinct keys (the first segment honors this flag).
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(&[add_special_tokens as u8]);
-        let mut prefix_hashes = Vec::with_capacity(boundaries.len());
-        let mut last_pos = 0;
-        let bytes = input.as_bytes();
-        for &boundary_pos in &boundaries {
-            hasher.update(&bytes[last_pos..boundary_pos]);
-            prefix_hashes.push((boundary_pos, *hasher.clone().finalize().as_bytes()));
-            last_pos = boundary_pos;
+    /// Like [`Self::longest_prefix_match`], but on a miss hands back the
+    /// `(boundary, digest)` pairs computed during the failed search so the caller can
+    /// seed entries via [`Self::populate_with_seeds`] without re-scanning the input
+    /// for boundaries or re-hashing the prefixes.
+    pub(super) fn lookup_with_seeds(
+        &self,
+        input: &str,
+        special_tokens: &[&str],
+        add_special_tokens: bool,
+    ) -> PrefixLookup {
+        let seeds = Self::boundary_seeds(input, special_tokens, add_special_tokens);
+
+        if seeds.is_empty() {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            return PrefixLookup::Miss(seeds);
         }
 
         // Search from the longest boundary to find the best match
-        for (boundary_pos, hash_bytes) in prefix_hashes.into_iter().rev() {
+        for &(boundary_pos, hash_bytes) in seeds.iter().rev() {
             let shard_idx = hash_bytes[0] as usize % NUM_SHARDS;
 
             if let Some(entry) = self.shards[shard_idx].get(&hash_bytes) {
@@ -166,13 +214,13 @@ impl L1Cache {
                 entry.last_accessed.store(timestamp, Ordering::Relaxed);
 
                 self.hits.fetch_add(1, Ordering::Relaxed);
-                // Convert Arc<[T]> to Vec<T> - caller will extend with suffix tokens
-                return Some((entry.tokens.to_vec(), boundary_pos));
+                // Share the cached allocation instead of copying it on every hit.
+                return PrefixLookup::Hit(Arc::clone(&entry.tokens), boundary_pos);
             }
         }
 
         self.misses.fetch_add(1, Ordering::Relaxed);
-        None
+        PrefixLookup::Miss(seeds)
     }
 
     /// Insert prefix entries at ALL special token boundaries
@@ -180,38 +228,97 @@ impl L1Cache {
     /// Uses incremental hashing and tokenization for O(N) performance.
     ///
     /// Optimized for workloads with high prefix reuse (e.g., chat templates with repeated system prompts).
-    pub fn insert_at_boundaries<E: super::super::traits::Encoder + ?Sized>(
+    ///
+    /// The miss path of [`super::CachedTokenizer`] uses [`Self::populate_with_seeds`]
+    /// instead, which reuses this same per-segment work to *also* return the full
+    /// encoding — avoiding a redundant second tokenization of the input.
+    pub fn insert_at_boundaries<E: Encoder + ?Sized>(
         &self,
         input: &str,
         tokenizer: &E,
         special_tokens: &[&str],
         add_special_tokens: bool,
     ) -> anyhow::Result<()> {
-        let boundaries = find_special_token_boundaries(input, special_tokens);
+        let seeds = Self::boundary_seeds(input, special_tokens, add_special_tokens);
 
-        if boundaries.is_empty() {
+        if seeds.is_empty() {
             return Ok(());
         }
 
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(&[add_special_tokens as u8]);
+        self.populate_boundaries(input, &seeds, tokenizer, add_special_tokens)?;
+        Ok(())
+    }
+
+    /// Miss-path encode: tokenize `input` exactly once, caching the cumulative prefix
+    /// at every special token boundary as we go, and return the assembled encoding.
+    /// This replaces a separate full `encode` + [`Self::insert_at_boundaries`], which
+    /// together tokenized the input ~twice (once whole for the result, once again
+    /// split across the boundary segments).
+    ///
+    /// The concatenation of the per-segment encodes equals an uncached
+    /// `encode(input, add_special_tokens)` because special tokens are atomic in BPE —
+    /// the same invariant the hit path's prefix + suffix splice relies on.
+    pub fn populate_and_encode<E: Encoder + ?Sized>(
+        &self,
+        input: &str,
+        tokenizer: &E,
+        special_tokens: &[&str],
+        add_special_tokens: bool,
+    ) -> anyhow::Result<Encoding> {
+        let seeds = Self::boundary_seeds(input, special_tokens, add_special_tokens);
+        self.populate_with_seeds(input, &seeds, tokenizer, add_special_tokens)
+    }
+
+    /// Like [`Self::populate_and_encode`], but reuses the `(boundary, digest)` seed
+    /// list a failed [`Self::lookup_with_seeds`] already computed, so the miss path
+    /// neither re-scans for boundaries nor re-hashes the prefixes it just hashed.
+    pub(super) fn populate_with_seeds<E: Encoder + ?Sized>(
+        &self,
+        input: &str,
+        seeds: &[(usize, Blake3Hash)],
+        tokenizer: &E,
+        add_special_tokens: bool,
+    ) -> anyhow::Result<Encoding> {
+        let Some(&(tail_start, _)) = seeds.last() else {
+            // No special token boundaries — nothing cacheable; a single plain encode
+            // (preserves the inner tokenizer's native encoding variant).
+            return tokenizer.encode(input, add_special_tokens);
+        };
+
+        // Tokenize + cache every boundary prefix; `running` covers input[0..last boundary].
+        let mut running = self.populate_boundaries(input, seeds, tokenizer, add_special_tokens)?;
+
+        // The trailing segment after the last boundary is not a cache key (boundaries
+        // exclude input.len()); encoding it completes the full tokenization. It is
+        // never segment 0, so special tokens are never re-added here.
+        let tail = tokenizer.encode(&input[tail_start..], false)?;
+        running.extend_from_slice(tail.token_ids());
+        Ok(Encoding::Plain(running))
+    }
+
+    /// Shared core of the insert and fused-miss paths: walk the precomputed `seeds`
+    /// (`(boundary, digest)` pairs), tokenizing each inter-boundary segment exactly
+    /// once, cache the cumulative prefix at each boundary, and return the running
+    /// token vector (covering `input[0..last boundary]`).
+    fn populate_boundaries<E: Encoder + ?Sized>(
+        &self,
+        input: &str,
+        seeds: &[(usize, Blake3Hash)],
+        tokenizer: &E,
+        add_special_tokens: bool,
+    ) -> anyhow::Result<Vec<TokenIdType>> {
         let mut running_tokens = Vec::new();
         let mut last_pos = 0;
-        let mut entries_to_insert = Vec::with_capacity(boundaries.len());
-        let bytes = input.as_bytes();
-        for (i, &boundary_pos) in boundaries.iter().enumerate() {
+        let mut entries_to_insert = Vec::with_capacity(seeds.len());
+        for (i, &(boundary_pos, hash_bytes)) in seeds.iter().enumerate() {
             let delta_text = &input[last_pos..boundary_pos];
 
-            // 1. Incremental Hash update
-            hasher.update(&bytes[last_pos..boundary_pos]);
-            let hash_bytes: Blake3Hash = *hasher.clone().finalize().as_bytes();
-
-            // 2. Incremental Tokenization
+            // 1. Incremental Tokenization
             // Only add special tokens (like BOS) for the very first segment to avoid duplicates
             let segment_encoding = tokenizer.encode(delta_text, (i == 0) && add_special_tokens)?;
             running_tokens.extend_from_slice(segment_encoding.token_ids());
 
-            // 3. Prepare entry
+            // 2. Prepare entry
             // Convert current tokens to Arc<[TokenIdType]> for sharing
             let prefix_tokens: Arc<[TokenIdType]> = running_tokens.as_slice().into();
 
@@ -224,7 +331,7 @@ impl L1Cache {
         }
 
         if entries_to_insert.is_empty() {
-            return Ok(());
+            return Ok(running_tokens);
         }
 
         let total_size_needed: usize = entries_to_insert.iter().map(|(_, _, size)| size).sum();
@@ -267,7 +374,7 @@ impl L1Cache {
             }
         }
 
-        Ok(())
+        Ok(running_tokens)
     }
 
     /// Evict least recently used entries using approximate LRU via random sampling
@@ -687,5 +794,72 @@ mod tests {
         assert!(cache
             .longest_prefix_match(input, special_tokens, false)
             .is_none());
+    }
+
+    #[test]
+    fn test_hit_returns_shared_prefix_allocation() {
+        use std::sync::Arc;
+
+        let cache = L1Cache::new(1024 * 1024);
+        let special_tokens = &["<|im_start|>", "<|im_end|>"];
+        let tokenizer = MockTokenizer::new();
+
+        let input = "<|im_start|>system\nYou are a helpful assistant.<|im_end|><|im_start|>user\nWhat is 2+2?<|im_end|>";
+        cache
+            .insert_at_boundaries(input, &tokenizer, special_tokens, false)
+            .unwrap();
+
+        let (first, first_offset) = cache
+            .longest_prefix_match(input, special_tokens, false)
+            .expect("hit after insert");
+        let (second, second_offset) = cache
+            .longest_prefix_match(input, special_tokens, false)
+            .expect("hit after insert");
+
+        assert_eq!(first_offset, second_offset);
+        // The hit path must hand back the cached allocation itself (shared
+        // ownership) — not a fresh per-hit copy of the prefix tokens.
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "longest_prefix_match must return the shared cached Arc, not a clone of its contents"
+        );
+    }
+
+    #[test]
+    fn test_populate_and_encode_matches_uncached_and_seeds_cache() {
+        let special_tokens = &["<|im_start|>", "<|im_end|>"];
+        let tokenizer = BosTokenizer;
+        let input = "<|im_start|>system\nhi<|im_end|><|im_start|>user\nquery<|im_end|>";
+
+        for add_special_tokens in [false, true] {
+            let cache = L1Cache::new(1024 * 1024);
+
+            // The fused miss path must return ids byte-exact to an uncached encode.
+            let assembled = cache
+                .populate_and_encode(input, &tokenizer, special_tokens, add_special_tokens)
+                .unwrap();
+            let plain = tokenizer.encode(input, add_special_tokens).unwrap();
+            assert_eq!(
+                assembled.token_ids(),
+                plain.token_ids(),
+                "fused miss encode must equal uncached encode (add_special_tokens={add_special_tokens})"
+            );
+
+            // It must also seed the cache, keyed on the same add_special_tokens flag.
+            assert!(
+                !cache.is_empty(),
+                "miss path must populate boundary entries"
+            );
+            let (_, offset) = cache
+                .longest_prefix_match(input, special_tokens, add_special_tokens)
+                .expect("hit after populate");
+            assert!(offset > 0);
+            assert!(
+                cache
+                    .longest_prefix_match(input, special_tokens, !add_special_tokens)
+                    .is_none(),
+                "opposite flag must not collide with populated entries"
+            );
+        }
     }
 }

--- a/crates/tokenizer/src/cache/mod.rs
+++ b/crates/tokenizer/src/cache/mod.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use anyhow::Result;
 pub use fingerprint::TokenizerFingerprint;
 pub use l0::{CacheStats, L0Cache};
+use l1::PrefixLookup;
 pub use l1::{L1Cache, L1CacheStats};
 use rayon::prelude::*;
 
@@ -171,7 +172,11 @@ impl Encoder for CachedTokenizer {
             }
         }
 
-        // L1 cache lookup (prefix match at special token boundaries)
+        // L1 path (prefix match at special token boundaries): a hit splices the
+        // shared cached prefix with a fresh suffix encode; a miss tokenizes the
+        // input exactly once, seeding every boundary entry along the way — no full
+        // encode followed by a per-boundary re-tokenize, and no re-hash of the
+        // prefixes the failed lookup already hashed.
         if let Some(l1) = &self.l1 {
             let tokens: Vec<&str> = self
                 .special_token_strings
@@ -179,50 +184,60 @@ impl Encoder for CachedTokenizer {
                 .map(|s| s.as_str())
                 .collect();
 
-            if let Some((prefix_tokens, prefix_len)) =
-                l1.longest_prefix_match(input, &tokens, add_special_tokens)
-            {
-                let suffix = &input[prefix_len..];
-                if !suffix.is_empty() {
+            let encoding = match l1.lookup_with_seeds(input, &tokens, add_special_tokens) {
+                PrefixLookup::Hit(prefix_tokens, prefix_len) if prefix_len < input.len() => {
+                    let suffix = &input[prefix_len..];
                     // The cached prefix already carries any leading special tokens,
                     // so the suffix must never re-add them (it is never segment 0).
                     let suffix_encoding = self.inner.encode(suffix, false)?;
+                    let suffix_tokens = suffix_encoding.token_ids();
 
-                    let mut merged_tokens = prefix_tokens;
-                    merged_tokens.extend_from_slice(suffix_encoding.token_ids());
-
-                    let merged_encoding = Encoding::Plain(merged_tokens);
-
-                    if let Some(l0) = &self.l0 {
-                        l0.insert(
-                            input.to_string(),
-                            add_special_tokens,
-                            merged_encoding.clone(),
-                        );
-                    }
-
-                    return Ok(merged_encoding);
+                    // Splice with exact capacity: one allocation and a single copy of
+                    // the shared prefix — no `to_vec` clone plus grow-realloc re-copy
+                    // of the (large) cached prefix on every hit.
+                    let mut merged_tokens =
+                        Vec::with_capacity(prefix_tokens.len() + suffix_tokens.len());
+                    merged_tokens.extend_from_slice(&prefix_tokens);
+                    merged_tokens.extend_from_slice(suffix_tokens);
+                    Encoding::Plain(merged_tokens)
                 }
+                // Defensive: boundaries always exclude input.len(), so a full-input
+                // match cannot occur; if it ever did, the entry is keyed on the whole
+                // input and the cached tokens ARE the full encoding.
+                PrefixLookup::Hit(prefix_tokens, _) => Encoding::Plain(prefix_tokens.to_vec()),
+                // No special token boundaries — nothing cacheable; single plain encode
+                // (preserves the inner tokenizer's native encoding variant).
+                PrefixLookup::Miss(seeds) if seeds.is_empty() => {
+                    self.inner.encode(input, add_special_tokens)?
+                }
+                PrefixLookup::Miss(seeds) => {
+                    match l1.populate_with_seeds(
+                        input,
+                        &seeds,
+                        self.inner.as_ref(),
+                        add_special_tokens,
+                    ) {
+                        Ok(encoding) => encoding,
+                        // Seeding failed mid-segment (nothing was inserted) — fall
+                        // back to the plain uncached encode, matching the previous
+                        // behavior where boundary-insert errors were swallowed.
+                        Err(_) => self.inner.encode(input, add_special_tokens)?,
+                    }
+                }
+            };
+
+            if let Some(l0) = &self.l0 {
+                l0.insert(input.to_string(), add_special_tokens, encoding.clone());
             }
+
+            return Ok(encoding);
         }
 
-        // Full tokenization (both L0 and L1 miss)
+        // Full tokenization (no L1 configured), cached in L0 only
         let encoding = self.inner.encode(input, add_special_tokens)?;
 
-        // Cache in L0
         if let Some(l0) = &self.l0 {
             l0.insert(input.to_string(), add_special_tokens, encoding.clone());
-        }
-
-        // Cache in L1 at special token boundaries
-        if let Some(l1) = &self.l1 {
-            let tokens: Vec<&str> = self
-                .special_token_strings
-                .iter()
-                .map(|s| s.as_str())
-                .collect();
-            let _ =
-                l1.insert_at_boundaries(input, self.inner.as_ref(), &tokens, add_special_tokens);
         }
 
         Ok(encoding)
@@ -296,6 +311,8 @@ impl Tokenizer for CachedTokenizer {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use crate::{mock::MockTokenizer, *};
 
     /// Tokenizer that prepends a sentinel BOS when `add_special_tokens` is set,
@@ -360,6 +377,163 @@ mod tests {
         }
         fn as_any(&self) -> &dyn std::any::Any {
             self
+        }
+    }
+
+    /// Wraps [`BosTokenizer`], counting `encode` invocations and the total bytes
+    /// of text tokenized, so tests can assert how much tokenizer work each cache
+    /// path actually performs.
+    struct CountingTokenizer {
+        inner: BosTokenizer,
+        encode_calls: AtomicUsize,
+        bytes_encoded: AtomicUsize,
+    }
+
+    impl CountingTokenizer {
+        fn new() -> Self {
+            Self {
+                inner: BosTokenizer::new(),
+                encode_calls: AtomicUsize::new(0),
+                bytes_encoded: AtomicUsize::new(0),
+            }
+        }
+
+        fn encode_calls(&self) -> usize {
+            self.encode_calls.load(Ordering::Relaxed)
+        }
+
+        fn bytes_encoded(&self) -> usize {
+            self.bytes_encoded.load(Ordering::Relaxed)
+        }
+
+        fn reset(&self) {
+            self.encode_calls.store(0, Ordering::Relaxed);
+            self.bytes_encoded.store(0, Ordering::Relaxed);
+        }
+    }
+
+    impl Encoder for CountingTokenizer {
+        fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Encoding> {
+            self.encode_calls.fetch_add(1, Ordering::Relaxed);
+            self.bytes_encoded.fetch_add(input.len(), Ordering::Relaxed);
+            self.inner.encode(input, add_special_tokens)
+        }
+
+        fn encode_batch(&self, inputs: &[&str], add_special_tokens: bool) -> Result<Vec<Encoding>> {
+            inputs
+                .iter()
+                .map(|i| self.encode(i, add_special_tokens))
+                .collect()
+        }
+    }
+
+    impl Decoder for CountingTokenizer {
+        fn decode(&self, token_ids: &[TokenIdType], skip_special_tokens: bool) -> Result<String> {
+            self.inner.decode(token_ids, skip_special_tokens)
+        }
+    }
+
+    impl traits::Tokenizer for CountingTokenizer {
+        fn vocab_size(&self) -> usize {
+            self.inner.vocab_size()
+        }
+        fn get_special_tokens(&self) -> &SpecialTokens {
+            self.inner.get_special_tokens()
+        }
+        fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
+            None
+        }
+        fn id_to_token(&self, _id: TokenIdType) -> Option<String> {
+            None
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    /// L1-only cache config used by the counting/equivalence tests (L0 disabled so
+    /// every call exercises the L1 hit/miss machinery).
+    fn l1_only_config() -> CacheConfig {
+        CacheConfig {
+            enable_l0: false,
+            l0_max_entries: 0,
+            enable_l1: true,
+            l1_max_memory: 1024 * 1024,
+        }
+    }
+
+    #[test]
+    fn test_l1_miss_tokenizes_input_exactly_once() {
+        let counting = Arc::new(CountingTokenizer::new());
+        let cached = CachedTokenizer::new(counting.clone(), l1_only_config());
+
+        let input = "<|im_start|>system\nhi<|im_end|><|im_start|>user\nquery<|im_end|>";
+
+        // Cold miss: the fused path must tokenize each input byte exactly once.
+        // (Previously: one full encode for the result + a re-encode of every
+        // boundary prefix while seeding — roughly 2x the input.)
+        let first = cached.encode(input, true).unwrap();
+        assert_eq!(
+            counting.bytes_encoded(),
+            input.len(),
+            "miss path must tokenize the input exactly once"
+        );
+
+        // Warm hit: only the suffix past the deepest cached boundary is tokenized.
+        // The deepest boundary is the end of the last special token occurrence that
+        // still leaves a suffix (the final <|im_end|> ends at input.len() and is
+        // never a boundary).
+        let deepest_boundary = input.rfind("<|im_start|>").unwrap() + "<|im_start|>".len();
+        counting.reset();
+        let second = cached.encode(input, true).unwrap();
+        assert_eq!(
+            counting.bytes_encoded(),
+            input.len() - deepest_boundary,
+            "hit path must tokenize only the suffix"
+        );
+        assert_eq!(
+            counting.encode_calls(),
+            1,
+            "hit path performs a single suffix encode"
+        );
+
+        // Both paths return the same stream as a fresh uncached encode.
+        let fresh = BosTokenizer::new().encode(input, true).unwrap();
+        assert_eq!(first.token_ids(), fresh.token_ids());
+        assert_eq!(second.token_ids(), fresh.token_ids());
+    }
+
+    #[test]
+    fn test_l1_multi_turn_growth_matches_uncached() {
+        // Append-only conversation: every turn's cached encode (miss on turn 0,
+        // prefix hits afterwards) must equal a fresh uncached encode, under both
+        // add_special_tokens keys.
+        let mut conversation = String::from("<|im_start|>system\nYou are helpful.<|im_end|>");
+        let mut turns = Vec::new();
+        for i in 0..4 {
+            conversation.push_str(&format!(
+                "<|im_start|>user\nquestion {i}<|im_end|><|im_start|>assistant\nanswer {i}<|im_end|>"
+            ));
+            turns.push(conversation.clone());
+        }
+
+        for add_special_tokens in [false, true] {
+            let cached = CachedTokenizer::new(Arc::new(BosTokenizer::new()), l1_only_config());
+            let plain = BosTokenizer::new();
+
+            for (i, turn) in turns.iter().enumerate() {
+                let got = cached.encode(turn, add_special_tokens).unwrap();
+                let want = plain.encode(turn, add_special_tokens).unwrap();
+                assert_eq!(
+                    got.token_ids(),
+                    want.token_ids(),
+                    "turn {i} (add_special_tokens={add_special_tokens}): cached encode must equal uncached"
+                );
+            }
+
+            // Growth actually exercised the hit path (turn 0 misses, later turns hit).
+            let stats = cached.l1_cache_stats().expect("L1 enabled");
+            assert!(stats.hits >= 1, "expected L1 prefix hits across turns");
         }
     }
 


### PR DESCRIPTION
## What changes per path
**Hit (warm prefix)** — was: full `to_vec()` clone of the cached prefix, then a guaranteed grow-realloc appending the suffix, plus a `hasher.clone()` per boundary during lookup. Now: the lookup returns the shared `Arc<[u32]>`; the caller splices into one exact-capacity buffer — one allocation, prefix copied once, zero hasher clones.

**Miss (boundaried input)** — was: two boundary scans + two full blake3 passes + **~2× tokenization** (full encode, then `insert_at_boundaries` re-encodes everything up to the deepest boundary). Now: one scan, one hash pass (the failed lookup hands its `(boundary, digest)` seeds to the insert side), and **exactly 1× tokenization** — per-segment encodes both seed the boundary entries and assemble the returned encoding (`populate_and_encode`, mirroring dynamo's fusion while keeping SMG's batched eviction).

At the #1685 reporter's 3k req/s this is a large alloc+memcpy eliminated per hit and half the tokenize CPU per miss — pure relief, no architectural change.

## Semantics preserved (the recent fixes are load-bearing)
- #1637 (`add_special_tokens` keying): the flag-seeding now lives in one shared `boundary_seeds` used by both lookup and insert — the keying can no longer drift. Tests pass unmodified.
- #1680 (suffix encoded without specials): hit path keeps `encode(suffix, false)`; the fused miss keeps the segment-0 rule. Test passes unmodified.
- E2e corpus (real Qwen3-4B tokenizer, 29 turns + 20 edge cases, all 4 cache configs): token streams identical to the uncached base, 95% L1 hit rate through the new code.

## New tests
`Arc::ptr_eq` across hits (shared ownership proven), fused-miss byte-exactness vs uncached for both flag values, a `CountingTokenizer` asserting the miss encodes exactly `input.len()` bytes (was ~2×) and the hit encodes exactly the suffix, and 4-turn growth token-exactness.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a seed-based L1 special-token boundary caching flow and a new `populate_and_encode` API to assemble cached prefixes with freshly encoded suffixes more efficiently.

* **Bug Fixes**
  * Improved cache miss/hit handling to prevent incorrect interaction between the `add_special_tokens` flag and seeded cache entries.

* **Tests**
  * Expanded coverage to confirm exact shared cache allocations on L1 hits and byte-exact token ID matches vs uncached encoding, including multi-turn append-only conversation growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->