### PR TITLE
perf(http-pd): use shared SseEncoder for logprob-merge SSE re-encode

### DIFF
--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -36,6 +36,7 @@ use crate::{
         common::{
             header_utils,
             retry::{is_retryable_status, RetryExecutor},
+            sse::SseEncoder,
         },
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
@@ -910,14 +911,20 @@ impl PDRouter {
         )]
         tokio::spawn(async move {
             futures_util::pin_mut!(stream);
+            // Reusable SSE encoder for the logprob-merge re-encode path.
+            let mut encoder = SseEncoder::new();
             while let Some(chunk_result) = stream.next().await {
                 match chunk_result {
                     Ok(chunk) => {
                         let is_done = memmem::find(&chunk, b"data: [DONE]").is_some();
 
                         let result = if return_logprob && prefill_logprobs.is_some() {
-                            Self::merge_streaming_logprobs(prefill_logprobs.clone(), &chunk)
-                                .unwrap_or(chunk)
+                            Self::merge_streaming_logprobs(
+                                prefill_logprobs.as_ref(),
+                                &chunk,
+                                &mut encoder,
+                            )
+                            .unwrap_or(chunk)
                         } else {
                             chunk
                         };
@@ -1136,8 +1143,9 @@ impl PDRouter {
     // Simple helper to merge logprobs in streaming responses
     // Optimized to reduce allocations in the merge path
     fn merge_streaming_logprobs(
-        prefill_logprobs: Option<Value>,
+        prefill_logprobs: Option<&Value>,
         decode_chunk: &[u8],
+        encoder: &mut SseEncoder,
     ) -> Result<bytes::Bytes, ()> {
         // Skip non-data chunks
         let chunk_str = std::str::from_utf8(decode_chunk).map_err(|_| ())?;
@@ -1150,7 +1158,7 @@ impl PDRouter {
         let mut decode_json: Value = serde_json::from_str(json_str).map_err(|_| ())?;
 
         // Merge prefill logprobs if available
-        if let Some(ref p_logprobs) = prefill_logprobs {
+        if let Some(p_logprobs) = prefill_logprobs {
             if let Some(meta) = decode_json.get_mut("meta_info") {
                 if let Some(d_logprobs) = meta.get_mut("input_token_logprobs") {
                     if let Some(p_arr) = p_logprobs.as_array() {
@@ -1168,12 +1176,8 @@ impl PDRouter {
             }
         }
 
-        // Re-serialize
-        let merged_str = format!(
-            "data: {}\n\n",
-            serde_json::to_string(&decode_json).unwrap_or_default()
-        );
-        Ok(bytes::Bytes::from(merged_str))
+        // Re-serialize via the shared encoder (reuses its buffer across chunks).
+        encoder.encode_data(&decode_json).map_err(|_| ())
     }
 }
 


### PR DESCRIPTION
## Description

### Problem

In the HTTP PD router, `merge_streaming_logprobs` re-encodes each decode chunk with `serde_json::to_string` + `format!("data: …\n\n")` — two heap allocations per chunk on the streaming relay hot path.

### Solution

Replace that pair with the shared `common::sse::SseEncoder`. A single encoder is created once per stream in the `create_streaming_response` relay task and threaded into `merge_streaming_logprobs`, so the serialization buffer is reused across every re-encoded chunk (1 allocation per chunk instead of 2).

## Changes

- `merge_streaming_logprobs` takes a `&mut SseEncoder` and encodes via it.
- The encoder is instantiated once in the relay task and reused per chunk.
- The idiosyncratic streaming-error frame in `handle_decode_error_response` (`data: {'error': …}` with no trailing blank line) is intentionally left untouched to avoid changing its wire format — only the hot per-chunk path is migrated.

## Test Plan

- `cargo +nightly fmt` ✅ and `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -p smg --lib http::pd_router` ✅ (6 passed)

Part of the shared SSE codec rollout (codec landed in #987). Sibling of the anthropic PRs (#1633/#1634) and openai PRs (#1759/#1760).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal streaming response encoding for improved efficiency and code reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->