### PR TITLE
fix(ci): lower vllm mooncake pd mmlu concurrency

### DIFF
--- a/e2e_test/router/test_pd_mmlu.py
+++ b/e2e_test/router/test_pd_mmlu.py
@@ -27,8 +27,15 @@ from types import SimpleNamespace
 
 import pytest
 from infra import run_eval
+from infra.constants import is_vllm, vllm_kv_backend
 
 logger = logging.getLogger(__name__)
+
+
+def _pd_mmlu_num_threads() -> int:
+    if is_vllm() and vllm_kv_backend() == "mooncake":
+        return 8
+    return 32
 
 
 @pytest.mark.engine("sglang")
@@ -49,7 +56,7 @@ class TestPDMMLUHttp:
             model=model,
             eval_name="mmlu",
             num_examples=64,
-            num_threads=32,
+            num_threads=_pd_mmlu_num_threads(),
             temperature=0.1,
         )
         metrics = run_eval(args)
@@ -77,7 +84,7 @@ class TestPDMMLUGrpc:
             model=model,
             eval_name="mmlu",
             num_examples=64,
-            num_threads=32,
+            num_threads=_pd_mmlu_num_threads(),
             temperature=0.1,
         )
         metrics = run_eval(args)


### PR DESCRIPTION
## Description

### Problem

`e2e-2gpu-pd (vllm-mooncake)` can hang under the current PD MMLU load when Mooncake is forced to TCP. The failing runner logs show Mooncake TCP connection creation failures:

- `TcpTransport::getConnection failed ... Cannot assign requested address`
- `Mooncake transfer engine returned -1`
- CI timeout in `test_pd_mmlu_basic[pd_grpc]`

Reference failure: https://github.com/lightseekorg/smg/actions/runs/27475222331/job/81214158643

### Solution

Lower the MMLU evaluation concurrency only for the `vllm + mooncake` PD leg. SGLang PD and vLLM NIXL keep the existing concurrency.

## Changes

- Add `_pd_mmlu_num_threads()` for PD MMLU tests.
- Use `8` threads for `E2E_RUNTIME=vllm` with `E2E_VLLM_KV_BACKEND=mooncake`.
- Keep the default `32` threads for SGLang and vLLM NIXL.

## Test Plan

Not run locally per request. PR CI should validate the affected `e2e-2gpu-pd (vllm-mooncake)` leg.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced MMLU evaluation test configuration with dynamic thread count allocation based on runtime environment and backend type for optimized test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->