### PR TITLE
fix(grpc_servicer): drain in-flight RPCs before closing ZMQ on shutdown

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/server.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/server.py
@@ -316,11 +316,16 @@ async def serve_grpc(
     finally:
         logger.info("Shutting down gRPC server")
 
-        # Shutdown request manager first - this closes ZMQ sockets and stops background tasks
-        await servicer.shutdown()
+        # Mark unhealthy first so probes and load balancers stop routing new
+        # requests before we drain.
+        health_servicer.set_not_serving()
 
-        # Stop the gRPC server
+        # Drain in-flight RPCs with the request manager's ZMQ sockets still
+        # open, then tear it down. Closing ZMQ before server.stop() drops the
+        # backing channel out from under streams that are still draining, so
+        # they error instead of completing.
         await server.stop(5.0)
+        await servicer.shutdown()
 
         # Wait for warmup thread to finish
         if warmup_thread.is_alive():


### PR DESCRIPTION
## Problem

On `SIGTERM`/`SIGINT` the sglang gRPC servicer tore down in the wrong order (`server.py`):

```python
await servicer.shutdown()   # closes the request manager's ZMQ sockets
await server.stop(5.0)      # only now drains in-flight gRPC RPCs
```

Closing ZMQ first drops the backing channel out from under gRPC streams that are still in flight, so they **error instead of draining** — on every rollout/restart.

## Fix

Reorder to the standard graceful gRPC shutdown sequence:

```python
health_servicer.set_not_serving()  # probes/LBs stop routing new requests
await server.stop(5.0)             # drain in-flight RPCs, ZMQ still open
await servicer.shutdown()          # now tear down the request manager (ZMQ)
```

`health_servicer.set_not_serving()` already exists; this just calls it first so the drain window reports NOT_SERVING. Mirrors the dynamo fix (`c8845b4120`). Scheduler-process termination still runs last, unchanged.

## Test plan

- `python -m py_compile` — OK.
- `ruff check` + `ruff format --check` — clean.
- Behavioral: a `SIGTERM` during an in-flight generation now drains within the 5s grace instead of erroring the stream; verifiable in the gRPC admin-ops e2e drain path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server graceful shutdown sequence to better handle pending request draining and connection cleanup during termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->