### PR TITLE
fix(ci): pin FastAPI below 0.137 for vLLM

### DIFF
--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -22,9 +22,11 @@ echo "Using uv version: $(uv --version)"
 # Floor 0.22.1: older vllm resolved an early transformers v5 that broke
 # e5-mistral last-token pooling (the old <0.19.1 pin); 0.22.1+ only admits
 # transformers >= 5.5.1. e2e-1gpu-embeddings is the quality gate.
+# FastAPI 0.137 makes vLLM's prometheus-fastapi-instrumentator health route
+# crash on _IncludedRouter entries; keep the last known-good FastAPI line.
 # --torch-backend=auto matches the torch CUDA variant to the pod's driver.
 echo "Installing vLLM..."
-uv pip install "vllm>=0.22.1" --torch-backend=auto
+uv pip install "vllm>=0.22.1" "fastapi<0.137" --torch-backend=auto
 
 # NIXL for vLLM PD disaggregation. The bare metapackage pulls both cu12 and
 # cu13 backends, so install the top-level shim alone, then the backend


### PR DESCRIPTION
## Description

### Problem

`e2e-1gpu-embeddings (vllm)` started failing after the CI environment resolved `fastapi==0.137.0`.

Failing examples:
- https://github.com/lightseekorg/smg/actions/runs/27506639500/job/81298979261
- https://github.com/lightseekorg/smg/actions/runs/27507453901/job/81302181471

In both runs, the vLLM HTTP embedding worker starts, but `/health` returns 500 because `prometheus-fastapi-instrumentator==8.0.0` tries to read `.path` from FastAPI's `_IncludedRouter` entries:

```text
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

A previous passing run for the same job resolved `fastapi==0.136.3`, while the failing runs resolved `fastapi==0.137.0` with the same `vllm==0.23.0`, `starlette==1.3.1`, and `prometheus-fastapi-instrumentator==8.0.0`.

### Solution

Pin FastAPI below `0.137` in the vLLM CI setup step so the vLLM OpenAI HTTP server keeps using the last known-good FastAPI line.

## Changes

- Add `fastapi<0.137` to `scripts/ci_install_vllm.sh` next to the existing `vllm>=0.22.1` install.
- Document why the upper bound exists.

## Test Plan

```bash
grep -q 'fastapi<0.137' scripts/ci_install_vllm.sh
bash -n scripts/ci_install_vllm.sh
```

Full GPU e2e was not run locally.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI installation stability by adding a FastAPI version constraint to prevent build-time crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->