### PR TITLE
fix(grpc_client): forward min_tokens/seed on chat sampling paths

### DIFF
--- a/crates/grpc_client/src/sglang_scheduler.rs
+++ b/crates/grpc_client/src/sglang_scheduler.rs
@@ -297,6 +297,7 @@ impl SglangSchedulerClient {
             presence_penalty: request.presence_penalty.unwrap_or(0.0),
             repetition_penalty: request.repetition_penalty.unwrap_or(1.0),
             max_new_tokens,
+            min_new_tokens: request.min_tokens.unwrap_or(0),
             stop: stop_sequences,
             stop_token_ids: request.stop_token_ids.clone().unwrap_or_default(),
             skip_special_tokens,
@@ -927,4 +928,25 @@ mod tests {
     }
 
     // TODO: ModelInfo not in current proto - skip test
+
+    #[test]
+    fn test_chat_sampling_params_min_tokens_is_passed_through() {
+        // Regression guard: build_grpc_sampling_params_from_chat() previously
+        // omitted min_new_tokens, so `..Default::default()` left it at 0 and
+        // min-token enforcement was silently dropped on every chat completion.
+        let request = ChatCompletionRequest {
+            min_tokens: Some(5),
+            ..Default::default()
+        };
+        let params = SglangSchedulerClient::build_grpc_sampling_params_from_chat(&request, None)
+            .expect("build sampling params");
+        assert_eq!(params.min_new_tokens, 5);
+
+        // No min_tokens → proto field stays at 0 (no floor).
+        let unset = ChatCompletionRequest::default();
+        let unset_params =
+            SglangSchedulerClient::build_grpc_sampling_params_from_chat(&unset, None)
+                .expect("build sampling params");
+        assert_eq!(unset_params.min_new_tokens, 0);
+    }
 }

--- a/crates/grpc_client/src/tokenspeed_scheduler.rs
+++ b/crates/grpc_client/src/tokenspeed_scheduler.rs
@@ -339,6 +339,7 @@ impl TokenSpeedSchedulerClient {
             presence_penalty: Some(request.presence_penalty.unwrap_or(0.0)),
             repetition_penalty: Some(request.repetition_penalty.unwrap_or(1.0)),
             max_new_tokens: request.max_completion_tokens,
+            min_new_tokens: request.min_tokens.unwrap_or(0),
             stop: stop_sequences,
             stop_token_ids: request.stop_token_ids.clone().unwrap_or_default(),
             skip_special_tokens: true,
@@ -694,5 +695,30 @@ impl From<tokenspeed_proto::GetLoadsResponse> for openai_protocol::worker::Worke
             dp_rank_count: resp.dp_rank_count,
             loads: resp.loads.into_iter().map(Into::into).collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_chat_sampling_params_min_tokens_is_passed_through() {
+        // Regression guard: build_sampling_params_from_chat() previously
+        // omitted min_new_tokens, so `..Default::default()` left it at 0 and
+        // min-token enforcement was silently dropped on every chat completion.
+        let request = ChatCompletionRequest {
+            min_tokens: Some(5),
+            ..Default::default()
+        };
+        let params = TokenSpeedSchedulerClient::build_sampling_params_from_chat(&request, None)
+            .expect("build sampling params");
+        assert_eq!(params.min_new_tokens, 5);
+
+        // No min_tokens → proto field stays at 0 (no floor).
+        let unset = ChatCompletionRequest::default();
+        let unset_params = TokenSpeedSchedulerClient::build_sampling_params_from_chat(&unset, None)
+            .expect("build sampling params");
+        assert_eq!(unset_params.min_new_tokens, 0);
     }
 }

--- a/crates/grpc_client/src/trtllm_service.rs
+++ b/crates/grpc_client/src/trtllm_service.rs
@@ -325,6 +325,10 @@ impl TrtllmServiceClient {
     /// - temperature: 1.0 (neutral sampling)
     /// - top_p: 1.0 (no nucleus filtering)
     /// - repetition_penalty: 1.0 (no penalty)
+    #[expect(
+        deprecated,
+        reason = "ChatCompletionRequest.seed is marked Legacy by openai-protocol, but TRT-LLM still honors it"
+    )]
     fn build_sampling_config_from_chat(request: &ChatCompletionRequest) -> proto::SamplingConfig {
         proto::SamplingConfig {
             beam_width: 1,
@@ -334,9 +338,9 @@ impl TrtllmServiceClient {
             top_p_min: None,
             top_p_reset_ids: None,
             top_p_decay: None,
-            seed: None,
+            seed: request.seed.map(|s| s as u64),
             temperature: Some(request.temperature.unwrap_or(1.0)),
-            min_tokens: None,
+            min_tokens: request.min_tokens,
             beam_search_diversity_rate: None,
             repetition_penalty: Some(request.repetition_penalty.unwrap_or(1.0)),
             presence_penalty: request.presence_penalty,
@@ -939,5 +943,31 @@ mod tests {
             proto::guided_decoding_params::GuideType::JsonSchema as i32
         );
         assert_eq!(guided.guide, r#"{"type": "object"}"#);
+    }
+
+    #[test]
+    #[expect(
+        deprecated,
+        reason = "ChatCompletionRequest.seed is marked Legacy by openai-protocol, but TRT-LLM still honors it"
+    )]
+    fn test_chat_sampling_config_min_tokens_and_seed_are_passed_through() {
+        // Regression guard: build_sampling_config_from_chat() previously
+        // hardcoded min_tokens and seed to None, silently dropping min-token
+        // enforcement on every chat completion and breaking reproducibility
+        // (seed) at temperature>0.
+        let request = ChatCompletionRequest {
+            min_tokens: Some(5),
+            seed: Some(42),
+            ..Default::default()
+        };
+        let config = TrtllmServiceClient::build_sampling_config_from_chat(&request);
+        assert_eq!(config.min_tokens, Some(5));
+        assert_eq!(config.seed, Some(42));
+
+        // Neither set → both stay None.
+        let unset = ChatCompletionRequest::default();
+        let unset_config = TrtllmServiceClient::build_sampling_config_from_chat(&unset);
+        assert_eq!(unset_config.min_tokens, None);
+        assert_eq!(unset_config.seed, None);
     }
 }

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -257,6 +257,7 @@ impl VllmEngineClient {
             presence_penalty: request.presence_penalty.unwrap_or(0.0),
             repetition_penalty: request.repetition_penalty.unwrap_or(1.0),
             max_tokens,
+            min_tokens: request.min_tokens.unwrap_or(0),
             stop: stop_sequences,
             stop_token_ids: request.stop_token_ids.clone().unwrap_or_default(),
             skip_special_tokens,
@@ -951,6 +952,26 @@ mod tests {
             VllmEngineClient::build_grpc_sampling_params_from_responses(&disabled, None)
                 .expect("build sampling params");
         assert_eq!(disabled_params.top_k, 0);
+    }
+
+    #[test]
+    fn test_chat_sampling_params_min_tokens_is_passed_through() {
+        // Regression guard: build_grpc_sampling_params_from_chat() previously
+        // omitted min_tokens, so `..Default::default()` left it at 0 and
+        // min-token enforcement was silently dropped on every chat completion.
+        let request = ChatCompletionRequest {
+            min_tokens: Some(5),
+            ..Default::default()
+        };
+        let params = VllmEngineClient::build_grpc_sampling_params_from_chat(&request, None)
+            .expect("build sampling params");
+        assert_eq!(params.min_tokens, 5);
+
+        // No min_tokens → proto field stays at 0 (no floor).
+        let unset = ChatCompletionRequest::default();
+        let unset_params = VllmEngineClient::build_grpc_sampling_params_from_chat(&unset, None)
+            .expect("build sampling params");
+        assert_eq!(unset_params.min_tokens, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

The chat-path gRPC sampling builders silently drop `min_tokens` on all four backends, and the TRT-LLM chat builder additionally drops `seed`, while the completion-path builders forward both. Both fields exist on the proto and on `ChatCompletionRequest`, so `..Default::default()` leaves them unset:

- `min_tokens` falls back to `0` on every chat completion, so minimum-token enforcement is silently broken.
- On TRT-LLM, `seed` stays unset, breaking reproducibility for chat completions at `temperature > 0`.

The completion path already forwards these correctly (e.g. `vllm_engine.rs` `build_grpc_sampling_params_from_completion` sets `min_tokens`, and `trtllm_service.rs` `build_sampling_config_from_completion` sets both `seed` and `min_tokens`), so the chat path was simply out of parity.

### Solution

Mirror the matching completion-path builder in each backend so the chat path forwards the same fields:

- `vllm_engine.rs` `build_grpc_sampling_params_from_chat`: add `min_tokens: request.min_tokens.unwrap_or(0)` (proto `u32`).
- `sglang_scheduler.rs` `build_grpc_sampling_params_from_chat`: add `min_new_tokens: request.min_tokens.unwrap_or(0)`.
- `tokenspeed_scheduler.rs` `build_sampling_params_from_chat`: add `min_new_tokens: request.min_tokens.unwrap_or(0)`.
- `trtllm_service.rs` `build_sampling_config_from_chat`: set `min_tokens: request.min_tokens` (optional) and `seed: request.seed.map(|s| s as u64)`, matching `build_sampling_config_from_completion`. Reading `ChatCompletionRequest.seed` (marked Legacy by openai-protocol but still honored by TRT-LLM) requires an `#[expect(deprecated, reason = ...)]`, mirroring the existing vLLM chat builder.

## Changes

- `crates/grpc_client/src/vllm_engine.rs`: forward `min_tokens` on the chat sampling builder; add regression test.
- `crates/grpc_client/src/sglang_scheduler.rs`: forward `min_new_tokens` on the chat sampling builder; add regression test.
- `crates/grpc_client/src/tokenspeed_scheduler.rs`: forward `min_new_tokens` on the chat sampling builder; add a `#[cfg(test)]` module with the regression test (none existed).
- `crates/grpc_client/src/trtllm_service.rs`: forward `min_tokens` and `seed` on the chat sampling config builder; add regression test.

## Test Plan

Added a per-backend regression test asserting the chat builder forwards `min_tokens` (and `seed` for TRT-LLM) from the request, and that the unset case stays at the proto default. Each test was confirmed to **fail before** the production fix and **pass after**, mirroring the existing vLLM seed regression tests.

Before the fix (tests present, fix reverted):

```
failures:
    sglang_scheduler::tests::test_chat_sampling_params_min_tokens_is_passed_through
    tokenspeed_scheduler::tests::test_chat_sampling_params_min_tokens_is_passed_through
    trtllm_service::tests::test_chat_sampling_config_min_tokens_and_seed_are_passed_through
    vllm_engine::tests::test_chat_sampling_params_min_tokens_is_passed_through

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 60 filtered out
```

After the fix:

```
cargo test -p smg-grpc-client
test result: ok. 64 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (default features; `--all-features` requires system OpenCV which is not installed locally — the changed crate `smg-grpc-client` does not use any feature-gated code)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Minimum token generation parameter is now correctly applied in chat completion requests across multiple backend services (previously ignored).
  * Seed parameter is now properly forwarded to TRT-LLM backend (previously ignored).

* **Tests**
  * Added comprehensive regression tests to verify proper parameter forwarding for minimum tokens and seed values across all affected backend implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->