### PR TITLE
fix(multimodal): honor Qwen2-VL preprocessor_config overrides

### DIFF
--- a/crates/multimodal/src/vision/processors/qwen2_vl.rs
+++ b/crates/multimodal/src/vision/processors/qwen2_vl.rs
@@ -132,6 +132,22 @@ impl Qwen2VLProcessor {
         }
     }
 
+    /// Build the effective processor for a request, applying any structural
+    /// overrides from `config`; otherwise reuse the existing defaults.
+    fn with_preprocessor_config(&self, config: &PreProcessorConfig) -> Self {
+        if config.patch_size.is_some()
+            || config.merge_size.is_some()
+            || config.min_pixels.is_some()
+            || config.max_pixels.is_some()
+            || config.temporal_patch_size.is_some()
+            || config.size.is_some()
+        {
+            Self::from_preprocessor_config(config)
+        } else {
+            self.clone()
+        }
+    }
+
     /// Get the patch size.
     pub fn patch_size(&self) -> usize {
         self.inner.patch_size()
@@ -211,11 +227,13 @@ impl VisionPreProcessor for Qwen2VLProcessor {
         images: &[DynamicImage],
         config: &PreProcessorConfig,
     ) -> Result<PreprocessedEncoderInputs, TransformError> {
-        self.inner.preprocess(images, config)
+        let processor = self.with_preprocessor_config(config);
+        processor.inner.preprocess(images, config)
     }
 
     fn calculate_num_tokens(&self, width: u32, height: u32, config: &PreProcessorConfig) -> usize {
-        self.inner.calculate_num_tokens(width, height, config)
+        let processor = self.with_preprocessor_config(config);
+        processor.inner.calculate_num_tokens(width, height, config)
     }
 
     fn model_name(&self) -> &'static str {
@@ -447,6 +465,50 @@ mod tests {
         assert_eq!(processor.min_pixels(), 100000);
         assert_eq!(processor.max_pixels(), 500000);
         assert_eq!(processor.temporal_patch_size(), 4);
+    }
+
+    #[test]
+    fn test_calculate_num_tokens_honors_config_max_pixels() {
+        let processor = Qwen2VLProcessor::new();
+
+        // A 1400x1400 image clamps to max_pixels before the grid is computed,
+        // so a lower config max_pixels must yield fewer tokens.
+        let default_tokens =
+            processor.calculate_num_tokens(1400, 1400, &PreProcessorConfig::default());
+        assert_eq!(default_tokens, 1225); // resized to 980x980 -> (70*70)/4
+
+        let config = PreProcessorConfig {
+            max_pixels: Some(512 * 28 * 28), // 401,408, below the 1,003,520 default
+            ..Default::default()
+        };
+        let config_tokens = processor.calculate_num_tokens(1400, 1400, &config);
+        assert_eq!(config_tokens, 484); // resized to 616x616 -> (44*44)/4
+        assert_ne!(
+            config_tokens, default_tokens,
+            "config max_pixels override must change the token count"
+        );
+    }
+
+    #[test]
+    fn test_preprocess_honors_config_max_pixels() {
+        let processor = Qwen2VLProcessor::new();
+        let image = create_test_image(1400, 1400, Rgb([128, 128, 128]));
+
+        let config = PreProcessorConfig {
+            max_pixels: Some(512 * 28 * 28),
+            ..Default::default()
+        };
+        let result = processor.preprocess(&[image], &config).unwrap();
+
+        // 616x616 -> grid (1, 44, 44) -> (44*44)/4 = 484 tokens, vs 1225 at the default.
+        assert_eq!(result.feature_token_counts[0], 484);
+        if let Some(ModelSpecificValue::IntTensor { data, .. }) =
+            result.model_specific.get("image_grid_thw")
+        {
+            assert_eq!(data, &[1, 44, 44]);
+        } else {
+            panic!("Expected image_grid_thw to be IntTensor");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

`Qwen2VLProcessor::preprocess` and `Qwen2VLProcessor::calculate_num_tokens` delegated directly to the inner `QwenVLProcessorBase`, which is constructed once from hardcoded Qwen2-VL defaults (`patch_size=14`, `merge_size=2`, `min_pixels=200704`, `max_pixels=1003520`, `temporal_patch_size=2`).

The base only reads normalization/resampling/`do_*` flags from the passed `PreProcessorConfig` — it uses its own stored structural params for smart-resize bounds and the token grid. As a result, a model's `preprocessor_config.json` overrides for `max_pixels`/`min_pixels`/`patch_size`/`merge_size`/`temporal_patch_size`/`size` were silently ignored, producing wrong resize dimensions and wrong vision token counts.

`Qwen3VLProcessor` already handled this correctly; Qwen2-VL did not.

### Solution

Mirror the existing `Qwen3VLProcessor` pattern: add a private `with_preprocessor_config` helper that rebuilds the processor via `from_preprocessor_config(config)` when any structural field (`patch_size`/`merge_size`/`min_pixels`/`max_pixels`/`temporal_patch_size`/`size`) is set, and otherwise reuses the existing defaults. Route both `preprocess` and `calculate_num_tokens` through this config-derived processor before delegating to the base.

`from_preprocessor_config` already existed for Qwen2-VL, so no new constructor was needed.

## Changes

- `crates/multimodal/src/vision/processors/qwen2_vl.rs`
  - Add `Qwen2VLProcessor::with_preprocessor_config` (private), mirroring `Qwen3VLProcessor`.
  - Route `VisionPreProcessor::preprocess` and `VisionPreProcessor::calculate_num_tokens` through the config-derived processor.
  - Add two regression tests asserting config `max_pixels` overrides change the resize/token result.

## Test Plan

Regression tests added to `qwen2_vl.rs` use a 1400x1400 image, which clamps to `max_pixels` before the grid is computed:

- `test_calculate_num_tokens_honors_config_max_pixels` — default config -> 1225 tokens (980x980 grid); config `max_pixels = 512*28*28` (401,408) -> 484 tokens (616x616 grid), and asserts the two differ.
- `test_preprocess_honors_config_max_pixels` — same override; asserts `feature_token_counts[0] == 484` and `image_grid_thw == [1, 44, 44]` (vs the default 1225 / larger grid).

Before the fix both tests **failed** (the buggy path returned the default 1225, ignoring the config). After the fix both pass.

```
$ cargo test -p llm-multimodal --lib qwen2_vl
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 159 filtered out
```

Full crate suite (default features) is green, including the existing `test_qwen2_vl_golden_*` NPZ comparison tests (default-config behavior unchanged):

```
$ cargo test -p llm-multimodal
test result: ok. 81 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (default features; `--all-features` enables `opencv-video`, which needs system OpenCV)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
