### PR TITLE
ci: run build-wheel and radix-tree benchmark on the CPU runner; let CPU runners use GPU-node CPU

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -24,6 +24,12 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: .
+        # The Go FFI build (bindings/golang/Makefile) overrides CARGO_TARGET_DIR
+        # to bindings/golang/target, which `workspaces: .` does not cover — so
+        # its dependency compilation was never cached. Cache that dir explicitly
+        # so the Go FFI build is incremental across runs like the wheel build.
+        cache-directories: |
+          bindings/golang/target
         shared-key: "rust-cache"
         cache-all-crates: true
         cache-on-failure: true

--- a/.github/workflows/benchmark-radix-tree.yml
+++ b/.github/workflows/benchmark-radix-tree.yml
@@ -36,7 +36,10 @@ jobs:
   benchmark:
     name: Radix Tree (Cache-Aware Routing)
     if: github.repository == 'lightseekorg/smg'
-    runs-on: k8s-runner-gpu
+    # CPU-only criterion/throughput benchmarks of the kv-index radix tree —
+    # no GPU needed, so it runs on the CPU runner pool rather than competing
+    # for GPU runners.
+    runs-on: k8s-runner-cpu
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -125,32 +125,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cache wheel and Go FFI artifacts
-        id: cache-wheel
-        uses: actions/cache@v5
-        with:
-          path: |
-            bindings/python/dist/*.whl
-            bindings/golang/target/release/libsmg_go.*
-            crates/wasm/tests/fixtures/*.wasm
-            clients/python/smg_client/types/_generated.py
-          key: wheel-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'crates/auth/src/**', 'bindings/python/src/**', 'crates/data_connector/src/**', 'crates/grpc_client/src/**', 'crates/kv_index/src/**', 'crates/mcp/src/**', 'crates/mesh/src/**', 'model_gateway/src/**', 'crates/multimodal/src/**', 'crates/protocols/src/**', 'crates/reasoning_parser/src/**', 'crates/tokenizer/src/**', 'crates/tool_parser/src/**', 'crates/wasm/src/**', 'crates/workflow/src/**', 'bindings/golang/src/**', 'examples/wasm/**') }}
-          restore-keys: |
-            wheel-${{ runner.os }}-
-
+      # No wheel-output cache here. It was keyed on a hash of every crate's
+      # source, so it missed on essentially every code PR (all-or-nothing), and
+      # on a miss it *masked* the incremental compilation cache by skipping the
+      # build entirely — which also meant rust-cache rarely got populated. The
+      # build now always runs and leans on rust-cache + sccache (set up in
+      # ./.github/actions/setup-rust), which degrade gracefully: with the
+      # dependency graph cached, only changed crates recompile.
       - name: Setup Rust
-        if: steps.cache-wheel.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-rust
 
       - name: Build Python wheel and Go FFI library
-        if: steps.cache-wheel.outputs.cache-hit != 'true'
         run: |
           rm -rf bindings/python/dist/
           bash scripts/ci_setup_python_venv.sh
           bash scripts/ci_build_wheel.sh
 
       - name: Generate Python client types
-        if: steps.cache-wheel.outputs.cache-hit != 'true'
         run: |
           source "$HOME/.cargo/env"
           mkdir -p clients/openapi
@@ -170,7 +161,6 @@ jobs:
           sed -i 's/class \(.*\)(Enum):/class \1(str, Enum):/' clients/python/smg_client/types/_generated.py
 
       - name: Build WASM test fixtures
-        if: steps.cache-wheel.outputs.cache-hit != 'true'
         run: |
           source "$HOME/.cargo/env"
           bash crates/wasm/tests/fixtures/build_fixtures.sh
@@ -205,7 +195,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Show sccache stats
-        if: always() && steps.cache-wheel.outputs.cache-hit != 'true'
+        if: always()
         run: sccache --show-stats
 
       - name: Set up Python

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -115,7 +115,11 @@ jobs:
           PY
 
   build-wheel:
-    runs-on: k8s-runner-gpu
+    # CPU-only Rust/wheel/Go-FFI/WASM compile — no GPU needed. Runs on the CPU
+    # runner pool (which also tolerates the nvidia.com/gpu taint, so it can use
+    # the abundant stranded CPU on GPU nodes) instead of competing for scarce
+    # GPU runners.
+    runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:

--- a/scripts/k8s-runner-resources/runner-values-cpu.yaml
+++ b/scripts/k8s-runner-resources/runner-values-cpu.yaml
@@ -18,6 +18,17 @@ keyVault: {}
 ## Runner pod template
 template:
   spec:
+    # Allow CPU runners to schedule onto GPU nodes' stranded CPU (those nodes
+    # taint themselves nvidia.com/gpu:NoSchedule but routinely have 80%+ of
+    # their cores idle while only the GPUs are consumed). `Exists` tolerates
+    # both `nvidia.com/gpu=true:NoSchedule` and `nvidia.com/gpu=:NoSchedule`.
+    # No nodeSelector, so runners still schedule on plain CPU nodes too. Other
+    # taints (robobrain, robobrain-vla, ci-runner) are intentionally NOT
+    # tolerated so those reservations stay honored.
+    tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
     volumes:
       - name: work
         emptyDir: {}


### PR DESCRIPTION
## Summary
Moves CPU-only jobs off the GPU runner pool and lets the CPU runner use GPU-node CPU.

**The problem (from a live cluster check):** `build-wheel` and the radix-tree benchmark are pure compiles/benchmarks — no GPU at build or runtime — but ran on `runs-on: k8s-runner-gpu`. That label is currently served by a runner pool **pinned to `BM.GPU.A10.4` nodes**, whose A10 GPUs are fully consumed by other (VLA/robobrain) workloads, so the runner pods sat `Pending` for 60–90 min and jobs reported "no runner" — even though the cluster had **~2,600 idle CPU cores on GPU nodes** (GPUs get exhausted while CPUs strand).

## Changes
1. **`build-wheel` → `k8s-runner-cpu`** (`pr-test-rust.yml`) — Rust workspace + Python wheel + Go FFI + WASM compile, no GPU.
2. **`benchmark-radix-tree` → `k8s-runner-cpu`** (`benchmark-radix-tree.yml`) — `cargo bench` on the kv-index radix tree / throughput suites, CPU-only.
3. **CPU runner tolerates the `nvidia.com/gpu` taint** (`runner-values-cpu.yaml`, `operator: Exists`) so it can also schedule onto GPU nodes' stranded CPU. No `nodeSelector` (still runs on plain CPU nodes); `robobrain` / `robobrain-vla` / `ci-runner` taints are deliberately **not** tolerated.

## To apply the runner change
The `runner-values-cpu.yaml` edit needs a Helm upgrade — the repo manifests aren't auto-reconciled to the cluster (live scale sets are already drifted from these files):
```
helm upgrade k8s-runner-cpu -n actions-runner-system \
  -f scripts/k8s-runner-resources/runner-values-cpu.yaml \
  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
```
The `runs-on` workflow changes take effect on merge regardless (they route to the existing CPU runners, which already run on the CPU node pool).

## Caveat / live test
The CPU runner is **8 CPU / 16Gi**, down from **32 CPU / 128Gi** that build-wheel got on the GPU runner. This PR's own `build-wheel` run executes on `k8s-runner-cpu` — watch its build time and for OOM. If 16Gi is too tight for a from-scratch workspace compile, the easy follow-up is bumping just the runner memory; kept at 8c/16Gi per the decision to start small.

## Not touched (separate review)
`nightly-benchmark.yml` and the disabled `go-bindings-benchmark` job still target `k8s-runner-gpu`; the nightly benchmark may legitimately want GPU.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to run Rust wheel builds and Radix Tree benchmarks on CPU-only runner pools instead of GPU runners.
  * Adjusted the CPU runner Kubernetes pod template tolerations so CPU runners can be scheduled onto nodes marked with GPU-related taints, while avoiding unrelated taints to preserve existing scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->