### PR TITLE
perf(grpc): offload tokenizer encode to a bounded blocking pool

### DIFF
--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -140,7 +140,13 @@ impl ChatPreparationStage {
         };
 
         // Step 3: Tokenize the processed text (no special tokens - chat template already handles them)
-        let encoding = match tokenizer.encode(&processed_messages.text, false) {
+        let encoding = match utils::encode_blocking(
+            tokenizer.clone(),
+            processed_messages.text.clone(),
+            false,
+        )
+        .await
+        {
             Ok(encoding) => encoding,
             Err(e) => {
                 error!(function = "ChatPreparationStage::execute", error = %e, "Tokenization failed");

--- a/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
@@ -39,14 +39,16 @@ impl PipelineStage for CompletionPreparationStage {
             }
         };
 
-        let encoding = tokenizer.encode(&prompt_text, false).map_err(|e| {
-            error!(
-                function = "CompletionPreparationStage::execute",
-                error = %e,
-                "Tokenization failed"
-            );
-            error::bad_request("tokenization_failed", format!("Tokenization failed: {e}"))
-        })?;
+        let encoding = utils::encode_blocking(tokenizer.clone(), prompt_text.clone(), false)
+            .await
+            .map_err(|e| {
+                error!(
+                    function = "CompletionPreparationStage::execute",
+                    error = %e,
+                    "Tokenization failed"
+                );
+                error::bad_request("tokenization_failed", format!("Tokenization failed: {e}"))
+            })?;
 
         let stop_decoder = utils::create_stop_decoder(
             &tokenizer,

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
@@ -53,8 +53,8 @@ impl PipelineStage for EmbeddingPreparationStage {
 
         // Tokenize with special tokens (BOS/EOS) for embeddings
         // This matches Python's transformers behavior which reads add_bos_token/add_eos_token from tokenizer_config.json
-        let token_ids = tokenizer
-            .encode(&text, true)
+        let token_ids = utils::encode_blocking(tokenizer.clone(), text.clone(), true)
+            .await
             .map_err(|e| {
                 error!(
                     function = "EmbeddingPreparationStage::execute",

--- a/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -27,7 +27,7 @@ pub(crate) struct GeneratePreparationStage;
 impl PipelineStage for GeneratePreparationStage {
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
         let request = ctx.generate_request_arc();
-        self.prepare_generate(ctx, &request)?;
+        self.prepare_generate(ctx, &request).await?;
         Ok(None)
     }
 
@@ -37,11 +37,7 @@ impl PipelineStage for GeneratePreparationStage {
 }
 
 impl GeneratePreparationStage {
-    #[expect(
-        clippy::result_large_err,
-        reason = "Response is the standard error type in the pipeline stage pattern"
-    )]
-    fn prepare_generate(
+    async fn prepare_generate(
         &self,
         ctx: &mut RequestContext,
         request: &GenerateRequest,
@@ -50,7 +46,10 @@ impl GeneratePreparationStage {
         let tokenizer = utils::resolve_tokenizer(ctx, "GeneratePreparationStage::prepare_generate")
             .map_err(|e| *e)?;
 
-        let (original_text, token_ids) = match self.resolve_generate_input(request, &tokenizer) {
+        let (original_text, token_ids) = match self
+            .resolve_generate_input(request, &tokenizer)
+            .await
+        {
             Ok(res) => res,
             Err(msg) => {
                 error!(function = "GeneratePreparationStage::execute", error = %msg, "Failed to resolve generate input");
@@ -80,7 +79,7 @@ impl GeneratePreparationStage {
         Ok(())
     }
 
-    fn resolve_generate_input(
+    async fn resolve_generate_input(
         &self,
         request: &GenerateRequest,
         tokenizer: &Arc<dyn Tokenizer>,
@@ -88,6 +87,7 @@ impl GeneratePreparationStage {
         if let Some(text) = &request.text {
             return self
                 .tokenize_single_text(tokenizer, text)
+                .await
                 .map(|(original, ids)| (Some(original), ids));
         }
 
@@ -109,18 +109,14 @@ impl GeneratePreparationStage {
         Err("Either `text` or `input_ids` must be provided".to_string())
     }
 
-    #[expect(
-        clippy::unused_self,
-        reason = "method on stage struct for consistency with resolve_generate_input"
-    )]
-    fn tokenize_single_text(
+    async fn tokenize_single_text(
         &self,
         tokenizer: &Arc<dyn Tokenizer>,
         text: &str,
     ) -> Result<(String, Vec<u32>), String> {
         // Don't add special tokens - raw text generation uses text as-is
-        let encoding = tokenizer
-            .encode(text, false)
+        let encoding = utils::encode_blocking(tokenizer.clone(), text.to_string(), false)
+            .await
             .map_err(|e| format!("Tokenization failed: {e}"))?;
         Ok((text.to_string(), encoding.token_ids().to_vec()))
     }

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -156,7 +156,13 @@ impl MessagePreparationStage {
         };
 
         // Step 3: Tokenize the processed text
-        let encoding = match tokenizer.encode(&processed_messages.text, false) {
+        let encoding = match utils::encode_blocking(
+            tokenizer.clone(),
+            processed_messages.text.clone(),
+            false,
+        )
+        .await
+        {
             Ok(encoding) => encoding,
             Err(e) => {
                 error!(function = "MessagePreparationStage::execute", error = %e, "Tokenization failed");

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -1,13 +1,18 @@
 //! Chat message processing, tool constraints, and shared utilities for gRPC routers.
 
-use std::{collections::HashMap, io, sync::Arc};
+use std::{
+    collections::HashMap,
+    io,
+    sync::{Arc, OnceLock},
+};
 
+use anyhow::anyhow;
 use axum::response::Response;
 use bytes::Bytes;
 use llm_tokenizer::{
     chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
     stop::StopSequenceDecoderBuilder,
-    traits::Tokenizer,
+    traits::{Encoding, Tokenizer},
     StopSequenceDecoder,
 };
 use openai_protocol::{
@@ -16,7 +21,7 @@ use openai_protocol::{
     generate::GenerateFinishReason,
 };
 use serde_json::{json, Value};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Semaphore};
 use tracing::error;
 use uuid::Uuid;
 
@@ -78,6 +83,47 @@ pub(crate) fn resolve_tokenizer(
     ctx.state.tokenizer = Some(tokenizer.clone());
 
     Ok(tokenizer)
+}
+
+/// Below this input size (in bytes) the `spawn_blocking` + permit round-trip
+/// costs more than the encode itself, so we tokenize inline. Larger prompts —
+/// the ones that actually pin a worker thread — are offloaded.
+const ENCODE_OFFLOAD_MIN_BYTES: usize = 512;
+
+/// Bounds how many CPU-bound encodes run concurrently on the blocking pool.
+/// tokio's blocking pool is otherwise unbounded (grows to 512 threads), so under
+/// a burst of large prompts the offloaded encodes would oversubscribe the CPU
+/// and starve the very request runtime this offload is meant to protect. Sized
+/// to the host's available parallelism.
+fn encode_permits() -> &'static Semaphore {
+    static SEM: OnceLock<Semaphore> = OnceLock::new();
+    SEM.get_or_init(|| {
+        let n = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8);
+        Semaphore::new(n)
+    })
+}
+
+/// Tokenize off the async worker threads so CPU-bound `encode` cannot stall the
+/// runtime, bounded by [`encode_permits`] so concurrent offloaded encodes cannot
+/// oversubscribe the CPU. Small inputs are encoded inline to avoid the offload
+/// round-trip dominating.
+pub(crate) async fn encode_blocking(
+    tokenizer: Arc<dyn Tokenizer>,
+    text: String,
+    add_special_tokens: bool,
+) -> anyhow::Result<Encoding> {
+    if text.len() < ENCODE_OFFLOAD_MIN_BYTES {
+        return tokenizer.encode(&text, add_special_tokens);
+    }
+    let _permit = encode_permits()
+        .acquire()
+        .await
+        .map_err(|e| anyhow!("encode semaphore closed: {e}"))?;
+    tokio::task::spawn_blocking(move || tokenizer.encode(&text, add_special_tokens))
+        .await
+        .map_err(|e| anyhow!("tokenization task failed: {e}"))?
 }
 
 /// Process tool call arguments in messages

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -10,9 +10,9 @@ pub(crate) mod tonic_ext;
 // Re-export all public items so consumer imports stay unchanged.
 pub use chat_utils::{create_stop_decoder, process_chat_messages};
 pub(crate) use chat_utils::{
-    filter_chat_request_by_tool_choice, filter_tools_by_tool_choice, generate_tool_call_id,
-    get_history_tool_calls_count, parse_finish_reason, parse_json_schema_response,
-    resolve_tokenizer, send_error_sse,
+    encode_blocking, filter_chat_request_by_tool_choice, filter_tools_by_tool_choice,
+    generate_tool_call_id, get_history_tool_calls_count, parse_finish_reason,
+    parse_json_schema_response, resolve_tokenizer, send_error_sse,
 };
 pub(crate) use logprobs::{
     convert_generate_input_logprobs, convert_generate_output_logprobs, convert_proto_logprobs,

--- a/model_gateway/src/routers/tokenize/handlers.rs
+++ b/model_gateway/src/routers/tokenize/handlers.rs
@@ -20,6 +20,7 @@ use tracing::{debug, error, warn};
 
 use crate::{
     app_context::AppContext,
+    routers::grpc::utils::encode_blocking,
     worker::UNKNOWN_MODEL_ID,
     workflow::{Job, TokenizerConfigRequest},
 };
@@ -98,7 +99,7 @@ pub async fn tokenize(registry: &Arc<TokenizerRegistry>, request: TokenizeReques
 
     for text in texts {
         // Don't add special tokens for tokenize API (matches Python behavior)
-        let encoding = match tokenizer.encode(text, false) {
+        let encoding = match encode_blocking(tokenizer.clone(), text.to_string(), false).await {
             Ok(enc) => enc,
             Err(e) => {
                 error!("Tokenization failed: {}", e);


### PR DESCRIPTION
## Description

### Problem

For gRPC workers the gateway tokenizes requests itself, and `tokenizer.encode(...)` runs **inline on the tokio async worker threads**. Tokenization is CPU-bound with no `.await` yield point, so a large prompt's `encode()` pins an async worker for its full duration. Under concurrency this starves request IO, KV-event ingestion, and the health/readiness probes — the event-loop canary (#1707) records it as stalls.

Refs #1693. A prior attempt (#1700) offloaded with a bare `spawn_blocking`, but onto tokio's **unbounded** blocking pool (grows to 512 threads) with no size threshold — on a many-core host that can oversubscribe the CPU and starve the very runtime it is meant to protect. This PR adds the missing bound + threshold.

### Solution

Add `encode_blocking()` and route every gateway-side encode through it (chat, completion, embedding, generate, messages preparation + `/v1/tokenize`). It offloads `encode` via `tokio::task::spawn_blocking`, but **bounded**:

- a process-wide `Semaphore` sized to `available_parallelism()` caps how many encodes run concurrently on the blocking pool, so a burst cannot oversubscribe the CPU and starve the request runtime;
- inputs below 512 bytes are encoded **inline**, since for small prompts the `spawn_blocking` + permit round-trip costs more than the encode itself.

Tokenization behaviour is unchanged (same inputs, same `Encoding`). The generate stage's three private helpers become `async` to reach the offload `.await` point.

## Changes

- `model_gateway/src/routers/grpc/utils/chat_utils.rs` — add bounded `encode_blocking` helper (`Semaphore` permit + `ENCODE_OFFLOAD_MIN_BYTES` inline threshold); import `Encoding`, `Semaphore`, `OnceLock`, `anyhow`.
- `model_gateway/src/routers/grpc/utils/mod.rs` — re-export `encode_blocking`.
- `model_gateway/src/routers/grpc/regular/stages/{chat,completion,embedding,messages}/preparation.rs` — route encode through `utils::encode_blocking(...).await`.
- `model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs` — same; make `prepare_generate`/`resolve_generate_input`/`tokenize_single_text` `async`.
- `model_gateway/src/routers/tokenize/handlers.rs` — offload the `/v1/tokenize` per-text encode.

## Test Plan

Benchmarked against a realistic gRPC mock fleet (`mock-worker --engine realistic`) with a real **Qwen3-8B** tokenizer (~1.1–1.7k input tokens/request), mixed chat+completions Poisson load. `inline` = `main`; `offload` = this PR. Same binaries built with the release profile.

**Reactor responsiveness** — gateway pinned to 2 tokio worker threads to expose contention; probing `/health` on the main runtime + reading the #1707 event-loop canary:

| metric (30 s window) | inline (main) | offload (this PR) |
|---|---|---|
| event-loop stalls | 114 | **0** |
| /health p99 | 17.5 ms | **2.8 ms** |
| /health p90 | 6.9 ms | 1.4 ms |
| cpu_ms/req | 3.15 | 3.20 (flat) |

**At scale** — matched A/B, `TOKIO_WORKER_THREADS=4`, `cache_aware`, realistic gRPC fleet:

| workers | metric | inline | offload |
|---|---|---|---|
| 64 | achieved rps | 1027 | **1506** |
| 64 | cpu_ms/req | 3.72 | 3.68 |
| 1024 | achieved rps | 892 | **1593** |
| 1024 | cpu_ms/req | 4.39 | 4.17 |
| 1024 | queue_depth | up to 137 | ≤ 66 |

The offload keeps the reactor responsive (stalls 114→0, `/health` p99 −84%) and lets CPU-bound encodes spill onto the bounded blocking pool instead of pinning a small reactor (higher throughput, lower queue depth), at **flat `cpu_ms/req`** — it relocates CPU rather than adding it. The behaviour holds at 1024 workers.

Gate (this environment has no nightly toolchain, and `--all-features` needs OpenCV which is not installed; CI runs the full matrix):

```
$ cargo fmt -p smg -- --check
(exit 0)

$ cargo clippy -p smg --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 06s
(exit 0)

$ cargo test -p smg --lib routers::grpc::utils
test result: ok. 17 passed; 0 failed; 0 ignored
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (nightly unavailable in this env; stable `cargo fmt -p smg --check` is clean)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (`--all-features` needs OpenCV, unavailable locally — ran `--all-targets`, clean; CI runs full features)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
