### PR TITLE
fix(ci): key main concurrency on commit SHA so every commit runs

### DIFF
--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -35,8 +35,10 @@ on:
 permissions:
   contents: read
 
+# Per-PR groups cancel superseded runs; pushes to main key on the commit SHA so
+# every commit on main gets its own run and is never cancelled by a later push.
 concurrency:
-  group: mlx-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
+  group: mlx-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -19,8 +19,10 @@ on:
 permissions:
   contents: read
 
+# Per-PR groups cancel superseded runs; pushes to main key on the commit SHA so
+# every commit on main gets its own run and is never cancelled by a later push.
 concurrency:
-  group: gateway-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
+  group: gateway-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:


### PR DESCRIPTION
## Description

### Problem

CI runs for commits on `main` were being cancelled. On push to `main`, the concurrency group resolved to a single shared group keyed on `github.ref_name` (always `main`):

```yaml
group: gateway-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
```

GitHub Actions allows only one in-progress + one pending run per concurrency group. When commits land on `main` faster than CI completes, each new push supersedes and cancels the previously-pending run before it can finish. This was observed in a recent burst of four commits within ~2 minutes — three runs were cancelled in 25–49s and only the latest survived.

### Solution

Key the push-to-`main` case on `github.sha` instead of `github.ref_name`, so each commit on `main` gets its own concurrency group and always runs to completion. PR behavior is unchanged: per-PR group with `cancel-in-progress` so superseded PR runs are still dropped to save CI resources.

## Changes

- `pr-test-rust.yml` (**PR Test (SMG)**) — push-to-main concurrency group now keys on `github.sha`.
- `pr-test-mlx.yml` (**PR Test (MLX)**) — same fix for the identical pattern (consistency).

`cancel-pr-workflows.yml` keys cleanup on the per-PR groups, which are unchanged, so PR-close cleanup is unaffected.

## Test Plan

- Trigger: push multiple commits to `main` in quick succession.
- Before: only the latest commit's run survives; earlier runs cancelled within seconds.
- After: each commit on `main` runs to completion in its own concurrency group.
- PR runs still cancel superseded runs on new pushes (per-PR group + `cancel-in-progress`).

> Trade-off: every main commit now runs full CI in parallel, increasing concurrent runner usage during rapid merge bursts. This is the intended behavior.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline concurrency handling for test workflows to optimize test execution and resource utilization across push events and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->