### PR TITLE
feat(mock-worker): realistic engine simulator for no-GPU routing A/B

### DIFF
--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -28,6 +28,11 @@ service TokenSpeedScheduler {
 
   // Stop the profiler and export traces
   rpc StopProfile(smg.grpc.common.StopProfileRequest) returns (smg.grpc.common.ProfileResponse);
+
+  // Subscribe to KV cache events (server-streaming). Lets the gateway's
+  // cache-aware router track which prefixes this scheduler has cached.
+  rpc SubscribeKvEvents(smg.grpc.common.SubscribeKvEventsRequest)
+      returns (stream smg.grpc.common.KvEventBatch);
 }
 
 // =====================
@@ -326,6 +331,13 @@ message SchedulerLoad {
   int32 num_used_tokens = 5;
   int32 max_total_num_tokens = 6;
   int32 max_running_requests = 7;
+
+  // Queued token-work: waiting-queue prompt tokens not served from cache
+  // (mirrors SGLang's num_waiting_uncached_tokens). The gateway's least_load
+  // policy uses this as its queued-token signal; 0 when not reported. Grouped
+  // with the other counts for readability; numbered 14 (the next free number)
+  // so the existing field numbers stay stable.
+  int32 num_waiting_uncached_tokens = 14;
 
   double token_usage = 8;
   double gen_throughput = 9;

--- a/crates/grpc_client/src/tokenspeed_scheduler.rs
+++ b/crates/grpc_client/src/tokenspeed_scheduler.rs
@@ -173,6 +173,7 @@ impl TokenSpeedSchedulerClient {
     }
 
     crate::impl_admin_ops!();
+    crate::impl_subscribe_kv_events!();
 
     // ── Request builders ──────────────────────────────────────────────
 
@@ -673,8 +674,7 @@ impl From<tokenspeed_proto::SchedulerLoad> for openai_protocol::worker::Schedule
             dp_rank: load.dp_rank,
             num_running_reqs: load.num_running_reqs,
             num_waiting_reqs: load.num_waiting_reqs,
-            // TokenSpeed does not report queued token-work; degrade to 0.
-            num_waiting_uncached_tokens: 0,
+            num_waiting_uncached_tokens: load.num_waiting_uncached_tokens,
             num_total_reqs: load.num_total_reqs,
             num_used_tokens: load.num_used_tokens,
             max_total_num_tokens: load.max_total_num_tokens,

--- a/crates/mock_worker/README.md
+++ b/crates/mock_worker/README.md
@@ -2,7 +2,17 @@
 
 Multi-port mock HTTP/gRPC inference workers for scale-testing the SMG gateway's
 routing and async-runtime behavior. One process hosts many protocol-accurate
-stand-ins for vLLM/SGLang engines; all responses are canned (no real model).
+stand-ins for vLLM/SGLang engines.
+
+Two modes:
+
+- **canned** (default) — every response is fixed (no model); a single optional
+  `--gen-ms` delay. Cheap enough to run thousands of idle workers for measuring
+  the gateway's own CPU/registration/routing cost.
+- **realistic** (`--engine realistic`) — each worker runs a continuous-batching
+  **engine simulator** that behaves like a real LLM engine on CPU, so the whole
+  gateway (including load- and cache-aware routing) can be exercised without
+  GPUs. See [Realistic engine](#realistic-engine).
 
 ## What it implements
 
@@ -15,9 +25,10 @@ stand-ins for vLLM/SGLang engines; all responses are canned (no real model).
 
 **gRPC** (TokenSpeed scheduler — the gateway tokenizes, the worker speaks token
 ids): `HealthCheck`, `GetModelInfo`, `GetServerInfo`, `Generate` (streamed
-chunks + complete), `GetLoads`, `Abort`; admin RPCs return `unimplemented`.
+chunks + complete), `GetLoads`, `Abort`, and (realistic mode only)
+`SubscribeKvEvents`; other admin RPCs return `unimplemented`.
 
-## Run
+## Run (canned)
 
 ```bash
 cargo run --release -p mock-worker -- \
@@ -30,16 +41,67 @@ Each worker is one port. Register them against an IGW gateway with
 `POST /workers` (`{"url":"http://127.0.0.1:9000"}`, or `grpc://…` with
 `connection_mode`/`runtime`/`models` for gRPC).
 
-## Scale-test rig
+## Realistic engine
 
-`scripts/scale_test.sh` launches an IGW gateway, starts the mock fleet,
-REST-registers it, and samples the gateway PID's CPU + `/health` latency at idle
-and under load (`scripts/scale_load.py`):
+`--engine realistic` backs each worker with a continuous-batching simulator
+([`src/engine.rs`](src/engine.rs)) that reproduces the behaviors driving routing:
+
+- **prefill latency scales with input length** — TTFT grows with the *uncached*
+  prompt size, chunked across scheduler steps;
+- **inter-token latency grows with batch size** — `ITL = base + slope · batch`,
+  so a busy replica is slower per token;
+- **finite KV capacity + queueing** — when KV is full, requests wait, producing
+  the `num_waiting_uncached_tokens` signal `least_load` consumes;
+- **prefix caching** — a request sharing a prefix with cached blocks pays less
+  prefill, reports `cached_tokens`, and the worker emits the KV-cache events
+  (`SubscribeKvEvents`) that drive event-driven `cache_aware` routing.
+
+The cost model is parametric (defaults approximate one mid-size replica):
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--prefill-tps` | 8000 | prefill throughput (tokens/s) |
+| `--decode-base-ms` | 6.0 | fixed decode-step latency (ms) |
+| `--decode-per-req-ms` | 0.35 | added decode latency per running request |
+| `--prefill-chunk` | 2048 | max prompt tokens prefilled per step |
+| `--max-running` | 256 | continuous-batching width |
+| `--kv-tokens` | 524288 | KV cache capacity (tokens) |
+| `--block-size` | 16 | cache block/page size (tokens) |
+| `--prefix-cache` | true | enable prefix caching + KV events |
+
+```bash
+cargo run --release -p mock-worker -- \
+  --engine realistic --grpc-base-port 19000 --grpc-count 8 --model mock-model
+```
+
+**Tokenizer note (gRPC):** the gateway tokenizes prompts before routing, so it
+needs a real tokenizer for the model. Register each worker with a tokenizer
+label, e.g. `"labels":{"tokenizer_path":"gpt2"}`, and a `"kv_block_size":16`, and
+do **not** pass `--disable-tokenizer-autoload`. (HTTP workers need no tokenizer
+but cannot drive event-driven `cache_aware`, which requires token ids.)
+
+## Scale-test rig (gateway CPU)
+
+`scripts/scale_test.sh` launches an IGW gateway, starts a canned mock fleet,
+REST-registers it, and samples the gateway PID's CPU + `/health` latency:
 
 ```bash
 scripts/scale_test.sh --http 2000 --policy cache_aware --rps 500 --duration 30
 scripts/scale_test.sh --grpc 1000 --policy least_load
 ```
 
-gRPC runs use `--disable-tokenizer-autoload` so registration/routing can be
-measured without a real tokenizer (generation itself is not exercised).
+## Policy A/B rig (no-GPU routing fidelity)
+
+`scripts/sim_ab.sh` launches the gateway + a **realistic** mock fleet, drives the
+same Poisson workload (`scripts/sim_load.py`, with a tunable shared-prefix
+fraction) under each routing policy, and prints a side-by-side table of
+TTFT / ITL / E2E / throughput:
+
+```bash
+# Full fidelity: gateway tokenizes (downloads gpt2) and routes on token ids,
+# so both least_load and event-driven cache_aware engage.
+scripts/sim_ab.sh --mode grpc --workers 8 --rps 120 --duration 30
+
+# Offline-friendly: no tokenizer; drives least_load + latency + approximate cache_aware.
+scripts/sim_ab.sh --mode http --workers 16 --policies "random least_load"
+```

--- a/crates/mock_worker/src/config.rs
+++ b/crates/mock_worker/src/config.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+use crate::engine::EngineParams;
+
 /// Configuration shared by every mocked HTTP and gRPC worker in the process.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -19,10 +21,16 @@ pub struct Config {
     pub model_id: String,
     /// Tokenizer path advertised by gRPC workers (for gateway autoload).
     pub tokenizer_path: String,
-    /// Simulated per-request generation latency.
+    /// Simulated per-request generation latency (canned mode only).
     pub gen_delay: Duration,
-    /// Number of canned output tokens per generation.
+    /// Number of canned output tokens per generation; also the default output
+    /// length for realistic mode when a request omits `max_tokens`.
     pub output_tokens: u32,
+    /// When true, each worker runs the realistic continuous-batching engine
+    /// simulator ([`EngineParams`]); when false, the cheap canned path.
+    pub realistic: bool,
+    /// Engine-simulator parameters (only used when `realistic`).
+    pub engine: EngineParams,
 }
 
 impl Config {
@@ -38,6 +46,8 @@ impl Config {
             tokenizer_path: String::new(),
             gen_delay: Duration::from_millis(0),
             output_tokens: 8,
+            realistic: false,
+            engine: EngineParams::default(),
         };
 
         let mut args = std::env::args().skip(1);
@@ -54,6 +64,33 @@ impl Config {
                     cfg.gen_delay = Duration::from_millis(parse(value(&mut args, &flag)?, &flag)?);
                 }
                 "--output-tokens" => cfg.output_tokens = parse(value(&mut args, &flag)?, &flag)?,
+                "--engine" => {
+                    cfg.realistic = match value(&mut args, &flag)?.as_str() {
+                        "realistic" => true,
+                        "canned" => false,
+                        other => {
+                            return Err(format!("--engine must be canned|realistic, got {other}"))
+                        }
+                    }
+                }
+                "--prefill-tps" => cfg.engine.prefill_tps = parse(value(&mut args, &flag)?, &flag)?,
+                "--decode-base-ms" => {
+                    cfg.engine.decode_base_ms = parse(value(&mut args, &flag)?, &flag)?;
+                }
+                "--decode-per-req-ms" => {
+                    cfg.engine.decode_per_req_ms = parse(value(&mut args, &flag)?, &flag)?;
+                }
+                "--prefill-chunk" => {
+                    cfg.engine.prefill_chunk_tokens = parse(value(&mut args, &flag)?, &flag)?;
+                }
+                "--max-running" => cfg.engine.max_running = parse(value(&mut args, &flag)?, &flag)?,
+                "--kv-tokens" => {
+                    cfg.engine.kv_capacity_tokens = parse(value(&mut args, &flag)?, &flag)?;
+                }
+                "--block-size" => cfg.engine.block_size = parse(value(&mut args, &flag)?, &flag)?,
+                "--prefix-cache" => {
+                    cfg.engine.prefix_cache = parse(value(&mut args, &flag)?, &flag)?
+                }
                 "-h" | "--help" => return Err(usage()),
                 other => return Err(format!("unknown flag: {other}\n\n{}", usage())),
             }
@@ -62,6 +99,9 @@ impl Config {
         if cfg.tokenizer_path.is_empty() {
             cfg.tokenizer_path = cfg.model_id.clone();
         }
+        // `--output-tokens` doubles as the realistic engine's default output
+        // length when a request omits `max_tokens`.
+        cfg.engine.max_new_default = cfg.output_tokens;
         if cfg.http_count == 0 && cfg.grpc_count == 0 {
             return Err(format!(
                 "nothing to do: pass --http-count and/or --grpc-count\n\n{}",
@@ -95,7 +135,18 @@ fn usage() -> String {
        --grpc-count <n>         number of gRPC workers (default 0)\n\
        --model <id>             advertised model id (default mock-model)\n\
        --tokenizer <path>       tokenizer path for gRPC autoload (default = model)\n\
-       --gen-ms <ms>            simulated generation latency (default 0)\n\
-       --output-tokens <n>      canned output tokens per request (default 8)"
+       --gen-ms <ms>            canned per-request latency (default 0)\n\
+       --output-tokens <n>      output tokens per request when unspecified (default 8)\n\
+     \n\
+     Realistic engine simulator (continuous batching; opt-in):\n\
+       --engine <canned|realistic>  engine mode (default canned)\n\
+       --prefill-tps <f>        prefill throughput, tokens/sec (default 8000)\n\
+       --decode-base-ms <f>     fixed decode-step latency, ms (default 6.0)\n\
+       --decode-per-req-ms <f>  added decode-step latency per running req (default 0.35)\n\
+       --prefill-chunk <n>      max prompt tokens prefilled per step (default 2048)\n\
+       --max-running <n>        max concurrent running requests (default 256)\n\
+       --kv-tokens <n>          KV cache capacity in tokens (default 524288)\n\
+       --block-size <n>         cache block/page size in tokens (default 16)\n\
+       --prefix-cache <bool>    enable prefix caching + KV events (default true)"
         .to_string()
 }

--- a/crates/mock_worker/src/engine.rs
+++ b/crates/mock_worker/src/engine.rs
@@ -1,0 +1,1052 @@
+//! A lightweight, CPU-only simulation of a continuous-batching LLM engine.
+//!
+//! The goal is fidelity, not fakery: the mock should exhibit the behaviors that
+//! drive SMG's routing decisions so the whole gateway can be exercised without
+//! GPUs. Concretely this models
+//!
+//! - **prefill latency that scales with input length** — time-to-first-token
+//!   grows with the (uncached) prompt size, chunked across scheduler steps;
+//! - **decode latency that grows with batch size** — inter-token latency is
+//!   `base + slope · batch`, so a busy replica is slower per token;
+//! - **finite KV capacity with admission/queueing** — when KV is full requests
+//!   wait, producing the `num_waiting_uncached_tokens` signal `least_load` uses;
+//! - **prefix caching** — a request sharing a prefix with cached blocks pays
+//!   less prefill, reports `cached_tokens`, and the engine emits the KV-cache
+//!   events (`KvBlocksStored` / `KvBlocksRemoved`) that drive `cache_aware`.
+//!
+//! The engine is an actor: one `tokio` task per virtual worker owns all mutable
+//! state and advances it in real wall-clock time, but the per-step work is plain
+//! arithmetic. Idle engines block on their request channel, so a fleet of mostly
+//! idle workers stays cheap. The scheduling math lives in [`SchedulerState::step`],
+//! a pure synchronous function returning the work done plus the time it took —
+//! which makes it deterministically unit-testable with no real timers.
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet, VecDeque},
+    pin::Pin,
+    sync::{Arc, Mutex, RwLock},
+    time::Duration,
+};
+
+use futures::{stream, Stream, StreamExt};
+use smg_grpc_client::common_proto as common;
+use tokio::sync::{broadcast, mpsc};
+use tonic::Status;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Tunable parameters of the simulated engine. Defaults approximate a single
+/// mid-size model replica on one accelerator; override via mock-worker flags.
+#[derive(Clone, Debug)]
+pub struct EngineParams {
+    /// Prefill throughput (prompt tokens processed per second).
+    pub prefill_tps: f64,
+    /// Fixed decode-step latency (ms) independent of batch size.
+    pub decode_base_ms: f64,
+    /// Added decode-step latency (ms) per running request — the batch slope.
+    pub decode_per_req_ms: f64,
+    /// Max prompt tokens prefilled per scheduler step (chunked prefill); keeps a
+    /// huge prompt from stalling the whole batch in a single step.
+    pub prefill_chunk_tokens: u32,
+    /// Max concurrent running requests (continuous-batching width).
+    pub max_running: usize,
+    /// KV cache capacity in tokens.
+    pub kv_capacity_tokens: u64,
+    /// Cache block (page) size in tokens.
+    pub block_size: u32,
+    /// Whether prefix caching + KV-event emission are enabled.
+    pub prefix_cache: bool,
+    /// Start evicting once KV usage exceeds this fraction of capacity.
+    pub kv_high_watermark: f64,
+    /// Evict down to this fraction of capacity once eviction starts.
+    pub kv_low_watermark: f64,
+    /// Output tokens to generate when a request does not specify `max_new_tokens`.
+    pub max_new_default: u32,
+    /// Capacity of the live KV-event broadcast channel.
+    pub kv_broadcast_capacity: usize,
+    /// How many recent KV-event batches to retain for subscriber replay.
+    pub kv_replay_capacity: usize,
+}
+
+impl Default for EngineParams {
+    fn default() -> Self {
+        Self {
+            prefill_tps: 8000.0,
+            decode_base_ms: 6.0,
+            decode_per_req_ms: 0.35,
+            prefill_chunk_tokens: 2048,
+            max_running: 256,
+            kv_capacity_tokens: 524_288,
+            block_size: 16,
+            prefix_cache: true,
+            kv_high_watermark: 0.92,
+            kv_low_watermark: 0.85,
+            max_new_default: 128,
+            kv_broadcast_capacity: 1024,
+            kv_replay_capacity: 4096,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public request / event types (transport-agnostic)
+// ---------------------------------------------------------------------------
+
+/// A request submitted to the engine. The transport (gRPC/HTTP) renders the
+/// resulting [`GenEvent`] stream into the wire format the gateway expects.
+pub struct NewRequest {
+    pub request_id: String,
+    /// The prompt's token ids (gRPC supplies real ids from the gateway's
+    /// tokenizer; HTTP supplies synthetic ids derived from the prompt text).
+    pub prompt_token_ids: Vec<u32>,
+    /// Requested output length; 0 means "use the engine default".
+    pub max_new: u32,
+    /// Sink for this request's generation events.
+    pub events: mpsc::UnboundedSender<GenEvent>,
+}
+
+/// One unit of generation output for a request.
+#[derive(Clone, Debug)]
+pub enum GenEvent {
+    /// A single decoded token. `prompt_tokens` / `cached_tokens` are constant
+    /// for the request and repeated for parity with real engines' chunk fields.
+    Token {
+        token_id: u32,
+        prompt_tokens: u32,
+        cached_tokens: u32,
+    },
+    /// Terminal event; the stream ends after this.
+    Done {
+        finish_reason: &'static str,
+        prompt_tokens: u32,
+        completion_tokens: u32,
+        cached_tokens: u32,
+    },
+}
+
+/// A point-in-time view of engine load, served via `GetLoads` / `/v1/loads`.
+#[derive(Clone, Debug)]
+pub struct LoadSnapshot {
+    pub num_running_reqs: i32,
+    pub num_waiting_reqs: i32,
+    pub num_waiting_uncached_tokens: i32,
+    pub num_used_tokens: i32,
+    pub max_total_num_tokens: i32,
+    pub max_running_requests: i32,
+    pub token_usage: f64,
+    pub gen_throughput: f64,
+    pub cache_hit_rate: f64,
+}
+
+// ---------------------------------------------------------------------------
+// Engine handle
+// ---------------------------------------------------------------------------
+
+/// Shared state readable from the transport handlers while the actor runs.
+struct EngineShared {
+    snapshot: RwLock<LoadSnapshot>,
+    kv_tx: broadcast::Sender<common::KvEventBatch>,
+    kv_replay: Mutex<VecDeque<common::KvEventBatch>>,
+    prefix_cache: bool,
+}
+
+/// A cloneable handle to one simulated engine.
+#[derive(Clone)]
+pub struct Engine {
+    tx: mpsc::UnboundedSender<NewRequest>,
+    shared: Arc<EngineShared>,
+}
+
+/// Concrete KV-event stream type returned to the gRPC `subscribe_kv_events` RPC.
+pub type KvEventStream = Pin<Box<dyn Stream<Item = Result<common::KvEventBatch, Status>> + Send>>;
+
+impl Engine {
+    /// Spawn the engine actor and return a handle to it.
+    ///
+    /// The actor task is detached intentionally: when the last [`Engine`] handle
+    /// drops, its request channel closes and `run` returns, so there is nothing
+    /// to wait on at shutdown.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "engine actor self-terminates when its request channel closes"
+    )]
+    pub fn spawn(params: EngineParams) -> Engine {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let (kv_tx, _) = broadcast::channel(params.kv_broadcast_capacity.max(1));
+        let shared = Arc::new(EngineShared {
+            snapshot: RwLock::new(LoadSnapshot::idle(&params)),
+            kv_tx,
+            kv_replay: Mutex::new(VecDeque::new()),
+            prefix_cache: params.prefix_cache,
+        });
+        tokio::spawn(run(params, rx, shared.clone()));
+        Engine { tx, shared }
+    }
+
+    /// Submit a request. Dropped silently if the engine has shut down.
+    pub fn submit(&self, req: NewRequest) {
+        let _ = self.tx.send(req);
+    }
+
+    /// Current load snapshot.
+    pub fn load(&self) -> LoadSnapshot {
+        self.shared
+            .snapshot
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone()
+    }
+
+    /// Whether this engine emits KV-cache events.
+    pub fn kv_enabled(&self) -> bool {
+        self.shared.prefix_cache
+    }
+
+    /// Build a KV-event stream: replay buffered batches newer than `start_seq`,
+    /// then live events. Subscribing to the live channel *before* snapshotting
+    /// the replay buffer guarantees no batch falls between the two (the gateway
+    /// dedups any overlap by `sequence_number`).
+    pub fn subscribe_kv(&self, start_seq: u64) -> KvEventStream {
+        let live_rx = self.shared.kv_tx.subscribe();
+        let replay: Vec<common::KvEventBatch> = {
+            let buf = self
+                .shared
+                .kv_replay
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            buf.iter()
+                .filter(|b| b.sequence_number > start_seq)
+                .cloned()
+                .collect()
+        };
+        let replay_stream = stream::iter(replay.into_iter().map(Ok));
+        let live_stream = stream::unfold(live_rx, |mut rx| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(batch) => return Some((Ok(batch), rx)),
+                    // A lagged slow consumer leaves a gap; the gateway detects it
+                    // and reconnects, replaying from the buffer. Skip and continue.
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        });
+        Box::pin(replay_stream.chain(live_stream))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The actor loop
+// ---------------------------------------------------------------------------
+
+async fn run(
+    params: EngineParams,
+    mut rx: mpsc::UnboundedReceiver<NewRequest>,
+    shared: Arc<EngineShared>,
+) {
+    let mut state = SchedulerState::new();
+    loop {
+        // When there is nothing to do, publish an idle snapshot and block on the
+        // request channel — an idle engine consumes no CPU.
+        if state.is_idle() {
+            *shared.snapshot.write().unwrap_or_else(|p| p.into_inner()) = state.snapshot(&params);
+            match rx.recv().await {
+                Some(req) => state.enqueue(req, &params),
+                None => return, // all handles dropped
+            }
+        }
+        // Drain any other already-queued submissions without blocking.
+        while let Ok(req) = rx.try_recv() {
+            state.enqueue(req, &params);
+        }
+
+        let step = state.step(&params);
+        if step.duration > Duration::ZERO {
+            tokio::time::sleep(step.duration).await;
+        }
+        // The step's outputs become observable only after its simulated time.
+        for (tx, ev) in step.sends {
+            let _ = tx.send(ev);
+        }
+        if let Some(batch) = step.batch {
+            {
+                let mut buf = shared.kv_replay.lock().unwrap_or_else(|p| p.into_inner());
+                buf.push_back(batch.clone());
+                while buf.len() > params.kv_replay_capacity {
+                    buf.pop_front();
+                }
+            }
+            let _ = shared.kv_tx.send(batch);
+        }
+        *shared.snapshot.write().unwrap_or_else(|p| p.into_inner()) = step.snapshot;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler state + step (pure, deterministic, unit-testable)
+// ---------------------------------------------------------------------------
+
+/// A request currently being prefilled or decoded.
+struct RunningReq {
+    events: mpsc::UnboundedSender<GenEvent>,
+    prompt_tokens: u32,
+    cached_tokens: u32,
+    max_new: u32,
+    generated: u32,
+    /// Uncached prompt tokens still to be prefilled before the first token.
+    prefill_remaining: u32,
+    /// FNV hash of all tokens seen so far (prompt + generated) — the content key
+    /// of the next block once `pending_block` fills.
+    rolling_hash: u64,
+    /// Block key of the most recently completed block (for parent chaining).
+    prev_block_key: Option<u64>,
+    /// Tokens accumulated toward the next (not-yet-full) block.
+    pending_block: Vec<u32>,
+    /// Generated token ids (for the terminal `output_ids`).
+    output_ids: Vec<u32>,
+    /// Per-request seed so decode blocks never collide across requests.
+    token_seed: u32,
+}
+
+/// A request admitted to the queue but not yet running.
+struct WaitingReq {
+    req: NewRequest,
+    prompt_tokens: u32,
+    /// Uncached prompt tokens at enqueue time (the queued token-work it adds).
+    uncached_tokens: u32,
+}
+
+/// Per-worker prefix cache: content-keyed block presence with LRU ordering.
+#[derive(Default)]
+struct Cache {
+    present: HashSet<u64>,
+    tick_of: HashMap<u64, u64>,
+    lru: BTreeSet<(u64, u64)>,
+    tick: u64,
+}
+
+impl Cache {
+    fn len(&self) -> usize {
+        self.present.len()
+    }
+
+    /// Number of consecutive cached blocks from the start of `keys`.
+    fn match_prefix(&self, keys: &[u64]) -> usize {
+        let mut n = 0;
+        for &k in keys {
+            if self.present.contains(&k) {
+                n += 1;
+            } else {
+                break;
+            }
+        }
+        n
+    }
+
+    /// Mark `keys` as just-used (warms shared prefixes so eviction prefers
+    /// colder leaves, keeping the block set prefix-closed in the common case).
+    fn touch(&mut self, keys: &[u64]) {
+        self.tick += 1;
+        let t = self.tick;
+        for &k in keys {
+            if self.present.contains(&k) {
+                if let Some(old) = self.tick_of.insert(k, t) {
+                    self.lru.remove(&(old, k));
+                }
+                self.lru.insert((t, k));
+            }
+        }
+    }
+
+    /// Insert a block; returns true if it was newly added.
+    fn insert(&mut self, k: u64) -> bool {
+        if self.present.contains(&k) {
+            self.touch(&[k]);
+            return false;
+        }
+        self.present.insert(k);
+        self.tick += 1;
+        let t = self.tick;
+        self.tick_of.insert(k, t);
+        self.lru.insert((t, k));
+        true
+    }
+
+    /// Evict the least-recently-used block; returns its key.
+    fn evict_one(&mut self) -> Option<u64> {
+        let &(t, k) = self.lru.iter().next()?;
+        self.lru.remove(&(t, k));
+        self.tick_of.remove(&k);
+        self.present.remove(&k);
+        Some(k)
+    }
+}
+
+/// The actor-owned scheduler state.
+pub(crate) struct SchedulerState {
+    running: Vec<RunningReq>,
+    waiting: VecDeque<WaitingReq>,
+    cache: Cache,
+    kv_seq: u64,
+    kv_event_id: u64,
+    gen_tp_ewma: f64,
+    cache_hit_ewma: f64,
+}
+
+/// The result of one scheduler step.
+pub(crate) struct Step {
+    duration: Duration,
+    sends: Vec<(mpsc::UnboundedSender<GenEvent>, GenEvent)>,
+    batch: Option<common::KvEventBatch>,
+    snapshot: LoadSnapshot,
+}
+
+impl SchedulerState {
+    pub(crate) fn new() -> Self {
+        Self {
+            running: Vec::new(),
+            waiting: VecDeque::new(),
+            cache: Cache::default(),
+            kv_seq: 0,
+            kv_event_id: 0,
+            gen_tp_ewma: 0.0,
+            cache_hit_ewma: 0.0,
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        self.running.is_empty() && self.waiting.is_empty()
+    }
+
+    /// Queue a request, recording the queued token-work it contributes.
+    pub(crate) fn enqueue(&mut self, req: NewRequest, p: &EngineParams) {
+        let prompt_tokens = req.prompt_token_ids.len() as u32;
+        let (block_keys, _, _) = prompt_blocks(&req.prompt_token_ids, p.block_size as usize);
+        let cached_blocks = if p.prefix_cache {
+            self.cache.match_prefix(&block_keys)
+        } else {
+            0
+        };
+        let cached = (cached_blocks as u32 * p.block_size).min(prompt_tokens);
+        let uncached = prompt_tokens - cached;
+        self.waiting.push_back(WaitingReq {
+            req,
+            prompt_tokens,
+            uncached_tokens: uncached,
+        });
+    }
+
+    /// Tokens currently resident in KV.
+    fn used_tokens(&self, p: &EngineParams) -> u64 {
+        if p.prefix_cache {
+            // KV holds the shared radix cache (blocks persist across requests
+            // until evicted) plus each running request's not-yet-blocked tail.
+            let blocks = self.cache.len() as u64 * p.block_size as u64;
+            let partial: u64 = self
+                .running
+                .iter()
+                .map(|r| r.pending_block.len() as u64)
+                .sum();
+            blocks + partial
+        } else {
+            // No sharing/persistence: each running request occupies its full
+            // current context; that KV frees when it leaves the batch.
+            self.running
+                .iter()
+                .map(|r| u64::from(r.prompt_tokens + r.generated))
+                .sum()
+        }
+    }
+
+    fn snapshot(&self, p: &EngineParams) -> LoadSnapshot {
+        let used = self.used_tokens(p);
+        let waiting_uncached: i64 = self.waiting.iter().map(|w| w.uncached_tokens as i64).sum();
+        LoadSnapshot {
+            num_running_reqs: self.running.len() as i32,
+            num_waiting_reqs: self.waiting.len() as i32,
+            num_waiting_uncached_tokens: waiting_uncached.min(i32::MAX as i64) as i32,
+            num_used_tokens: used.min(i32::MAX as u64) as i32,
+            max_total_num_tokens: p.kv_capacity_tokens.min(i32::MAX as u64) as i32,
+            max_running_requests: p.max_running.min(i32::MAX as usize) as i32,
+            token_usage: (used as f64 / p.kv_capacity_tokens.max(1) as f64).clamp(0.0, 1.0),
+            gen_throughput: self.gen_tp_ewma,
+            cache_hit_rate: self.cache_hit_ewma,
+        }
+    }
+
+    /// Advance the engine by one scheduler iteration. Pure: mutates state and
+    /// returns the work produced plus how long it took, but performs no I/O.
+    pub(crate) fn step(&mut self, p: &EngineParams) -> Step {
+        let mut kv: Vec<common::KvCacheEvent> = Vec::new();
+
+        // ---- 1. Admission ----
+        self.admit(p, &mut kv);
+
+        // ---- 2. Chunked prefill ----
+        let mut budget = p.prefill_chunk_tokens;
+        let mut prefill_tokens = 0u32;
+        for r in &mut self.running {
+            if r.prefill_remaining > 0 && budget > 0 {
+                let c = r.prefill_remaining.min(budget);
+                r.prefill_remaining -= c;
+                budget -= c;
+                prefill_tokens += c;
+            }
+        }
+
+        // ---- 3. Decode (one token per ready request) ----
+        let block_size = p.block_size as usize;
+        let mut sends: Vec<(mpsc::UnboundedSender<GenEvent>, GenEvent)> = Vec::new();
+        let mut new_blocks: Vec<(u64, Vec<u32>, Option<u64>)> = Vec::new();
+        let mut decode_tokens = 0u32;
+        let num_decode = self
+            .running
+            .iter()
+            .filter(|r| {
+                r.prefill_remaining == 0 && r.generated < r.max_new && !r.events.is_closed()
+            })
+            .count();
+
+        for r in &mut self.running {
+            if r.prefill_remaining != 0 || r.generated >= r.max_new || r.events.is_closed() {
+                continue;
+            }
+            let token_id = next_token(r);
+            r.generated += 1;
+            r.output_ids.push(token_id);
+            r.rolling_hash = fnv_step(r.rolling_hash, token_id);
+            r.pending_block.push(token_id);
+            decode_tokens += 1;
+            if r.pending_block.len() == block_size {
+                let key = r.rolling_hash;
+                new_blocks.push((key, std::mem::take(&mut r.pending_block), r.prev_block_key));
+                r.prev_block_key = Some(key);
+            }
+            sends.push((
+                r.events.clone(),
+                GenEvent::Token {
+                    token_id,
+                    prompt_tokens: r.prompt_tokens,
+                    cached_tokens: r.cached_tokens,
+                },
+            ));
+        }
+
+        // Commit newly completed decode blocks to the cache (+ stored events).
+        for (key, tokens, parent) in new_blocks {
+            if p.prefix_cache && self.cache.insert(key) {
+                kv.push(self.stored_event(key, tokens, parent, p.block_size));
+            }
+        }
+
+        // ---- 4. Completion ----
+        let mut still = Vec::with_capacity(self.running.len());
+        for r in std::mem::take(&mut self.running) {
+            let done = r.prefill_remaining == 0 && r.generated >= r.max_new;
+            if done || r.events.is_closed() {
+                if done {
+                    sends.push((
+                        r.events.clone(),
+                        GenEvent::Done {
+                            finish_reason: "length",
+                            prompt_tokens: r.prompt_tokens,
+                            completion_tokens: r.generated,
+                            cached_tokens: r.cached_tokens,
+                        },
+                    ));
+                }
+            } else {
+                still.push(r);
+            }
+        }
+        self.running = still;
+
+        // ---- 5. Eviction under KV pressure ----
+        self.evict(p, &mut kv);
+
+        // ---- 6. Timing + bookkeeping ----
+        let prefill_time = prefill_tokens as f64 / p.prefill_tps.max(1.0);
+        let decode_time = if num_decode > 0 {
+            (p.decode_base_ms + p.decode_per_req_ms * num_decode as f64) / 1000.0
+        } else {
+            0.0
+        };
+        let mut secs = prefill_time.max(decode_time);
+        if secs <= 0.0 && !self.is_idle() {
+            secs = 0.001; // never busy-spin while work remains
+        }
+        let throughput_sample = if secs > 0.0 && decode_tokens > 0 {
+            decode_tokens as f64 / secs
+        } else {
+            0.0
+        };
+        self.gen_tp_ewma = ewma(self.gen_tp_ewma, throughput_sample, 0.3);
+
+        let batch = if kv.is_empty() {
+            None
+        } else {
+            self.kv_seq += 1;
+            Some(common::KvEventBatch {
+                sequence_number: self.kv_seq,
+                timestamp: 0.0,
+                events: kv,
+                dp_rank: Some(0),
+            })
+        };
+
+        Step {
+            duration: Duration::from_secs_f64(secs.max(0.0)),
+            sends,
+            batch,
+            snapshot: self.snapshot(p),
+        }
+    }
+
+    /// Admit waiting requests while batch width and KV capacity allow.
+    fn admit(&mut self, p: &EngineParams, kv: &mut Vec<common::KvCacheEvent>) {
+        let block_size = p.block_size as usize;
+        while self.running.len() < p.max_running {
+            let Some(front) = self.waiting.front() else {
+                break;
+            };
+            let (block_keys, rolling, pending) =
+                prompt_blocks(&front.req.prompt_token_ids, block_size);
+            let cached_blocks = if p.prefix_cache {
+                self.cache.match_prefix(&block_keys)
+            } else {
+                0
+            };
+            let cached_tokens = (cached_blocks as u32 * p.block_size).min(front.prompt_tokens);
+            let uncached = front.prompt_tokens - cached_tokens;
+
+            // Admission control: require KV room for the uncached prompt unless
+            // the engine is empty (a prompt larger than all of KV must still run).
+            let free = p.kv_capacity_tokens.saturating_sub(self.used_tokens(p));
+            if u64::from(uncached) > free && !self.running.is_empty() {
+                break;
+            }
+
+            let w = self.waiting.pop_front().expect("front exists");
+            let NewRequest {
+                request_id,
+                prompt_token_ids,
+                max_new,
+                events,
+            } = w.req;
+
+            if cached_blocks > 0 {
+                self.cache.touch(&block_keys[..cached_blocks]);
+            }
+            // Allocate + announce the uncached prompt blocks (resident during prefill).
+            let mut prev = cached_blocks.checked_sub(1).map(|i| block_keys[i]);
+            for j in cached_blocks..block_keys.len() {
+                let key = block_keys[j];
+                if p.prefix_cache && self.cache.insert(key) {
+                    let toks = prompt_token_ids[j * block_size..(j + 1) * block_size].to_vec();
+                    kv.push(self.stored_event(key, toks, prev, p.block_size));
+                }
+                prev = Some(key);
+            }
+
+            let resolved_max_new = if max_new == 0 {
+                p.max_new_default
+            } else {
+                max_new
+            };
+            let sample = if w.prompt_tokens > 0 {
+                f64::from(cached_tokens) / f64::from(w.prompt_tokens)
+            } else {
+                0.0
+            };
+            self.cache_hit_ewma = ewma(self.cache_hit_ewma, sample, 0.2);
+
+            self.running.push(RunningReq {
+                events,
+                prompt_tokens: w.prompt_tokens,
+                cached_tokens,
+                max_new: resolved_max_new,
+                generated: 0,
+                prefill_remaining: uncached,
+                rolling_hash: rolling,
+                prev_block_key: prev,
+                pending_block: pending,
+                output_ids: Vec::new(),
+                token_seed: fnv_hash_str(&request_id) as u32,
+            });
+        }
+    }
+
+    /// Evict LRU blocks once KV usage crosses the high watermark.
+    fn evict(&mut self, p: &EngineParams, kv: &mut Vec<common::KvCacheEvent>) {
+        if !p.prefix_cache {
+            return;
+        }
+        let b = p.block_size as u64;
+        let partial: u64 = self
+            .running
+            .iter()
+            .map(|r| r.pending_block.len() as u64)
+            .sum();
+        let mut blocks = self.cache.len() as u64;
+        let high = (p.kv_capacity_tokens as f64 * p.kv_high_watermark) as u64;
+        if blocks * b + partial <= high {
+            return;
+        }
+        let low = (p.kv_capacity_tokens as f64 * p.kv_low_watermark) as u64;
+        let mut removed: Vec<i64> = Vec::new();
+        while blocks * b + partial > low {
+            match self.cache.evict_one() {
+                Some(key) => {
+                    removed.push(key as i64);
+                    blocks -= 1;
+                }
+                None => break,
+            }
+        }
+        if !removed.is_empty() {
+            self.kv_event_id += 1;
+            kv.push(common::KvCacheEvent {
+                event_id: self.kv_event_id,
+                data: Some(common::kv_cache_event::Data::Removed(
+                    common::KvBlocksRemoved {
+                        block_hashes: removed,
+                        cache_level: None,
+                    },
+                )),
+            });
+        }
+    }
+
+    fn stored_event(
+        &mut self,
+        key: u64,
+        token_ids: Vec<u32>,
+        parent: Option<u64>,
+        block_size: u32,
+    ) -> common::KvCacheEvent {
+        self.kv_event_id += 1;
+        common::KvCacheEvent {
+            event_id: self.kv_event_id,
+            data: Some(common::kv_cache_event::Data::Stored(
+                common::KvBlocksStored {
+                    blocks: vec![common::KvBlock {
+                        block_hash: key as i64,
+                        token_ids,
+                        block_size: block_size as i32,
+                        lora_id: None,
+                        cache_level: None,
+                    }],
+                    parent_block_hash: parent.map(|k| k as i64),
+                },
+            )),
+        }
+    }
+}
+
+impl LoadSnapshot {
+    fn idle(p: &EngineParams) -> Self {
+        Self {
+            num_running_reqs: 0,
+            num_waiting_reqs: 0,
+            num_waiting_uncached_tokens: 0,
+            num_used_tokens: 0,
+            max_total_num_tokens: p.kv_capacity_tokens.min(i32::MAX as u64) as i32,
+            max_running_requests: p.max_running.min(i32::MAX as usize) as i32,
+            token_usage: 0.0,
+            gen_throughput: 0.0,
+            cache_hit_rate: 0.0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+fn fnv_step(mut h: u64, token: u32) -> u64 {
+    for b in token.to_le_bytes() {
+        h ^= u64::from(b);
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    h
+}
+
+fn fnv_hash_str(s: &str) -> u64 {
+    let mut h = FNV_OFFSET;
+    for b in s.bytes() {
+        h ^= u64::from(b);
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    h
+}
+
+/// Chunk `ids` into `block_size`-token blocks, returning each full block's
+/// cumulative-prefix content key, the rolling hash after all tokens, and the
+/// trailing partial block. The partial (< block_size) tail is never a block —
+/// matching real engines, which only cache full pages.
+fn prompt_blocks(ids: &[u32], block_size: usize) -> (Vec<u64>, u64, Vec<u32>) {
+    let mut h = FNV_OFFSET;
+    let mut keys = Vec::new();
+    let mut pending = Vec::new();
+    for &t in ids {
+        h = fnv_step(h, t);
+        pending.push(t);
+        if block_size > 0 && pending.len() == block_size {
+            keys.push(h);
+            pending.clear();
+        }
+    }
+    (keys, h, pending)
+}
+
+/// A synthetic, request-specific output token id. Decode blocks must never
+/// collide across requests (only shared *prompt* prefixes should match), so the
+/// id is derived from the request seed and position.
+fn next_token(r: &RunningReq) -> u32 {
+    let mixed = r
+        .token_seed
+        .wrapping_add(r.generated)
+        .wrapping_mul(2_654_435_761);
+    100 + (mixed % 30_000)
+}
+
+fn ewma(prev: f64, sample: f64, alpha: f64) -> f64 {
+    alpha * sample + (1.0 - alpha) * prev
+}
+
+// ---------------------------------------------------------------------------
+// Tests — drive the pure `step()` directly, no real timers.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Make a request plus a receiver to observe its events.
+    fn req(
+        id: &str,
+        prompt: Vec<u32>,
+        max_new: u32,
+    ) -> (NewRequest, mpsc::UnboundedReceiver<GenEvent>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            NewRequest {
+                request_id: id.to_string(),
+                prompt_token_ids: prompt,
+                max_new,
+                events: tx,
+            },
+            rx,
+        )
+    }
+
+    /// Run steps until the given request emits its first Token, returning the
+    /// accumulated simulated time (TTFT) and step count.
+    fn run_to_first_token(
+        st: &mut SchedulerState,
+        p: &EngineParams,
+        rx: &mut mpsc::UnboundedReceiver<GenEvent>,
+    ) -> (Duration, u32) {
+        let mut total = Duration::ZERO;
+        for _ in 0..100_000 {
+            let step = st.step(p);
+            total += step.duration;
+            for (tx, ev) in step.sends {
+                let _ = tx.send(ev);
+            }
+            if let Ok(GenEvent::Token { .. }) = rx.try_recv() {
+                return (total, 1);
+            }
+        }
+        panic!("no token produced");
+    }
+
+    #[test]
+    fn ttft_scales_with_uncached_prompt_length() {
+        let p = EngineParams {
+            prefix_cache: false,
+            ..Default::default()
+        };
+        let mut s1 = SchedulerState::new();
+        let (r1, mut rx1) = req("a", vec![7; 64], 4);
+        s1.enqueue(r1, &p);
+        let (short, _) = run_to_first_token(&mut s1, &p, &mut rx1);
+
+        let mut s2 = SchedulerState::new();
+        let (r2, mut rx2) = req("b", vec![7; 8192], 4);
+        s2.enqueue(r2, &p);
+        let (long, _) = run_to_first_token(&mut s2, &p, &mut rx2);
+
+        assert!(
+            long > short * 5,
+            "TTFT should grow with prompt size: short={short:?} long={long:?}"
+        );
+    }
+
+    #[test]
+    fn itl_grows_with_batch_size() {
+        let p = EngineParams {
+            prefix_cache: false,
+            prefill_chunk_tokens: 1_000_000, // finish prefill in one step
+            ..Default::default()
+        };
+
+        let decode_step_duration = |n: usize| -> Duration {
+            let mut st = SchedulerState::new();
+            // Keep receivers alive: a dropped receiver looks like a disconnected
+            // client and the engine would abort the request.
+            let mut rxs = Vec::new();
+            for i in 0..n {
+                let (r, rx) = req(&format!("r{i}"), vec![1, 2, 3, 4], 8);
+                st.enqueue(r, &p);
+                rxs.push(rx);
+            }
+            st.step(&p); // admit + prefill + first tokens
+            let duration = st.step(&p).duration; // a pure decode step
+            drop(rxs);
+            duration
+        };
+
+        let one = decode_step_duration(1);
+        let many = decode_step_duration(64);
+        assert!(
+            many > one,
+            "decode step should be slower with a bigger batch: one={one:?} many={many:?}"
+        );
+    }
+
+    #[test]
+    fn shared_prefix_yields_cached_tokens() {
+        let p = EngineParams {
+            block_size: 4,
+            ..Default::default()
+        };
+        let mut st = SchedulerState::new();
+
+        // First request stores its prompt blocks.
+        let prompt: Vec<u32> = (0..16).collect(); // 4 full blocks of 4
+        let (r1, mut rx1) = req("first", prompt.clone(), 2);
+        st.enqueue(r1, &p);
+        for _ in 0..50 {
+            let step = st.step(&p);
+            for (tx, ev) in step.sends {
+                let _ = tx.send(ev);
+            }
+        }
+
+        // Second request shares the whole prompt prefix.
+        let (r2, mut rx2) = req("second", prompt, 2);
+        st.enqueue(r2, &p);
+        st.step(&p); // admission computes the cache hit
+        let _ = &mut rx1;
+
+        let mut saw_cached = false;
+        for _ in 0..50 {
+            let step = st.step(&p);
+            for (tx, ev) in step.sends {
+                let _ = tx.send(ev);
+            }
+            while let Ok(ev) = rx2.try_recv() {
+                if let GenEvent::Token { cached_tokens, .. } = ev {
+                    assert_eq!(cached_tokens, 16, "full prompt prefix should be cached");
+                    saw_cached = true;
+                }
+            }
+        }
+        assert!(saw_cached, "second request should report cached tokens");
+    }
+
+    #[test]
+    fn saturation_produces_queued_token_work() {
+        let p = EngineParams {
+            max_running: 1,
+            prefix_cache: false,
+            ..Default::default()
+        };
+        let mut st = SchedulerState::new();
+        let mut rxs = Vec::new(); // keep receivers alive (see itl test)
+        for i in 0..3 {
+            let (r, rx) = req(&format!("r{i}"), vec![5; 100], 32);
+            st.enqueue(r, &p);
+            rxs.push(rx);
+        }
+        let step = st.step(&p); // admit only 1; 2 remain queued
+        assert_eq!(step.snapshot.num_running_reqs, 1);
+        assert_eq!(step.snapshot.num_waiting_reqs, 2);
+        assert_eq!(step.snapshot.num_waiting_uncached_tokens, 200);
+        drop(rxs);
+    }
+
+    #[test]
+    fn prompt_blocks_emit_chained_kv_events() {
+        let p = EngineParams {
+            block_size: 4,
+            ..Default::default()
+        };
+        let mut st = SchedulerState::new();
+        let (r, _rx) = req("x", (0..8).collect(), 1); // 2 full blocks
+        st.enqueue(r, &p);
+        let step = st.step(&p);
+        let batch = step.batch.expect("stored events expected");
+        assert_eq!(batch.sequence_number, 1);
+        let stored: Vec<_> = batch
+            .events
+            .iter()
+            .filter_map(|e| match &e.data {
+                Some(common::kv_cache_event::Data::Stored(s)) => Some(s),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(stored.len(), 2, "two prompt blocks");
+        assert!(
+            stored[0].parent_block_hash.is_none(),
+            "first block has no parent"
+        );
+        let first_hash = stored[0].blocks[0].block_hash;
+        assert_eq!(
+            stored[1].parent_block_hash,
+            Some(first_hash),
+            "second block chains to the first"
+        );
+    }
+
+    #[test]
+    fn kv_pressure_evicts_and_emits_removed() {
+        // Tiny KV so a couple of prompts overflow it.
+        let p = EngineParams {
+            block_size: 4,
+            kv_capacity_tokens: 64,
+            kv_high_watermark: 0.5,
+            kv_low_watermark: 0.25,
+            max_running: 64,
+            prefill_chunk_tokens: 1_000_000,
+            ..Default::default()
+        };
+        let mut st = SchedulerState::new();
+        for i in 0..8 {
+            // Distinct prompts so each contributes its own blocks.
+            let base = (i as u32) * 1000;
+            let (r, _rx) = req(&format!("r{i}"), (base..base + 16).collect(), 1);
+            st.enqueue(r, &p);
+        }
+        let mut saw_removed = false;
+        for _ in 0..50 {
+            let step = st.step(&p);
+            if let Some(batch) = step.batch {
+                if batch
+                    .events
+                    .iter()
+                    .any(|e| matches!(e.data, Some(common::kv_cache_event::Data::Removed(_))))
+                {
+                    saw_removed = true;
+                }
+            }
+        }
+        assert!(saw_removed, "KV pressure should emit a removed event");
+    }
+}

--- a/crates/mock_worker/src/grpc.rs
+++ b/crates/mock_worker/src/grpc.rs
@@ -9,13 +9,17 @@ use std::{
 
 use futures::{stream, Stream};
 use smg_grpc_client::{common_proto as common, tokenspeed_scheduler::tokenspeed_proto as ts};
+use tokio::sync::mpsc;
 use tonic::{transport::Server, Request, Response, Status};
 use ts::{
     generate_response::Response as GenResp,
     token_speed_scheduler_server::{TokenSpeedScheduler, TokenSpeedSchedulerServer},
 };
 
-use crate::config::Config;
+use crate::{
+    config::Config,
+    engine::{self, Engine, NewRequest},
+};
 
 /// Serve the mock TokenSpeed gRPC service on `port` until the process exits.
 pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
@@ -27,7 +31,9 @@ pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
         }
     };
     let addr = SocketAddr::new(ip, port);
-    let service = MockScheduler { cfg };
+    // One simulated engine per listener (i.e. per virtual worker).
+    let engine = cfg.realistic.then(|| Engine::spawn(cfg.engine.clone()));
+    let service = MockScheduler { cfg, engine };
     if let Err(e) = Server::builder()
         .add_service(TokenSpeedSchedulerServer::new(service))
         .serve(addr)
@@ -40,18 +46,50 @@ pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
 #[derive(Clone)]
 struct MockScheduler {
     cfg: Arc<Config>,
+    /// Present iff the worker runs the realistic engine simulator.
+    engine: Option<Engine>,
 }
 
 type GenStream = Pin<Box<dyn Stream<Item = Result<ts::GenerateResponse, Status>> + Send>>;
+type KvEventStream = Pin<Box<dyn Stream<Item = Result<common::KvEventBatch, Status>> + Send>>;
 
 #[tonic::async_trait]
 impl TokenSpeedScheduler for MockScheduler {
     type GenerateStream = GenStream;
+    type SubscribeKvEventsStream = KvEventStream;
 
     async fn generate(
         &self,
         request: Request<ts::GenerateRequest>,
     ) -> Result<Response<Self::GenerateStream>, Status> {
+        // Realistic mode: submit to the engine simulator and stream its output.
+        if let Some(engine) = &self.engine {
+            let req = request.into_inner();
+            let request_id = req.request_id;
+            let prompt_token_ids = req.tokenized.map(|t| t.input_ids).unwrap_or_default();
+            // Omitted limit falls back to the worker default, matching the HTTP
+            // path; `unwrap_or(0)` here would make unbounded requests generate
+            // nothing (zero tokens), starving the routing signals.
+            let max_new = req
+                .sampling_params
+                .and_then(|s| s.max_new_tokens)
+                .unwrap_or(self.cfg.output_tokens);
+            let stream_chunks = req.stream;
+            let (tx, rx) = mpsc::unbounded_channel();
+            engine.submit(NewRequest {
+                request_id: request_id.clone(),
+                prompt_token_ids,
+                max_new,
+                events: tx,
+            });
+            return Ok(Response::new(generate_stream(
+                rx,
+                stream_chunks,
+                request_id,
+            )));
+        }
+
+        // Canned mode: a single up-front delay, then synthetic token ids.
         let request_id = request.into_inner().request_id;
         if !self.cfg.gen_delay.is_zero() {
             tokio::time::sleep(self.cfg.gen_delay).await;
@@ -152,14 +190,13 @@ impl TokenSpeedScheduler for MockScheduler {
         &self,
         _request: Request<ts::GetLoadsRequest>,
     ) -> Result<Response<ts::GetLoadsResponse>, Status> {
-        Ok(Response::new(ts::GetLoadsResponse {
-            timestamp: String::new(),
-            version: "mock".to_string(),
-            dp_rank_count: 1,
-            loads: vec![ts::SchedulerLoad {
+        let load = match &self.engine {
+            Some(engine) => snapshot_to_scheduler_load(&engine.load()),
+            None => ts::SchedulerLoad {
                 dp_rank: 0,
                 num_running_reqs: 0,
                 num_waiting_reqs: 0,
+                num_waiting_uncached_tokens: 0,
                 num_total_reqs: 0,
                 num_used_tokens: 0,
                 max_total_num_tokens: 1_000_000,
@@ -170,9 +207,33 @@ impl TokenSpeedScheduler for MockScheduler {
                 utilization: 0.0,
                 memory: None,
                 queues: None,
-            }],
+            },
+        };
+        Ok(Response::new(ts::GetLoadsResponse {
+            timestamp: String::new(),
+            version: "mock".to_string(),
+            dp_rank_count: 1,
+            loads: vec![load],
             aggregate: None,
         }))
+    }
+
+    async fn subscribe_kv_events(
+        &self,
+        request: Request<common::SubscribeKvEventsRequest>,
+    ) -> Result<Response<Self::SubscribeKvEventsStream>, Status> {
+        match &self.engine {
+            // Realistic mode with prefix caching: stream the engine's KV events.
+            Some(engine) if engine.kv_enabled() => {
+                let start = request.into_inner().start_sequence_number;
+                Ok(Response::new(engine.subscribe_kv(start)))
+            }
+            // Otherwise Unimplemented makes the gateway's KvEventMonitor give up
+            // cleanly (no idle per-worker task), exactly as before this RPC existed.
+            _ => Err(Status::unimplemented(
+                "mock-worker (KV events require --engine realistic with --prefix-cache true)",
+            )),
+        }
     }
 
     async fn flush_cache(
@@ -194,5 +255,91 @@ impl TokenSpeedScheduler for MockScheduler {
         _request: Request<common::StopProfileRequest>,
     ) -> Result<Response<common::ProfileResponse>, Status> {
         Err(Status::unimplemented("mock-worker"))
+    }
+}
+
+/// Map the engine's [`engine::GenEvent`] channel to the gRPC generate stream.
+/// In streaming mode each token becomes a `Chunk`; otherwise tokens are
+/// accumulated and only the final `Complete` is sent. After `Complete` the
+/// engine has dropped the sender, so the next `recv()` yields `None` and the
+/// stream ends.
+fn generate_stream(
+    rx: mpsc::UnboundedReceiver<engine::GenEvent>,
+    stream_chunks: bool,
+    request_id: String,
+) -> GenStream {
+    let init = (rx, Vec::<u32>::new(), stream_chunks, request_id);
+    Box::pin(stream::unfold(
+        init,
+        |(mut rx, mut output_ids, stream_chunks, request_id)| async move {
+            loop {
+                match rx.recv().await {
+                    Some(engine::GenEvent::Token {
+                        token_id,
+                        prompt_tokens,
+                        cached_tokens,
+                    }) => {
+                        output_ids.push(token_id);
+                        if stream_chunks {
+                            let resp = ts::GenerateResponse {
+                                request_id: request_id.clone(),
+                                response: Some(GenResp::Chunk(ts::GenerateStreamChunk {
+                                    token_ids: vec![token_id],
+                                    prompt_tokens,
+                                    completion_tokens: output_ids.len() as u32,
+                                    cached_tokens,
+                                    output_logprobs: None,
+                                    index: 0,
+                                })),
+                            };
+                            return Some((Ok(resp), (rx, output_ids, stream_chunks, request_id)));
+                        }
+                        // Non-streaming: keep accumulating until Done.
+                    }
+                    Some(engine::GenEvent::Done {
+                        finish_reason,
+                        prompt_tokens,
+                        completion_tokens,
+                        cached_tokens,
+                    }) => {
+                        let resp = ts::GenerateResponse {
+                            request_id: request_id.clone(),
+                            response: Some(GenResp::Complete(ts::GenerateComplete {
+                                output_ids: std::mem::take(&mut output_ids),
+                                finish_reason: finish_reason.to_string(),
+                                prompt_tokens,
+                                completion_tokens,
+                                cached_tokens,
+                                output_logprobs: None,
+                                matched_stop: None,
+                                index: 0,
+                            })),
+                        };
+                        return Some((Ok(resp), (rx, output_ids, stream_chunks, request_id)));
+                    }
+                    None => return None,
+                }
+            }
+        },
+    ))
+}
+
+/// Map an engine load snapshot to the TokenSpeed `SchedulerLoad` wire type.
+fn snapshot_to_scheduler_load(s: &engine::LoadSnapshot) -> ts::SchedulerLoad {
+    ts::SchedulerLoad {
+        dp_rank: 0,
+        num_running_reqs: s.num_running_reqs,
+        num_waiting_reqs: s.num_waiting_reqs,
+        num_waiting_uncached_tokens: s.num_waiting_uncached_tokens,
+        num_total_reqs: s.num_running_reqs + s.num_waiting_reqs,
+        num_used_tokens: s.num_used_tokens,
+        max_total_num_tokens: s.max_total_num_tokens,
+        max_running_requests: s.max_running_requests,
+        token_usage: s.token_usage,
+        gen_throughput: s.gen_throughput,
+        cache_hit_rate: s.cache_hit_rate,
+        utilization: s.token_usage,
+        memory: None,
+        queues: None,
     }
 }

--- a/crates/mock_worker/src/http.rs
+++ b/crates/mock_worker/src/http.rs
@@ -1,7 +1,20 @@
 //! Mock HTTP worker endpoints — the vLLM/SGLang-compatible surface the SMG
-//! gateway probes and routes to. Every response is canned; no real model.
+//! gateway probes and routes to.
+//!
+//! In canned mode every response is fixed (no model). In realistic mode each
+//! worker is backed by the engine simulator ([`crate::engine`]); since the HTTP
+//! path carries text rather than token ids, the prompt is approximated into
+//! synthetic token ids (one per whitespace word) so shared text prefixes still
+//! produce cache hits and prompt length still drives prefill latency. Token-id
+//! KV events (event-driven `cache_aware`) remain a gRPC-path feature.
 
-use std::{convert::Infallible, sync::Arc};
+use std::{
+    convert::Infallible,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use axum::{
     body::Bytes,
@@ -15,20 +28,29 @@ use axum::{
 };
 use futures::{stream, Stream};
 use serde_json::{json, Value};
-use tokio::net::TcpListener;
+use tokio::{net::TcpListener, sync::mpsc};
 
-use crate::config::Config;
+use crate::{
+    config::Config,
+    engine::{self, Engine, NewRequest},
+};
+
+/// Per-listener HTTP state: shared config plus an optional engine simulator.
+pub struct AppState {
+    cfg: Arc<Config>,
+    engine: Option<Engine>,
+}
 
 /// Build the router serving the mock HTTP worker contract.
-pub fn router(cfg: Arc<Config>) -> Router {
+pub fn router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/v1/models", get(models))
-        .route("/v1/chat/completions", post(chat))
-        .route("/v1/completions", post(chat))
-        .route("/generate", post(chat))
+        .route("/v1/chat/completions", post(chat_completions))
+        .route("/v1/completions", post(completions))
+        .route("/generate", post(chat_completions))
         .route("/v1/loads", get(loads))
-        .with_state(cfg)
+        .with_state(state)
 }
 
 /// Serve the mock HTTP worker contract on `port` until the process exits.
@@ -40,7 +62,10 @@ pub async fn serve(cfg: Arc<Config>, host: String, port: u16) {
             return;
         }
     };
-    if let Err(e) = axum::serve(listener, router(cfg)).await {
+    // One simulated engine per listener (i.e. per virtual worker).
+    let engine = cfg.realistic.then(|| Engine::spawn(cfg.engine.clone()));
+    let state = Arc::new(AppState { cfg, engine });
+    if let Err(e) = axum::serve(listener, router(state)).await {
         tracing::error!("http worker {port} stopped: {e}");
     }
 }
@@ -49,26 +74,39 @@ async fn health() -> &'static str {
     "OK"
 }
 
-async fn models(State(cfg): State<Arc<Config>>) -> Response {
+async fn models(State(state): State<Arc<AppState>>) -> Response {
     Json(json!({
         "object": "list",
         "data": [{
-            "id": cfg.model_id,
+            "id": state.cfg.model_id,
             "object": "model",
             "created": 0,
             "owned_by": "sglang",
-            "root": cfg.model_id,
+            "root": state.cfg.model_id,
             "max_model_len": 32768,
         }],
     }))
     .into_response()
 }
 
-async fn loads() -> Response {
-    Json(json!({
-        "timestamp": "",
-        "dp_rank_count": 1,
-        "loads": [{
+async fn loads(State(state): State<Arc<AppState>>) -> Response {
+    let load = state.engine.as_ref().map(|e| e.load());
+    let value = match load {
+        Some(s) => json!({
+            "dp_rank": 0,
+            "num_running_reqs": s.num_running_reqs,
+            "num_waiting_reqs": s.num_waiting_reqs,
+            "num_waiting_uncached_tokens": s.num_waiting_uncached_tokens,
+            "num_total_reqs": s.num_running_reqs + s.num_waiting_reqs,
+            "num_used_tokens": s.num_used_tokens,
+            "max_total_num_tokens": s.max_total_num_tokens,
+            "token_usage": s.token_usage,
+            "gen_throughput": s.gen_throughput,
+            "cache_hit_rate": s.cache_hit_rate,
+            "utilization": s.token_usage,
+            "max_running_requests": s.max_running_requests,
+        }),
+        None => json!({
             "dp_rank": 0,
             "num_running_reqs": 0,
             "num_waiting_reqs": 0,
@@ -81,27 +119,73 @@ async fn loads() -> Response {
             "cache_hit_rate": 0.0,
             "utilization": 0.0,
             "max_running_requests": 0,
-        }],
-    }))
-    .into_response()
+        }),
+    };
+    Json(json!({ "timestamp": "", "dp_rank_count": 1, "loads": [value] })).into_response()
 }
 
-async fn chat(State(cfg): State<Arc<Config>>, body: Bytes) -> Response {
-    let stream_requested = serde_json::from_slice::<Value>(&body)
-        .ok()
+/// OpenAI response shape this worker replies in. Chat emits
+/// `choices[].message` / `choices[].delta.content`; completions emits
+/// `choices[].text`. The load generator parses the two differently, so
+/// `/v1/completions` must not be answered with chat-shaped frames.
+#[derive(Clone, Copy)]
+enum Endpoint {
+    Chat,
+    Completions,
+}
+
+async fn chat_completions(State(state): State<Arc<AppState>>, body: Bytes) -> Response {
+    handle(Endpoint::Chat, state, body).await
+}
+
+async fn completions(State(state): State<Arc<AppState>>, body: Bytes) -> Response {
+    handle(Endpoint::Completions, state, body).await
+}
+
+async fn handle(endpoint: Endpoint, state: Arc<AppState>, body: Bytes) -> Response {
+    let parsed: Option<Value> = serde_json::from_slice(&body).ok();
+    let stream_requested = parsed
+        .as_ref()
         .and_then(|v| v.get("stream").and_then(Value::as_bool))
         .unwrap_or(false);
 
-    if !cfg.gen_delay.is_zero() {
-        tokio::time::sleep(cfg.gen_delay).await;
+    // Realistic mode: drive the engine simulator.
+    if let Some(engine) = &state.engine {
+        let parsed = parsed.unwrap_or(Value::Null);
+        let prompt_ids = synth_token_ids(&extract_prompt_text(&parsed));
+        let prompt_tokens = prompt_ids.len() as u32;
+        let max_new = extract_max_tokens(&parsed).unwrap_or(state.cfg.output_tokens);
+        let request_id = next_request_id();
+        let (tx, rx) = mpsc::unbounded_channel();
+        engine.submit(NewRequest {
+            request_id,
+            prompt_token_ids: prompt_ids,
+            max_new,
+            events: tx,
+        });
+        let model = state.cfg.model_id.clone();
+        return if stream_requested {
+            realistic_sse(rx, model, endpoint).into_response()
+        } else {
+            realistic_completion(rx, model, prompt_tokens, endpoint)
+                .await
+                .into_response()
+        };
     }
 
+    // Canned mode: a single up-front delay, then a fixed response. Always
+    // chat-shaped (unchanged) so the existing scale rig is unaffected.
+    if !state.cfg.gen_delay.is_zero() {
+        tokio::time::sleep(state.cfg.gen_delay).await;
+    }
     if stream_requested {
-        stream_chat(&cfg).into_response()
+        stream_chat(&state.cfg).into_response()
     } else {
-        Json(completion(&cfg)).into_response()
+        Json(completion(&state.cfg)).into_response()
     }
 }
+
+// ── Canned responses ───────────────────────────────────────────────────────
 
 fn completion(cfg: &Config) -> Value {
     json!({
@@ -140,4 +224,202 @@ fn stream_chat(cfg: &Config) -> Sse<impl Stream<Item = Result<Event, Infallible>
     events.push(Ok(Event::default().data(final_frame.to_string())));
     events.push(Ok(Event::default().data("[DONE]")));
     Sse::new(stream::iter(events))
+}
+
+// ── Realistic responses ─────────────────────────────────────────────────────
+
+/// Non-streaming: drain the engine's events and assemble one completion JSON.
+async fn realistic_completion(
+    mut rx: mpsc::UnboundedReceiver<engine::GenEvent>,
+    model: String,
+    prompt_tokens: u32,
+    endpoint: Endpoint,
+) -> Json<Value> {
+    let mut completion_tokens = 0u32;
+    let mut cached_tokens = 0u32;
+    while let Some(ev) = rx.recv().await {
+        match ev {
+            engine::GenEvent::Token { .. } => completion_tokens += 1,
+            engine::GenEvent::Done {
+                completion_tokens: c,
+                cached_tokens: cached,
+                ..
+            } => {
+                completion_tokens = c;
+                cached_tokens = cached;
+            }
+        }
+    }
+    let usage = json!({
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+        "cached_tokens": cached_tokens,
+    });
+    Json(match endpoint {
+        Endpoint::Chat => json!({
+            "id": "chatcmpl-mock",
+            "object": "chat.completion",
+            "created": 0,
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "mock"},
+                "finish_reason": "stop",
+            }],
+            "usage": usage,
+        }),
+        Endpoint::Completions => json!({
+            "id": "cmpl-mock",
+            "object": "text_completion",
+            "created": 0,
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "text": "mock",
+                "finish_reason": "stop",
+            }],
+            "usage": usage,
+        }),
+    })
+}
+
+/// Streaming: map the engine's events to SSE chunks, ending with a finish frame
+/// and `[DONE]`. Frame shape follows `endpoint` (chat delta vs completion text).
+fn realistic_sse(
+    rx: mpsc::UnboundedReceiver<engine::GenEvent>,
+    model: String,
+    endpoint: Endpoint,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    enum St {
+        Active {
+            rx: mpsc::UnboundedReceiver<engine::GenEvent>,
+            model: String,
+            endpoint: Endpoint,
+        },
+        Closing,
+        Ended,
+    }
+
+    let body = stream::unfold(
+        St::Active {
+            rx,
+            model,
+            endpoint,
+        },
+        |st| async move {
+            match st {
+                St::Active {
+                    mut rx,
+                    model,
+                    endpoint,
+                } => match rx.recv().await {
+                    Some(engine::GenEvent::Token { .. }) => {
+                        let frame = token_chunk(endpoint, &model);
+                        Some((
+                            Ok(Event::default().data(frame.to_string())),
+                            St::Active {
+                                rx,
+                                model,
+                                endpoint,
+                            },
+                        ))
+                    }
+                    Some(engine::GenEvent::Done { .. }) => {
+                        let frame = final_chunk(endpoint, &model);
+                        Some((Ok(Event::default().data(frame.to_string())), St::Closing))
+                    }
+                    None => None,
+                },
+                St::Closing => Some((Ok(Event::default().data("[DONE]")), St::Ended)),
+                St::Ended => None,
+            }
+        },
+    );
+    Sse::new(body)
+}
+
+/// One streamed token frame in the shape the requesting endpoint expects.
+fn token_chunk(endpoint: Endpoint, model: &str) -> Value {
+    match endpoint {
+        Endpoint::Chat => json!({
+            "id": "chatcmpl-mock",
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{"index": 0, "delta": {"content": "x"}, "finish_reason": null}],
+        }),
+        Endpoint::Completions => json!({
+            "id": "cmpl-mock",
+            "object": "text_completion",
+            "model": model,
+            "choices": [{"index": 0, "text": "x", "finish_reason": null}],
+        }),
+    }
+}
+
+/// The terminal frame (`finish_reason = stop`) for the requesting endpoint.
+fn final_chunk(endpoint: Endpoint, model: &str) -> Value {
+    match endpoint {
+        Endpoint::Chat => json!({
+            "id": "chatcmpl-mock",
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        }),
+        Endpoint::Completions => json!({
+            "id": "cmpl-mock",
+            "object": "text_completion",
+            "model": model,
+            "choices": [{"index": 0, "text": "", "finish_reason": "stop"}],
+        }),
+    }
+}
+
+// ── HTTP prompt helpers ──────────────────────────────────────────────────────
+
+/// Extract prompt text from a chat/completions/generate body.
+fn extract_prompt_text(v: &Value) -> String {
+    if let Some(messages) = v.get("messages").and_then(Value::as_array) {
+        return messages
+            .iter()
+            .filter_map(|m| m.get("content").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join(" ");
+    }
+    for key in ["prompt", "text", "inputs"] {
+        if let Some(s) = v.get(key).and_then(Value::as_str) {
+            return s.to_string();
+        }
+    }
+    String::new()
+}
+
+/// Approximate a prompt's token ids from its text: one id per whitespace word,
+/// each a stable hash of the word. Identical leading words yield identical
+/// leading ids, so shared prefixes still produce cache hits.
+fn synth_token_ids(text: &str) -> Vec<u32> {
+    text.split_whitespace().map(hash_word).collect()
+}
+
+fn hash_word(w: &str) -> u32 {
+    let mut h: u32 = 2_166_136_261;
+    for b in w.bytes() {
+        h ^= u32::from(b);
+        h = h.wrapping_mul(16_777_619);
+    }
+    h % 30_000
+}
+
+fn extract_max_tokens(v: &Value) -> Option<u32> {
+    for key in ["max_tokens", "max_new_tokens"] {
+        if let Some(n) = v.get(key).and_then(Value::as_u64) {
+            return Some(n as u32);
+        }
+    }
+    None
+}
+
+fn next_request_id() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    format!("mock-http-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
 }

--- a/crates/mock_worker/src/main.rs
+++ b/crates/mock_worker/src/main.rs
@@ -7,6 +7,7 @@
 //! All responses are canned — there is no real model.
 
 mod config;
+mod engine;
 mod grpc;
 mod http;
 

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -315,11 +315,9 @@ impl GrpcClient {
             Self::Sglang(client) => client.subscribe_kv_events(start_seq).await,
             Self::Vllm(client) => client.subscribe_kv_events(start_seq).await,
             Self::Trtllm(client) => client.subscribe_kv_events(start_seq).await,
+            Self::TokenSpeed(client) => client.subscribe_kv_events(start_seq).await,
             Self::Mlx(_) => Err(tonic::Status::unimplemented(
                 "SubscribeKvEvents RPC not supported for MLX backend",
-            )),
-            Self::TokenSpeed(_) => Err(tonic::Status::unimplemented(
-                "SubscribeKvEvents RPC not supported for TokenSpeed backend",
             )),
         }
     }

--- a/scripts/sim_ab.sh
+++ b/scripts/sim_ab.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# No-GPU routing-policy A/B harness for SMG, using the realistic mock engine.
+#
+# For each routing policy, this launches an IGW gateway plus a fleet of mock
+# workers running the continuous-batching engine simulator (crates/mock_worker
+# --engine realistic), drives the same Poisson workload (scripts/sim_load.py),
+# and prints a side-by-side table of TTFT / ITL / E2E / throughput. Because the
+# mock reports realistic loads and emits KV-cache events, least_load and
+# cache_aware engage exactly as they would against a real engine — on CPU.
+#
+# Modes:
+#   grpc (default) — full fidelity. The gateway tokenizes prompts and routes on
+#     token ids, so BOTH least_load (queued token-work) and cache_aware
+#     (event-driven KV overlap) are exercised. Requires a real tokenizer for the
+#     model (default: the public `gpt2`, downloaded by the gateway, or pass a
+#     local dir via --tokenizer). Workers register with runtime=tokenspeed.
+#   http — offline-friendly. No tokenizer needed; drives least_load + latency and
+#     the approximate (string-tree) cache_aware. Workers register runtime=sglang.
+#
+# Usage:
+#   scripts/sim_ab.sh [--mode grpc|http] [--workers N] [--rps R] [--duration S]
+#                     [--policies "p1 p2 ..."] [--tokenizer ID|DIR]
+#                     [--output-tokens N] [--no-build]
+# Examples:
+#   scripts/sim_ab.sh --mode grpc --workers 8 --rps 120 --duration 30
+#   scripts/sim_ab.sh --mode http --workers 16 --policies "random least_load"
+set -euo pipefail
+
+# ---- defaults ----
+MODE=grpc
+WORKERS=8
+POLICIES="random round_robin least_load cache_aware"
+RPS=80
+DURATION=20
+OUTPUT_TOKENS=64
+TOKENIZER=gpt2
+SHARED_PREFIX_WORDS=200
+SHARED_PREFIX_FRAC=0.7
+GW_PORT=30100
+HTTP_BASE=9200
+GRPC_BASE=19200
+MODEL=mock-model
+BUILD=1
+# Realistic engine knobs (forwarded to mock-worker).
+PREFILL_TPS=8000
+DECODE_BASE_MS=6
+DECODE_PER_REQ_MS=0.35
+MAX_RUNNING=256
+KV_TOKENS=524288
+BLOCK_SIZE=16
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) MODE="$2"; shift 2 ;;
+    --workers) WORKERS="$2"; shift 2 ;;
+    --policies) POLICIES="$2"; shift 2 ;;
+    --rps) RPS="$2"; shift 2 ;;
+    --duration) DURATION="$2"; shift 2 ;;
+    --output-tokens) OUTPUT_TOKENS="$2"; shift 2 ;;
+    --tokenizer) TOKENIZER="$2"; shift 2 ;;
+    --shared-prefix-frac) SHARED_PREFIX_FRAC="$2"; shift 2 ;;
+    --kv-tokens) KV_TOKENS="$2"; shift 2 ;;
+    --max-running) MAX_RUNNING="$2"; shift 2 ;;
+    --decode-per-req-ms) DECODE_PER_REQ_MS="$2"; shift 2 ;;
+    --gw-port) GW_PORT="$2"; shift 2 ;;
+    --no-build) BUILD=0; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+case "$MODE" in grpc|http) ;; *) echo "--mode must be grpc|http" >&2; exit 2 ;; esac
+
+ulimit -n "$(ulimit -Hn)" 2>/dev/null || true
+
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT/target}"
+if [[ "$BUILD" -eq 1 ]]; then
+  echo "==> building smg + mock-worker (release)"
+  RUSTC_WRAPPER="" cargo build --release -p smg -p mock-worker
+fi
+SMG="$CARGO_TARGET_DIR/release/smg"
+MOCK="$CARGO_TARGET_DIR/release/mock-worker"
+[[ -x "$SMG" && -x "$MOCK" ]] || { echo "binaries missing (drop --no-build)" >&2; exit 1; }
+
+LOGDIR="${TMPDIR:-/tmp}/smg-sim"
+RESULTS="${TMPDIR:-/tmp}/smg-sim/results"
+mkdir -p "$LOGDIR" "$RESULTS"
+rm -f "$RESULTS"/*.json
+echo "==> logs: $LOGDIR  results: $RESULTS  mode: $MODE  workers: $WORKERS"
+
+GW_PID=""; MOCK_PID=""
+cleanup() {
+  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null || true
+  [[ -n "$GW_PID" ]] && kill "$GW_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+start_fleet() {
+  # Fresh fleet per policy → a clean prefix cache (no cross-policy carryover).
+  local args=(--model "$MODEL" --engine realistic
+    --prefill-tps "$PREFILL_TPS" --decode-base-ms "$DECODE_BASE_MS"
+    --decode-per-req-ms "$DECODE_PER_REQ_MS" --max-running "$MAX_RUNNING"
+    --kv-tokens "$KV_TOKENS" --block-size "$BLOCK_SIZE" --output-tokens "$OUTPUT_TOKENS")
+  if [[ "$MODE" == grpc ]]; then
+    args+=(--grpc-base-port "$GRPC_BASE" --grpc-count "$WORKERS")
+  else
+    args+=(--http-base-port "$HTTP_BASE" --http-count "$WORKERS")
+  fi
+  "$MOCK" "${args[@]}" >"$LOGDIR/mock.log" 2>&1 &
+  MOCK_PID=$!
+  sleep 2
+}
+
+register_workers() {
+  local W="http://127.0.0.1:$GW_PORT/workers"
+  local H='"health":{"disable_health_check":true}'
+  if [[ "$MODE" == grpc ]]; then
+    # runtime=tokenspeed; per-worker tokenizer label so the gateway tokenizes
+    # mock-model; kv_block_size seeds the cache-aware block size.
+    seq "$GRPC_BASE" $((GRPC_BASE + WORKERS - 1)) | xargs -P 16 -I{} \
+      curl -s -o /dev/null --max-time 20 -X POST "$W" -H 'content-type: application/json' \
+      -d "{\"url\":\"grpc://127.0.0.1:{}\",\"connection_mode\":\"grpc\",\"runtime\":\"tokenspeed\",\"models\":[{\"id\":\"$MODEL\"}],\"labels\":{\"tokenizer_path\":\"$TOKENIZER\"},\"kv_block_size\":$BLOCK_SIZE,$H}" || true
+  else
+    seq "$HTTP_BASE" $((HTTP_BASE + WORKERS - 1)) | xargs -P 16 -I{} \
+      curl -s -o /dev/null --max-time 20 -X POST "$W" -H 'content-type: application/json' \
+      -d "{\"url\":\"http://127.0.0.1:{}\",\"connection_mode\":\"http\",\"runtime\":\"sglang\",\"models\":[{\"id\":\"$MODEL\"}],$H}" || true
+  fi
+}
+
+run_policy() {
+  local policy="$1"
+  echo "==> policy: $policy"
+  pkill -9 -x mock-worker 2>/dev/null || true
+  pkill -9 -x smg 2>/dev/null || true
+  sleep 2
+
+  start_fleet
+
+  local gw_args=(--host 127.0.0.1 --port "$GW_PORT" --enable-igw --policy "$policy")
+  # NOTE: tokenizer autoload stays ENABLED in grpc mode — the sim needs real
+  # tokenization for token-aware routing. (scale_test.sh disables it because it
+  # only measures registration/routing cost, not generation.)
+  "$SMG" "${gw_args[@]}" >"$LOGDIR/gateway-$policy.log" 2>&1 &
+  GW_PID=$!
+
+  for _ in $(seq 1 60); do
+    curl -sf "http://127.0.0.1:$GW_PORT/health" >/dev/null 2>&1 && break
+    sleep 1
+  done
+  register_workers
+
+  # Give workers time to reach Ready (and, in grpc mode, the tokenizer to load).
+  sleep 5
+  # Use /v1/completions (raw prompt, no chat template) so any tokenizer works —
+  # base tokenizers like gpt2 have no chat_template. (For chat, start the gateway
+  # with --chat-template and switch sim_load.py to --endpoint chat.)
+  local warm
+  warm=$(curl -s --max-time 30 "http://127.0.0.1:$GW_PORT/v1/completions" \
+    -H 'content-type: application/json' \
+    -d "{\"model\":\"$MODEL\",\"prompt\":\"warmup\",\"max_tokens\":4}" || true)
+  if ! grep -q '"choices"' <<<"$warm"; then
+    echo "    WARN: warmup failed for $policy (tokenizer not ready in grpc mode?)" >&2
+    echo "    response: ${warm:0:200}" >&2
+  fi
+
+  python3 "$ROOT/scripts/sim_load.py" \
+    --url "http://127.0.0.1:$GW_PORT/v1/completions" --endpoint completions --model "$MODEL" \
+    --rps "$RPS" --duration "$DURATION" --output-tokens "$OUTPUT_TOKENS" \
+    --shared-prefix-words "$SHARED_PREFIX_WORDS" --shared-prefix-frac "$SHARED_PREFIX_FRAC" \
+    --label "$policy" --json "$RESULTS/$policy.json" || true
+
+  kill "$GW_PID" 2>/dev/null || true; GW_PID=""
+  kill "$MOCK_PID" 2>/dev/null || true; MOCK_PID=""
+  sleep 2
+}
+
+for p in $POLICIES; do
+  run_policy "$p"
+done
+
+echo
+echo "================ A/B comparison (mode=$MODE, workers=$WORKERS, rps=$RPS, ${DURATION}s) ================"
+python3 - "$RESULTS" <<'PY'
+import glob, json, os, sys
+results_dir = sys.argv[1]
+rows = []
+for path in sorted(glob.glob(os.path.join(results_dir, "*.json"))):
+    with open(path) as f:
+        rows.append(json.load(f))
+if not rows:
+    print("no results"); sys.exit(0)
+hdr = ["policy", "ok", "err", "rps", "out_tps",
+       "TTFT_p50", "TTFT_p90", "TTFT_p99", "ITL_p50", "E2E_p50", "E2E_p99"]
+print("{:<14}{:>7}{:>6}{:>7}{:>9}{:>10}{:>10}{:>10}{:>9}{:>10}{:>10}".format(*hdr))
+for r in rows:
+    print("{:<14}{:>7}{:>6}{:>7}{:>9}{:>10}{:>10}{:>10}{:>9}{:>10}{:>10}".format(
+        r.get("label", "?"), r["ok"], r["err"], r["achieved_rps"], r["output_tps"],
+        r["ttft_ms_p50"], r["ttft_ms_p90"], r["ttft_ms_p99"],
+        r["itl_ms_p50"], r["e2e_ms_p50"], r["e2e_ms_p99"]))
+print("\n(ms unless noted; lower TTFT/ITL/E2E is better; cache_aware should win")
+print(" TTFT on shared-prefix workloads, least_load should tighten the tail.)")
+PY
+echo "==> done"

--- a/scripts/sim_load.py
+++ b/scripts/sim_load.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Streaming load generator for the no-GPU SMG simulation (realistic mock fleet).
+
+Drives the gateway's OpenAI chat endpoint with an open-loop (Poisson) arrival
+process and a workload designed to exercise the routing policies:
+
+- a *shared* system/few-shot prefix prepended to a tunable fraction of requests,
+  so prefix caching (and cache-aware routing) can pay off;
+- a varied unique body, so prompt length (hence prefill/TTFT) varies.
+
+It measures what those policies actually move: time-to-first-token (TTFT),
+inter-token latency (ITL), end-to-end latency, output throughput, and errors —
+and prints percentiles plus a machine-readable summary line. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Result:
+    ok: bool
+    ttft: float | None = None  # seconds to first token
+    e2e: float | None = None  # seconds to final token
+    itls: list[float] = field(default_factory=list)  # inter-token gaps (s)
+    output_tokens: int = 0
+
+
+def make_prefix_pool(n: int, words: int) -> list[str]:
+    """A pool of `n` distinct but internally-fixed prefixes (think: sessions or
+    few-shot templates). Each is identical every time it is reused, so it caches;
+    distinct prefixes spread across workers, which is where cache-aware routing
+    pays off (route each prefix to the worker that holds it) and load-balancing
+    does not (it scatters reuse, forcing recompute)."""
+    return [" ".join(f"sys{i}_{j}" for j in range(words)) for i in range(max(1, n))]
+
+
+def build_prompt(
+    rng: random.Random, args: argparse.Namespace, prefixes: list[str], idx: int
+) -> str:
+    """Construct one prompt: a reused shared prefix (cache hit) plus a unique
+    body (varied length → varied prefill)."""
+    parts: list[str] = []
+    if rng.random() < args.shared_prefix_frac:
+        parts.append(rng.choice(prefixes))
+    body_words = rng.randint(args.body_words_min, args.body_words_max)
+    parts.append(f"request {idx} topic {rng.randint(0, 100_000)}")
+    parts.append(" ".join(f"w{rng.randint(0, 5000)}" for _ in range(body_words)))
+    return " ".join(parts)
+
+
+def _request_body(endpoint: str, model: str, prompt: str, max_tokens: int) -> bytes:
+    """Build the request body for the chat or completions endpoint."""
+    if endpoint == "completions":
+        payload = {"model": model, "prompt": prompt}
+    else:
+        payload = {"model": model, "messages": [{"role": "user", "content": prompt}]}
+    payload.update({"stream": True, "max_tokens": max_tokens})
+    return json.dumps(payload).encode()
+
+
+def _chunk_text(endpoint: str, obj: dict) -> str | None:
+    """Extract the incremental text from a streamed chunk for either endpoint."""
+    choice = obj.get("choices", [{}])[0]
+    if endpoint == "completions":
+        return choice.get("text") or None
+    return choice.get("delta", {}).get("content") or None
+
+
+def send_streaming(url: str, endpoint: str, model: str, prompt: str, max_tokens: int) -> Result:
+    """Send one streaming request, timing first/last token and inter-token gaps."""
+    body = _request_body(endpoint, model, prompt, max_tokens)
+    req = urllib.request.Request(url, data=body, headers={"content-type": "application/json"})
+    start = time.perf_counter()
+    last = start
+    res = Result(ok=False)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            for raw in resp:
+                line = raw.decode("utf-8", "ignore").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[len("data:") :].strip()
+                if payload == "[DONE]":
+                    break
+                try:
+                    obj = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                if _chunk_text(endpoint, obj):
+                    now = time.perf_counter()
+                    if res.ttft is None:
+                        res.ttft = now - start
+                    else:
+                        res.itls.append(now - last)
+                    last = now
+                    res.output_tokens += 1
+        res.e2e = time.perf_counter() - start
+        res.ok = res.output_tokens > 0
+        return res
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return Result(ok=False)
+
+
+def pct(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    return s[min(len(s) - 1, int(len(s) * q))]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required=True, help="gateway chat/completions URL")
+    ap.add_argument(
+        "--endpoint",
+        choices=["chat", "completions"],
+        default="chat",
+        help="request/response format; use 'completions' for tokenizers without a chat template",
+    )
+    ap.add_argument("--model", default="mock-model")
+    ap.add_argument("--rps", type=float, default=50.0)
+    ap.add_argument("--duration", type=int, default=20)
+    ap.add_argument("--concurrency", type=int, default=256)
+    ap.add_argument("--output-tokens", type=int, default=64)
+    ap.add_argument("--shared-prefix-words", type=int, default=200)
+    ap.add_argument("--shared-prefix-frac", type=float, default=0.7)
+    ap.add_argument(
+        "--num-prefixes",
+        type=int,
+        default=16,
+        help="size of the reused-prefix pool (distinct sessions/templates)",
+    )
+    ap.add_argument("--body-words-min", type=int, default=16)
+    ap.add_argument("--body-words-max", type=int, default=128)
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--json", default="", help="optional path to write JSON summary")
+    ap.add_argument("--label", default="", help="label echoed in the summary")
+    args = ap.parse_args()
+    if args.rps <= 0:
+        # A non-positive rate makes the arrival loop spin with no sleep,
+        # submitting tasks as fast as possible until the process OOMs.
+        ap.error("--rps must be greater than 0")
+
+    rng = random.Random(args.seed)
+    prefixes = make_prefix_pool(args.num_prefixes, args.shared_prefix_words)
+    results: list[Result] = []
+    results_lock = threading.Lock()
+    submitted = 0
+    deadline = time.monotonic() + args.duration
+
+    def task(prompt: str) -> None:
+        r = send_streaming(args.url, args.endpoint, args.model, prompt, args.output_tokens)
+        with results_lock:
+            results.append(r)
+
+    t0 = time.monotonic()
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        # Open-loop Poisson arrivals: exponential inter-arrival gaps at `rps`.
+        while time.monotonic() < deadline:
+            prompt = build_prompt(rng, args, prefixes, submitted)
+            pool.submit(task, prompt)
+            submitted += 1
+            if args.rps > 0:
+                time.sleep(rng.expovariate(args.rps))
+        # Drain in-flight requests after the arrival window closes.
+    elapsed = time.monotonic() - t0
+
+    ok = [r for r in results if r.ok]
+    ttfts = [r.ttft for r in ok if r.ttft is not None]
+    e2es = [r.e2e for r in ok if r.e2e is not None]
+    all_itls = [g for r in ok for g in r.itls]
+    total_out = sum(r.output_tokens for r in ok)
+    achieved_rps = len(ok) / elapsed if elapsed > 0 else 0.0
+    out_tps = total_out / elapsed if elapsed > 0 else 0.0
+
+    summary = {
+        "label": args.label,
+        "sent": submitted,
+        "ok": len(ok),
+        "err": len(results) - len(ok),
+        "elapsed_s": round(elapsed, 2),
+        "achieved_rps": round(achieved_rps, 1),
+        "output_tps": round(out_tps, 1),
+        "ttft_ms_p50": round(pct(ttfts, 0.50) * 1000, 1),
+        "ttft_ms_p90": round(pct(ttfts, 0.90) * 1000, 1),
+        "ttft_ms_p99": round(pct(ttfts, 0.99) * 1000, 1),
+        "itl_ms_p50": round(pct(all_itls, 0.50) * 1000, 2),
+        "itl_ms_p99": round(pct(all_itls, 0.99) * 1000, 2),
+        "e2e_ms_p50": round(pct(e2es, 0.50) * 1000, 1),
+        "e2e_ms_p99": round(pct(e2es, 0.99) * 1000, 1),
+        "ttft_ms_mean": round(statistics.fmean(ttfts) * 1000, 1) if ttfts else 0.0,
+    }
+
+    print(
+        f"[{args.label or 'load'}] ok={summary['ok']} err={summary['err']} "
+        f"rps={summary['achieved_rps']} out_tps={summary['output_tps']} "
+        f"TTFT(ms) p50={summary['ttft_ms_p50']} p90={summary['ttft_ms_p90']} "
+        f"p99={summary['ttft_ms_p99']} | ITL(ms) p50={summary['itl_ms_p50']} "
+        f"p99={summary['itl_ms_p99']} | E2E(ms) p50={summary['e2e_ms_p50']} "
+        f"p99={summary['e2e_ms_p99']}"
+    )
+    print("SUMMARY_JSON " + json.dumps(summary))
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

### Problem

The mock-worker fleet (#1696) answers with **canned** responses: a single flat `--gen-ms` delay, zero inter-token delay, `prompt_tokens` hardcoded to 1, and all load/KV metrics reported as zero. That is enough to measure the gateway's own CPU/registration cost, but it leaves the two routing brains effectively dark:

- `least_load` scores `(queued_tokens + inflight)/throughput + λ·k/(1−k)`, but the mock reports `token_usage=0`, `gen_throughput=0`, `num_waiting_uncached_tokens=0`, so only the gateway-side in-flight term does anything.
- event-driven `cache_aware` needs a stream of KV-cache events to build its index; the mock emits none, and the TokenSpeed gRPC service has no `SubscribeKvEvents` RPC.

So there is no GPU-free way to validate routing-policy behavior (e.g. the least_load rework) end to end.

### Solution

Add an opt-in `--engine realistic` mode that backs each worker with a continuous-batching LLM-engine **simulator** running on CPU, and extend the TokenSpeed gRPC contract so its load + cache signals reach the gateway. With this, both `least_load` and event-driven `cache_aware` engage exactly as they would against a real vLLM/SGLang/TokenSpeed engine — no GPUs.

The engine reproduces the behaviors that drive routing:

- **prefill latency ∝ input length** (chunked across scheduler steps) → TTFT grows with the uncached prompt size;
- **inter-token latency ∝ batch size** (`base + slope · batch`) → a busy replica is slower per token, and `gen_throughput = batch / step`;
- **finite KV capacity with admission/queueing** → when KV is full, requests wait, producing the `num_waiting_uncached_tokens` signal;
- **prefix caching** → a request sharing a prefix pays less prefill, reports `cached_tokens`/`cache_hit_rate`, and the worker emits `KvBlocksStored` / `KvBlocksRemoved` events (parent-chained, LRU tail eviction).

The scheduler step is a pure function, so the timing/queueing/caching logic is unit-tested deterministically without real timers. Default (canned) behavior is unchanged, so the existing thousands-of-idle-workers scale rig still works.

## Changes

- `crates/mock_worker/src/engine.rs` (new) — the continuous-batching simulator (parametric latency model, KV admission/eviction, prefix cache, KV-event emission) + unit tests.
- `crates/mock_worker/src/{grpc,http,config,main}.rs` — opt-in `--engine realistic` (+ `--prefill-tps` / `--decode-base-ms` / `--decode-per-req-ms` / `--max-running` / `--kv-tokens` / `--block-size` / `--prefix-cache`); realistic `generate` / `get_loads` / `subscribe_kv_events` (gRPC) and chat / `/v1/loads` (HTTP).
- `crates/grpc_client/proto/tokenspeed_scheduler.proto` — add `SchedulerLoad.num_waiting_uncached_tokens` (field 14) and a `SubscribeKvEvents` server-streaming RPC.
- `crates/grpc_client/src/tokenspeed_scheduler.rs` — read the new field in the load conversion (was hardcoded 0) and expose `subscribe_kv_events` (shared macro).
- `model_gateway/src/routers/grpc/client.rs` — forward `SubscribeKvEvents` for the TokenSpeed backend (was `Unimplemented`).
- `scripts/sim_load.py`, `scripts/sim_ab.sh` (new) — Poisson, shared-prefix-pool workload + policy A/B table (TTFT / ITL / E2E / throughput).
- `crates/mock_worker/README.md` — document realistic mode + the A/B rig.

The proto additions are backward compatible: the new field defaults to 0 and the Python servicer auto-returns `UNIMPLEMENTED` for the new RPC until the real TokenSpeed engine implements them (the gateway already handles `Unimplemented`).

## Test Plan

**Engine units** (deterministic — drive the pure `step()`, no timers): TTFT scales with prompt length, ITL grows with batch, saturation produces queued token-work, a shared prefix yields `cached_tokens`, KV events are parent-chained, KV pressure evicts.

```
cargo test -p mock-worker --bins   # 6 passed
cargo test -p smg-grpc-client      # 60 passed
```

**Live A/B (no GPU): gateway + 4 realistic gRPC TokenSpeed workers**, `gpt2` tokenizer via per-worker `labels.tokenizer_path`, `/v1/completions`. The gateway subscribes to the new KV-event stream (`Learned block_size from KV event … block_size=16`) and event-driven `cache_aware` makes overlap-based decisions (`Event-driven routing: overlap match worker=… score=7`). Same Poisson shared-prefix-pool workload per policy (`scripts/sim_ab.sh --mode grpc --workers 4 --rps 80 --duration 8 --shared-prefix-frac 0.9`):

| policy | TTFT p50 | TTFT p99 | E2E p99 |
|---|---|---|---|
| cache_aware | 56 ms | 745 ms | 2047 ms |
| least_load | 69 ms | 1006 ms | 3618 ms |
| random | 91 ms | 1285 ms | 4199 ms |

→ `cache_aware` wins TTFT via prefix-cache hits; `least_load` tightens the tail vs `random`. Both signals (queued token-work, KV events) now flow from a TokenSpeed backend with no further gateway changes.

Gate (sccache off, `RUSTC_WRAPPER=""`):

```
$ cargo clippy -p smg-grpc-client -p mock-worker --all-targets --all-features -- -D warnings
exit 0
$ cargo clippy -p smg
exit 0
```

Note: `cargo +nightly fmt` was not runnable in this environment (no nightly toolchain); stable `cargo fmt --check` is clean and imports are pre-grouped to the repo's nightly config. The full-workspace `cargo test` was not run locally (the smg suite is large/environment-sensitive); the touched-crate tests pass as above.

Builds on #1696. Enables GPU-free A/B validation of `least_load` and `cache_aware`.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes (nightly unavailable in this env; stable fmt clean, imports pre-grouped)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added KV cache event streaming over gRPC to let clients subscribe to KV event batches.
  * Introduced a realistic continuous-batching engine simulator in the mock worker, including realistic HTTP/generation responses and dynamic load reporting.
  * Added A/B simulation tooling, including a streaming load generator script.

* **Bug Fixes**
  * Improved scheduler load reporting by correctly propagating “waiting uncached tokens” metrics.

* **Documentation**
  * Updated mock worker README with realistic mode usage, tuning guidance, and example policy A/B runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->