### PR TITLE
fix(ci): pin CUDA 13 CUTLASS DSL libs

### DIFF
--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -45,6 +45,9 @@ fi
 echo "Installing SGLang..."
 uv pip install --prerelease=allow "sglang[all]==0.5.12.post1"
 
+# Work around NVIDIA/cutlass#3259 until the fix ships in CUTLASS 4.6.
+uv pip install --force-reinstall --no-deps "nvidia-cutlass-dsl-libs-cu13==4.5.2"
+
 # sglang 0.5.12.post1 leaves its `kernels` dependency unpinned, so the resolver
 # picks kernels >=0.15, which requires LayerRepository(revision=/version=) —
 # an argument the transformers 5.6.0 hub_kernels integration (pinned by sglang)


### PR DESCRIPTION
## Description

### Problem

SGLang CI now uses the CUDA 13 stack, and H100 runner jobs can fail during FlashInfer/CUTLASS JIT startup with the CUTLASS DSL / MLIR verifier error:

`'llvm.mlir.global_dtors' op requires attribute 'data'`

Observed runner failure: https://github.com/lightseekorg/smg/actions/runs/27462835749/job/81201134115

Related issue link(though in vllm): https://github.com/vllm-project/vllm/issues/44949#issuecomment-4663334157

This matches the upstream CUTLASS issue: https://github.com/NVIDIA/cutlass/issues/3259

### Solution

Force-reinstall `nvidia-cutlass-dsl-libs-cu13==4.5.2` after installing SGLang. This is the upstream workaround until the fix ships in CUTLASS 4.6.

## Changes

- Pin `nvidia-cutlass-dsl-libs-cu13` to `4.5.2` in `scripts/ci_install_sglang.sh`.
- Leave the rest of the SGLang / CUDA 13 install flow unchanged.

## Test Plan

- [x] `bash -n scripts/ci_install_sglang.sh`
- [ ] Local CI / `pre-commit run --all-files` not run per maintainer request; CI should validate the runtime install path.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation compatibility issues to ensure proper setup of the build environment during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->