### PR TITLE
perf(cache-aware): gather worker routing state in one pass

### DIFF
--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -59,8 +59,8 @@ use tokio::sync::watch;
 use tracing::{debug, warn};
 
 use super::{
-    get_healthy_worker_indices, normalize_model_key, utils::PeriodicTask, CacheAwareConfig,
-    LoadBalancingPolicy, SelectWorkerInfo,
+    normalize_model_key, utils::PeriodicTask, CacheAwareConfig, LoadBalancingPolicy,
+    SelectWorkerInfo,
 };
 use crate::{
     mesh::adapters::tree_sync::{RepairEntry, TreeRepairPage},
@@ -275,7 +275,18 @@ impl CacheAwarePolicy {
     /// - **count spread**: request-count dispersion (abs AND rel) over healthy
     ///   workers. Always evaluated, so high-count / low-KV imbalance is still
     ///   caught when KV looks even.
-    fn is_imbalanced(&self, workers: &[Arc<dyn Worker>], healthy_indices: &[usize]) -> bool {
+    /// Whether to abandon cache affinity for shortest-queue because the pool is
+    /// imbalanced — by backend KV usage (overload ceiling or hot-vs-cool spread)
+    /// or by request-count spread. `min_load`/`max_load` are the request-count
+    /// bounds over the healthy workers, which `select_worker` gathers in its
+    /// single worker pass (tests use the `imbalanced` helper to fold them).
+    fn is_imbalanced(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        healthy_indices: &[usize],
+        min_load: usize,
+        max_load: usize,
+    ) -> bool {
         // KV-based triggers — need a load snapshot; both default 1.0 = disabled.
         if let Some((min_usage, max_usage)) =
             self.backend_token_usage_bounds(workers, healthy_indices)
@@ -291,14 +302,6 @@ impl CacheAwarePolicy {
         }
 
         // Count spread (abs AND rel) over healthy workers.
-        let (min_load, max_load) =
-            healthy_indices
-                .iter()
-                .fold((usize::MAX, 0usize), |(min, max), &idx| {
-                    let load = workers[idx].load();
-                    (min.min(load), max.max(load))
-                });
-        let min_load = if min_load == usize::MAX { 0 } else { min_load };
         max_load.saturating_sub(min_load) > self.config.balance_abs_threshold
             && (max_load as f32) > (min_load as f32 * self.config.balance_rel_threshold)
     }
@@ -470,7 +473,7 @@ impl CacheAwarePolicy {
         &self,
         workers: &[Arc<dyn Worker>],
         info: &SelectWorkerInfo,
-        healthy_indices: &[usize],
+        min_load_idx: Option<usize>,
         model_id: &str,
     ) -> Option<usize> {
         // Log load balancing trigger (only compute worker loads if debug enabled)
@@ -480,11 +483,10 @@ impl CacheAwarePolicy {
             debug!("Load balancing triggered | workers: {:?}", worker_loads);
         }
 
-        // Use shortest queue when imbalanced
-        let min_load_idx = healthy_indices
-            .iter()
-            .min_by_key(|&&idx| (workers[idx].load(), workers[idx].processed_requests(), idx))
-            .copied()?;
+        // Shortest queue when imbalanced. The min-load index is gathered upstream
+        // in select_worker with the (load, processed_requests, idx) tie-break
+        // from #1714 (spreads load when decode outpaces prefill).
+        let min_load_idx = min_load_idx?;
 
         let worker_url = workers[min_load_idx].url();
 
@@ -767,20 +769,50 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
     fn select_worker(&self, workers: &[Arc<dyn Worker>], info: &SelectWorkerInfo) -> Option<usize> {
         let request_text = info.request_text;
         let request_tokens = info.tokens;
-        let healthy_indices = get_healthy_worker_indices(workers);
+
+        // Single O(workers) gather: read each worker once via routing_state()
+        // (status + load + processed under one ArcSwap guard), replacing the
+        // former separate passes whose per-worker guard traffic dominated routing
+        // CPU at scale. Collects healthy indices, load min/max, and the min-load
+        // index; cache-hit tenant lookup is a hash-free scan over healthy_indices.
+        let mut healthy_indices: Vec<usize> = Vec::with_capacity(workers.len());
+        let mut min_load = usize::MAX;
+        let mut max_load = 0usize;
+        // Min-load worker, (load, processed_requests, idx) tie-break (#1714);
+        // `processed` rides the same guard as `load`, so it is free here.
+        let mut min_key: Option<(usize, usize, usize)> = None;
+        let mut min_load_idx: Option<usize> = None;
+        for (idx, worker) in workers.iter().enumerate() {
+            let state = worker.routing_state();
+            if state.healthy && state.can_execute {
+                healthy_indices.push(idx);
+                min_load = min_load.min(state.load);
+                max_load = max_load.max(state.load);
+                let key = (state.load, state.processed, idx);
+                match min_key {
+                    Some(best) if key >= best => {}
+                    _ => {
+                        min_key = Some(key);
+                        min_load_idx = Some(idx);
+                    }
+                }
+            }
+        }
 
         if healthy_indices.is_empty() {
             return None;
         }
+        let min_load = if min_load == usize::MAX { 0 } else { min_load };
 
         // Determine the model for this set of workers (router pre-filters by model)
         // All workers should be from the same model
         let model_id = normalize_model_key(workers[healthy_indices[0]].model_id());
 
         // Abandon cache affinity for shortest-queue when the pool is imbalanced —
-        // by request count, or (for long-context workloads) by backend KV usage.
-        if self.is_imbalanced(workers, &healthy_indices) {
-            return self.select_worker_min_load(workers, info, &healthy_indices, model_id);
+        // by request count (using the loads already gathered above), or (for
+        // long-context workloads) by backend KV usage.
+        if self.is_imbalanced(workers, &healthy_indices, min_load, max_load) {
+            return self.select_worker_min_load(workers, info, min_load_idx, model_id);
         }
 
         // Cache-aware routing when balanced — three types (mutually exclusive):
@@ -789,13 +821,25 @@ impl LoadBalancingPolicy for CacheAwarePolicy {
         //   3. Approximate string tree: Tree prefix matching (HTTP)
         if let Some(tokens) = request_tokens {
             if self.has_event_indexer(model_id) {
-                self.select_worker_event_driven(workers, tokens, &healthy_indices, model_id)
+                self.select_worker_event_driven(
+                    workers,
+                    tokens,
+                    &healthy_indices,
+                    min_load_idx,
+                    model_id,
+                )
             } else {
-                self.select_worker_with_tokens(workers, tokens, &healthy_indices, model_id)
+                self.select_worker_with_tokens(
+                    workers,
+                    tokens,
+                    &healthy_indices,
+                    min_load_idx,
+                    model_id,
+                )
             }
         } else {
             let text = request_text.unwrap_or("");
-            self.select_worker_with_text(workers, text, &healthy_indices, model_id)
+            self.select_worker_with_text(workers, text, &healthy_indices, min_load_idx, model_id)
         }
     }
 
@@ -848,6 +892,7 @@ impl CacheAwarePolicy {
         workers: &[Arc<dyn Worker>],
         tokens: &[u32],
         healthy_indices: &[usize],
+        min_load_idx: Option<usize>,
         model_id: &str,
     ) -> Option<usize> {
         let guard = self.kv_monitor.read();
@@ -865,11 +910,8 @@ impl CacheAwarePolicy {
             return Some(idx);
         }
 
-        // No cache overlap — min-load fallback (no token tree involved)
-        let min_idx = healthy_indices
-            .iter()
-            .min_by_key(|&&idx| (workers[idx].load(), workers[idx].processed_requests(), idx))
-            .copied()?;
+        // No cache overlap — min-load fallback (min-load index gathered upstream)
+        let min_idx = min_load_idx?;
         debug!(
             worker = workers[min_idx].url(),
             model_id, "Event-driven routing: no overlap, min-load fallback"
@@ -946,6 +988,7 @@ impl CacheAwarePolicy {
         workers: &[Arc<dyn Worker>],
         tokens: &[u32],
         healthy_indices: &[usize],
+        min_load_idx: Option<usize>,
         model_id: &str,
     ) -> Option<usize> {
         let tree = self
@@ -974,18 +1017,16 @@ impl CacheAwarePolicy {
                 };
 
                 selected_idx = if match_rate > self.config.cache_threshold {
+                    // Cache hit: scan healthy_indices for the tenant (hash-free;
+                    // url() is cheap). "Healthy" excludes circuit-broken workers, so
+                    // a CB-tripped tenant falls through to min-load (intended).
                     let tenant_url: &str = &result.tenant;
-                    workers
-                        .iter()
-                        .position(|w| w.url() == tenant_url)
-                        .filter(|&idx| workers[idx].is_healthy())
-                } else {
                     healthy_indices
                         .iter()
-                        .min_by_key(|&&idx| {
-                            (workers[idx].load(), workers[idx].processed_requests(), idx)
-                        })
                         .copied()
+                        .find(|&idx| workers[idx].url() == tenant_url)
+                } else {
+                    min_load_idx
                 };
 
                 // Insert for the selected worker (None => no insert, exactly
@@ -1037,6 +1078,7 @@ impl CacheAwarePolicy {
         workers: &[Arc<dyn Worker>],
         text: &str,
         healthy_indices: &[usize],
+        min_load_idx: Option<usize>,
         model_id: &str,
     ) -> Option<usize> {
         let tree = self
@@ -1058,18 +1100,16 @@ impl CacheAwarePolicy {
                 };
 
                 selected_idx = if match_rate > self.config.cache_threshold {
+                    // Cache hit: scan healthy_indices for the tenant (hash-free;
+                    // url() is cheap). "Healthy" excludes circuit-broken workers, so
+                    // a CB-tripped tenant falls through to min-load (intended).
                     let tenant_url: &str = &result.tenant;
-                    workers
-                        .iter()
-                        .position(|w| w.url() == tenant_url)
-                        .filter(|&idx| workers[idx].is_healthy())
-                } else {
                     healthy_indices
                         .iter()
-                        .min_by_key(|&&idx| {
-                            (workers[idx].load(), workers[idx].processed_requests(), idx)
-                        })
                         .copied()
+                        .find(|&idx| workers[idx].url() == tenant_url)
+                } else {
+                    min_load_idx
                 };
 
                 // Insert for the selected worker (None => no insert, exactly
@@ -1302,6 +1342,21 @@ mod tests {
         (0..workers.len()).collect()
     }
 
+    /// Run the imbalance check the way `select_worker` does: fold the request-count
+    /// bounds over the healthy workers (production gathers them in one pass), then
+    /// call `is_imbalanced`.
+    fn imbalanced(policy: &CacheAwarePolicy, workers: &[Arc<dyn Worker>]) -> bool {
+        let healthy = all_healthy(workers);
+        let (min_load, max_load) = healthy
+            .iter()
+            .fold((usize::MAX, 0usize), |(min, max), &idx| {
+                let load = workers[idx].load();
+                (min.min(load), max.max(load))
+            });
+        let min_load = if min_load == usize::MAX { 0 } else { min_load };
+        policy.is_imbalanced(workers, &healthy, min_load, max_load)
+    }
+
     #[test]
     fn is_imbalanced_uniform_high_kv_does_not_fire() {
         // All engines equally saturated: high utilization, zero spread.
@@ -1310,7 +1365,7 @@ mod tests {
         let _tx = inject_kv(&policy, &workers, &[0.9, 0.9, 0.9]);
         // max 0.9 < 0.95 ceiling, spread 0.0 < 0.3 → keep cache affinity.
         assert!(
-            !policy.is_imbalanced(&workers, &all_healthy(&workers)),
+            !imbalanced(&policy, &workers),
             "uniform-high KV (no cooler home) must not abandon cache affinity"
         );
     }
@@ -1323,7 +1378,7 @@ mod tests {
         let _tx = inject_kv(&policy, &workers, &[0.9, 0.15, 0.15]);
         // spread 0.75 > 0.3 → spill toward a cooler engine.
         assert!(
-            policy.is_imbalanced(&workers, &all_healthy(&workers)),
+            imbalanced(&policy, &workers),
             "a hot engine with idle neighbors (large KV spread) must rebalance"
         );
     }
@@ -1336,7 +1391,7 @@ mod tests {
         let _tx = inject_kv(&policy, &workers, &[0.97, 0.80]);
         // spread 0.17 < 0.3 (balance quiet) but 0.97 > 0.95 ceiling → shed.
         assert!(
-            policy.is_imbalanced(&workers, &all_healthy(&workers)),
+            imbalanced(&policy, &workers),
             "a critically-saturated engine must shed even below the spread threshold"
         );
     }
@@ -1359,7 +1414,7 @@ mod tests {
         }
         // KV spread 0.0, max 0.3 → KV quiet; count 20 vs 0 → fire.
         assert!(
-            policy.is_imbalanced(&workers, &all_healthy(&workers)),
+            imbalanced(&policy, &workers),
             "count spread must still trigger when KV utilization looks even"
         );
     }
@@ -1376,7 +1431,7 @@ mod tests {
         let _tx = inject_kv(&policy, &workers, &[0.95, 0.05]);
         // ...is ignored at the 1.0 default; counts balanced → no rebalance.
         assert!(
-            !policy.is_imbalanced(&workers, &all_healthy(&workers)),
+            !imbalanced(&policy, &workers),
             "default thresholds (1.0) must ignore KV usage entirely"
         );
     }

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -327,6 +327,20 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
         self.is_healthy() && self.circuit_breaker_can_execute()
     }
 
+    /// One-shot routing snapshot for the per-request O(workers) selection loops:
+    /// reads status, load and processed together so the hot path takes one
+    /// `ArcSwap` guard per backing cell per worker instead of one per accessor
+    /// (that guard traffic is a large share of routing CPU at scale). `BasicWorker`
+    /// overrides this to share the runtime guard.
+    fn routing_state(&self) -> RoutingState {
+        RoutingState {
+            healthy: self.is_healthy(),
+            can_execute: self.circuit_breaker_can_execute(),
+            load: self.load(),
+            processed: self.processed_requests(),
+        }
+    }
+
     /// Record the outcome of a request based on the HTTP status code.
     ///
     /// The worker decides whether the status is a CB failure using its
@@ -773,6 +787,19 @@ impl WorkerMetadata {
     }
 }
 
+/// One-shot routing snapshot — see [`Worker::routing_state`].
+#[derive(Clone, Copy, Debug)]
+pub struct RoutingState {
+    /// `status == Ready`.
+    pub healthy: bool,
+    /// Circuit breaker permits execution (closed or half-open).
+    pub can_execute: bool,
+    /// Active in-flight request count.
+    pub load: usize,
+    /// Lifetime processed-request count (min-load tie-break).
+    pub processed: usize,
+}
+
 /// Shared mutable worker state preserved across same-URL replacements.
 #[derive(Debug)]
 pub struct WorkerRuntime {
@@ -1103,6 +1130,19 @@ impl Worker for BasicWorker {
 
     fn circuit_breaker_can_execute(&self) -> bool {
         self.circuit_breaker.load().can_execute()
+    }
+
+    fn routing_state(&self) -> RoutingState {
+        // One runtime guard covers status + load + processed (all live in
+        // `self.runtime`); the circuit breaker is a separate ArcSwap, so it needs
+        // its own guard.
+        let rt = self.runtime.load();
+        RoutingState {
+            healthy: rt.status() == WorkerStatus::Ready,
+            can_execute: self.circuit_breaker.load().can_execute(),
+            load: rt.load(),
+            processed: rt.processed_requests(),
+        }
     }
 
     fn record_circuit_breaker_outcome(&self, success: bool) {


### PR DESCRIPTION
## Description

### Problem

`cache_aware` worker selection made several O(workers) passes per request — the healthy filter (`get_healthy_worker_indices`), the `is_imbalanced` request-count fold, and the cache-hit tenant→worker / cache-miss min-load scans. Each per-worker access went through an `ArcSwap` guard: `is_healthy()`→`status()` and `load()` both load the worker's `runtime` guard, and `circuit_breaker_can_execute()` loads a second (circuit-breaker) guard. So a healthy worker was read ~3 times per request via separate guarded virtual calls.

In a no-GPU benchmark (4 reactor threads, saturating shared-prefix load, mock fleet) this per-worker guard traffic is what makes cache_aware's per-request CPU grow with worker count. gdb sampling at 2048 workers attributed the cost to `arc_swap` guard load/drop + per-worker dynamic dispatch in the selection loops — **not** the radix-tree insert, which is cheap and worker-count-independent.

### Solution

Gather everything the balanced and imbalanced paths need in a **single pass** over the workers, reading each worker once via a new `Worker::routing_state()` that shares the `runtime` guard for `status` + `load` + `processed_requests` (the circuit breaker is a separate `ArcSwap`, so it keeps its own guard). The pass collects the healthy indices, the load min/max for the imbalance count-spread, and the min-load index — with the `(load, processed_requests, idx)` tie-break from #1714, free here since `processed` rides the same guard. `is_imbalanced` and the min-load fallback consume the gathered values instead of re-scanning; a cache hit resolves its tenant→worker with a hash-free linear scan over the gathered healthy indices (`url()` is a cheap field read — no per-request map).

Net: ~3 guarded virtual calls/worker across ~3 passes → 2 guards + 1 virtual call/worker in a single pass. Worker selection is unchanged **except** that a cache hit no longer routes onto a `Ready`-but-circuit-broken worker — it now falls through to min-load, consistent with the rest of selection.

## Changes

- **`worker/worker.rs`**: add `RoutingState { healthy, can_execute, load, processed }` and `Worker::routing_state()`. The default impl composes the existing accessors; `BasicWorker` overrides it to read `status`/`load`/`processed` under one `runtime` guard.
- **`policies/cache_aware.rs`**: `select_worker` performs the single-pass gather; `is_imbalanced` takes the precomputed load bounds; the token-tree, string-tree, event-driven and min-load paths consume the gathered min-load index; cache-hit tenant→worker resolution is a hash-free scan over the gathered healthy indices.

## Test Plan

No-GPU simulation: 4 reactor threads (saturating), mock fleet (`--engine realistic`), 16 shared prefixes at 0.8 fraction, 8k offered req/s, `cache_aware` with the imbalance valve held open so the balanced (tree-route) path is exercised. Metric is gateway `cpu_ms/req` (CPU-time per completed request; lower is better), reported as the **marginal over `round_robin` at the same worker count** so tokenization/proxy overhead cancels and the policy cost is isolated. Single-run, so figures carry measurement noise (~±0.07 at these windows); the marginal is the robust signal.

Routing marginal over round_robin, HTTP path (string tree — not masked by tokenization, so routing cost is visible). The shipped (hash-free scan) and the earlier (per-request map) revisions were A/B'd at 2048 workers back-to-back under identical conditions:

| @2048 workers (same conditions) | cpu_ms/req | marginal vs round_robin |
|---|---|---|
| round_robin (baseline) | 1.684 | — |
| cache_aware — per-request `url→index` map (earlier revision) | 1.865 | +0.181 |
| **cache_aware — hash-free scan (shipped)** | **1.708** | **+0.024** |

The shipped version's cache_aware routing is **within noise of round_robin at 2048 workers (+0.024 cpu_ms/req)**, down from +0.181 with the per-request map and ~+0.40 unoptimized — the per-worker `ArcSwap` guard traffic that scaled with worker count is gone. At 64 workers the marginal is within measurement noise for all variants. gRPC path (token tree) is unchanged — per-request tokenization dominates there either way. (Simulator numbers; absolute magnitudes need a live A/B.)

Gates on this branch (rebased on `main`):

```
cargo +nightly fmt --check                          clean
cargo clippy -p smg --all-targets -- -D warnings    clean (rc=0)
cargo test -p smg --lib policies                     107 passed
cargo test -p smg --lib worker::                     207 passed
```

Full `cargo test -p smg --lib` shows one unrelated failure, `middleware::metrics::tests::distinct_ids_on_matched_route_do_not_grow_interner`, which passes in isolation (a shared-interner test sensitive to parallel execution) and is untouched by this change. `--all-features` is not run locally (it pulls in the `opencv-video` feature absent in this environment, per CONTRIBUTING); CI runs the full matrix.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized load-balancing algorithm to reduce computational overhead during request routing and worker selection.
  * Improved cache-affinity routing logic to better align worker selection with cached content placement.
  * Enhanced worker state management for more consistent and efficient request distribution across available resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->