### PR TITLE
perf(openai-responses): parse SSE blocks via shared codec

### DIFF
--- a/model_gateway/src/routers/openai/responses/common.rs
+++ b/model_gateway/src/routers/openai/responses/common.rs
@@ -6,6 +6,8 @@ use std::borrow::Cow;
 
 use serde_json::Value;
 
+use crate::routers::common::sse::parse_block;
+
 /// Extract output_index from a JSON value
 #[inline]
 pub(crate) fn extract_output_index(value: &Value) -> Option<usize> {
@@ -22,6 +24,14 @@ pub(crate) fn get_event_type<'a>(event_name: Option<&'a str>, parsed: &'a Value)
 
 /// Processes incoming byte chunks into complete SSE blocks.
 /// Handles buffering of partial chunks and CRLF normalization.
+///
+/// This yields the *raw* block text (not a parsed frame) because the
+/// streaming pass-through path forwards upstream events verbatim and only
+/// rewrites the `data:` payload in place — see `rewrite_streaming_block`.
+/// The shared [`crate::routers::common::sse::SseDecoder`] yields parsed
+/// frames and would lose that verbatim text, so block buffering is kept
+/// local; the actual field parsing is delegated to the shared codec via
+/// [`parse_sse_block`].
 pub(super) struct ChunkProcessor {
     pending: String,
 }
@@ -70,27 +80,70 @@ impl ChunkProcessor {
     }
 }
 
-/// Parse an SSE block into event name and data
+/// Parse an SSE block into event name and data.
 ///
-/// Returns borrowed strings when possible to avoid allocations in hot paths.
-/// Only allocates when multiple data lines need to be joined.
+/// Delegates field parsing to the shared [`parse_block`] codec. Returns
+/// borrowed strings for the common single-line `data:` case (zero
+/// allocation); multi-line `data:` joins into an owned `String`.
+///
+/// All callers treat an empty `data` as "skip", so the shared codec's
+/// behavior of dropping data-less control blocks (returning no frame) is
+/// equivalent to the previous `(event_name, "")` result.
 pub(super) fn parse_sse_block(block: &str) -> (Option<&str>, Cow<'_, str>) {
-    let mut event_name: Option<&str> = None;
-    let mut data_lines: Vec<&str> = Vec::new();
-
-    for line in block.lines() {
-        if let Some(rest) = line.strip_prefix("event:") {
-            event_name = Some(rest.trim());
-        } else if let Some(rest) = line.strip_prefix("data:") {
-            data_lines.push(rest.trim_start());
+    match parse_block(block) {
+        Some(frame) => {
+            // `parse_block` always borrows the event type from `block`; trim it
+            // to match the previous parser's `.trim()` of the `event:` value.
+            let event_name = frame.event_type.and_then(|e| match e {
+                Cow::Borrowed(s) => Some(s.trim()),
+                Cow::Owned(_) => None,
+            });
+            (event_name, frame.data)
         }
+        None => (None, Cow::Borrowed("")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_sse_block_event_and_data() {
+        let (event, data) =
+            parse_sse_block("event: response.created\ndata: {\"type\":\"response.created\"}");
+        assert_eq!(event, Some("response.created"));
+        assert_eq!(data, "{\"type\":\"response.created\"}");
     }
 
-    let data = if data_lines.len() == 1 {
-        Cow::Borrowed(data_lines[0])
-    } else {
-        Cow::Owned(data_lines.join("\n"))
-    };
+    #[test]
+    fn test_parse_sse_block_data_only() {
+        let (event, data) = parse_sse_block("data: {\"type\":\"response.output_text.delta\"}");
+        assert_eq!(event, None);
+        assert_eq!(data, "{\"type\":\"response.output_text.delta\"}");
+    }
 
-    (event_name, data)
+    #[test]
+    fn test_parse_sse_block_multiline_data() {
+        let (event, data) = parse_sse_block("event: x\ndata: line1\ndata: line2");
+        assert_eq!(event, Some("x"));
+        assert_eq!(data, "line1\nline2");
+    }
+
+    #[test]
+    fn test_parse_sse_block_control_only_has_empty_data() {
+        // A block with no `data:` line yields empty data; all callers skip it.
+        let (_event, data) = parse_sse_block(": keep-alive");
+        assert!(data.is_empty());
+
+        let (_event, data) = parse_sse_block("event: ping");
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn test_parse_sse_block_empty_input() {
+        let (event, data) = parse_sse_block("");
+        assert_eq!(event, None);
+        assert!(data.is_empty());
+    }
 }

--- a/model_gateway/src/routers/openai/responses/common.rs
+++ b/model_gateway/src/routers/openai/responses/common.rs
@@ -86,7 +86,10 @@ pub(super) fn parse_sse_block(block: &str) -> (Option<&str>, Cow<'_, str>) {
         Some(frame) => {
             let event_name = frame.event_type.and_then(|e| match e {
                 Cow::Borrowed(s) => Some(s.trim()),
-                Cow::Owned(_) => None,
+                Cow::Owned(_) => {
+                    debug_assert!(false, "parse_block returned Cow::Owned for event_type");
+                    None
+                }
             });
             (event_name, frame.data)
         }

--- a/model_gateway/src/routers/openai/responses/common.rs
+++ b/model_gateway/src/routers/openai/responses/common.rs
@@ -24,14 +24,6 @@ pub(crate) fn get_event_type<'a>(event_name: Option<&'a str>, parsed: &'a Value)
 
 /// Processes incoming byte chunks into complete SSE blocks.
 /// Handles buffering of partial chunks and CRLF normalization.
-///
-/// This yields the *raw* block text (not a parsed frame) because the
-/// streaming pass-through path forwards upstream events verbatim and only
-/// rewrites the `data:` payload in place — see `rewrite_streaming_block`.
-/// The shared [`crate::routers::common::sse::SseDecoder`] yields parsed
-/// frames and would lose that verbatim text, so block buffering is kept
-/// local; the actual field parsing is delegated to the shared codec via
-/// [`parse_sse_block`].
 pub(super) struct ChunkProcessor {
     pending: String,
 }
@@ -92,8 +84,6 @@ impl ChunkProcessor {
 pub(super) fn parse_sse_block(block: &str) -> (Option<&str>, Cow<'_, str>) {
     match parse_block(block) {
         Some(frame) => {
-            // `parse_block` always borrows the event type from `block`; trim it
-            // to match the previous parser's `.trim()` of the `event:` value.
             let event_name = frame.event_type.and_then(|e| match e {
                 Cow::Borrowed(s) => Some(s.trim()),
                 Cow::Owned(_) => None,


### PR DESCRIPTION
## Description

### Problem

`openai/responses/common.rs` had a hand-rolled `parse_sse_block` that duplicated SSE field-parsing logic and allocated a `Vec` per block to collect `data:` lines.

### Solution

Reimplement `parse_sse_block` on top of the shared `common::sse::parse_block`, removing the duplicate parser. Single-line `data:` (the common case) is now zero-allocation. The `(Option<&str>, Cow<str>)` contract is preserved — every caller skips empty `data`, so the shared codec dropping data-less control blocks is equivalent to the prior `(event_name, "")`.

## Changes

- `parse_sse_block` now delegates field parsing to the shared `parse_block`.
- `ChunkProcessor` is **intentionally retained**: the pass-through path forwards upstream events verbatim and rewrites only the `data:` payload in place, so it needs the raw block text that `SseDecoder` (which yields parsed frames) cannot provide. Removing it would reformat forwarded events — a wire-format change we explicitly avoid.
- Added unit tests for `parse_sse_block` (event+data, data-only, multi-line, control-only, empty).

## Test Plan

- `cargo +nightly fmt` ✅ and `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -p smg --lib openai::responses` ✅ (24 passed, incl. new `parse_sse_block` tests)

Part of the shared SSE codec rollout (design doc, codec landed in #987). Sibling of the anthropic SSE PRs (#1633 encode / #1634 decode) and #1759 (openai encode).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal Server-Sent Events parsing logic through code consolidation while maintaining existing behavior and compatibility.

* **Tests**
  * Added and updated test coverage for SSE event handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->