### PR TITLE
chore(mesh): remove dead mTLS alias + unused field, trim comments

### DIFF
--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -97,9 +97,7 @@ pub struct Subscription {
 /// Function signature for stream drain callbacks. Called exactly once per
 /// gossip round. Returns accumulated entries to be sent in this round's
 /// batch. Values are `Bytes` so fan-out to N peers is an Arc refcount bump
-/// per peer rather than N heap copies — keeps a single ~1.5 GB tenant-delta
-/// round from ballooning to 20 × 1.5 GB when chunked across every peer's
-/// sender task.
+/// per peer rather than N heap copies.
 pub type StreamDrainFn = Box<dyn Fn() -> Vec<(String, Bytes)> + Send + Sync>;
 
 /// Handle returned by `register_drain`. Dropping unregisters the drain callback.
@@ -121,13 +119,11 @@ impl Drop for DrainHandle {
 
 /// A single subscription event: (key, value). `None` value means deletion.
 ///
-/// Values are a `Vec<Bytes>` — a list of zero-copy buffer fragments. For
-/// single-value writes this is a 1-element Vec; for reassembled chunked
-/// stream receives it is an N-element Vec where each element wraps one
-/// chunk's original allocation. Subscribers that need a contiguous buffer
-/// can concat; those that fan out further can clone the Bytes cheaply.
-/// The fragmented shape avoids the 2× peak a contiguous reassembly would
-/// impose when a near-cap multi-chunk value completes.
+/// Values are a `Vec<Bytes>` of zero-copy fragments: a 1-element Vec for
+/// single-value writes, an N-element Vec for reassembled chunked receives
+/// (each element wraps one chunk's original allocation). The fragmented
+/// shape avoids the 2× peak a contiguous reassembly would impose when a
+/// near-cap multi-chunk value completes.
 type SubscriptionEvent = (String, Option<Vec<Bytes>>);
 
 /// Tracks all active subscriptions by prefix.

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -30,7 +30,7 @@ pub use kv::{
     StreamRouting, Subscription,
 };
 pub use metrics::init_mesh_metrics;
-pub use mtls::{MTLSConfig, MTLSManager, OptionalMTLSManager};
+pub use mtls::{MTLSConfig, MTLSManager};
 pub use partition::PartitionDetector;
 pub use service::{gossip, ClusterState, MeshServerBuilder, MeshServerConfig, MeshServerHandler};
 pub use transport::limits::MAX_STREAM_CHUNK_BYTES;

--- a/crates/mesh/src/mtls.rs
+++ b/crates/mesh/src/mtls.rs
@@ -187,6 +187,3 @@ impl MTLSManager {
         self.client_config.read().await.clone()
     }
 }
-
-/// Optional mTLS manager
-pub type OptionalMTLSManager = Option<Arc<MTLSManager>>;

--- a/crates/mesh/src/service.rs
+++ b/crates/mesh/src/service.rs
@@ -51,7 +51,6 @@ pub struct MeshServerConfig {
 pub struct MeshServerHandler {
     pub state: ClusterState,
     pub self_name: String,
-    _self_addr: SocketAddr,
     signal_tx: watch::Sender<bool>,
     partition_detector: Option<Arc<PartitionDetector>>,
     /// Shared with the MeshServer so adapters can subscribe to stream
@@ -218,7 +217,6 @@ impl MeshServerBuilder {
             MeshServerHandler {
                 state: self.state.clone(),
                 self_name: self.self_name.clone(),
-                _self_addr: self.advertise_addr,
                 signal_tx,
                 partition_detector: Some(partition_detector),
                 mesh_kv,

--- a/crates/mesh/src/transport/chunk_assembler.rs
+++ b/crates/mesh/src/transport/chunk_assembler.rs
@@ -30,10 +30,7 @@ pub const DEFAULT_MAX_ASSEMBLER_BYTES: usize = 512 * 1024 * 1024;
 /// Hard cap on the chunk count advertised by a single chunk header.
 /// AssemblyState allocates a `chunks` vector sized to `total`, so an
 /// unvalidated peer-supplied `total = u32::MAX` would trigger a
-/// multi-GB allocation before the byte-cap enforcer can react. 1024
-/// chunks × 10 MB/chunk is 10 GB of assembled payload — well past the
-/// byte cap, so bounds still catch any realistic traffic, while the
-/// per-assembly vector overhead stays under ~25 KB.
+/// multi-GB allocation before the byte-cap enforcer can react.
 pub const MAX_TOTAL_CHUNKS: u32 = 1024;
 
 /// Composite key scoping an assembly by sender peer + application key.


### PR DESCRIPTION
## Description

### Problem

Part of the audit cleanup (`.claude/audit-2026-06-15`) — low-severity `dead_code` + `comment_bloat` findings in `crates/mesh`.

### Solution

Mechanical, behavior-preserving cleanup of the confirmed `dead_code` + `comment_bloat` findings only; every removal was re-validated against current code and confirmed unreferenced repo-wide before deleting. (One PR per crate; produced by a worktree-isolated agent and human-reviewed before opening.)

## Changes

- Remove dead `OptionalMTLSManager` type alias (verified no users repo-wide) and the unused private `_self_addr` field; trim invented-figure perf comments. Left the mtls/partition 'wire-up-or-delete' cluster (a design decision tied to the server-mTLS bug, not mechanical cleanup).

## Test Plan

`cargo +nightly fmt -p smg-mesh` clean; `cargo clippy -p smg-mesh --all-targets --all-features -- -D warnings` clean; `cargo test -p smg-mesh --all-features` (191 passed) pass.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
