### PR TITLE
chore(ci): temporarily disable nightly MLX benchmark schedule

### DIFF
--- a/.github/workflows/nightly-mlx-bench.yml
+++ b/.github/workflows/nightly-mlx-bench.yml
@@ -1,9 +1,11 @@
 name: Nightly MLX Benchmark
 
 on:
-  schedule:
-    # 09:17 UTC — off-peak, off the round hour.
-    - cron: "17 9 * * *"
+  # Temporarily disabled — nightly schedule commented out. Re-enable by
+  # uncommenting the cron below. Manual runs via workflow_dispatch still work.
+  # schedule:
+  #   # 09:17 UTC — off-peak, off the round hour.
+  #   - cron: "17 9 * * *"
   workflow_dispatch:
     inputs:
       model:


### PR DESCRIPTION
## Description

### Problem

The nightly MLX benchmark workflow runs automatically on a cron schedule (09:17 UTC daily). We want to temporarily stop these automated nightly runs.

### Solution

Comment out the `schedule`/`cron` trigger in `.github/workflows/nightly-mlx-bench.yml`. Manual runs via `workflow_dispatch` remain available, and the schedule can be re-enabled later by uncommenting the block.

## Changes

- Comment out the nightly `schedule` cron trigger in `nightly-mlx-bench.yml`.
- Add a note explaining how to re-enable it.

## Test Plan

- No automated nightly run will be triggered (cron disabled).
- The workflow can still be triggered manually from the Actions tab via `workflow_dispatch`.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic nightly scheduling for the MLX benchmark workflow. Manual workflow execution remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->