### PR TITLE
chore: add OpenCV setup script for the opencv-video feature

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -278,15 +278,7 @@ jobs:
           cargo check --manifest-path bindings/golang/Cargo.toml
 
       - name: Install OpenCV build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            clang \
-            libclang-dev \
-            cmake \
-            ninja-build \
-            pkg-config \
-            libopencv-dev
+        run: AUTO_INSTALL=1 bash scripts/install_opencv.sh
 
       - name: Build WASM test fixtures
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,10 @@ Every PR must pass these five checks **locally** before requesting review:
 
 "Probably passes" is not passing. Paste the output or re-run.
 
+Check 2's `--all-features` enables the `opencv-video` feature, which links
+system OpenCV. Install it once with `bash scripts/install_opencv.sh`, or lint
+without the feature using `cargo clippy --workspace --all-targets -- -D warnings`.
+
 ---
 
 ## Commits

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
     $(info sccache not found. Install it for faster builds: cargo install sccache)
 endif
 
-.PHONY: help build test clean docs check fmt dev-setup pre-commit setup-sccache sccache-stats sccache-clean sccache-stop \
+.PHONY: help build test clean docs check fmt opencv-deps dev-setup pre-commit setup-sccache sccache-stats sccache-clean sccache-stop \
         python-dev python-build python-build-release python-install python-clean python-test python-check \
         generate-openapi generate-python-types generate-java-types generate-clients \
         show-version bump-version check-versions
@@ -58,6 +58,9 @@ check: ## Run cargo check and clippy
 fmt: ## Format code with rustfmt
 	@echo "Formatting code..."
 	@rustup run nightly cargo fmt
+
+opencv-deps: ## Install system OpenCV for the opencv-video feature (needed by check/--all-features)
+	@bash scripts/install_opencv.sh
 
 # Development workflow shortcuts
 dev-setup: build test ## Set up development environment

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -32,6 +32,10 @@ All code must pass clippy without warnings:
 cargo clippy --all-targets --all-features -- -D warnings
 ```
 
+`--all-features` enables the `opencv-video` feature, which links system OpenCV
+(`bash scripts/install_opencv.sh` to install it). Without that system
+dependency, lint with `cargo clippy --workspace --all-targets -- -D warnings`.
+
 ---
 
 ## Naming Conventions

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -150,6 +150,16 @@ cargo clippy --all-targets --all-features -- -D warnings
 cargo clippy --all-targets --all-features --fix --allow-dirty -- -D warnings
 ```
 
+!!! note "`--all-features` needs OpenCV"
+    `--all-features` enables the `opencv-video` feature, which links system
+    OpenCV. Install it once with `bash scripts/install_opencv.sh` (Homebrew on
+    macOS, apt on Debian/Ubuntu). To lint without that system dependency, drop
+    `--all-features` — it skips the multimodal video-decode code:
+
+    ```bash
+    cargo clippy --workspace --all-targets -- -D warnings
+    ```
+
 ### Linting and Formatting (Python)
 
 Python code in `e2e_test/`, `bindings/python/`, and `scripts/` is checked with
@@ -427,6 +437,20 @@ Tests may conflict if run in parallel:
 ```bash
 # Run tests serially
 cargo test -- --test-threads=1
+```
+
+### `Failed to find installed OpenCV package`
+
+The `--all-features` build (used by `make check`, `make pre-commit`, and CI's
+lint job) enables the `opencv-video` feature, which links system OpenCV.
+Install it, or lint without `--all-features`:
+
+```bash
+# Install OpenCV (Homebrew on macOS, apt on Debian/Ubuntu)
+bash scripts/install_opencv.sh
+
+# ...or skip the feature for a quick lint
+cargo clippy --workspace --all-targets -- -D warnings
 ```
 
 ### Clippy Errors in CI

--- a/scripts/install_opencv.sh
+++ b/scripts/install_opencv.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Install the system libraries needed to build the multimodal `opencv-video`
+# feature (crate `llm-multimodal`, optional dep `opencv`).
+#
+# This feature is OFF by default, so a normal `cargo build` / `cargo test` does
+# NOT need anything here. You only need it when building with `--all-features`
+# or `--features opencv-video` — which is what `make check`, `make pre-commit`,
+# and CI's lint job run. Without these libraries the build fails with:
+#
+#     Error: "Failed to find installed OpenCV package using pkg-config ..."
+#
+# CI (Debian) calls this script; it also works on macOS (Homebrew). For a quick
+# local lint that skips this feature entirely, run clippy without
+# `--all-features`:
+#
+#     cargo clippy --workspace --all-targets -- -D warnings
+#
+# Usage:
+#   bash scripts/install_opencv.sh          # interactive on a dev machine
+#   AUTO_INSTALL=1 bash scripts/install_opencv.sh   # non-interactive (CI)
+#   DRY_RUN=1 bash scripts/install_opencv.sh        # print commands, run nothing
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+has_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+# Run a command, or just print it under DRY_RUN=1.
+run() {
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    ( IFS=' '; echo "+ $*" )
+  else
+    "$@"
+  fi
+}
+
+# CI sets CI=true; treat that as auto-confirm so the script never blocks a runner.
+auto_install() { [[ "${AUTO_INSTALL:-0}" == "1" || "${CI:-}" == "true" ]]; }
+
+confirm() {
+  if auto_install; then
+    return 0
+  fi
+  read -r -p "$1 [y/N] " response
+  [[ "${response:-N}" =~ ^[Yy]$ ]]
+}
+
+install_apt() {
+  local sudo=""
+  has_cmd sudo && sudo="sudo"
+  export DEBIAN_FRONTEND=noninteractive
+  # Keep this list in sync with .github/workflows/pr-test-rust.yml.
+  run $sudo apt-get update
+  run $sudo apt-get install -y --no-install-recommends \
+    clang \
+    libclang-dev \
+    cmake \
+    ninja-build \
+    pkg-config \
+    libopencv-dev
+}
+
+install_brew() {
+  # OpenCV + pkg-config let the `opencv` crate's build script discover the
+  # libraries. libclang (for bindgen) ships with the Xcode Command Line Tools;
+  # `brew install llvm` is the fallback if it is missing.
+  run brew install opencv pkg-config
+  if [[ "${DRY_RUN:-0}" != "1" ]] && ! has_cmd clang && [[ ! -e /Library/Developer/CommandLineTools/usr/lib/libclang.dylib ]]; then
+    echo "libclang not found. Install the Xcode Command Line Tools (xcode-select --install)"
+    echo "or run: brew install llvm  (then set LIBCLANG_PATH=\"\$(brew --prefix llvm)/lib\")"
+  fi
+}
+
+main() {
+  echo "Installing system libraries for the opencv-video feature..."
+
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    if has_cmd brew; then
+      confirm "Install OpenCV via Homebrew?" && install_brew
+    else
+      echo "Homebrew not found. Install it from https://brew.sh, then run:"
+      echo "  brew install opencv pkg-config"
+      exit 1
+    fi
+  elif has_cmd apt-get; then
+    confirm "Install OpenCV build dependencies via apt-get?" && install_apt
+  else
+    echo "Unsupported package manager. Install OpenCV development headers, libclang,"
+    echo "pkg-config, and cmake manually for your distribution, for example:"
+    echo "  dnf:    sudo dnf install opencv-devel clang-devel cmake pkgconf-pkg-config"
+    echo "  pacman: sudo pacman -S opencv clang cmake pkgconf"
+    exit 1
+  fi
+
+  if [[ "${DRY_RUN:-0}" != "1" ]] && has_cmd pkg-config; then
+    echo "Done. Detected OpenCV: $(pkg-config --modversion opencv4 2>/dev/null || echo 'not on pkg-config path yet')"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Problem

The `opencv-video` feature (crate `llm-multimodal`, added in #1603) links system OpenCV. It is off by default, so plain `cargo build`/`cargo test` is unaffected — but **`--all-features` builds need it**, and that path is exactly what `make check`, `make pre-commit`, and CI's lint job (`cargo clippy --all-targets --all-features`) run. Without OpenCV installed the build fails with:

```
Error: "Failed to find installed OpenCV package using pkg-config ..."
```

CI handles this by `apt-get install`-ing OpenCV inline before the lint step, but that package list was **undocumented and duplicated only in the workflow**. A contributor running the standard local gate — especially on **macOS**, where `libopencv-dev` (apt) doesn't apply — hits a wall with no guidance.

## Fix

- **`scripts/install_opencv.sh`** — a cross-platform installer (Homebrew on macOS, apt on Debian/Ubuntu) that installs the same packages CI uses. Non-interactive under `AUTO_INSTALL=1`/`CI=true`; supports `DRY_RUN=1`.
- **CI** (`pr-test-rust.yml`) now calls the script instead of an inline `apt-get` block, so the package list has a single source of truth.
- **`make opencv-deps`** exposes the installer locally.
- **Docs** (`development.md`, `code-style.md`, `CONTRIBUTING.md`) document the OpenCV requirement and the no-OpenCV quick-lint escape hatch: `cargo clippy --workspace --all-targets -- -D warnings` (skips `opencv-video`).

No product behavior changes; this is dev-experience + CI de-duplication only.

## Verification

- `bash -n` syntax check passes; dry-ran **both** OS branches (macOS native + apt via PATH shims) — each emits the correct package list with nothing actually installed.
- `--all-features` clippy/test behavior in CI is unchanged (same packages installed, just via the script).