### PR TITLE
feat(router): add --enable-wasm flag to Python CLI and Helm chart

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -476,6 +476,7 @@ struct Router {
     /// New parameters MUST be appended here (not inserted mid-list) to avoid
     /// breaking external Python callers that pass `_Router(...)` positionally.
     drain_settle_secs: u64,
+    enable_wasm: bool,
 }
 
 impl Router {
@@ -749,6 +750,7 @@ impl Router {
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .maybe_storage_hook_wasm_path(self.storage_hook_wasm_path.as_deref())
+            .enable_wasm(self.enable_wasm)
             .dp_aware(self.dp_aware)
             .retries(!self.disable_retries)
             .circuit_breaker(!self.disable_circuit_breaker)
@@ -879,6 +881,7 @@ impl Router {
         mesh_peer_urls = vec![],
         mesh_advertise_host = None,
         drain_settle_secs = 5,
+        enable_wasm = false,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1119,6 +1122,7 @@ impl Router {
             mesh_port,
             mesh_peer_urls,
             drain_settle_secs,
+            enable_wasm,
         })
     }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -997,6 +997,7 @@ impl Router {
         mesh_peer_urls: Vec<String>,
         mesh_advertise_host: Option<String>,
         drain_settle_secs: u64,
+        enable_wasm: bool,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -138,6 +138,8 @@ class RouterArgs:
     mcp_config_path: str | None = None
     # Backend selection
     backend: str = "sglang"
+    # WASM support
+    enable_wasm: bool = False
     # Storage hooks (WASM)
     storage_hook_wasm_path: str | None = None
     # History backend configuration
@@ -891,6 +893,12 @@ class RouterArgs:
             default=RouterArgs.backend,
             choices=["sglang", "openai", "anthropic"],
             help="Backend runtime to use (default: sglang)",
+        )
+        backend_group.add_argument(
+            f"--{prefix}enable-wasm",
+            action="store_true",
+            default=False,
+            help="Enable WebAssembly (WASM) module support",
         )
         backend_group.add_argument(
             f"--{prefix}storage-hook-wasm-path",

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -897,7 +897,7 @@ class RouterArgs:
         backend_group.add_argument(
             f"--{prefix}enable-wasm",
             action="store_true",
-            default=False,
+            default=None,
             help="Enable WebAssembly (WASM) module support",
         )
         backend_group.add_argument(

--- a/deploy/helm/smg/templates/_helpers.tpl
+++ b/deploy/helm/smg/templates/_helpers.tpl
@@ -280,6 +280,9 @@ Called from the router Deployment template.
 - "--rate-limit-tokens-per-second"
 - {{ .Values.auth.rateLimitTokensPerSecond | quote }}
 {{- end }}
+{{- if .Values.router.wasm.enabled }}
+- "--enable-wasm"
+{{- end }}
 {{- if .Values.router.wasm.path }}
 - "--storage-hook-wasm-path"
 - {{ .Values.router.wasm.path | quote }}

--- a/deploy/helm/smg/values.yaml
+++ b/deploy/helm/smg/values.yaml
@@ -183,6 +183,7 @@ router:
 
   # -- Optional features
   wasm:
+    enabled: false
     path: ""
   mcp:
     enabled: false


### PR DESCRIPTION
## Description

### Problem

The --enable-wasm CLI flag was previously only available in the Rust binary entrypoint but missing from the Python launcher (launch_router.py) and Helm chart, causing the WASM module manager to never support posting wasm plugins and the post request always return 500.

### Solution

Adds `enable_wasm` field to RouterArgs dataclass + argparse, to the
PyO3 Router struct + RouterConfigBuilder chain, and a new
`router.wasm.enabled` value in the Helm chart.
<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Router WebAssembly (WASM) enablement support via a new `enable_wasm` option (default: disabled).
  * Expanded the Router configuration API to accept `enable_wasm`.
  * Introduced a router CLI flag `--<prefix>enable-wasm` to turn WASM support on when set.
  * Updated Helm chart configuration with a WASM toggle (`router.wasm.enabled`), defaulting to disabled for backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->