### PR TITLE
fix(ci): pin grpcio generated-code companions to the protobuf-6 stable line

### DIFF
--- a/scripts/ci_install_e2e_deps.sh
+++ b/scripts/ci_install_e2e_deps.sh
@@ -22,4 +22,17 @@ if [ $# -gt 0 ]; then
     python3 -m pip --no-cache-dir install --upgrade "$@"
 fi
 
+# Pin grpcio-health-checking to the protobuf-6 stable line.
+#
+# Engine setup (sglang's `uv pip install --prerelease=allow` in
+# ci_install_sglang.sh) can pull a prerelease wheel such as
+# grpcio-health-checking==1.82.0rc1, whose bundled protobuf gencode (7.x) is
+# newer than the protobuf 6.x runtime the engine stack pins. e2e gRPC workers
+# then die at `import grpc_health.v1.health_pb2` with "Detected incompatible
+# Protobuf Gencode/Runtime versions ... gencode 7.x runtime 6.x". The 1.81.x
+# line caps protobuf<7 and is built against the 6.x gencode, so it stays
+# compatible. This runs last to override whatever engine/extra-dep installs
+# selected. Drop the cap once the stack moves to a protobuf 7 runtime.
+python3 -m pip install "grpcio-health-checking==1.81.*"
+
 echo "E2E test dependencies installed"

--- a/scripts/ci_install_e2e_deps.sh
+++ b/scripts/ci_install_e2e_deps.sh
@@ -22,17 +22,20 @@ if [ $# -gt 0 ]; then
     python3 -m pip --no-cache-dir install --upgrade "$@"
 fi
 
-# Pin grpcio-health-checking to the protobuf-6 stable line.
+# Pin the grpcio generated-code companions to the protobuf-6 stable line.
 #
 # Engine setup (sglang's `uv pip install --prerelease=allow` in
-# ci_install_sglang.sh) can pull a prerelease wheel such as
-# grpcio-health-checking==1.82.0rc1, whose bundled protobuf gencode (7.x) is
-# newer than the protobuf 6.x runtime the engine stack pins. e2e gRPC workers
-# then die at `import grpc_health.v1.health_pb2` with "Detected incompatible
-# Protobuf Gencode/Runtime versions ... gencode 7.x runtime 6.x". The 1.81.x
-# line caps protobuf<7 and is built against the 6.x gencode, so it stays
-# compatible. This runs last to override whatever engine/extra-dep installs
-# selected. Drop the cap once the stack moves to a protobuf 7 runtime.
-python3 -m pip install "grpcio-health-checking==1.81.*"
+# ci_install_sglang.sh) can pull prerelease grpcio wheels such as
+# grpcio-health-checking / grpcio-reflection ==1.82.0rc1, whose bundled protobuf
+# gencode (7.x) is newer than the protobuf 6.x runtime the engine stack pins.
+# Anything that then loads those modules dies with "Detected incompatible
+# Protobuf Gencode/Runtime versions ... gencode 7.x runtime 6.x" — e2e workers at
+# `import grpc_health.v1.health_pb2`, and the sglang gRPC server at
+# `grpc_reflection/v1alpha/reflection.proto`. The 1.81.x line caps protobuf<7 and
+# ships the 6.x gencode, so it stays compatible. This runs last to override
+# whatever engine/extra-dep installs selected. (grpcio core has no generated
+# protobuf, so it is left at the engine-selected version.) Drop the cap once the
+# stack moves to a protobuf 7 runtime.
+python3 -m pip install "grpcio-health-checking==1.81.*" "grpcio-reflection==1.81.*"
 
 echo "E2E test dependencies installed"


### PR DESCRIPTION
## Description

### Problem

The `benchmarks` job and the sglang gRPC e2e jobs (e.g. `e2e-1gpu-chat (sglang)`) fail because the gRPC worker / health-check path hits a protobuf gencode/runtime mismatch:

```
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf
Gencode/Runtime versions ... gencode 7.35.0 runtime 6.33.6.
```

Root cause: `scripts/ci_install_sglang.sh` installs with `uv pip install --prerelease=allow` (needed for sglang). That flag also lets uv resolve the **prerelease grpcio family `1.82.0rc1`**, whose generated-code companions (`grpcio-health-checking`, `grpcio-reflection`) bundle protobuf **gencode 7.x**, while the engine stack pins the protobuf **6.x** runtime (`6.33.6`). Any import of those modules then raises `VersionError`:

- the e2e harness at `e2e_test/infra/worker.py` → `import grpc_health.v1.health_pb2`
- the sglang gRPC server (`sglang/srt/entrypoints/grpc_server.py`) → `grpc_reflection/v1alpha/reflection.proto` (this crashes the worker → `RuntimeError: Worker ... died during startup`)

It is environmental (a freshly published PyPI prerelease), not caused by any PR — it reproduces on unrelated PRs and across runs.

### Solution

Pin the grpcio **generated-code companions** to the `1.81.x` stable line in `scripts/ci_install_e2e_deps.sh`:

```sh
python3 -m pip install "grpcio-health-checking==1.81.*" "grpcio-reflection==1.81.*"
```

Stable `1.81.1` requires `protobuf<7.0.0,>=6.33.5` and ships the 6.x gencode, so it is compatible with the `6.33.6` runtime. This script runs in **every** benchmark / e2e GPU job *after* engine setup, so it overrides whatever prerelease the engine install selected. `grpcio` core ships no generated protobuf and is left at the engine-selected version. All SMG packages only require `grpcio-*>=1.78.0`, so the pin conflicts with nothing.

## Changes

- `scripts/ci_install_e2e_deps.sh`: as the final dependency step, pin `grpcio-health-checking` and `grpcio-reflection` to `1.81.*`, with a comment explaining the prerelease/gencode mismatch. Drop the cap once the stack moves to a protobuf 7 runtime.

## Test Plan

Before (run https://github.com/lightseekorg/smg/actions/runs/27667539805): `test_regular_perf[grpc]` errors at the health-check import with the protobuf `VersionError`.

After the first commit (run https://github.com/lightseekorg/smg/actions/runs/27671100829): the health-check import is fixed, but the sglang gRPC worker still died at startup loading `reflection.proto` (same VersionError on `grpcio-reflection`) — so this PR adds the `grpcio-reflection` pin.

Validated by the `benchmarks` and `e2e-1gpu-*(sglang)` jobs on this PR (both touch `scripts/ci_install_e2e_deps.sh`, so they re-run here).

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI end-to-end test dependency installer to pin compatible gRPC health checking and reflection packages, improving stability when protobuf-related runtime and generated code versions differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->