### PR TITLE
fix(tool-parser): coerce minimax_m2 args by declared schema type

### DIFF
--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -9,6 +9,57 @@ use crate::{
     types::{StreamingParseResult, ToolCallItem},
 };
 
+/// `param_name -> declared JSON-schema type` for the named function (empty if the
+/// function or its `properties` are absent). Lets XML-style parsers coerce by the
+/// declared type instead of guessing from text (e.g. keep a numeric-looking
+/// `string` as a string).
+pub fn param_types_for_function(tools: &[Tool], func_name: &str) -> HashMap<String, String> {
+    let mut types = HashMap::new();
+    let Some(tool) = tools.iter().find(|t| t.function.name == func_name) else {
+        return types;
+    };
+    if let Some(props) = tool
+        .function
+        .parameters
+        .get("properties")
+        .and_then(Value::as_object)
+    {
+        for (key, schema) in props {
+            if let Some(ty) = schema.get("type").and_then(Value::as_str) {
+                types.insert(key.clone(), ty.to_string());
+            }
+        }
+    }
+    types
+}
+
+/// Coerce a raw value by its declared JSON-schema type. `string` is kept verbatim;
+/// numeric/boolean/structured types are parsed. `None` (unknown type or parse
+/// failure) means the caller should fall back to its own inference.
+pub fn coerce_by_schema_type(text: &str, declared_type: Option<&str>) -> Option<Value> {
+    match declared_type? {
+        "string" => Some(Value::String(text.to_string())),
+        "integer" => text
+            .trim()
+            .parse::<i64>()
+            .ok()
+            .map(|n| Value::Number(n.into())),
+        "number" => text
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .and_then(serde_json::Number::from_f64)
+            .map(Value::Number),
+        "boolean" => match text.trim() {
+            "true" | "True" => Some(Value::Bool(true)),
+            "false" | "False" => Some(Value::Bool(false)),
+            _ => None,
+        },
+        "object" | "array" => serde_json::from_str::<Value>(text).ok(),
+        _ => None,
+    }
+}
+
 /// Get a mapping of tool names to their indices
 pub fn get_tool_indices(tools: &[Tool]) -> HashMap<String, usize> {
     tools

--- a/crates/tool_parser/src/parsers/minimax_m2.rs
+++ b/crates/tool_parser/src/parsers/minimax_m2.rs
@@ -109,20 +109,25 @@ impl MinimaxM2Parser {
         }
     }
 
-    /// Parse parameters from parameter tags
-    fn parse_parameters(&self, params_text: &str) -> serde_json::Map<String, Value> {
+    /// Parse parameter tags, coercing each value by its declared schema type when
+    /// known (so a numeric-looking `string` stays a string), else inferring.
+    fn parse_parameters(
+        &self,
+        params_text: &str,
+        param_types: &HashMap<String, String>,
+    ) -> serde_json::Map<String, Value> {
         let mut parameters = serde_json::Map::new();
 
         for capture in self.param_extractor.captures_iter(params_text) {
             let key = capture.get(1).map_or("", |m| m.as_str()).trim();
             let value_str = capture.get(2).map_or("", |m| m.as_str());
 
-            // Decode XML entities and parse value
             let decoded_value = Self::decode_xml_entities(value_str);
-
-            // Note: We keep JSON-like strings as strings (not parsed JSON)
-            // This matches the behavior of other parsers like GLM4 MOE
-            let value = Self::parse_value(&decoded_value);
+            let value = helpers::coerce_by_schema_type(
+                &decoded_value,
+                param_types.get(key).map(String::as_str),
+            )
+            .unwrap_or_else(|| Self::parse_value(&decoded_value));
 
             parameters.insert(key.to_string(), value);
         }
@@ -140,7 +145,7 @@ impl MinimaxM2Parser {
     }
 
     /// Parse a single tool call block
-    fn parse_tool_call(&self, block: &str) -> ParserResult<Option<ToolCall>> {
+    fn parse_tool_call(&self, block: &str, tools: &[Tool]) -> ParserResult<Option<ToolCall>> {
         if let Some(captures) = self.invoke_extractor.captures(block) {
             // Get function name from invoke tag attribute
             let func_name = captures.get(1).map_or("", |m| m.as_str()).trim();
@@ -148,8 +153,9 @@ impl MinimaxM2Parser {
             // Get parameters text
             let params_text = captures.get(2).map_or("", |m| m.as_str());
 
-            // Parse parameters
-            let parameters = self.parse_parameters(params_text);
+            // Parse parameters, coerced by this function's declared schema.
+            let param_types = helpers::param_types_for_function(tools, func_name);
+            let parameters = self.parse_parameters(params_text, &param_types);
 
             let arguments_str = serde_json::to_string(&parameters)
                 .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
@@ -166,17 +172,21 @@ impl MinimaxM2Parser {
     }
 
     /// Parse all tool calls from text and return first valid position
-    fn parse_tool_calls_from_text(&self, text: &str) -> (Vec<ToolCall>, Option<usize>) {
-        let mut tools = Vec::new();
+    fn parse_tool_calls_from_text(
+        &self,
+        text: &str,
+        tools: &[Tool],
+    ) -> (Vec<ToolCall>, Option<usize>) {
+        let mut tool_calls = Vec::new();
         let mut first_valid_pos = None;
 
         for mat in self.tool_call_extractor.find_iter(text) {
-            match self.parse_tool_call(mat.as_str()) {
+            match self.parse_tool_call(mat.as_str(), tools) {
                 Ok(Some(tool)) => {
                     if first_valid_pos.is_none() {
                         first_valid_pos = Some(mat.start());
                     }
-                    tools.push(tool);
+                    tool_calls.push(tool);
                 }
                 Ok(None) => continue,
                 Err(e) => {
@@ -186,12 +196,29 @@ impl MinimaxM2Parser {
             }
         }
 
-        (tools, first_valid_pos)
+        (tool_calls, first_valid_pos)
+    }
+
+    /// Shared non-streaming parse; `tools` empty means infer types from text.
+    fn parse_complete_inner(&self, text: &str, tools: &[Tool]) -> (String, Vec<ToolCall>) {
+        if !self.has_tool_markers(text) {
+            return (text.to_string(), vec![]);
+        }
+        let (tool_calls, first_valid_tool_pos) = self.parse_tool_calls_from_text(text, tools);
+        if tool_calls.is_empty() {
+            return (text.to_string(), vec![]);
+        }
+        let normal_text = match first_valid_tool_pos {
+            Some(pos) => text[..pos].to_string(),
+            None => text.to_string(),
+        };
+        (normal_text, tool_calls)
     }
 
     /// Parse and stream parameters incrementally
-    fn parse_and_stream_parameters(&mut self, text: &str, _tools: &[Tool]) -> Vec<ToolCallItem> {
+    fn parse_and_stream_parameters(&mut self, text: &str, tools: &[Tool]) -> Vec<ToolCallItem> {
         let mut calls = Vec::new();
+        let param_types = helpers::param_types_for_function(tools, &self.current_function_name);
 
         // Find all complete parameter patterns in the buffer
         let param_matches: Vec<_> = self
@@ -202,16 +229,20 @@ impl MinimaxM2Parser {
                 let value_str = cap.get(2).map_or("", |m| m.as_str());
                 let decoded = Self::decode_xml_entities(value_str);
 
-                // Try parsing as JSON first (for nested objects/arrays)
-                let value = if decoded.starts_with('{') || decoded.starts_with('[') {
-                    if let Ok(json_val) = serde_json::from_str::<Value>(&decoded) {
-                        json_val
+                // Coerce by declared type when known; otherwise keep the prior
+                // JSON-first-then-infer behavior for nested objects/arrays.
+                let value = helpers::coerce_by_schema_type(
+                    &decoded,
+                    param_types.get(&name).map(String::as_str),
+                )
+                .unwrap_or_else(|| {
+                    if decoded.starts_with('{') || decoded.starts_with('[') {
+                        serde_json::from_str::<Value>(&decoded)
+                            .unwrap_or_else(|_| Self::parse_value(&decoded))
                     } else {
                         Self::parse_value(&decoded)
                     }
-                } else {
-                    Self::parse_value(&decoded)
-                };
+                });
 
                 (name, value)
             })
@@ -311,29 +342,15 @@ impl Default for MinimaxM2Parser {
 #[async_trait]
 impl ToolParser for MinimaxM2Parser {
     async fn parse_complete(&self, text: &str) -> ParserResult<(String, Vec<ToolCall>)> {
-        // Check if text contains MiniMax M2 format
-        if !self.has_tool_markers(text) {
-            return Ok((text.to_string(), vec![]));
-        }
+        Ok(self.parse_complete_inner(text, &[]))
+    }
 
-        // Parse all tool calls and get first valid position
-        let (tools, first_valid_tool_pos) = self.parse_tool_calls_from_text(text);
-
-        // If no tools were successfully parsed, return entire text as fallback
-        if tools.is_empty() {
-            return Ok((text.to_string(), vec![]));
-        }
-
-        // Determine what text to return as normal_text
-        let normal_text = if let Some(pos) = first_valid_tool_pos {
-            // Return text up to the first valid tool call
-            text[..pos].to_string()
-        } else {
-            // No valid tool calls found, return entire text
-            text.to_string()
-        };
-
-        Ok((normal_text, tools))
+    async fn parse_complete_with_tools(
+        &self,
+        text: &str,
+        tools: &[Tool],
+    ) -> ParserResult<(String, Vec<ToolCall>)> {
+        Ok(self.parse_complete_inner(text, tools))
     }
 
     async fn parse_incremental(

--- a/crates/tool_parser/src/traits.rs
+++ b/crates/tool_parser/src/traits.rs
@@ -13,6 +13,17 @@ pub trait ToolParser: Send + Sync {
     /// Returns (remaining_normal_text, tool_calls) tuple
     async fn parse_complete(&self, output: &str) -> ParserResult<(String, Vec<ToolCall>)>;
 
+    /// Like [`Self::parse_complete`], but with the request's tool schemas so
+    /// schema-aware parsers coerce arg values by declared type. The default
+    /// ignores `tools` and delegates to `parse_complete`.
+    async fn parse_complete_with_tools(
+        &self,
+        output: &str,
+        _tools: &[Tool],
+    ) -> ParserResult<(String, Vec<ToolCall>)> {
+        self.parse_complete(output).await
+    }
+
     /// Parse tool calls from model output (streaming)
     /// Parsers now maintain internal state, so self is mutable
     ///

--- a/crates/tool_parser/tests/tool_parser_minimax_m2.rs
+++ b/crates/tool_parser/tests/tool_parser_minimax_m2.rs
@@ -2,7 +2,128 @@
 mod common;
 
 use common::create_test_tools;
+use openai_protocol::common::{Function, Tool};
+use serde_json::json;
 use tool_parser::{MinimaxM2Parser, ToolParser};
+
+/// Tools matching issue #1743: `update_task(taskId: string, subject: string)`.
+fn update_task_tools() -> Vec<Tool> {
+    vec![Tool {
+        tool_type: "function".to_string(),
+        function: Function {
+            name: "update_task".to_string(),
+            description: None,
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "taskId":  {"type": "string"},
+                    "subject": {"type": "string"}
+                },
+                "required": ["taskId", "subject"]
+            }),
+            strict: None,
+        },
+    }]
+}
+
+const UPDATE_TASK_CALL: &str = r#"<minimax:tool_call>
+<invoke name="update_task">
+<parameter name="taskId">3</parameter>
+<parameter name="subject">X</parameter>
+</invoke>
+</minimax:tool_call>"#;
+
+/// Issue #1743: a `string`-typed parameter whose value looks numeric must be
+/// emitted as a JSON string when the schema is available, not coerced to a number.
+#[tokio::test]
+async fn test_minimax_string_arg_kept_as_string_with_schema() {
+    let parser = MinimaxM2Parser::new();
+    let tools = update_task_tools();
+
+    let (_normal, calls) = parser
+        .parse_complete_with_tools(UPDATE_TASK_CALL, &tools)
+        .await
+        .unwrap();
+
+    assert_eq!(calls.len(), 1);
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(
+        args["taskId"],
+        json!("3"),
+        "string schema -> must stay string"
+    );
+    assert_eq!(args["subject"], json!("X"));
+}
+
+/// Numeric schema types are still coerced: an `integer` field stays a number.
+#[tokio::test]
+async fn test_minimax_integer_arg_coerced_with_schema() {
+    let parser = MinimaxM2Parser::new();
+    let tools = vec![Tool {
+        tool_type: "function".to_string(),
+        function: Function {
+            name: "update_task".to_string(),
+            description: None,
+            parameters: json!({
+                "type": "object",
+                "properties": { "taskId": {"type": "integer"} }
+            }),
+            strict: None,
+        },
+    }];
+
+    let (_normal, calls) = parser
+        .parse_complete_with_tools(UPDATE_TASK_CALL, &tools)
+        .await
+        .unwrap();
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(args["taskId"], json!(3), "integer schema -> number");
+}
+
+/// Backward compatible: with no schema, text-based inference is unchanged
+/// (a numeric-looking value becomes a number).
+#[tokio::test]
+async fn test_minimax_no_schema_infers_number() {
+    let parser = MinimaxM2Parser::new();
+    let (_normal, calls) = parser.parse_complete(UPDATE_TASK_CALL).await.unwrap();
+    let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+    assert_eq!(
+        args["taskId"],
+        json!(3),
+        "no schema -> inferred number (unchanged)"
+    );
+}
+
+/// Streaming honors the schema too (tools were previously received but ignored).
+#[tokio::test]
+async fn test_minimax_streaming_string_arg_kept_as_string_with_schema() {
+    let mut parser = MinimaxM2Parser::new();
+    let tools = update_task_tools();
+
+    let mut args_json = String::new();
+    for chunk in [
+        "<minimax:tool_call>",
+        r#"<invoke name="update_task">"#,
+        r#"<parameter name="taskId">3</parameter>"#,
+        r#"<parameter name="subject">X</parameter>"#,
+        "</invoke>",
+        "</minimax:tool_call>",
+    ] {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if call.name.is_none() {
+                args_json.push_str(&call.parameters);
+            }
+        }
+    }
+
+    let args: serde_json::Value = serde_json::from_str(&args_json).unwrap();
+    assert_eq!(
+        args["taskId"],
+        json!("3"),
+        "streaming string schema -> stay string"
+    );
+}
 
 #[tokio::test]
 async fn test_minimax_complete_parsing() {

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -11,7 +11,7 @@ use llm_tokenizer::{
 };
 use openai_protocol::{
     chat::{ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse},
-    common::{FunctionCallResponse, ToolCall, ToolChoice, ToolChoiceValue, Usage},
+    common::{FunctionCallResponse, Tool, ToolCall, ToolChoice, ToolChoiceValue, Usage},
     completion::{CompletionChoice, CompletionRequest, CompletionResponse},
     generate::{GenerateMetaInfo, GenerateRequest, GenerateResponse},
     messages::{self, CreateMessageRequest, Message},
@@ -166,6 +166,7 @@ impl ResponseProcessor {
                     .parse_tool_calls(
                         &processed_text,
                         &original_request.model,
+                        original_request.tools.as_deref().unwrap_or(&[]),
                         history_tool_calls_count,
                     )
                     .await;
@@ -309,6 +310,7 @@ impl ResponseProcessor {
         &self,
         processed_text: &str,
         model: &str,
+        tools: &[Tool],
         history_tool_calls_count: usize,
     ) -> (Option<Vec<ToolCall>>, String) {
         // Get pooled parser for this model
@@ -318,10 +320,14 @@ impl ResponseProcessor {
             model,
         );
 
-        // Try parsing directly (parser will handle detection internally)
+        // Try parsing directly (parser will handle detection internally). Pass the
+        // tool schemas so schema-aware parsers coerce argument types by their
+        // declared type instead of guessing from the raw text.
         let result = {
             let parser = pooled_parser.lock().await;
-            parser.parse_complete(processed_text).await
+            parser
+                .parse_complete_with_tools(processed_text, tools)
+                .await
             // Lock is dropped here
         };
 
@@ -651,10 +657,16 @@ impl ResponseProcessor {
                     utils::message_utils::get_history_tool_calls_count_messages(&messages_request),
                 );
             } else if tool_parser_available {
+                let chat_tools = messages_request
+                    .tools
+                    .as_deref()
+                    .map(utils::message_utils::extract_chat_tools)
+                    .unwrap_or_default();
                 (tool_calls, processed_text) = self
                     .parse_tool_calls(
                         &processed_text,
                         &messages_request.model,
+                        &chat_tools,
                         utils::message_utils::get_history_tool_calls_count_messages(
                             &messages_request,
                         ),

--- a/model_gateway/src/routers/parse/handlers.rs
+++ b/model_gateway/src/routers/parse/handlers.rs
@@ -44,7 +44,10 @@ pub async fn parse_function_call(
     };
 
     let parser = pooled_parser.lock().await;
-    match parser.parse_complete(&req.text).await {
+    match parser
+        .parse_complete_with_tools(&req.text, &req.tools)
+        .await
+    {
         Ok((remaining_text, tool_calls)) => (
             StatusCode::OK,
             Json(serde_json::json!({


### PR DESCRIPTION
## Description

Closes #1743.

### Problem

The `minimax_m2` tool parser infers argument types from the raw text of a tool call instead of the tool's declared JSON schema: `parse_value()` tries `i64`, then `f64`, before falling back to `String`. A `string`-typed parameter whose value happens to look numeric (e.g. `taskId: "3"`) is emitted as a JSON **number**, which breaks strict clients — e.g. Claude Code, where `taskId` is `{"type":"string"}`, triggering a tool-input validation loop.

The schema never reached the parser: non-streaming `parse_complete()` took no `tools` argument at all, and streaming `parse_incremental()` received `tools` but passed them unused (`_tools`).

### Solution

Coerce each parameter value by its **declared** JSON-schema type, falling back to text inference only when the type is unknown:

- `string` is kept verbatim (the fix); `integer` / `number` / `boolean` / `object` / `array` are parsed; absent/unknown types use the previous heuristic, so behavior is backward compatible.
- Thread the request's `tools` to the non-streaming path via a new `ToolParser::parse_complete_with_tools()` whose default delegates to `parse_complete` (the other parsers need no change), and make streaming use the `tools` it already receives.

Mirrors the Python sglang fix (`_get_param_types_from_config`).

## Changes

- **`tool_parser/parsers/helpers.rs`**: `param_types_for_function(tools, fn)` builds a param→declared-type map; `coerce_by_schema_type(text, type)` coerces by that type. Shared so other XML-style parsers (e.g. GLM4) can reuse them.
- **`tool_parser/traits.rs`**: add `parse_complete_with_tools(output, tools)` with a default that delegates to `parse_complete`.
- **`tool_parser/parsers/minimax_m2.rs`**: build the function's param→type map and coerce by declared type on both the non-streaming and streaming paths.
- **`model_gateway`**: forward `request.tools` to the parser on the non-streaming paths — the gRPC chat + messages processors, and the `/parse` handler (which already received `tools` and was discarding them).

## Test Plan

**Unit** — added 4 `minimax_m2` tests: schema `string` stays a string (the issue repro), `integer` schema still coerces to a number, no-schema keeps the prior inference (backward compat), and streaming honors the schema.

```
cargo test -p tool-parser    # tool_parser_minimax_m2: 31 passed
```

**End-to-end (real model)** — served **MiniMax-M2** (230B, fp8) via the vLLM gRPC engine behind the smg router with `--tool-call-parser minimax_m2`, and ran the issue's scenario. The model emits its native `<minimax:tool_call>` XML and smg parses it:

```
finish_reason: tool_calls
tool: update_task   arguments: {"taskId":"3","subject":"X"}
taskId -> "3"  (json type: string)  ✅
```

`taskId` is the string `"3"`, not the number `3` — the reported failure is fixed over the wire.

Gates on this branch: `cargo +nightly fmt` clean; `cargo clippy -p smg -p tool-parser --all-targets -- -D warnings` clean; `cargo test -p tool-parser` passing. (`--all-features` not run locally — it pulls in the OpenCV feature absent in this environment, per CONTRIBUTING; CI runs the full matrix.)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
