### PR TITLE
chore(data-connector): remove dead ResponseChain methods + duplicate migration arrays

### DIFF
--- a/crates/data_connector/src/common.rs
+++ b/crates/data_connector/src/common.rs
@@ -376,17 +376,13 @@ mod tests {
         assert!(sql.contains("id")); // core cols still there
     }
 
-    // ── Schema config replaces forked Oracle (temp_oracle.rs scenario) ───
+    // ── Schema config drives Oracle-compatible SQL ───
 
-    /// Proves that SchemaConfig with custom names generates the same SQL
-    /// patterns that temp_oracle.rs used with hardcoded strings — without
-    /// forking the backend code.
+    /// SchemaConfig with custom names generates Oracle-compatible SQL.
     #[test]
     fn schema_config_produces_oracle_compatible_sql() {
-        // Build a config matching what temp_oracle.rs hardcoded:
-        // - default table names (conversations, responses, etc.)
-        // - default column names (Oracle uses unquoted identifiers = case-insensitive)
-        // - Oracle owner prefix
+        // Default table/column names with an Oracle owner prefix; Oracle uses
+        // unquoted identifiers, which are case-insensitive.
         let mut cfg = SchemaConfig {
             owner: Some("ADMIN".to_string()),
             ..SchemaConfig::default()
@@ -409,8 +405,7 @@ mod tests {
         }
     }
 
-    /// Proves that adding a TENANT_ID extra column (a common fork reason)
-    /// works purely through config — no code changes needed.
+    /// Adding a TENANT_ID extra column works purely through config.
     #[test]
     fn schema_config_adds_tenant_column_without_forking() {
         let mut cfg = SchemaConfig {
@@ -418,8 +413,6 @@ mod tests {
             ..SchemaConfig::default()
         };
 
-        // Add TENANT_ID — this is the column that temp_oracle.rs would
-        // require forking the entire backend to add
         cfg.responses.extra_columns.insert(
             "TENANT_ID".to_string(),
             crate::schema::ColumnDef {

--- a/crates/data_connector/src/core.rs
+++ b/crates/data_connector/src/core.rs
@@ -1,12 +1,5 @@
-// core.rs
-//
 // Core types for the data connector module.
 // Contains all traits, data types, error types, and IDs for all storage backends.
-//
-// Structure:
-// 1. Conversation types + trait
-// 2. ConversationItem types + trait
-// 3. Response types + trait
 
 use std::{
     collections::{HashMap, HashSet},
@@ -412,36 +405,9 @@ impl ResponseChain {
         }
     }
 
-    /// Get the ID of the most recent response in the chain
-    pub fn latest_response_id(&self) -> Option<&ResponseId> {
-        self.responses.last().map(|r| &r.id)
-    }
-
     /// Add a response to the chain
     pub fn add_response(&mut self, response: StoredResponse) {
         self.responses.push(response);
-    }
-
-    /// Build context from the chain for the next request
-    pub fn build_context(&self, max_responses: Option<usize>) -> Vec<(Value, Value)> {
-        let responses = if let Some(max) = max_responses {
-            let start = self.responses.len().saturating_sub(max);
-            &self.responses[start..]
-        } else {
-            &self.responses[..]
-        };
-
-        responses
-            .iter()
-            .map(|r| {
-                let output = r
-                    .raw_response
-                    .get("output")
-                    .cloned()
-                    .unwrap_or(Value::Array(vec![]));
-                (r.input.clone(), output)
-            })
-            .collect()
     }
 }
 
@@ -902,79 +868,5 @@ mod tests {
         assert_eq!(chain.responses.len(), 2, "chain should have 2 responses");
         assert_eq!(chain.responses[0].id, r1_id, "first response should be r1");
         assert_eq!(chain.responses[1].id, r2_id, "second response should be r2");
-    }
-
-    #[test]
-    fn response_chain_latest_response_id_returns_last() {
-        let mut chain = ResponseChain::new();
-        let r1 = StoredResponse::new(None);
-        let r2 = StoredResponse::new(None);
-        let r2_id = r2.id.clone();
-
-        chain.add_response(r1);
-        chain.add_response(r2);
-
-        assert_eq!(
-            chain.latest_response_id(),
-            Some(&r2_id),
-            "latest_response_id should return the last response's ID"
-        );
-    }
-
-    #[test]
-    fn response_chain_latest_response_id_returns_none_for_empty() {
-        let chain = ResponseChain::new();
-        assert_eq!(
-            chain.latest_response_id(),
-            None,
-            "latest_response_id should return None for empty chain"
-        );
-    }
-
-    #[test]
-    fn response_chain_build_context_returns_input_output_pairs() {
-        use serde_json::json;
-
-        let mut chain = ResponseChain::new();
-
-        let mut r1 = StoredResponse::new(None);
-        r1.input = Value::String("input1".to_string());
-        r1.raw_response = json!({"output": "output1"});
-
-        let mut r2 = StoredResponse::new(None);
-        r2.input = Value::String("input2".to_string());
-        r2.raw_response = json!({"output": "output2"});
-
-        chain.add_response(r1);
-        chain.add_response(r2);
-
-        let context = chain.build_context(None);
-        assert_eq!(context.len(), 2, "should return 2 pairs");
-        assert_eq!(context[0].0, Value::String("input1".to_string()));
-        assert_eq!(context[0].1, Value::String("output1".to_string()));
-        assert_eq!(context[1].0, Value::String("input2".to_string()));
-        assert_eq!(context[1].1, Value::String("output2".to_string()));
-    }
-
-    #[test]
-    fn response_chain_build_context_with_max_responses_limits_output() {
-        use serde_json::json;
-
-        let mut chain = ResponseChain::new();
-
-        for i in 0..5 {
-            let mut resp = StoredResponse::new(None);
-            resp.input = Value::String(format!("input{i}"));
-            resp.raw_response = json!({"output": format!("output{i}")});
-            chain.add_response(resp);
-        }
-
-        let context = chain.build_context(Some(2));
-        assert_eq!(context.len(), 2, "should return only 2 most recent pairs");
-        // Should be the last 2 responses (index 3 and 4)
-        assert_eq!(context[0].0, Value::String("input3".to_string()));
-        assert_eq!(context[0].1, Value::String("output3".to_string()));
-        assert_eq!(context[1].0, Value::String("input4".to_string()));
-        assert_eq!(context[1].1, Value::String("output4".to_string()));
     }
 }

--- a/crates/data_connector/src/hooked.rs
+++ b/crates/data_connector/src/hooked.rs
@@ -969,13 +969,10 @@ mod tests {
         );
     }
 
-    // ── temp_oracle.rs scenario: hooks + extra columns replace forking ──
+    // ── Hooks + extra columns: end-to-end ──
 
-    /// Simulates the temp_oracle.rs use case end-to-end:
-    /// Instead of forking Oracle to add a TENANT_ID column, configure
-    /// `extra_columns` on the schema and attach a hook that provides values.
-    ///
-    /// This test verifies:
+    /// Configures `extra_columns` on the schema with a hook that provides a
+    /// TENANT_ID value, and verifies:
     /// 1. Hook `before()` is called with `StoreResponse`
     /// 2. ExtraColumns from the hook are available via task-local during write
     /// 3. Hook `after()` is called with the result
@@ -984,8 +981,7 @@ mod tests {
     async fn hook_with_extra_columns_replaces_forked_backend() {
         use crate::context::current_extra_columns;
 
-        /// Hook that returns TENANT_ID extra column, simulating what
-        /// a forked Oracle backend would hardcode.
+        /// Hook that returns a TENANT_ID extra column value.
         struct TenantHook;
 
         #[async_trait]

--- a/crates/data_connector/src/memory.rs
+++ b/crates/data_connector/src/memory.rs
@@ -1,11 +1,6 @@
 //! In-memory storage implementations
 //!
 //! Used for development and testing - no persistence.
-//!
-//! Structure:
-//! 1. MemoryConversationStorage
-//! 2. MemoryConversationItemStorage
-//! 3. MemoryResponseStorage
 
 use std::{
     collections::{BTreeMap, HashMap},

--- a/crates/data_connector/src/noop.rs
+++ b/crates/data_connector/src/noop.rs
@@ -1,11 +1,6 @@
 //! NoOp storage implementations
 //!
 //! These implementations do nothing - useful for when persistence is disabled.
-//!
-//! Structure:
-//! 1. NoOpConversationStorage
-//! 2. NoOpConversationItemStorage
-//! 3. NoOpResponseStorage
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};

--- a/crates/data_connector/src/oracle.rs
+++ b/crates/data_connector/src/oracle.rs
@@ -1,10 +1,4 @@
 //! Oracle storage implementation using OracleStore helper.
-//!
-//! Structure:
-//! 1. OracleStore helper and common utilities
-//! 2. OracleConversationStorage
-//! 3. OracleConversationItemStorage
-//! 4. OracleResponseStorage
 
 use std::{path::Path, sync::Arc, time::Duration};
 

--- a/crates/data_connector/src/oracle_migrations.rs
+++ b/crates/data_connector/src/oracle_migrations.rs
@@ -27,12 +27,6 @@ const ORACLE_V3: Migration = Migration {
 /// storage path during normal gateway startup.
 pub(crate) static ORACLE_HISTORY_MIGRATIONS: [Migration; 3] = [ORACLE_V1, ORACLE_V2, ORACLE_V3];
 
-/// Oracle migration list. Append new migrations here.
-///
-/// Versions 4–8 (skills / tenant-alias / bundle-token / continuation-cookie
-/// tables) were removed with the Skills subsystem.
-pub(crate) static ORACLE_MIGRATIONS: [Migration; 3] = [ORACLE_V1, ORACLE_V2, ORACLE_V3];
-
 fn oracle_v1_up(schema: &SchemaConfig) -> Vec<String> {
     let s = &schema.responses;
     if s.is_skipped("safety_identifier") {
@@ -120,10 +114,8 @@ mod tests {
 
     #[test]
     fn oracle_migrations_are_strictly_increasing() {
-        // Versions must be strictly increasing and unique. A numbering gap is
-        // allowed (skills migrations 4–8 were removed), so we no longer require
-        // `version == index + 1`.
-        for pair in ORACLE_MIGRATIONS.windows(2) {
+        // Versions must be strictly increasing and unique; a numbering gap is allowed.
+        for pair in ORACLE_HISTORY_MIGRATIONS.windows(2) {
             assert!(
                 pair[1].version > pair[0].version,
                 "migration versions must strictly increase: {} then {}",
@@ -238,7 +230,7 @@ mod tests {
     #[test]
     fn all_oracle_migration_identifiers_are_within_30_chars() {
         let schema = SchemaConfig::default();
-        let all: Vec<String> = ORACLE_MIGRATIONS
+        let all: Vec<String> = ORACLE_HISTORY_MIGRATIONS
             .iter()
             .flat_map(|m| (m.up)(&schema))
             .collect();

--- a/crates/data_connector/src/postgres.rs
+++ b/crates/data_connector/src/postgres.rs
@@ -1,10 +1,4 @@
 //! Postgres storage implementation using PostgresStore helper
-//!
-//! Structure:
-//! 1. PostgresStore helper and common utilities
-//! 2. PostgresConversationStorage
-//! 3. PostgresConversationItemStorage
-//! 4. PostgresResponseStorage
 
 use std::{str::FromStr, sync::Arc};
 

--- a/crates/data_connector/src/postgres_migrations.rs
+++ b/crates/data_connector/src/postgres_migrations.rs
@@ -28,12 +28,6 @@ const POSTGRES_V3: Migration = Migration {
 pub(crate) static POSTGRES_HISTORY_MIGRATIONS: [Migration; 3] =
     [POSTGRES_V1, POSTGRES_V2, POSTGRES_V3];
 
-/// Postgres migration list. Append new migrations here.
-///
-/// Versions 4–8 (skills / tenant-alias / bundle-token / continuation-cookie
-/// tables) were removed with the Skills subsystem.
-pub(crate) static POSTGRES_MIGRATIONS: [Migration; 3] = [POSTGRES_V1, POSTGRES_V2, POSTGRES_V3];
-
 fn pg_v1_up(schema: &SchemaConfig) -> Vec<String> {
     let s = &schema.responses;
     if s.is_skipped("safety_identifier") {
@@ -116,10 +110,8 @@ mod tests {
 
     #[test]
     fn postgres_migrations_are_strictly_increasing() {
-        // Versions must be strictly increasing and unique. A numbering gap is
-        // allowed (skills migrations 4–8 were removed), so we no longer require
-        // `version == index + 1`.
-        for pair in POSTGRES_MIGRATIONS.windows(2) {
+        // Versions must be strictly increasing and unique; a numbering gap is allowed.
+        for pair in POSTGRES_HISTORY_MIGRATIONS.windows(2) {
             assert!(
                 pair[1].version > pair[0].version,
                 "migration versions must strictly increase: {} then {}",

--- a/crates/data_connector/src/redis.rs
+++ b/crates/data_connector/src/redis.rs
@@ -1,10 +1,4 @@
 //! Redis storage implementation using RedisStore helper
-//!
-//! Structure:
-//! 1. RedisStore helper and common utilities
-//! 2. RedisConversationStorage
-//! 3. RedisConversationItemStorage
-//! 4. RedisResponseStorage
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/crates/data_connector/src/schema.rs
+++ b/crates/data_connector/src/schema.rs
@@ -1,8 +1,6 @@
 //! Schema configuration for storage backends.
 //!
 //! Provides YAML-driven customization of table names and column names.
-//! When no schema config is provided, all defaults match the current
-//! hardcoded behavior — zero behavioral change.
 
 use std::collections::{HashMap, HashSet};
 
@@ -15,8 +13,8 @@ use serde_json::Value;
 
 /// Top-level schema configuration. Drives all SQL generation and key naming.
 ///
-/// Every field has a default matching current hardcoded behavior, so omitting
-/// the entire `schema:` section in YAML produces identical queries to today.
+/// Every field defaults to its logical name, so omitting the entire `schema:`
+/// section in YAML uses the default table and column names.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct SchemaConfig {


### PR DESCRIPTION
## Description

### Problem

Part of the audit cleanup (`.claude/audit-2026-06-15`) — low-severity `dead_code` + `comment_bloat` findings in `crates/data_connector`.

### Solution

Mechanical, behavior-preserving cleanup of the confirmed `dead_code` + `comment_bloat` findings only; every removal was re-validated against current code and confirmed unreferenced repo-wide before deleting. (One PR per crate; produced by a worktree-isolated agent and human-reviewed before opening.)

## Changes

- Remove dead `ResponseChain::{latest_response_id, build_context}` (no callers repo-wide) and the byte-identical duplicate `ORACLE_MIGRATIONS`/`POSTGRES_MIGRATIONS` arrays (tests repointed to the live `*_HISTORY_MIGRATIONS`, preserving coverage). Trim 'temp_oracle.rs'/'forking'/'Structure: 1.2.3' narrative comments.

## Test Plan

`cargo +nightly fmt -p data-connector` clean; `cargo clippy -p data-connector --all-targets --all-features -- -D warnings` clean; `cargo test -p data-connector --all-features` (215 passed) pass.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
