### PR TITLE
fix(server): keep accepting during LB propagation window on shutdown

### DIFF
--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1366,7 +1366,16 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     let handle = axum_server::Handle::new();
     let handle_clone = handle.clone();
     let inflight_tracker = app_context.inflight_tracker.clone();
-    let drain_timeout = Duration::from_secs(config.shutdown_grace_period_secs);
+    let grace = Duration::from_secs(config.shutdown_grace_period_secs);
+    // Keep accepting for a short settle window before gating, so requests still
+    // routed here during load-balancer / EndpointSlice propagation lag are
+    // served instead of connection-refused — readiness already reports 503 by
+    // then (#1694), so the orchestrator is removing this endpoint meanwhile.
+    // Carved out of the grace budget (never more than half, capped at 5s — the
+    // per-worker `drain_settle_secs` default) so total shutdown stays within
+    // `shutdown_grace_period_secs` and never overruns terminationGracePeriod.
+    let settle = (grace / 2).min(Duration::from_secs(5));
+    let drain_timeout = grace.saturating_sub(settle);
     #[expect(
         clippy::disallowed_methods,
         reason = "shutdown signal handler must outlive the server to trigger graceful shutdown"
@@ -1374,12 +1383,21 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     spawn(async move {
         shutdown_signal().await;
 
-        // Phase 1: Gate — stop accepting new connections, mark as draining
+        // Phase 1: Flip readiness to 503, hold the listener open through the
+        // settle window so propagation-lagged requests still land, then gate
+        // new connections.
         info!(
             in_flight = inflight_tracker.len(),
-            "Beginning graceful shutdown: gating new connections"
+            "Beginning graceful shutdown: readiness draining"
         );
         inflight_tracker.begin_drain();
+        if !settle.is_zero() {
+            info!(
+                settle_secs = settle.as_secs(),
+                "Keeping listener open during load-balancer propagation window"
+            );
+            tokio::time::sleep(settle).await;
+        }
         handle_clone.graceful_shutdown(Some(drain_timeout));
 
         // Phase 2: Drain — wait for in-flight requests to complete


### PR DESCRIPTION
## Problem

#1711 made `/readiness` flip to `503` on `begin_drain()`, but the gateway's accept loop still stops at **T+0** of SIGTERM (`server.rs`):

```rust
inflight_tracker.begin_drain();                    // readiness -> 503
handle_clone.graceful_shutdown(Some(drain_timeout)); // accept stops immediately
```

With IGW / Kubernetes EndpointSlice propagation lag, the load balancer keeps routing to this pod for a short window *after* readiness flips. Stopping accept at T+0 means those still-routed requests (and kubelet probes) get **connection-refused** for the whole drain window — an error manufactured on every rollout. This is the other half of the drain story #1711 set up.

## Fix

Hold the listener open for a short **settle window** between the readiness flip and the accept gate:

```rust
inflight_tracker.begin_drain();        // readiness -> 503, orchestrator deregisters
tokio::time::sleep(settle).await;      // keep accepting; propagation-lagged reqs still land
handle_clone.graceful_shutdown(...);   // now gate + drain in-flight
```

The window is **carved out of the existing grace budget** — `settle = min(grace/2, 5s)`, `drain = grace - settle` — so:
- total shutdown never exceeds `shutdown_grace_period_secs` (no `terminationGracePeriodSeconds` overrun);
- in-flight requests still get the full grace to progress (they run during both settle and drain);
- 5s matches the per-worker `drain_settle_secs` default already in the codebase.

No new config knob (kept deliberately minimal); can be promoted to a configurable field later if operators want to tune it independently.

## Test plan

- `cargo +nightly fmt --all` — clean.
- `cargo clippy --workspace --all-targets` — clean (no `--all-features`: avoids the unrelated local OpenCV dep; CI runs the full lint with OpenCV installed).
- `cargo test -p smg` — **1071 lib tests + all integration binaries pass, 0 failed**. (The shutdown path runs only on a real SIGTERM/SIGINT, so it isn't exercised by `cargo test`; behavior verified by reasoning + the bounded-budget arithmetic.)