### PR TITLE
ci: increase gpu timeout budgets

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -315,7 +315,7 @@ jobs:
   benchmarks:
     needs: build-wheel
     runs-on: 4-gpu-h100
-    timeout-minutes: 30
+    timeout-minutes: 36
     permissions:
       contents: read
     steps:
@@ -357,6 +357,7 @@ jobs:
         env:
           ROUTER_LOCAL_MODEL_PATH: /models
           E2E_LOG_DIR: benchmark-logs
+          GENAI_BENCH_TEST_TIMEOUT: "480"
         run: |
           mkdir -p benchmark-logs
           bash scripts/ci_killall_sglang.sh "nuke_gpus"
@@ -494,8 +495,8 @@ jobs:
       matrix:
         include:
           - engine: sglang
-            timeout: 28
-            test_timeout: 20
+            timeout: 40
+            test_timeout: 32
           - engine: vllm
             timeout: 24
             test_timeout: 18

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -495,8 +495,8 @@ jobs:
       matrix:
         include:
           - engine: sglang
-            timeout: 40
-            test_timeout: 32
+            timeout: 36
+            test_timeout: 28
           - engine: vllm
             timeout: 24
             test_timeout: 18


### PR DESCRIPTION
## Description

### Problem

Two GPU CI jobs are timing out even though the underlying workers are not crashing:

- Benchmark run [27478078225 / job 81220991394](https://github.com/lightseekorg/smg/actions/runs/27478078225/job/81220991394) completed the HTTP benchmark and wrote results, but the genai-bench subprocess hit the default 240s harness timeout while it was still saving reports.
- Chat run [27479120581 / job 81223683996](https://github.com/lightseekorg/smg/actions/runs/27479120581/job/81223683996) hit the 20-minute `Run E2E tests` step timeout after slow SGLang large-model startup and a rerun consumed most of the shard budget.

### Solution

Increase the affected CI timeout budgets so these jobs have enough room for slow tokenizer/report startup and large-model reloads.

## Changes

- Increase the standalone benchmark job timeout from 30 to 36 minutes.
- Set `GENAI_BENCH_TEST_TIMEOUT=480` for the benchmark job.
- Increase the 1GPU SGLang chat job timeout from 28 to 36 minutes.
- Increase the 1GPU SGLang chat pytest step timeout from 20 to 28 minutes.

## Test Plan

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-test-rust.yml"); puts "yaml ok"'`
- `pre-commit run --files .github/workflows/pr-test-rust.yml`

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased CI job timeouts for benchmark and test workflows.
  * Set a longer benchmark test timeout via environment configuration.
  * Extended end-to-end job and per-test timeouts for the sglang engine matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->