### PR TITLE
fix(cache-aware): fix load imbalance when decode is faster than prefill

### DIFF
--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -483,7 +483,7 @@ impl CacheAwarePolicy {
         // Use shortest queue when imbalanced
         let min_load_idx = healthy_indices
             .iter()
-            .min_by_key(|&&idx| workers[idx].load())
+            .min_by_key(|&&idx| (workers[idx].load(), workers[idx].processed_requests(), idx))
             .copied()?;
 
         let worker_url = workers[min_load_idx].url();
@@ -982,7 +982,13 @@ impl CacheAwarePolicy {
                 } else {
                     healthy_indices
                         .iter()
-                        .min_by_key(|&&idx| workers[idx].load())
+                        .min_by_key(|&&idx| {
+                        (
+                            workers[idx].load(),
+                            workers[idx].processed_requests(),
+                            idx,
+                        )
+                    })
                         .copied()
                 };
 
@@ -1064,7 +1070,13 @@ impl CacheAwarePolicy {
                 } else {
                     healthy_indices
                         .iter()
-                        .min_by_key(|&&idx| workers[idx].load())
+                        .min_by_key(|&&idx| {
+                        (
+                            workers[idx].load(),
+                            workers[idx].processed_requests(),
+                            idx,
+                        )
+                    })
                         .copied()
                 };
 

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -2280,24 +2280,28 @@ mod tests {
         // Empty indexer → has_event_indexer returns false → falls through to token tree
         assert!(!policy.has_event_indexer("unknown"));
 
-        // Route a request — should use token tree, not event-driven min-load
+        // Tokens must be >= PAGE_SIZE (16) to populate the tree; shorter
+        // sequences are uncacheable and fall through to min-load.
+        let tokens: Vec<u32> = (1..=16).collect();
+
+        // First request populates the token tree for the selected worker.
         let idx = policy
             .select_worker(
                 &workers,
                 &SelectWorkerInfo {
-                    tokens: Some(&[1, 2, 3, 4]),
+                    tokens: Some(&tokens),
                     ..Default::default()
                 },
             )
             .unwrap();
         assert!(idx < 2); // valid worker via token tree
 
-        // Route the same tokens again — token tree should route to same worker (cache hit)
+        // Same tokens again — token-tree cache hit routes to the same worker.
         let idx2 = policy
             .select_worker(
                 &workers,
                 &SelectWorkerInfo {
-                    tokens: Some(&[1, 2, 3, 4]),
+                    tokens: Some(&tokens),
                     ..Default::default()
                 },
             )

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -868,7 +868,7 @@ impl CacheAwarePolicy {
         // No cache overlap — min-load fallback (no token tree involved)
         let min_idx = healthy_indices
             .iter()
-            .min_by_key(|&&idx| workers[idx].load())
+            .min_by_key(|&&idx| (workers[idx].load(), workers[idx].processed_requests(), idx))
             .copied()?;
         debug!(
             worker = workers[min_idx].url(),
@@ -983,12 +983,8 @@ impl CacheAwarePolicy {
                     healthy_indices
                         .iter()
                         .min_by_key(|&&idx| {
-                        (
-                            workers[idx].load(),
-                            workers[idx].processed_requests(),
-                            idx,
-                        )
-                    })
+                            (workers[idx].load(), workers[idx].processed_requests(), idx)
+                        })
                         .copied()
                 };
 
@@ -1071,12 +1067,8 @@ impl CacheAwarePolicy {
                     healthy_indices
                         .iter()
                         .min_by_key(|&&idx| {
-                        (
-                            workers[idx].load(),
-                            workers[idx].processed_requests(),
-                            idx,
-                        )
-                    })
+                            (workers[idx].load(), workers[idx].processed_requests(), idx)
+                        })
                         .copied()
                 };
 

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -524,8 +524,7 @@ impl PDRouter {
                 context.return_logprob,
                 Some(decode_url),
                 Some(response_headers),
-                decode,
-                load_guards
+                load_guards,
             )
         } else {
             // Handle non-streaming error response
@@ -712,8 +711,7 @@ impl PDRouter {
                 context.return_logprob,
                 None,
                 Some(response_headers),
-                decode, 
-                load_guards
+                load_guards,
             )
         } else {
             // Non-streaming response
@@ -900,7 +898,6 @@ impl PDRouter {
         return_logprob: bool,
         decode_url: Option<String>,
         headers: Option<HeaderMap>,
-        decode: Arc<dyn Worker>,
         load_guards: Vec<WorkerLoadGuard>,
     ) -> Response {
         use crate::worker::AttachedBody;
@@ -1646,8 +1643,7 @@ mod tests {
                 false,
                 None,
                 None,
-                decode_ref.clone(),
-                guards
+                guards,
             );
 
             // Guards are now attached to response body, so load should be 1

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1575,8 +1575,13 @@ mod tests {
             headers: None,
         };
 
+        let load_guards = vec![
+            WorkerLoadGuard::new(prefill.clone(), None),
+            WorkerLoadGuard::new(decode.clone(), None),
+        ];
+
         let response = router
-            .handle_decode_error_response(decode_response, &context, prefill, decode)
+            .handle_decode_error_response(decode_response, &context, decode, load_guards)
             .await;
 
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -489,8 +489,8 @@ impl PDRouter {
         &self,
         res: reqwest::Response,
         context: &PDRequestContext<'_>,
-        prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
+        load_guards: Vec<WorkerLoadGuard>,
     ) -> Response {
         let status = res.status();
 
@@ -524,8 +524,8 @@ impl PDRouter {
                 context.return_logprob,
                 Some(decode_url),
                 Some(response_headers),
-                prefill,
                 decode,
+                load_guards
             )
         } else {
             // Handle non-streaming error response
@@ -609,12 +609,10 @@ impl PDRouter {
         prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
     ) -> Response {
-        // For non-streaming: use guard for automatic load management
-        // For streaming: load will be managed in create_streaming_response
-        let _prefill_guard =
-            (!context.is_stream).then(|| WorkerLoadGuard::new(prefill.clone(), headers));
-        let _decode_guard =
-            (!context.is_stream).then(|| WorkerLoadGuard::new(decode.clone(), headers));
+        let load_guards = vec![
+            WorkerLoadGuard::new(prefill.clone(), headers),
+            WorkerLoadGuard::new(decode.clone(), headers),
+        ];
 
         let mut headers_with_trace = headers.cloned().unwrap_or_default();
         inject_trace_context_http(&mut headers_with_trace);
@@ -680,7 +678,7 @@ impl PDRouter {
             );
 
             return self
-                .handle_decode_error_response(decode_response, &context, prefill, decode)
+                .handle_decode_error_response(decode_response, &context, decode, load_guards)
                 .await;
         }
 
@@ -714,8 +712,8 @@ impl PDRouter {
                 context.return_logprob,
                 None,
                 Some(response_headers),
-                prefill,
-                decode,
+                decode, 
+                load_guards
             )
         } else {
             // Non-streaming response
@@ -902,8 +900,8 @@ impl PDRouter {
         return_logprob: bool,
         decode_url: Option<String>,
         headers: Option<HeaderMap>,
-        prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
+        load_guards: Vec<WorkerLoadGuard>,
     ) -> Response {
         use crate::worker::AttachedBody;
 
@@ -949,11 +947,6 @@ impl PDRouter {
         let stream = UnboundedReceiverStream::new(rx);
         let body = Body::from_stream(stream);
 
-        let guards = vec![
-            WorkerLoadGuard::new(prefill, headers.as_ref()),
-            WorkerLoadGuard::new(decode, headers.as_ref()),
-        ];
-
         let mut response = Response::new(body);
         *response.status_mut() = status;
 
@@ -961,7 +954,7 @@ impl PDRouter {
         response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
         *response.headers_mut() = response_headers;
 
-        AttachedBody::wrap_response(response, guards)
+        AttachedBody::wrap_response(response, load_guards)
     }
 
     // Helper to process non-streaming decode response with logprob merging
@@ -1638,6 +1631,14 @@ mod tests {
         let stream = UnboundedReceiverStream::new(rx);
 
         {
+            let guards = vec![
+                WorkerLoadGuard::new(prefill_ref.clone(), None),
+                WorkerLoadGuard::new(decode_ref.clone(), None),
+            ];
+
+            assert_eq!(prefill_ref.load(), 1);
+            assert_eq!(decode_ref.load(), 1);
+
             let response = router.create_streaming_response(
                 stream.map(Ok),
                 StatusCode::OK,
@@ -1645,8 +1646,8 @@ mod tests {
                 false,
                 None,
                 None,
-                prefill_ref.clone(),
                 decode_ref.clone(),
+                guards
             );
 
             // Guards are now attached to response body, so load should be 1


### PR DESCRIPTION

## Description

### Problem

In some extreme scenarios, default cache_aware policy will lead to severe load imbalance problem.

For example, 32k input and output only 1 token. In such case, all the requests will be routed to the same prefill worker and others are always left unused.

The reason is that in the select_worker of CacheAwarePolicy, only workers[idx].load() is used for sorting. After the worker is selected, worker.load() will only be updated till create_streaming_response is called (after stream response is returned from decode worker to the router). If prefill is very slow and decode is very fast, then at most of the time, worker.load() will be the same for all prefill workers. Then pd-router will always select the first prefill worker.

### Solution

<!-- How does this PR solve the problem? -->

## Changes

1. Create WorkerLoadGuard before request is sent to the worker for inference.
2. In select_worker, sort the workers according to (load, processed_requests, idx), instead of solely depending on load.

## Test Plan

1. Unit test test_streaming_load_tracking Passed
`cd ./model-gateway && TMPDIR=/private/tmp cargo test --lib test_streaming_load_tracking`

<img width="694" height="71" alt="image" src="https://github.com/user-attachments/assets/84d5bc9c-76ba-42df-a5dc-a50f4ba5799e" />

2. bench_serving
benching random dataset with 32k input and 1 token output, all the prefill workers have requests received.
<img width="1336" height="261" alt="image" src="https://github.com/user-attachments/assets/d293930f-0f96-4583-a1b2-da25812dab0d" />

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

- **Performance Improvements**
  - Enhanced cache-aware worker selection by improving tie-breaking with additional workload metrics for more balanced routing.

- **Bug Fixes**
  - Fixed streaming load tracking to consistently apply to both streaming success and streaming decode-error responses.

- **Refactor**
  - Streamlined streaming response creation by passing a pre-built load-guard set through the streaming paths rather than constructing it internally.

- **Tests**
  - Updated token-tree routing coverage to use the full page-sized token sequence in the empty-indexer scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->