### PR TITLE
fix(tool_parser): strip trailing fence/end markers in deepseek streaming

### DIFF
--- a/crates/tool_parser/src/parsers/deepseek.rs
+++ b/crates/tool_parser/src/parsers/deepseek.rs
@@ -187,7 +187,12 @@ impl ToolParser for DeepSeekParser {
             // No tool markers detected - return all buffered content as normal text
             // Strip out end tokens if present
             let mut normal_text = std::mem::take(&mut self.buffer);
-            for e_token in ["<｜tool▁calls▁end｜>", "```", "<｜tool▁call▁end｜>"] {
+            for e_token in [
+                "<｜tool▁calls▁end｜>",
+                "```",
+                "<｜tool▁call▁end｜>",
+                "<｜end▁of▁sentence｜>",
+            ] {
                 normal_text = normal_text.replace(e_token, "");
             }
             return Ok(StreamingParseResult {
@@ -243,9 +248,32 @@ impl ToolParser for DeepSeekParser {
                     .map(|s| s.as_str())
                     .unwrap_or("");
 
-                let argument_diff = func_args_raw
+                // Strip the closing markdown fence and end markers that may arrive in
+                // the same chunk as the final JSON bytes. The partial_tool_call_regex
+                // group 3 greedily captures everything after ```json, including the
+                // trailing ``` fence and any stacked end tokens. Use an iterative loop
+                // so markers in any order are all removed before the diff/completion
+                // checks (mirrors deepseek31.rs).
+                const END_MARKERS: [&str; 4] = [
+                    "```",
+                    "<｜end▁of▁sentence｜>",
+                    "<｜tool▁calls▁end｜>",
+                    "<｜tool▁call▁end｜>",
+                ];
+                let mut func_args_clean = func_args_raw.trim_end();
+                loop {
+                    let before = func_args_clean;
+                    for marker in END_MARKERS {
+                        func_args_clean = func_args_clean.trim_end_matches(marker).trim_end();
+                    }
+                    if func_args_clean == before {
+                        break;
+                    }
+                }
+
+                let argument_diff = func_args_clean
                     .strip_prefix(last_sent)
-                    .unwrap_or(func_args_raw);
+                    .unwrap_or(func_args_clean);
 
                 if !argument_diff.is_empty() {
                     calls.push(ToolCallItem {
@@ -259,9 +287,9 @@ impl ToolParser for DeepSeekParser {
                 }
 
                 // Check if JSON is complete
-                if helpers::is_complete_json(func_args_raw) {
+                if helpers::is_complete_json(func_args_clean) {
                     // Update the stored arguments
-                    if let Ok(parsed_args) = serde_json::from_str::<Value>(func_args_raw) {
+                    if let Ok(parsed_args) = serde_json::from_str::<Value>(func_args_clean) {
                         let tool_id = self.current_tool_id as usize;
                         if tool_id < self.prev_tool_call_arr.len() {
                             if let Some(obj) = self.prev_tool_call_arr[tool_id].as_object_mut() {

--- a/crates/tool_parser/tests/tool_parser_deepseek.rs
+++ b/crates/tool_parser/tests/tool_parser_deepseek.rs
@@ -139,6 +139,95 @@ async fn test_deepseek_malformed_json_handling() {
 }
 
 #[tokio::test]
+async fn test_deepseek_streaming_final_chunk_strips_fence_and_markers() {
+    // Regression: when the closing ```` ``` ```` fence and end tokens arrive in the
+    // same chunk as the final JSON bytes, the greedy partial regex captures them into
+    // the arguments group. They must be stripped before the diff/completion checks,
+    // otherwise the fence/markers get streamed as argument content and
+    // is_complete_json never returns true (the tool call never completes).
+    let tools = create_test_tools();
+    let mut parser = DeepSeekParser::new();
+
+    // First chunk: emit through the function name so the args stream begins.
+    parser
+        .parse_incremental(
+            "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n",
+            &tools,
+        )
+        .await
+        .unwrap();
+
+    // Final chunk: complete JSON immediately followed by the closing fence and end markers.
+    let final_chunk =
+        "{\"location\": \"Tokyo\"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>";
+    let result = parser.parse_incremental(final_chunk, &tools).await.unwrap();
+
+    // Accumulate every argument delta streamed on the final chunk.
+    let streamed_args: String = result
+        .calls
+        .iter()
+        .filter(|c| c.name.is_none())
+        .map(|c| c.parameters.as_str())
+        .collect();
+
+    // No fence or end-marker bytes may leak into streamed argument content.
+    assert!(
+        !streamed_args.contains("```"),
+        "streamed args leaked the closing fence: {streamed_args:?}"
+    );
+    assert!(
+        !streamed_args.contains('｜'),
+        "streamed args leaked an end marker: {streamed_args:?}"
+    );
+
+    // The streamed arguments must be exactly the clean JSON object and parse cleanly.
+    assert_eq!(streamed_args, r#"{"location": "Tokyo"}"#);
+    let parsed: serde_json::Value = serde_json::from_str(&streamed_args).unwrap();
+    assert_eq!(parsed["location"], "Tokyo");
+
+    // The tool call must complete on this final chunk: the parser advances to the next
+    // tool and consumes the finished call from its buffer. A following second tool call
+    // is therefore parsed as a new tool (index 1) with its own clean name and args -
+    // which only happens if the first call completed instead of staying open.
+    let second = parser
+        .parse_incremental(
+            "<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n```json\n{\"location\": \"Paris\"}\n```<｜tool▁call▁end｜>",
+            &tools,
+        )
+        .await
+        .unwrap();
+    assert!(
+        second
+            .calls
+            .iter()
+            .any(|c| c.name.as_deref() == Some("get_weather") && c.tool_index == 1),
+        "second tool call not started as a new tool: {:?}",
+        second.calls
+    );
+}
+
+#[tokio::test]
+async fn test_deepseek_streaming_normal_text_strips_end_of_sentence() {
+    // Regression: streamed normal text (no tool call) must strip the end-of-sentence
+    // marker, matching deepseek31 — otherwise it leaks into client-visible content.
+    let tools = create_test_tools();
+    let mut parser = DeepSeekParser::new();
+
+    let result = parser
+        .parse_incremental("All done.<｜end▁of▁sentence｜>", &tools)
+        .await
+        .unwrap();
+
+    assert!(
+        !result.normal_text.contains('｜'),
+        "end-of-sentence marker leaked into normal text: {:?}",
+        result.normal_text
+    );
+    assert_eq!(result.normal_text, "All done.");
+    assert!(result.calls.is_empty());
+}
+
+#[tokio::test]
 async fn test_multiple_tool_calls() {
     let parser = DeepSeekParser::new();
 


### PR DESCRIPTION
## Description

### Problem

DeepSeek V3 streaming tool calls never complete. The streaming partial pattern
`(?s)<｜tool▁call▁begin｜>(.*)<｜tool▁sep｜>(.*)\n```json\n(.*)` captures group 3
greedily, so when the closing ```` ``` ```` fence and the end tokens
(`<｜tool▁call▁end｜>`, `<｜tool▁calls▁end｜>`, `<｜end▁of▁sentence｜>`) arrive in
the final chunk, they land inside `func_args_raw`. As a result:

- `helpers::is_complete_json(func_args_raw)` is called on
  `{...}\n```<｜tool▁call▁end｜>...`, which is not valid JSON, so it returns
  `false` and the completion branch never fires.
- The fence and marker bytes are emitted to the client as tool-call argument
  content.

`crates/tool_parser/src/parsers/deepseek31.rs` already guards against this with
an iterative `END_MARKERS` loop, but `deepseek.rs` did not.

### Solution

Before the argument-diff and `is_complete_json` checks in `parse_incremental`,
strip a trailing markdown fence plus the tool/call/calls-end and
end-of-sentence markers from the captured arguments into a local
`func_args_clean`, using the same iterative loop approach as `deepseek31.rs`
(extended with the ```` ``` ```` fence that V3 wraps its JSON in). The diff,
completion check, and stored arguments all use the cleaned string.

## Changes

- `crates/tool_parser/src/parsers/deepseek.rs`: strip the trailing ```` ``` ````
  fence and end markers from `func_args_raw` (iterative `END_MARKERS` loop)
  before the diff and `is_complete_json` checks; use the cleaned string for the
  argument delta, completion check, and parsed arguments.
- `crates/tool_parser/tests/tool_parser_deepseek.rs`: add a regression test for
  the final-chunk case.

## Test Plan

Regression test `test_deepseek_streaming_final_chunk_strips_fence_and_markers`
reproduces the streaming scenario where the final chunk carries the JSON body
followed by the closing fence and all three end markers:

`{"location": "Tokyo"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>`

- **Before the fix**: the streamed argument content is
  `{"location": "Tokyo"}\n```<｜tool▁call▁end｜><｜tool▁calls▁end｜><｜end▁of▁sentence｜>`
  — the test fails on the "no fence leaked into streamed args" assertion, and
  the tool call never completes.
- **After the fix**: streamed args are exactly `{"location": "Tokyo"}` (no fence
  or marker bytes), the call completes on the final chunk, and a following
  second tool call is parsed as a new tool (index 1).

Commands (default features, scoped to the crate):

```
cargo +nightly fmt -p tool-parser -- --check   # clean
cargo clippy -p tool-parser --all-targets -- -D warnings   # clean
cargo test -p tool-parser   # all suites pass (tool_parser_deepseek: 8 passed)
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy -p tool-parser --all-targets -- -D warnings` passes (default features; change is confined to `tool-parser`)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming data handling in tool argument parsing to properly process content when closing markers and final data arrive in the same chunk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->