### PR TITLE
chore: audit cleanup batch 2 — dead code + comment trims (auth, wasm)

### DIFF
--- a/crates/auth/src/config.rs
+++ b/crates/auth/src/config.rs
@@ -224,13 +224,11 @@ impl ControlPlaneAuthConfig {
     /// Find an API key by its value and return the entry if found.
     /// Uses constant-time hash comparison to prevent timing attacks.
     pub fn find_api_key(&self, key: &str) -> Option<&ApiKeyEntry> {
-        // Iterate through all keys to prevent timing leaks about key existence
-        // We use a variable to track the match to ensure constant-time behavior
+        // Scan all entries (no early return) to avoid leaking which key matched.
         let mut found: Option<&ApiKeyEntry> = None;
         for entry in &self.api_keys {
             if entry.verify(key) {
                 found = Some(entry);
-                // Don't break early to maintain constant-time behavior
             }
         }
         found

--- a/crates/auth/src/jwt.rs
+++ b/crates/auth/src/jwt.rs
@@ -156,10 +156,6 @@ pub struct ValidatedToken {
 
     /// Display name if present
     pub name: Option<String>,
-
-    /// Full claims for additional processing
-    #[expect(dead_code)]
-    pub(crate) claims: StandardClaims,
 }
 
 /// JTI (JWT ID) cache entry with expiration tracking.
@@ -211,7 +207,6 @@ impl JwtValidator {
         // Set leeway for clock skew
         validation.leeway = config.leeway_secs;
 
-        // We'll set the algorithm per-token based on the key
         validation.algorithms = vec![
             Algorithm::RS256,
             Algorithm::RS384,
@@ -339,7 +334,6 @@ impl JwtValidator {
             role,
             email: claims.email.clone(),
             name: claims.name.clone(),
-            claims,
         })
     }
 
@@ -355,7 +349,6 @@ impl JwtValidator {
 
         let mut cache = cache.lock();
 
-        // Clean up expired entries first (lazy cleanup)
         let now = Instant::now();
 
         // Check if JTI exists and is still valid

--- a/crates/auth/src/middleware.rs
+++ b/crates/auth/src/middleware.rs
@@ -285,9 +285,7 @@ pub async fn control_plane_auth_middleware(
                 return next.run(request).await;
             }
             Err(e) => {
-                // If the token looks like a JWT (3 parts separated by dots), it's likely
-                // an invalid JWT, not an API key. Fail fast with a specific error
-                // instead of silently falling back. This provides better feedback.
+                // 3 dot-separated parts => almost certainly a JWT; fail fast instead of trying API key.
                 if token.split('.').count() == 3 {
                     warn!("Invalid JWT provided: {}. Not falling back to API key.", e);
                     auth_state.audit_logger.log_auth_failure(

--- a/crates/wasm/src/module_manager.rs
+++ b/crates/wasm/src/module_manager.rs
@@ -85,14 +85,6 @@ impl WasmModuleManager {
         Ok(())
     }
 
-    pub fn get_all_modules(&self) -> Result<Vec<WasmModule>> {
-        let modules = self
-            .modules
-            .read()
-            .map_err(|e| WasmManagerError::LockFailed(e.to_string()))?;
-        Ok(modules.values().cloned().collect())
-    }
-
     pub fn get_module(&self, module_uuid: Uuid) -> Result<Option<WasmModule>> {
         let modules = self
             .modules
@@ -125,10 +117,6 @@ impl WasmModuleManager {
             .collect())
     }
 
-    pub fn get_runtime(&self) -> &Arc<WasmRuntime> {
-        &self.runtime
-    }
-
     /// Get the configured maximum body size for HTTP request/response processing
     pub fn get_max_body_size(&self) -> usize {
         self.runtime.get_config().max_body_size
@@ -143,8 +131,7 @@ impl WasmModuleManager {
     ) -> Result<WasmComponentOutput> {
         let start_time = std::time::Instant::now();
 
-        // Get the SHA256 hash and Arc-wrapped WASM bytes with a read lock.
-        // The Arc clone is ~1ns (atomic increment) instead of cloning the full bytes.
+        // Get the SHA256 hash and Arc-wrapped WASM bytes under a read lock.
         let (sha256_hash, wasm_bytes) = {
             let modules = self
                 .modules
@@ -156,7 +143,7 @@ impl WasmModuleManager {
 
             (
                 module.module_meta.sha256_hash,
-                module.module_meta.wasm_bytes.clone(), // Arc clone (cheap)
+                module.module_meta.wasm_bytes.clone(),
             )
         };
 
@@ -166,15 +153,9 @@ impl WasmModuleManager {
                 .write()
                 .map_err(|e| WasmManagerError::LockFailed(e.to_string()))?;
             if let Some(module) = modules.get_mut(&module_uuid) {
-                // SystemTime::duration_since only fails if the system time is before UNIX_EPOCH,
-                // which should never happen in normal operation. If it does, use current time as fallback.
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_else(|_| {
-                        // Fallback to a reasonable timestamp if system time is invalid
-                        // This should never occur in practice, but provides a safe fallback
-                        std::time::Duration::from_nanos(0)
-                    })
+                    .unwrap_or(std::time::Duration::ZERO)
                     .as_nanos() as u64;
                 module.module_meta.last_accessed_at = now;
                 module.module_meta.access_count += 1;
@@ -202,17 +183,6 @@ impl WasmModuleManager {
         }
 
         result
-    }
-
-    /// Execute WASM module using WebAssembly component model (sync version)
-    pub fn execute_module_interface_sync(
-        &self,
-        module_uuid: Uuid,
-        attach_point: WasmModuleAttachPoint,
-        input: WasmComponentInput,
-    ) -> Result<WasmComponentOutput> {
-        let handle = tokio::runtime::Handle::current();
-        handle.block_on(self.execute_module_interface(module_uuid, attach_point, input))
     }
 
     /// Get current metrics

--- a/crates/wasm/src/runtime.rs
+++ b/crates/wasm/src/runtime.rs
@@ -101,13 +101,6 @@ impl WasmRuntime {
         (cpu_count, max_recommended)
     }
 
-    /// get current thread pool status
-    pub fn get_thread_pool_info(&self) -> (usize, usize) {
-        let (_cpu_count, max_recommended) = Self::get_cpu_info();
-        let current_workers = self.thread_pool.workers.len();
-        (current_workers, max_recommended)
-    }
-
     /// Execute WASM component using WASM interface based on attach_point
     pub async fn execute_component_async(
         &self,
@@ -374,11 +367,10 @@ impl WasmThreadPool {
         input: WasmComponentInput,
         config: &WasmRuntimeConfig,
     ) -> Result<WasmComponentOutput> {
-        // Compile component from bytes OR retrieve from cache.
-        // Cache is keyed by SHA256 hash (~20ns lookup) instead of raw Vec<u8>
-        // (~24µs for a 500KB module), a 1200× improvement.
+        // Compile component from bytes, or retrieve from cache (keyed by SHA256
+        // hash to avoid hashing the full module bytes per lookup).
         let component = if let Some(comp) = cache.get(&sha256_hash) {
-            comp.clone() // Component is just a handle (cheap clone)
+            comp.clone()
         } else {
             // Compile new component
             let comp = Component::new(engine, wasm_bytes).map_err(|e| {
@@ -406,7 +398,7 @@ impl WasmThreadPool {
             })?;
         let limits = StoreLimitsBuilder::new()
             .memory_size(memory_limit_bytes)
-            .trap_on_grow_failure(true) // Trap instead of returning -1 for easier debugging
+            .trap_on_grow_failure(true)
             .build();
 
         let mut store = Store::new(

--- a/crates/wasm/src/types.rs
+++ b/crates/wasm/src/types.rs
@@ -6,10 +6,7 @@
 use wasmtime::{component::ResourceTable, StoreLimits};
 use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView};
 
-use crate::{
-    module::{MiddlewareAttachPoint, WasmModuleAttachPoint},
-    spec::smg::gateway::middleware_types,
-};
+use crate::spec::smg::gateway::middleware_types;
 
 /// Generic input type for WASM component execution
 ///
@@ -31,59 +28,6 @@ pub enum WasmComponentInput {
 pub enum WasmComponentOutput {
     /// Middleware Action output
     MiddlewareAction(middleware_types::Action),
-}
-
-impl WasmComponentInput {
-    /// Create input based on attach_point and raw data
-    ///
-    /// This helper function validates that the attach_point matches
-    /// the expected input type.
-    pub fn from_attach_point(attach_point: &WasmModuleAttachPoint) -> Result<Self, String> {
-        match attach_point {
-            WasmModuleAttachPoint::Middleware(MiddlewareAttachPoint::OnRequest) => {
-                // OnRequest expects a Request type, but we can't construct it here
-                // The caller should use MiddlewareRequest variant directly
-                Err("OnRequest requires MiddlewareRequest input. Use WasmComponentInput::MiddlewareRequest directly.".to_string())
-            }
-            WasmModuleAttachPoint::Middleware(MiddlewareAttachPoint::OnResponse) => {
-                // OnResponse expects a Response type
-                Err("OnResponse requires MiddlewareResponse input. Use WasmComponentInput::MiddlewareResponse directly.".to_string())
-            }
-            WasmModuleAttachPoint::Middleware(MiddlewareAttachPoint::OnError) => {
-                Err("OnError attach point not yet implemented".to_string())
-            }
-        }
-    }
-
-    /// Get the expected attach_point for this input type
-    pub fn expected_attach_point(&self) -> WasmModuleAttachPoint {
-        match self {
-            WasmComponentInput::MiddlewareRequest(_) => {
-                WasmModuleAttachPoint::Middleware(MiddlewareAttachPoint::OnRequest)
-            }
-            WasmComponentInput::MiddlewareResponse(_) => {
-                WasmModuleAttachPoint::Middleware(MiddlewareAttachPoint::OnResponse)
-            }
-        }
-    }
-}
-
-impl WasmComponentOutput {
-    /// Get the attach_point that produced this output type
-    pub fn from_attach_point(attach_point: &WasmModuleAttachPoint) -> Result<Self, String> {
-        match attach_point {
-            WasmModuleAttachPoint::Middleware(MiddlewareAttachPoint::OnRequest) => {
-                // This would be set after execution
-                Err("Cannot create output before execution".to_string())
-            }
-            WasmModuleAttachPoint::Middleware(MiddlewareAttachPoint::OnResponse) => {
-                Err("Cannot create output before execution".to_string())
-            }
-            WasmModuleAttachPoint::Middleware(MiddlewareAttachPoint::OnError) => {
-                Err("OnError attach point not yet implemented".to_string())
-            }
-        }
-    }
 }
 
 pub struct WasiState {


### PR DESCRIPTION
## Description

### Problem

Continuation of the audit cleanup (`.claude/audit-2026-06-15`) after the merged
batch 1 (#1732). This is batch 2: low-severity `dead_code` + `comment_bloat`
findings in `crates/auth` and `crates/wasm`.

### Solution

Mechanical, **behavior-preserving** removal of confirmed-dead code plus
PR-narrative comment trims, **one crate per commit**, each verified independently
and gated against the full workspace. Every removal was confirmed unreferenced
repo-wide before deleting.

## Changes

- **`auth`** — drop the `#[expect(dead_code)]` `ValidatedToken::claims` field
  (never read; removes a per-request `StandardClaims` clone incl. its `extra`
  map). Trim misleading/narrative comments (the JTI "lazy cleanup" note, the
  per-token algorithm note, the constant-time API-key scan block, the JWT-shape
  heuristic). *Left* the reserved/standard claim fields (`aud`/`Audience`,
  `iat`/`nbf`, `AuditEvent` `Serialize`) — author-marked reserved / `pub` API.
- **`wasm`** — remove 6 methods with no workspace callers:
  `WasmComponentInput::{from_attach_point, expected_attach_point}`,
  `WasmComponentOutput::from_attach_point` (the `from_attach_point` helpers only
  ever returned `Err`), `WasmModuleManager::{get_all_modules` (dup of
  `get_modules`)`, get_runtime, execute_module_interface_sync}` (the last would
  panic via `Handle::current().block_on` inside a runtime), and
  `WasmRuntime::get_thread_pool_info`. Trim invented-timing / over-explained
  comments. *Left* the duplicate `WasmRuntime` metrics counters + `WasmThreadPool`
  fields (entangled with the execution hot path / overlaps the perf finding).

No bug/perf/failure/lock findings are touched here.

## Test Plan

Per crate, before its commit:

```
cargo +nightly fmt -p <crate> -- --check
cargo clippy -p <crate> --all-targets --all-features -- -D warnings
cargo test  -p <crate> --all-features
```

- `auth`: clippy clean, 25 tests pass.
- `wasm`: clippy clean, 33 tests pass.

Full workspace: `cargo +nightly fmt --all -- --check` clean; `cargo clippy
--all-targets -- -D warnings` clean (compiles `model_gateway`, `smg-python`,
`smg-golang` — confirms the removed `pub` items had no dependents).

> Note: the full `--all-features` workspace clippy can't run in this environment
> (`--all-features` enables `opencv-video`, whose `opencv` build needs a system
> OpenCV/cmake); neither crate touches opencv, and each was verified with
> `--all-features` individually.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (per changed crate; full-workspace via default features — `--all-features` blocked only by the unrelated `opencv` system dep)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org)

</details>
