### PR TITLE
ci: bin-pack GPU CI runners via Volcano + sync runner values with live cluster

### DIFF
--- a/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
@@ -6,8 +6,8 @@ githubConfigUrl: "https://github.com/lightseekorg/smg"
 githubConfigSecret: github-arc-secret
 
 ## Runner scaling configuration
-minRunners: 0
-maxRunners: 6
+minRunners: 4
+maxRunners: 20
 
 ## name of the runner scale set to create.  Defaults to the helm release name
 runnerScaleSetName: "1-gpu-h100"
@@ -20,6 +20,20 @@ template:
   spec:
     terminationGracePeriodSeconds: 600
 
+    # Schedule runner pods with Volcano so the binpack plugin consolidates GPU
+    # runners onto fewer H100 nodes. The bin-packing weights live in the cluster
+    # scheduler config: volcano-system/volcano-scheduler-configmap
+    # (see volcano-scheduler-configmap.yaml in this directory).
+    schedulerName: volcano
+
+    # hostNetwork puts the runner in the host netns so PD disaggregation KV
+    # transfer (NIXL/Mooncake) sees the host's populated RoCE GID tables. An
+    # overlay-CNI pod sees the mlx5 NICs as PORT_ACTIVE but with an empty GID
+    # table, so RDMA init dies at worker startup. ClusterFirstWithHostNet keeps
+    # cluster DNS working while on the host network.
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+
     nodeSelector:
       nvidia.com/gpu: "true"
       node.kubernetes.io/instance-type: BM.GPU.H100.8
@@ -30,26 +44,18 @@ template:
         value: "true"
         effect: "NoSchedule"
 
-    affinity:
-      podAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: actions.github.com/scale-set-name
-                    operator: In
-                    values:
-                      - 1-gpu-h100
-                      - 2-gpu-h100
-              topologyKey: kubernetes.io/hostname
+    # Pod affinity/anti-affinity intentionally omitted: GPU placement is now
+    # driven by the Volcano binpack plugin. NOTE: with hostNetwork, runners
+    # co-located by binpack share the host port space — jobs binding fixed host
+    # ports can collide when packed onto the same node.
 
     volumes:
       - name: work
         emptyDir: {}
       - name: model-cache
-        persistentVolumeClaim:
-          claimName: model-cache
+        hostPath:
+          path: /raid/models
+          type: Directory
       - name: dshm
         emptyDir:
           medium: Memory
@@ -60,23 +66,62 @@ template:
         emptyDir: {}
       - name: docker-storage
         emptyDir: {}
+      - name: infiniband
+        hostPath:
+          path: /dev/infiniband
+          type: Directory
 
     containers:
       - name: runner
-        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.2
+        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.3
         command:
           - /home/runner/run.sh
+        securityContext:
+          # Non-root runner (uid 1001) + IPC_LOCK lets RDMA pin completion-queue
+          # memory (ibv_create_cq) without granting full privileged.
+          privileged: false
+          capabilities:
+            add:
+              - IPC_LOCK
         env:
           - name: DOCKER_HOST
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
+          - name: HF_HOME
+            value: /models
+          - name: HF_TOKEN  # required: ci_download_model.sh runs `hf download` for the gated Llama model
+            valueFrom:
+              secretKeyRef:
+                key: HUGGINGFACE_API_KEY
+                name: huggingface-secret
+          - name: OPENAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: OPENAI_API_KEY
+                name: openai-api-key
+          - name: ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: ANTHROPIC_API_KEY
+                name: anthropic-api-key
+          - name: XAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: XAI_API_KEY
+                name: xai-api-key
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
         resources:
           requests:
-            cpu: "8"
-            memory: "32Gi"
+            cpu: '32'
+            memory: 128Gi
+            rdma/hca_shared_devices_a: '1'
           limits:
             nvidia.com/gpu: 1
+            rdma/hca_shared_devices_a: '1'
         volumeMounts:
           - name: model-cache
             mountPath: /models
@@ -88,6 +133,8 @@ template:
             mountPath: /var/run
           - name: docker-storage
             mountPath: /var/lib/docker
+          - name: infiniband
+            mountPath: /dev/infiniband
 
     initContainers:
       - name: init-dind-externals
@@ -97,7 +144,7 @@ template:
           - /home/runner/tmpDir/
         command:
           - cp
-        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.2
+        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.3
         volumeMounts:
           - mountPath: /home/runner/tmpDir
             name: dind-externals
@@ -109,10 +156,22 @@ template:
         env:
           - name: DOCKER_GROUP_GID
             value: '123'
+          # Suppress dind's default TLS TCP listener (:2376). dockerd only needs
+          # the unix socket here; under hostNetwork a TCP listener would bind a
+          # node port unnecessarily.
+          - name: DOCKER_TLS_CERTDIR
+            value: ""
         image: fra.ocir.io/idqj093njucb/docker:dind
         restartPolicy: Always
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: '2'
+            memory: 4Gi
+          requests:
+            cpu: '1'
+            memory: 2Gi
         startupProbe:
           exec:
             command:

--- a/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
@@ -144,12 +144,18 @@ template:
         securityContext:
           privileged: true
         resources:
+          # genai-bench (and any `docker run` workload) executes inside this dind
+          # cgroup, whose memory limit also caps the page cache for reading the
+          # multi-GB CUDA/torch image. At 4Gi a cold image read thrashes (constant
+          # reclaim + re-read), ballooning container startup to minutes and
+          # tripping the benchmark suite's 480s watchdog. Size for driver RSS +
+          # image page cache; the H100 nodes have ample RAM.
           limits:
-            cpu: '2'
-            memory: 4Gi
+            cpu: '8'
+            memory: 32Gi
           requests:
-            cpu: '1'
-            memory: 2Gi
+            cpu: '4'
+            memory: 8Gi
         startupProbe:
           exec:
             command:

--- a/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
@@ -20,17 +20,12 @@ template:
   spec:
     terminationGracePeriodSeconds: 600
 
-    # Schedule runner pods with Volcano so the binpack plugin consolidates GPU
-    # runners onto fewer H100 nodes. The bin-packing weights live in the cluster
-    # scheduler config: volcano-system/volcano-scheduler-configmap
-    # (see volcano-scheduler-configmap.yaml in this directory).
+    # Volcano binpack packs GPU runners onto fewer nodes
+    # (weights: volcano-scheduler-configmap.yaml).
     schedulerName: volcano
 
-    # hostNetwork puts the runner in the host netns so PD disaggregation KV
-    # transfer (NIXL/Mooncake) sees the host's populated RoCE GID tables. An
-    # overlay-CNI pod sees the mlx5 NICs as PORT_ACTIVE but with an empty GID
-    # table, so RDMA init dies at worker startup. ClusterFirstWithHostNet keeps
-    # cluster DNS working while on the host network.
+    # hostNetwork: RDMA KV transfer (NIXL/Mooncake) needs the host's RoCE GID
+    # tables; an overlay netns has empty GIDs and RDMA init fails.
     hostNetwork: true
     dnsPolicy: ClusterFirstWithHostNet
 
@@ -44,10 +39,8 @@ template:
         value: "true"
         effect: "NoSchedule"
 
-    # Pod affinity/anti-affinity intentionally omitted: GPU placement is now
-    # driven by the Volcano binpack plugin. NOTE: with hostNetwork, runners
-    # co-located by binpack share the host port space — jobs binding fixed host
-    # ports can collide when packed onto the same node.
+    # No affinity: placement left to binpack. e2e servers bind OS-assigned
+    # ports on 127.0.0.1, so co-located hostNetwork runners don't collide.
 
     volumes:
       - name: work

--- a/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
@@ -95,21 +95,6 @@ template:
               secretKeyRef:
                 key: HUGGINGFACE_API_KEY
                 name: huggingface-secret
-          - name: OPENAI_API_KEY
-            valueFrom:
-              secretKeyRef:
-                key: OPENAI_API_KEY
-                name: openai-api-key
-          - name: ANTHROPIC_API_KEY
-            valueFrom:
-              secretKeyRef:
-                key: ANTHROPIC_API_KEY
-                name: anthropic-api-key
-          - name: XAI_API_KEY
-            valueFrom:
-              secretKeyRef:
-                key: XAI_API_KEY
-                name: xai-api-key
           - name: NODE_IP
             valueFrom:
               fieldRef:

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -98,21 +98,6 @@ template:
               secretKeyRef:
                 key: HUGGINGFACE_API_KEY
                 name: huggingface-secret
-          - name: OPENAI_API_KEY
-            valueFrom:
-              secretKeyRef:
-                key: OPENAI_API_KEY
-                name: openai-api-key
-          - name: ANTHROPIC_API_KEY
-            valueFrom:
-              secretKeyRef:
-                key: ANTHROPIC_API_KEY
-                name: anthropic-api-key
-          - name: XAI_API_KEY
-            valueFrom:
-              secretKeyRef:
-                key: XAI_API_KEY
-                name: xai-api-key
           - name: NODE_IP
             valueFrom:
               fieldRef:

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -144,12 +144,18 @@ template:
         securityContext:
           privileged: true
         resources:
+          # genai-bench (and any `docker run` workload) executes inside this dind
+          # cgroup, whose memory limit also caps the page cache for reading the
+          # multi-GB CUDA/torch image. At 4Gi a cold image read thrashes (constant
+          # reclaim + re-read), ballooning container startup to minutes and
+          # tripping the benchmark suite's 480s watchdog. Size for driver RSS +
+          # image page cache; the H100 nodes have ample RAM.
           limits:
-            cpu: '2'
-            memory: 4Gi
+            cpu: '8'
+            memory: 32Gi
           requests:
-            cpu: '1'
-            memory: 2Gi
+            cpu: '4'
+            memory: 8Gi
         startupProbe:
           exec:
             command:

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -20,17 +20,12 @@ template:
   spec:
     terminationGracePeriodSeconds: 600
 
-    # Schedule runner pods with Volcano so the binpack plugin consolidates GPU
-    # runners onto fewer H100 nodes. The bin-packing weights live in the cluster
-    # scheduler config: volcano-system/volcano-scheduler-configmap
-    # (see volcano-scheduler-configmap.yaml in this directory).
+    # Volcano binpack packs GPU runners onto fewer nodes
+    # (weights: volcano-scheduler-configmap.yaml).
     schedulerName: volcano
 
-    # hostNetwork puts the runner in the host netns so PD disaggregation KV
-    # transfer (NIXL/Mooncake) sees the host's populated RoCE GID tables. An
-    # overlay-CNI pod sees the mlx5 NICs as PORT_ACTIVE but with an empty GID
-    # table, so RDMA init dies at worker startup. ClusterFirstWithHostNet keeps
-    # cluster DNS working while on the host network.
+    # hostNetwork: RDMA KV transfer (NIXL/Mooncake) needs the host's RoCE GID
+    # tables; an overlay netns has empty GIDs and RDMA init fails.
     hostNetwork: true
     dnsPolicy: ClusterFirstWithHostNet
 
@@ -44,13 +39,8 @@ template:
         value: "true"
         effect: "NoSchedule"
 
-    # Pod affinity/anti-affinity intentionally omitted: GPU placement is now
-    # driven by the Volcano binpack plugin. NOTE: 2-gpu PD runners use
-    # hostNetwork and may bind fixed host ports; previously a podAntiAffinity
-    # spread them one-per-node to avoid host-port collisions between concurrent
-    # PD jobs. Under binpack they can be packed onto the same node — watch for
-    # host-port collisions, or re-add a podAntiAffinity for this scale set if
-    # they recur.
+    # No affinity: placement left to binpack. e2e servers bind OS-assigned
+    # ports on 127.0.0.1, so co-located hostNetwork runners don't collide.
 
     volumes:
       - name: work

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -6,7 +6,7 @@ githubConfigUrl: "https://github.com/lightseekorg/smg"
 githubConfigSecret: github-arc-secret
 
 ## Runner scaling configuration
-minRunners: 2
+minRunners: 4
 maxRunners: 8
 
 ## name of the runner scale set to create.  Defaults to the helm release name
@@ -19,6 +19,12 @@ keyVault: {}
 template:
   spec:
     terminationGracePeriodSeconds: 600
+
+    # Schedule runner pods with Volcano so the binpack plugin consolidates GPU
+    # runners onto fewer H100 nodes. The bin-packing weights live in the cluster
+    # scheduler config: volcano-system/volcano-scheduler-configmap
+    # (see volcano-scheduler-configmap.yaml in this directory).
+    schedulerName: volcano
 
     # hostNetwork puts the runner in the host netns so PD disaggregation KV
     # transfer (NIXL/Mooncake) sees the host's populated RoCE GID tables. An
@@ -38,28 +44,21 @@ template:
         value: "true"
         effect: "NoSchedule"
 
-    # With hostNetwork the pod shares the host port space, so spread 2-gpu PD
-    # runners one-per-node to avoid host-port collisions between concurrent PD
-    # jobs (replaces the previous GPU bin-packing podAffinity).
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: actions.github.com/scale-set-name
-                    operator: In
-                    values:
-                      - 2-gpu-h100
-              topologyKey: kubernetes.io/hostname
+    # Pod affinity/anti-affinity intentionally omitted: GPU placement is now
+    # driven by the Volcano binpack plugin. NOTE: 2-gpu PD runners use
+    # hostNetwork and may bind fixed host ports; previously a podAntiAffinity
+    # spread them one-per-node to avoid host-port collisions between concurrent
+    # PD jobs. Under binpack they can be packed onto the same node — watch for
+    # host-port collisions, or re-add a podAntiAffinity for this scale set if
+    # they recur.
 
     volumes:
       - name: work
         emptyDir: {}
       - name: model-cache
-        persistentVolumeClaim:
-          claimName: model-cache
+        hostPath:
+          path: /raid/models
+          type: Directory
       - name: dshm
         emptyDir:
           medium: Memory
@@ -70,6 +69,10 @@ template:
         emptyDir: {}
       - name: docker-storage
         emptyDir: {}
+      - name: infiniband
+        hostPath:
+          path: /dev/infiniband
+          type: Directory
 
     containers:
       - name: runner
@@ -77,12 +80,12 @@ template:
         command:
           - /home/runner/run.sh
         securityContext:
-          # The runner runs as non-root (uid 1001), so capabilities.add:
-          # [IPC_LOCK] only reaches the bounding set (not effective) and the
-          # default 64KiB RLIMIT_MEMLOCK blocks RDMA completion-queue
-          # allocation (ibv_create_cq -> ENOMEM, e.g. sglang/Mooncake).
-          # privileged makes IPC_LOCK effective and lifts the memlock cap.
-          privileged: true
+          # Non-root runner (uid 1001) + IPC_LOCK lets RDMA pin completion-queue
+          # memory (ibv_create_cq) without granting full privileged.
+          privileged: false
+          capabilities:
+            add:
+              - IPC_LOCK
         env:
           - name: DOCKER_HOST
             value: unix:///var/run/docker.sock
@@ -118,8 +121,10 @@ template:
           requests:
             cpu: '32'
             memory: 128Gi
+            rdma/hca_shared_devices_a: '1'
           limits:
             nvidia.com/gpu: 2
+            rdma/hca_shared_devices_a: '1'
         volumeMounts:
           - name: model-cache
             mountPath: /models
@@ -131,6 +136,8 @@ template:
             mountPath: /var/run
           - name: docker-storage
             mountPath: /var/lib/docker
+          - name: infiniband
+            mountPath: /dev/infiniband
 
     initContainers:
       - name: init-dind-externals

--- a/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
@@ -6,7 +6,7 @@ githubConfigUrl: "https://github.com/lightseekorg/smg"
 githubConfigSecret: github-arc-secret
 
 ## Runner scaling configuration
-minRunners: 4
+minRunners: 2
 maxRunners: 8
 
 ## name of the runner scale set to create.  Defaults to the helm release name
@@ -20,6 +20,20 @@ template:
   spec:
     terminationGracePeriodSeconds: 600
 
+    # Schedule runner pods with Volcano so the binpack plugin consolidates GPU
+    # runners onto fewer H100 nodes. The bin-packing weights live in the cluster
+    # scheduler config: volcano-system/volcano-scheduler-configmap
+    # (see volcano-scheduler-configmap.yaml in this directory).
+    schedulerName: volcano
+
+    # hostNetwork puts the runner in the host netns so PD disaggregation KV
+    # transfer (NIXL/Mooncake) sees the host's populated RoCE GID tables. An
+    # overlay-CNI pod sees the mlx5 NICs as PORT_ACTIVE but with an empty GID
+    # table, so RDMA init dies at worker startup. ClusterFirstWithHostNet keeps
+    # cluster DNS working while on the host network.
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+
     nodeSelector:
       nvidia.com/gpu: "true"
       node.kubernetes.io/instance-type: BM.GPU.H100.8
@@ -30,25 +44,18 @@ template:
         value: "true"
         effect: "NoSchedule"
 
-    affinity:
-      podAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: actions.github.com/scale-set-name
-                    operator: In
-                    values:
-                      - 4-gpu-h100
-              topologyKey: kubernetes.io/hostname
+    # Pod affinity/anti-affinity intentionally omitted: GPU placement is now
+    # driven by the Volcano binpack plugin. NOTE: with hostNetwork, runners
+    # co-located by binpack share the host port space — jobs binding fixed host
+    # ports can collide when packed onto the same node.
 
     volumes:
       - name: work
         emptyDir: {}
       - name: model-cache
-        persistentVolumeClaim:
-          claimName: model-cache
+        hostPath:
+          path: /raid/models
+          type: Directory
       - name: dshm
         emptyDir:
           medium: Memory
@@ -59,23 +66,62 @@ template:
         emptyDir: {}
       - name: docker-storage
         emptyDir: {}
+      - name: infiniband
+        hostPath:
+          path: /dev/infiniband
+          type: Directory
 
     containers:
       - name: runner
-        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.2
+        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.3
         command:
           - /home/runner/run.sh
+        securityContext:
+          # Non-root runner (uid 1001) + IPC_LOCK lets RDMA pin completion-queue
+          # memory (ibv_create_cq) without granting full privileged.
+          privileged: false
+          capabilities:
+            add:
+              - IPC_LOCK
         env:
           - name: DOCKER_HOST
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
+          - name: HF_HOME
+            value: /models
+          - name: HF_TOKEN  # required: ci_download_model.sh runs `hf download` for the gated Llama model
+            valueFrom:
+              secretKeyRef:
+                key: HUGGINGFACE_API_KEY
+                name: huggingface-secret
+          - name: OPENAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: OPENAI_API_KEY
+                name: openai-api-key
+          - name: ANTHROPIC_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: ANTHROPIC_API_KEY
+                name: anthropic-api-key
+          - name: XAI_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: XAI_API_KEY
+                name: xai-api-key
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
         resources:
           requests:
-            cpu: "32"
-            memory: "128Gi"
+            cpu: '32'
+            memory: 128Gi
+            rdma/hca_shared_devices_a: '1'
           limits:
             nvidia.com/gpu: 4
+            rdma/hca_shared_devices_a: '1'
         volumeMounts:
           - name: model-cache
             mountPath: /models
@@ -87,6 +133,8 @@ template:
             mountPath: /var/run
           - name: docker-storage
             mountPath: /var/lib/docker
+          - name: infiniband
+            mountPath: /dev/infiniband
 
     initContainers:
       - name: init-dind-externals
@@ -96,7 +144,7 @@ template:
           - /home/runner/tmpDir/
         command:
           - cp
-        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.2
+        image: fra.ocir.io/idqj093njucb/action-runner:v0.0.3
         volumeMounts:
           - mountPath: /home/runner/tmpDir
             name: dind-externals
@@ -108,10 +156,22 @@ template:
         env:
           - name: DOCKER_GROUP_GID
             value: '123'
+          # Suppress dind's default TLS TCP listener (:2376). dockerd only needs
+          # the unix socket here; under hostNetwork a TCP listener would bind a
+          # node port unnecessarily.
+          - name: DOCKER_TLS_CERTDIR
+            value: ""
         image: fra.ocir.io/idqj093njucb/docker:dind
         restartPolicy: Always
         securityContext:
           privileged: true
+        resources:
+          limits:
+            cpu: '2'
+            memory: 4Gi
+          requests:
+            cpu: '1'
+            memory: 2Gi
         startupProbe:
           exec:
             command:

--- a/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
@@ -144,12 +144,18 @@ template:
         securityContext:
           privileged: true
         resources:
+          # genai-bench (and any `docker run` workload) executes inside this dind
+          # cgroup, whose memory limit also caps the page cache for reading the
+          # multi-GB CUDA/torch image. At 4Gi a cold image read thrashes (constant
+          # reclaim + re-read), ballooning container startup to minutes and
+          # tripping the benchmark suite's 480s watchdog. Size for driver RSS +
+          # image page cache; the H100 nodes have ample RAM.
           limits:
-            cpu: '2'
-            memory: 4Gi
+            cpu: '8'
+            memory: 32Gi
           requests:
-            cpu: '1'
-            memory: 2Gi
+            cpu: '4'
+            memory: 8Gi
         startupProbe:
           exec:
             command:

--- a/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
@@ -20,17 +20,12 @@ template:
   spec:
     terminationGracePeriodSeconds: 600
 
-    # Schedule runner pods with Volcano so the binpack plugin consolidates GPU
-    # runners onto fewer H100 nodes. The bin-packing weights live in the cluster
-    # scheduler config: volcano-system/volcano-scheduler-configmap
-    # (see volcano-scheduler-configmap.yaml in this directory).
+    # Volcano binpack packs GPU runners onto fewer nodes
+    # (weights: volcano-scheduler-configmap.yaml).
     schedulerName: volcano
 
-    # hostNetwork puts the runner in the host netns so PD disaggregation KV
-    # transfer (NIXL/Mooncake) sees the host's populated RoCE GID tables. An
-    # overlay-CNI pod sees the mlx5 NICs as PORT_ACTIVE but with an empty GID
-    # table, so RDMA init dies at worker startup. ClusterFirstWithHostNet keeps
-    # cluster DNS working while on the host network.
+    # hostNetwork: RDMA KV transfer (NIXL/Mooncake) needs the host's RoCE GID
+    # tables; an overlay netns has empty GIDs and RDMA init fails.
     hostNetwork: true
     dnsPolicy: ClusterFirstWithHostNet
 
@@ -44,10 +39,8 @@ template:
         value: "true"
         effect: "NoSchedule"
 
-    # Pod affinity/anti-affinity intentionally omitted: GPU placement is now
-    # driven by the Volcano binpack plugin. NOTE: with hostNetwork, runners
-    # co-located by binpack share the host port space — jobs binding fixed host
-    # ports can collide when packed onto the same node.
+    # No affinity: placement left to binpack. e2e servers bind OS-assigned
+    # ports on 127.0.0.1, so co-located hostNetwork runners don't collide.
 
     volumes:
       - name: work

--- a/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
@@ -95,21 +95,6 @@ template:
               secretKeyRef:
                 key: HUGGINGFACE_API_KEY
                 name: huggingface-secret
-          - name: OPENAI_API_KEY
-            valueFrom:
-              secretKeyRef:
-                key: OPENAI_API_KEY
-                name: openai-api-key
-          - name: ANTHROPIC_API_KEY
-            valueFrom:
-              secretKeyRef:
-                key: ANTHROPIC_API_KEY
-                name: anthropic-api-key
-          - name: XAI_API_KEY
-            valueFrom:
-              secretKeyRef:
-                key: XAI_API_KEY
-                name: xai-api-key
           - name: NODE_IP
             valueFrom:
               fieldRef:

--- a/scripts/k8s-runner-resources/volcano-scheduler-configmap.yaml
+++ b/scripts/k8s-runner-resources/volcano-scheduler-configmap.yaml
@@ -1,0 +1,43 @@
+# Volcano scheduler config for the moirai-dev cluster.
+#
+# This is the cluster-side half of GPU bin-packing for the CI runners. The
+# runner pods opt in via `schedulerName: volcano` in their values files; this
+# configmap tells Volcano's binpack plugin to pack by GPU.
+#
+# binpack.weight    raised to 10 so packing dominates nodeorder's spreading.
+# binpack.resources adds nvidia.com/gpu (default only weights cpu+memory) so
+#                   runners consolidate onto already-utilized H100 nodes.
+#
+# Apply: kubectl apply -f volcano-scheduler-configmap.yaml
+#        kubectl -n volcano-system rollout restart deploy/volcano-scheduler
+#
+# NOTE: cluster-wide — affects every workload scheduled by Volcano, not just
+# the CI runners.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "enqueue, allocate, backfill"
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+        enablePreemptable: false
+      - name: conformance
+    - plugins:
+      - name: overcommit
+      - name: drf
+        enablePreemptable: false
+      - name: predicates
+      - name: proportion
+      - name: nodeorder
+      - name: binpack
+        arguments:
+          binpack.weight: 10
+          binpack.cpu: 1
+          binpack.memory: 1
+          binpack.resources: nvidia.com/gpu
+          binpack.resources.nvidia.com/gpu: 10


### PR DESCRIPTION
## Description

### Problem

The GPU CI runners (`1/2/4-gpu-h100`) run under the default kube-scheduler, which spreads pods across H100 nodes. Fragmenting GPUs one-or-two-per-node blocks full-node (8-GPU) training jobs from ever scheduling.

Separately, the `runner-values-*.yaml` files here had drifted far from what is actually deployed on the moirai-dev cluster (stale image, model cache, resources, env, security context, networking), so the repo could no longer reproduce the live runner sets.

### Solution

- Schedule the GPU runners with the **Volcano** scheduler and enable its **binpack** plugin weighted by `nvidia.com/gpu`, so runners consolidate onto fewer H100 nodes and leave whole nodes free.
- Re-sync the three GPU values files with the live `AutoscalingRunnerSet`s so the repo is the source of truth again — a `helm upgrade` reproduces the running config instead of reverting it.

## Changes

**Bin-packing**
- `schedulerName: volcano` on `1/2/4-gpu-h100`.
- New `volcano-scheduler-configmap.yaml` — `binpack.weight: 10`, `binpack.resources: nvidia.com/gpu` (cluster-wide Volcano scheduler config).
- Removed the per-scale-set pod (anti-)affinity so binpack drives placement.

**Sync values with live runnersets** (files were stale)
- Runner image `v0.0.2` → `v0.0.3`.
- Model cache: `model-cache` PVC at `/models` → **hostPath `/raid/models`**.
- Resources: `cpu 8 / 32Gi` → `cpu 32 / 128Gi`; add `rdma/hca_shared_devices_a`.
- Add `/dev/infiniband` hostPath volume + mount.
- Runner securityContext: `privileged: true` → `privileged: false` + `IPC_LOCK`.
- Add `hostNetwork: true` + `dnsPolicy: ClusterFirstWithHostNet` (RDMA GID tables).
- `min/max` runners aligned with live: 1-gpu 4/20, 2-gpu 4/8, 4-gpu 2/8.

**Env cleanup**
- Dropped unused `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `XAI_API_KEY` from the GPU runners (kept `HF_TOKEN` for model download).

**Docs**
- Tightened the explanatory comments in the values files.

## Test Plan

- Values were generated from the live `AutoscalingRunnerSet`s; each file's rendered `template.spec` was verified identical to live (minus chart-injected `serviceAccountName` / `restartPolicy`).
- Already applied on moirai-dev: new runner pods schedule via `volcano` (`schedulerName=volcano`, Volcano PodGroups created) and co-locate onto already-utilized nodes instead of spreading.
- `pre-commit run` (yaml / whitespace / eof / codespell) passes.

**Deployment note:** `volcano-scheduler-configmap.yaml` is cluster-wide — apply it and `kubectl -n volcano-system rollout restart deploy/volcano-scheduler` for the binpack weights to take effect. A follow-up PR (`ci/bfcl-dynamic-ports`) makes the nightly BFCL job use OS-assigned ports — the only remaining fixed-host-port CI job — so co-locating under bin-packing is collision-free.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes — N/A (YAML/infra only)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes — N/A
- [x] pre-commit passes on changed files

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Kubernetes GPU runner scheduling using Volcano for improved GPU bin-packing and capacity planning, including safer host-network DNS behavior.
  * Adjusted autoscaling ranges and pod placement rules, with updated CPU/memory sizing and tightened runtime permissions.
  * Improved performance and data locality by switching model caching to node-local storage and adding direct InfiniBand device access.
  * Updated runner and initialization images and refreshed Hugging Face caching environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
