### PR TITLE
fix(ci): allocate BFCL arm ports dynamically to avoid host-port collisions

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -137,8 +137,10 @@ jobs:
         run: |
           set -euo pipefail
           # TP=2 per arm: Arm A (pure vLLM) on GPUs 0,1; Arm B (SMG -> vLLM gRPC) on GPUs 2,3.
-          A_URL=$(BFCL_GPU=0,1 BFCL_ARM_A_PORT=31199 bash scripts/bfcl/launch_arm.sh a)
-          B_URL=$(BFCL_GPU=2,3 BFCL_ARM_B_GRPC_PORT=50081 BFCL_ARM_B_GW_PORT=31200 bash scripts/bfcl/launch_arm.sh b)
+          # Ports are left unset so launch_arm.sh picks free ones — lets two bfcl
+          # runners share a node (bin-packed, hostNetwork) without port collisions.
+          A_URL=$(BFCL_GPU=0,1 bash scripts/bfcl/launch_arm.sh a)
+          B_URL=$(BFCL_GPU=2,3 bash scripts/bfcl/launch_arm.sh b)
           echo "arm A: $A_URL   arm B: $B_URL"
           python scripts/bfcl/run_ab.py \
             --baseline  "vllm=$A_URL" \

--- a/scripts/bfcl/launch_arm.sh
+++ b/scripts/bfcl/launch_arm.sh
@@ -41,10 +41,13 @@ SMG_REASONING_PARSER="${BFCL_SMG_REASONING_PARSER:-}"
 # more stable under sustained bfcl load on shared/contended GPUs.
 VLLM_EXTRA="${BFCL_VLLM_EXTRA:-}"
 
-# Ports (override to avoid collisions on a shared box).
-ARM_A_PORT="${BFCL_ARM_A_PORT:-31199}"          # pure-vLLM OpenAI port
-ARM_B_GRPC_PORT="${BFCL_ARM_B_GRPC_PORT:-50081}" # vLLM gRPC worker port
-ARM_B_GW_PORT="${BFCL_ARM_B_GW_PORT:-31200}"     # SMG OpenAI gateway port
+# Ports. Default to an OS-assigned free port (resolved per-arm in the case
+# below) so concurrent arms/jobs sharing a host — e.g. bin-packed CI runners
+# under hostNetwork — don't collide on a fixed port. Pin via env for a stable
+# port on a dev box.
+ARM_A_PORT="${BFCL_ARM_A_PORT:-}"          # pure-vLLM OpenAI port
+ARM_B_GRPC_PORT="${BFCL_ARM_B_GRPC_PORT:-}" # vLLM gRPC worker port
+ARM_B_GW_PORT="${BFCL_ARM_B_GW_PORT:-}"     # SMG OpenAI gateway port
 
 # Executables (override for venv / box paths).
 VLLM_BIN="${VLLM_BIN:-vllm}"                      # `vllm serve` console script
@@ -78,8 +81,13 @@ wait_grpc() {  # crude TCP-listen check for the gRPC port
   exec 3>&- 2>/dev/null || true
 }
 
+free_port() {  # OS-assigned free TCP port (same idiom as the e2e infra's get_open_port)
+  python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()'
+}
+
 case "$ARM" in
   a)
+    ARM_A_PORT="${ARM_A_PORT:-$(free_port)}"
     declare -a cmd=(
       CUDA_VISIBLE_DEVICES="$GPU" "$VLLM_BIN" serve "$MODEL"
       --served-model-name "$MODEL"
@@ -97,6 +105,8 @@ case "$ARM" in
     ;;
 
   b)
+    ARM_B_GRPC_PORT="${ARM_B_GRPC_PORT:-$(free_port)}"
+    ARM_B_GW_PORT="${ARM_B_GW_PORT:-$(free_port)}"
     # 1) vLLM gRPC worker (raw-token; SMG will own template+parsing).
     declare -a wcmd=(
       CUDA_VISIBLE_DEVICES="$GPU" "$VLLM_PYTHON" -m vllm.entrypoints.grpc_server


### PR DESCRIPTION
## Description

### Problem

`scripts/bfcl/launch_arm.sh` defaulted to fixed ports — `31199` (arm A OpenAI), `50081` (arm B gRPC), `31200` (arm B SMG gateway) — bound to `0.0.0.0`, and the nightly BFCL workflow pinned those same values. The runner pods use `hostNetwork`, so two BFCL runners bin-packed onto the same H100 node would collide on these host ports. This is the only CI job that still binds fixed host ports (the e2e suite already uses OS-assigned ports), so it's the last blocker to safely co-locating GPU runners under bin-packing.

### Solution

Default each arm's port to an OS-assigned free port (the same `bind(("", 0))` idiom as the e2e infra's `get_open_port`), resolved per-arm so `stop` and the unused arm don't allocate. Ports can still be pinned via env for a stable port on a dev box. The nightly workflow no longer pins ports and just captures the URLs the script prints.

## Changes

- `scripts/bfcl/launch_arm.sh`: add a `free_port()` helper; `ARM_A_PORT` / `ARM_B_GRPC_PORT` / `ARM_B_GW_PORT` default to a free port when unset, resolved inside the `a` / `b` case branches.
- `.github/workflows/nightly-bfcl.yml`: drop the hardcoded `BFCL_ARM_A_PORT=31199` / `BFCL_ARM_B_GRPC_PORT=50081` / `BFCL_ARM_B_GW_PORT=31200`.

## Test Plan

- Arms A and B still bind distinct ports; `run_ab.py` consumes the `A_URL`/`B_URL` the script prints, so it is unaffected by the port change.
- Two concurrent BFCL runs on one node no longer collide on `0.0.0.0:<fixed>`.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes — N/A (shell + workflow only)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes — N/A

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential network port collision issues when running multiple concurrent CI/CD jobs on the same host by switching to automatic per-run port allocation for BFCL A/B launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
