### PR TITLE
ci(release-docker): fail loud on push detection and add run summary

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -60,7 +60,11 @@ jobs:
           # Uses the full push range (before..after) to catch changes across
           # multiple commits, not just HEAD~1.
           if [[ "${EVENT_NAME}" == "push" ]]; then
-            if git diff --name-only "${EVENT_BEFORE}" "${EVENT_AFTER}" | grep -q '^bindings/python/pyproject.toml$'; then
+            # Capture changed files first so a git failure fails the step,
+            # instead of being swallowed by the pipe and silently leaving
+            # PUSH=false.
+            CHANGED=$(git diff --name-only "${EVENT_BEFORE}" "${EVENT_AFTER}")
+            if grep -q '^bindings/python/pyproject.toml$' <<<"${CHANGED}"; then
               PUSH="true"
             fi
           fi
@@ -81,6 +85,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -92,3 +97,42 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+      - name: Summary
+        if: always()
+        env:
+          PUSH: ${{ steps.should-push.outputs.push }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          IMAGE="lightseekorg/smg:${VERSION}"
+          LATEST="lightseekorg/smg:latest"
+          if [[ "${BUILD_OUTCOME}" == "success" && "${PUSH}" == "true" ]]; then
+            {
+              echo "### ✅ Docker image pushed successfully"
+              echo ""
+              echo "| Tag | Reference |"
+              echo "| --- | --- |"
+              echo "| \`${VERSION}\` | \`${IMAGE}\` |"
+              echo "| \`latest\` | \`${LATEST}\` |"
+              if [[ -n "${DIGEST}" ]]; then
+                echo ""
+                echo "Digest: \`${DIGEST}\`"
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [[ "${BUILD_OUTCOME}" == "success" ]]; then
+            {
+              echo "### ⚠️ Docker image built but NOT pushed"
+              echo ""
+              echo "\`${IMAGE}\` was built and validated, but not published — no version bump in \`bindings/python/pyproject.toml\` and not a manual dispatch."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Docker image ${IMAGE} was built but not pushed."
+          else
+            {
+              echo "### ❌ Docker image build failed"
+              echo ""
+              echo "\`${IMAGE}\` was **not** pushed because the build did not succeed (outcome: \`${BUILD_OUTCOME}\`)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Docker image ${IMAGE} was not pushed (build outcome: ${BUILD_OUTCOME})."
+          fi


### PR DESCRIPTION
## Description

### Problem

The `Check if this is a release (should push)` step in `release-docker.yml`
piped `git diff` into `grep` inside an `if` condition. Because the `if`
suppresses `set -e` and the pipeline's exit status comes from `grep`, a real
`git` failure (e.g. `git: command not found` on a self-hosted runner, or a bad
commit range) was silently swallowed — the step succeeded and left
`push=false`. A release could be quietly skipped with a green check.

There was also no at-a-glance record of whether an image was actually pushed.

### Solution

- Run `git diff` in a standalone assignment (`CHANGED=$(git diff …)`) instead of
  piping it into `grep`. Under the default `bash -eo pipefail`, a git failure now
  aborts the step instead of defaulting to `push=false`. Minimal change — same
  structure and comments otherwise.
- Add a `Summary` step (`if: always()`) that writes to `$GITHUB_STEP_SUMMARY`:
  - ✅ pushed → image references (`version` + `latest`) and digest
  - ⚠️ built but not pushed → warning annotation
  - ❌ build failed → warning annotation

## Changes

- `.github/workflows/release-docker.yml`
  - `should-push`: split `git diff | grep` so git failures fail the step.
  - Added `id: build` to the build step and a new `Summary` step.

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-docker.yml'))"` parses cleanly.
- Before: with `git` unavailable, the step logged `git: command not found` and
  still printed `Will push: false` with a successful step.
- After: the same condition aborts the `should-push` step instead of silently
  proceeding; a successful release push renders the image ref + digest in the
  run summary, and a non-push build renders a warning.

> Note: a force-push / first push to `main` has an all-zero `github.event.before`,
> so `git diff` fails and the step now fails loudly by design. Can add a zero-SHA
> guard if that's undesirable.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-visible changes in this release. Internal improvements to the Docker build workflow have been implemented to enhance the development infrastructure process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->