### PR TITLE
ci: cancel PR workflows on close

### DIFF
--- a/.github/workflows/cancel-pr-workflows.yml
+++ b/.github/workflows/cancel-pr-workflows.yml
@@ -1,0 +1,46 @@
+name: Cancel PR Workflows
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cancel:
+    name: ${{ matrix.workflow }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Keep these in sync with the concurrency groups used by PR workflows.
+          - workflow: PR Test (SMG)
+            group: gateway-tests-pr-{0}
+          - workflow: PR Test (MLX)
+            group: mlx-tests-pr-{0}
+          - workflow: PR Validation
+            group: pr-validation-{0}
+          - workflow: PR Labeler
+            group: labeler-{0}
+          - workflow: Claude PR Review
+            group: claude-review-{0}
+          - workflow: Benchmark - Tokenizer
+            group: benchmark-tokenizer-refs/pull/{0}/merge
+          - workflow: Benchmark - Radix Tree
+            group: benchmark-radix-tree-refs/pull/{0}/merge
+          - workflow: Benchmark - Tool Parser
+            group: benchmark-tool-parser-refs/pull/{0}/merge
+          - workflow: Benchmark - Request Processing
+            group: benchmark-request-processing-refs/pull/{0}/merge
+          - workflow: Benchmark - Manual Policy
+            group: benchmark-manual-policy-refs/pull/{0}/merge
+    concurrency:
+      group: ${{ format(matrix.group, github.event.pull_request.number) }}
+      cancel-in-progress: true
+    steps:
+      - name: Touch cancellation group
+        run: |
+          echo "PR #${{ github.event.pull_request.number }} was closed."
+          echo "Cancellation group: ${{ format(matrix.group, github.event.pull_request.number) }}"


### PR DESCRIPTION
## Description

### Problem

Long-running PR workflows can keep consuming runners after a PR is merged or manually closed because the existing PR workflows only run on open/update/reopen activity. No final close-event run is created to cancel the active PR concurrency groups.

### Solution

Add a lightweight `pull_request.closed` workflow that starts no-op matrix jobs in the same concurrency groups as the existing PR workflows. With `cancel-in-progress: true`, GitHub Actions cancels any active run in those groups when the PR closes. This keeps the change scoped to workflows that already define PR concurrency groups and does not modify release workflows.

## Changes

- Add `.github/workflows/cancel-pr-workflows.yml`.
- Cover PR Test (SMG), PR Test (MLX), PR Validation, PR Labeler, Claude PR Review, and benchmark PR concurrency groups.
- Leave release workflows unchanged.

## Test Plan

- [x] `actionlint .github/workflows/cancel-pr-workflows.yml`
- [x] `pre-commit run --files .github/workflows/cancel-pr-workflows.yml`
- [x] `git diff --check`

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automation to stop in-progress pull request workflows when a PR is closed.
  * Reduced wasted CI time by preventing outdated runs from continuing after closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->