### PR TITLE
fix(ci): make Oracle test users unique

### DIFF
--- a/scripts/ci_agentic_svc_deps.sh
+++ b/scripts/ci_agentic_svc_deps.sh
@@ -10,9 +10,6 @@
 
 set -uo pipefail
 
-COMMAND="${1:?Usage: ci_agentic_svc_deps.sh <command> [args...]}"
-shift
-
 check_port() {
     local name="$1" host="$2" port="$3"
     echo -n "Checking $name on $host:$port... "
@@ -21,6 +18,34 @@ check_port() {
     else
         echo "FAILED"
         return 1
+    fi
+}
+
+ci_oracle_username() {
+    local prefix="$1"
+    local random="${CI_ORACLE_NAME_RANDOM:-$(openssl rand -hex 3)}"
+    random=$(printf "%s" "$random" | tr '[:lower:]' '[:upper:]' | tr -cd 'A-Z0-9')
+
+    local tag
+    if [ -n "${GITHUB_RUN_ID:-}" ]; then
+        local run_tail="${GITHUB_RUN_ID: -10}"
+        local attempt="${GITHUB_RUN_ATTEMPT:-0}"
+        tag="${run_tail}_${attempt}_${random}"
+    else
+        # Fallback for local/manual runs: keep the old hostname signal, plus entropy.
+        local raw_name
+        raw_name=$(echo "${HOSTNAME:-runner}" | rev | cut -d'-' -f1,2 | rev | tr '[:lower:]-' '[:upper:]_')
+        tag="${raw_name}_${random}"
+    fi
+
+    tag=$(printf "%s" "$tag" | tr -cd 'A-Z0-9_')
+    local max_tag_len=$((30 - ${#prefix} - 1))
+    printf "%s_%s\n" "$prefix" "${tag:0:$max_tag_len}"
+}
+
+append_github_env() {
+    if [ -n "${GITHUB_ENV:-}" ]; then
+        echo "$1" >> "$GITHUB_ENV"
     fi
 }
 
@@ -83,9 +108,7 @@ cmd_create_oracle_user() {
 
     pip install oracledb
 
-    # Use last two segments of pod name (e.g. arc-runner-gpu-h100-jfvzm-m2lm8 -> JFVZM_M2LM8)
-    RAW_NAME=$(echo "$HOSTNAME" | rev | cut -d'-' -f1,2 | rev | tr '[:lower:]-' '[:upper:]_')
-    TEST_USER="TEST_${RAW_NAME}"
+    TEST_USER="$(ci_oracle_username TEST)"
     # Prefix with 'P' so the password always starts with a letter (Oracle requirement)
     TEST_PASS="P$(openssl rand -hex 8)"
     echo "Creating Oracle test user: $TEST_USER"
@@ -93,6 +116,10 @@ cmd_create_oracle_user() {
     export ORA_TEST_USER="$TEST_USER"
     export ORA_TEST_PASS="$TEST_PASS"
     export ORA_DSN="$oracle_dsn"
+    append_github_env "ATP_USER=$TEST_USER"
+    append_github_env "ATP_PASSWORD=$TEST_PASS"
+    append_github_env "ATP_DSN=$oracle_dsn"
+    append_github_env "DB_AUTO_MIGRATE=true"
 
     python3 << 'PYEOF'
 import os, oracledb
@@ -107,11 +134,6 @@ conn.commit()
 conn.close()
 print("Oracle test user created successfully")
 PYEOF
-
-    echo "ATP_USER=$TEST_USER" >> "$GITHUB_ENV"
-    echo "ATP_PASSWORD=$TEST_PASS" >> "$GITHUB_ENV"
-    echo "ATP_DSN=$oracle_dsn" >> "$GITHUB_ENV"
-    echo "DB_AUTO_MIGRATE=true" >> "$GITHUB_ENV"
 }
 
 cmd_cleanup_oracle_user() {
@@ -152,9 +174,7 @@ cmd_create_oracle_flyway_user() {
 
     pip install oracledb
 
-    # Use last two segments of pod name (same logic as create-oracle-user)
-    RAW_NAME=$(echo "$HOSTNAME" | rev | cut -d'-' -f1,2 | rev | tr '[:lower:]-' '[:upper:]_')
-    FLYWAY_USER="FLYWAY_${RAW_NAME}"
+    FLYWAY_USER="$(ci_oracle_username FLYWAY)"
     # Prefix with 'P' so the password always starts with a letter (Oracle requirement)
     FLYWAY_PASS="P$(openssl rand -hex 8)"
     echo "Creating Oracle Flyway test user: $FLYWAY_USER"
@@ -162,6 +182,9 @@ cmd_create_oracle_flyway_user() {
     export ORA_FLYWAY_USER="$FLYWAY_USER"
     export ORA_FLYWAY_PASS="$FLYWAY_PASS"
     export ORA_DSN="$oracle_dsn"
+    append_github_env "ATP_FLYWAY_USER=$FLYWAY_USER"
+    append_github_env "ATP_FLYWAY_PASSWORD=$FLYWAY_PASS"
+    append_github_env "ATP_FLYWAY_DSN=$oracle_dsn"
 
     # Locate Flyway SQL files relative to the repo root
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -207,12 +230,6 @@ flyway_conn.commit()
 flyway_conn.close()
 print("Flyway SQL files executed successfully")
 PYEOF
-
-    {
-        echo "ATP_FLYWAY_USER=$FLYWAY_USER"
-        echo "ATP_FLYWAY_PASSWORD=$FLYWAY_PASS"
-        echo "ATP_FLYWAY_DSN=$oracle_dsn"
-    } >> "$GITHUB_ENV"
 }
 
 cmd_cleanup_oracle_flyway_user() {
@@ -245,6 +262,13 @@ except Exception as e:
     print(f"Warning: failed to drop Flyway test user: {e}")
 PYEOF
 }
+
+if [ "${CI_AGENTIC_SVC_DEPS_LIB_ONLY:-0}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+COMMAND="${1:?Usage: ci_agentic_svc_deps.sh <command> [args...]}"
+shift
 
 case "$COMMAND" in
     check)                cmd_check "$@" ;;

--- a/scripts/tests/test_ci_agentic_svc_deps.sh
+++ b/scripts/tests/test_ci_agentic_svc_deps.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+CI_AGENTIC_SVC_DEPS_LIB_ONLY=1 source "$REPO_ROOT/scripts/ci_agentic_svc_deps.sh"
+
+assert_eq() {
+    local expected="$1" actual="$2"
+    if [ "$expected" != "$actual" ]; then
+        echo "expected: $expected"
+        echo "actual:   $actual"
+        exit 1
+    fi
+}
+
+assert_matches() {
+    local value="$1" pattern="$2"
+    if [[ ! "$value" =~ $pattern ]]; then
+        echo "expected '$value' to match /$pattern/"
+        exit 1
+    fi
+}
+
+assert_max_len() {
+    local value="$1" max="$2"
+    if [ "${#value}" -gt "$max" ]; then
+        echo "expected '$value' to be at most $max chars, got ${#value}"
+        exit 1
+    fi
+}
+
+test_run_scoped_oracle_usernames_are_unique_and_oracle_safe() {
+    local test_user_a
+    test_user_a=$(
+        HOSTNAME=2-gpu-h100 \
+            GITHUB_RUN_ID=27463234653 \
+            GITHUB_RUN_ATTEMPT=4 \
+            CI_ORACLE_NAME_RANDOM=A1B2C3 \
+            ci_oracle_username TEST
+    )
+    assert_eq "TEST_7463234653_4_A1B2C3" "$test_user_a"
+
+    local test_user_b
+    test_user_b=$(
+        HOSTNAME=2-gpu-h100 \
+            GITHUB_RUN_ID=27463234653 \
+            GITHUB_RUN_ATTEMPT=4 \
+            CI_ORACLE_NAME_RANDOM=D4E5F6 \
+            ci_oracle_username TEST
+    )
+    assert_eq "TEST_7463234653_4_D4E5F6" "$test_user_b"
+
+    local flyway_user
+    flyway_user=$(
+        HOSTNAME=2-gpu-h100 \
+            GITHUB_RUN_ID=27463234653 \
+            GITHUB_RUN_ATTEMPT=4 \
+            CI_ORACLE_NAME_RANDOM=A1B2C3 \
+            ci_oracle_username FLYWAY
+    )
+    assert_eq "FLYWAY_7463234653_4_A1B2C3" "$flyway_user"
+    assert_max_len "$flyway_user" 30
+}
+
+test_hostname_fallback_keeps_entropy_and_stays_under_oracle_limit() {
+    local username
+    username=$(
+        HOSTNAME=arc-runner-gpu-h100-jfvzm-m2lm8 \
+            GITHUB_RUN_ID= \
+            GITHUB_RUN_ATTEMPT= \
+            CI_ORACLE_NAME_RANDOM=ABCDEF \
+            ci_oracle_username TEST
+    )
+
+    assert_matches "$username" '^TEST_[A-Z0-9_]+_ABCDEF$'
+    assert_max_len "$username" 30
+}
+
+test_run_scoped_oracle_usernames_are_unique_and_oracle_safe
+test_hostname_fallback_keeps_entropy_and_stays_under_oracle_limit
+
+echo "ci_agentic_svc_deps tests passed"


### PR DESCRIPTION
## Description

### Problem

Shared Oracle CI setup derived test usernames from runner hostnames, so jobs could reuse names like `TEST_H100_2` and fail with `ORA-01920` when a previous user or role still existed in the long-lived shared Oracle DB.

Failed run: https://github.com/lightseekorg/smg/actions/runs/27463234653/job/81211642345

### Solution

Generate Oracle test usernames from the GitHub run ID, run attempt, and random entropy while keeping them within Oracle's 30-character identifier limit. Also write cleanup environment variables before `CREATE USER` so the cleanup step can find partially-created users if setup fails later.

## Changes

- Add `ci_oracle_username` to create run-scoped `TEST_*` and `FLYWAY_*` usernames.
- Add `append_github_env` and write Oracle cleanup env vars before user creation.
- Add focused shell coverage for username uniqueness, fallback naming, and Oracle identifier length limits.

## Test Plan

- Reproduced the failure mode by confirming stale `TEST_H100_2` and `FLYWAY_H100_2` users existed in the shared Oracle DB with no active sessions.
- Verified the focused shell test passes:

```bash
bash scripts/tests/test_ci_agentic_svc_deps.sh
```

- Verified shell syntax:

```bash
bash -n scripts/ci_agentic_svc_deps.sh scripts/tests/test_ci_agentic_svc_deps.sh
```

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated tests for CI infrastructure components to ensure reliable configuration handling

* **Chores**
  * Enhanced CI/CD pipeline with improved environment configuration management and reusable helper utilities to support more consistent deployment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->