### PR TITLE
ci: use rdma for mooncake pd

### DIFF
--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -276,12 +276,7 @@ class Worker:
         if self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE):
             kv_role = "kv_producer" if self.worker_type == WorkerType.PREFILL else "kv_consumer"
             if vllm_kv_backend() == "mooncake":
-                # tcp keeps the transfer off RDMA, which is flaky on shared CI nodes
-                config = {
-                    "kv_connector": "MooncakeConnector",
-                    "kv_role": kv_role,
-                    "kv_connector_extra_config": {"mooncake_protocol": "tcp"},
-                }
+                config = {"kv_connector": "MooncakeConnector", "kv_role": kv_role}
             else:
                 config = {"kv_connector": "NixlConnector", "kv_role": kv_role}
             cmd.extend(["--kv-transfer-config", json.dumps(config)])

--- a/e2e_test/router/test_pd_mmlu.py
+++ b/e2e_test/router/test_pd_mmlu.py
@@ -27,15 +27,8 @@ from types import SimpleNamespace
 
 import pytest
 from infra import run_eval
-from infra.constants import is_vllm, vllm_kv_backend
 
 logger = logging.getLogger(__name__)
-
-
-def _pd_mmlu_num_threads() -> int:
-    if is_vllm() and vllm_kv_backend() == "mooncake":
-        return 8
-    return 32
 
 
 @pytest.mark.engine("sglang")
@@ -56,7 +49,7 @@ class TestPDMMLUHttp:
             model=model,
             eval_name="mmlu",
             num_examples=64,
-            num_threads=_pd_mmlu_num_threads(),
+            num_threads=32,
             temperature=0.1,
         )
         metrics = run_eval(args)
@@ -84,7 +77,7 @@ class TestPDMMLUGrpc:
             model=model,
             eval_name="mmlu",
             num_examples=64,
-            num_threads=_pd_mmlu_num_threads(),
+            num_threads=32,
             temperature=0.1,
         )
         metrics = run_eval(args)


### PR DESCRIPTION
## Description

### Problem

The vLLM Mooncake PD CI leg still stalls with TCP transfer failures even after lowering the MMLU thread count:

- Failing job: [27479120581 / job 81224575573](https://github.com/lightseekorg/smg/actions/runs/27479120581/job/81224575573)
- Worker logs show repeated `TcpTransport::getConnection failed ... Cannot assign requested address`, followed by Mooncake request timeouts after 480 seconds.

The TCP protocol override was introduced in `0ec9d91c64cd253c5eeffd586c170d5410146b6f` on June 11, 2026 in PR #1664.

### Solution

Remove the explicit `mooncake_protocol: tcp` override so Mooncake can use its default RDMA transfer path on the H100 CI nodes, which now have the node/runtime RDMA setup expected by Mooncake.

Also revert the temporary PR #1720 thread reduction so the PD MMLU test returns to the original 32-thread behavior while we validate the RDMA path.

## Changes

- Remove `kv_connector_extra_config: {"mooncake_protocol": "tcp"}` from the vLLM Mooncake PD worker config.
- Revert `e2e_test/router/test_pd_mmlu.py` to use `num_threads=32`.
- Remove the now-unused Mooncake-specific thread helper.

## Test Plan

- `pre-commit run --files e2e_test/infra/worker.py e2e_test/router/test_pd_mmlu.py`

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified configuration for distributed model testing.
  * Standardized test execution parameters.

* **Chores**
  * Removed deprecated test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->