### PR TITLE
fix(policy): keep bucket l_max idempotent and fall back when mapped worker is absent

### DIFF
--- a/model_gateway/src/policies/bucket.rs
+++ b/model_gateway/src/policies/bucket.rs
@@ -258,7 +258,19 @@ impl LoadBalancingPolicy for BucketPolicy {
             prefill_url
         };
 
-        workers.iter().position(|w| w.url() == prefill_url)
+        // The chosen URL comes from the bucket's stored set, which can drift
+        // from the live healthy slice under worker churn. If it is gone, fall
+        // back to a healthy worker rather than failing the request.
+        workers
+            .iter()
+            .position(|w| w.url() == prefill_url)
+            .or_else(|| {
+                warn!(
+                    "Selected prefill worker {} not in healthy set, falling back",
+                    prefill_url
+                );
+                healthy_indices.first().copied()
+            })
     }
 
     fn name(&self) -> &'static str {
@@ -357,14 +369,16 @@ impl Bucket {
         let boundary = match self.l_max.checked_div(worker_cnt) {
             None => Vec::new(),
             Some(gap) => {
-                self.l_max = usize::MAX;
+                // Last bucket is an open-ended catch-all. Use a local bound so
+                // `self.l_max` stays the gap source and re-init is idempotent.
+                let last_max = usize::MAX;
                 prefill_worker_urls
                     .iter()
                     .enumerate()
                     .map(|(i, url)| {
                         let min = i * gap;
                         let max = if i == worker_cnt - 1 {
-                            self.l_max
+                            last_max
                         } else {
                             (i + 1) * gap - 1
                         };
@@ -1322,5 +1336,118 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// Re-init must be idempotent: `update_policies` calls
+    /// `init_prefill_worker_urls` on every worker-registration event, so a
+    /// second init with the same workers must reproduce the same boundaries.
+    /// Regression for `self.l_max` being overwritten to `usize::MAX` on the
+    /// first init, which corrupted the gap (`usize::MAX / N`) on every re-init.
+    #[test]
+    fn test_init_prefill_worker_urls_is_idempotent() {
+        let policy = BucketPolicy::with_config(BucketConfig::default());
+        let prefill_workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .api_key("test_api_key")
+                    .health_config(no_health_check())
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .api_key("test_api_key")
+                    .health_config(no_health_check())
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w3:8000")
+                    .worker_type(WorkerType::Regular)
+                    .api_key("test_api_key")
+                    .health_config(no_health_check())
+                    .build(),
+            ),
+        ];
+
+        // 4096 / 3 = 1365 gap => [0, 1364] [1365, 2729] [2730, MAX].
+        let expected = vec![[0, 1364], [1365, 2729], [2730, usize::MAX]];
+
+        // Wildcard workers (no model set) normalize to UNKNOWN_MODEL_ID.
+        let model_key = normalize_model_key(prefill_workers[0].model_id());
+        let read_state = || {
+            let bucket = policy
+                .buckets
+                .get(model_key)
+                .map(|entry| entry.value().clone())
+                .expect("bucket should exist after init");
+            let guard = bucket.read();
+            let ranges: Vec<[usize; 2]> = guard.boundary.iter().map(|b| b.range).collect();
+            (guard.l_max, ranges)
+        };
+
+        policy.init_prefill_worker_urls(&prefill_workers);
+        let (l_max_first, ranges_first) = read_state();
+        assert_eq!(l_max_first, 4096, "l_max must not be mutated by init");
+        assert_eq!(ranges_first, expected);
+
+        // Re-init with the same workers (mirrors a re-registration event).
+        policy.init_prefill_worker_urls(&prefill_workers);
+        let (l_max_second, ranges_second) = read_state();
+        assert_eq!(l_max_second, 4096, "l_max must stay 4096 across re-init");
+        assert_eq!(
+            ranges_second, expected,
+            "boundaries must be unchanged after re-init"
+        );
+    }
+
+    /// `select_worker` must not fail a request when the bucket-chosen URL maps
+    /// to a worker that is absent from the live healthy slice while OTHER
+    /// healthy workers remain. Regression for `position(...)` returning `None`
+    /// (request failure) instead of falling back to a healthy worker.
+    #[tokio::test]
+    async fn test_select_worker_falls_back_when_mapped_url_absent() {
+        let policy = BucketPolicy::with_config(BucketConfig::default());
+
+        let make = |url: &str| -> Arc<dyn Worker> {
+            Arc::new(
+                BasicWorkerBuilder::new(url)
+                    .worker_type(WorkerType::Regular)
+                    .api_key("test_api_key")
+                    .health_config(no_health_check())
+                    .build(),
+            )
+        };
+
+        // Bucket boundaries are built for all three workers, so a small request
+        // maps to w1 (boundary[0]).
+        let all_workers: Vec<Arc<dyn Worker>> = vec![
+            make("http://w1:8000"),
+            make("http://w2:8000"),
+            make("http://w3:8000"),
+        ];
+        policy.init_prefill_worker_urls(&all_workers);
+
+        // Live slice excludes w1: the mapped URL is absent but w2/w3 are healthy.
+        let live_workers: Vec<Arc<dyn Worker>> =
+            vec![Arc::clone(&all_workers[1]), Arc::clone(&all_workers[2])];
+
+        let idx = policy.select_worker(
+            &live_workers,
+            &SelectWorkerInfo {
+                request_text: Some("short"),
+                ..Default::default()
+            },
+        );
+
+        let idx = idx.expect("must fall back to a healthy worker, not fail the request");
+        assert!(
+            idx < live_workers.len(),
+            "fallback index must be within the live worker slice"
+        );
+        assert!(
+            live_workers[idx].is_healthy(),
+            "fallback must select a healthy worker"
+        );
     }
 }


### PR DESCRIPTION
## Description

### Problem

Two high-severity bugs in the bucket routing policy (`model_gateway/src/policies/bucket.rs`):

- **`l_max` corruption (re-init not idempotent).** `Bucket::init_prefill_worker_urls` overwrote `self.l_max = usize::MAX` while building boundaries. Because the policy calls this on every worker-registration event (re-init), the gap source became `usize::MAX / N` on the second and later inits, corrupting every boundary range. The policy degraded permanently after the first re-init.
- **Spurious request failure in `select_worker`.** The final step resolved the chosen prefill URL with `workers.iter().position(...)` and returned its `Option` directly. The chosen URL comes from the bucket's stored set, which can drift from the live healthy `workers` slice under worker churn. When the mapped worker was absent, `select_worker` returned `None` (a request failure) even though other healthy workers were available.

### Solution

- Use a local `last_max = usize::MAX` for the open-ended final bucket's upper bound and leave `self.l_max` untouched, so it remains the `4096/N` gap source and re-init is idempotent.
- In `select_worker`, fall back to a healthy worker (`healthy_indices.first()`) when the bucket-chosen URL is not present in the live slice, logging a `warn!`. This mirrors how `cache_aware` recovers from a stale tenant mapping. The fallback only draws from `healthy_indices`, which is already filtered by `is_healthy() && circuit_breaker_can_execute()`, and preserves the existing "no healthy workers -> None" contract.

## Changes

- `model_gateway/src/policies/bucket.rs`
  - `Bucket::init_prefill_worker_urls`: replace `self.l_max = usize::MAX` mutation with a local `last_max` for the last bucket's upper bound.
  - `BucketPolicy::select_worker`: add `.or_else(|| healthy_indices.first().copied())` fallback (with a `warn!`) when the chosen URL is absent from the live workers.
  - Add two regression tests (below).

## Test Plan

Both regression tests were confirmed to **fail before** the fix and **pass after**:

- `test_init_prefill_worker_urls_is_idempotent` — calls `init_prefill_worker_urls` twice with the same 3 workers and asserts `l_max` stays `4096` and boundaries stay `[0,1364] [1365,2729] [2730,MAX]` across both inits. Pre-fix: `l_max` was `usize::MAX` already after the first init.
- `test_select_worker_falls_back_when_mapped_url_absent` — builds boundaries for w1/w2/w3, then calls `select_worker` with a live slice of only {w2, w3}; a small request maps to the absent w1. Asserts a healthy worker is returned (not `None`). Pre-fix: returned `None`.

Reproduce:

```
cargo test -p smg --lib 'policies::bucket::tests::test_init_prefill_worker_urls_is_idempotent'
cargo test -p smg --lib 'policies::bucket::tests::test_select_worker_falls_back_when_mapped_url_absent'
```

Full gate (default features; `--all-features` skipped because it links system OpenCV, which is not installed — used the documented per-package alternative):

- `cargo +nightly fmt -p smg` — clean (`--check` clean)
- `cargo clippy -p smg --all-targets -- -D warnings` — clean
- `cargo test -p smg` — all pass, including integration binaries:
  - lib: `1073 passed; 0 failed; 4 ignored`
  - `routing_tests`: `92 passed; 0 failed`
  - `spec_test`: `95 passed; 1 ignored; 0 failed`
  - `api_tests`: `105 passed; 0 failed`
  - `security_tests`: `48 passed; 0 failed`
  - (all other binaries: 0 failed)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (default features; `--all-features` needs system OpenCV)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
