### PR TITLE
feat(grpc): add TokenSpeed KV cache event support (SubscribeKvEvents bridge)

### DIFF
--- a/docs/getting-started/kv-events-cache-aware.md
+++ b/docs/getting-started/kv-events-cache-aware.md
@@ -117,6 +117,31 @@ SMG learns the block size from the `BlockStored` events themselves, so you needn
 
 Everything downstream — SMG flags, block-size learning, and the verification logs — is unchanged; `KvEventMonitor` consumes the events the same way for any gRPC worker.
 
+### Alternative: launch a TokenSpeed worker
+
+TokenSpeed's scheduler publishes KV cache events on a ZMQ socket; enable them with `--kv-events-config`. The TokenSpeed gRPC server *is* the SMG gRPC entrypoint, so there is no separate `--grpc` flag:
+
+```bash
+# TokenSpeed is installed from source (engine + kernel + scheduler); see
+# scripts/ci_install_tokenspeed.sh. Install the bridge's extra deps:
+pip install "smg-grpc-servicer[tokenspeed]"
+
+# --kv-events-config turns on KV-event publishing in the scheduler:
+python -m smg_grpc_servicer.tokenspeed \
+  --model meta-llama/Llama-3.1-8B-Instruct \
+  --host 0.0.0.0 \
+  --port 50051 \
+  --kv-events-config '{"enable_kv_cache_events": true, "publisher": "zmq", "endpoint": "tcp://*:5557", "topic": "kv-events"}'
+```
+
+| Field | Why |
+|---|---|
+| `enable_kv_cache_events: true` | TokenSpeed master switch. Without it the scheduler records no events even if a publisher is set. |
+| `publisher: "zmq"` | Selects the ZMQ publisher the servicer bridges. Unset defaults to `"zmq"` when events are enabled; `"null"` (or any other value) disables bridging. |
+| `endpoint` / `topic` | ZMQ `PUB` address and topic prefix. The publisher binds in the scheduler subprocess; for data-parallel the port is `endpoint_port + dp_rank`, and SMG currently consumes rank 0. |
+
+`--kv-events-config` is parsed by TokenSpeed's `KVEventsConfig.from_cli`. SMG learns the block size from the `BlockStored` events themselves, so you needn't set it; pass TokenSpeed's `--page-size N` only to pin a non-default value. Everything downstream is identical to the SGLang and vLLM paths.
+
 ---
 
 ## Step 2 — Launch SMG
@@ -240,4 +265,7 @@ If events never arrive, the policy keeps working — it falls back to the approx
 - Event subscription manager: `model_gateway/src/worker/kv_event_monitor.rs`
 - KV event proto: `crates/grpc_client/proto/common.proto` (messages `KvEventBatch`, `KvCacheEvent`, `KvBlocksStored`, `KvBlocksRemoved`)
 - Servicer bridge: `grpc_servicer/smg_grpc_servicer/sglang/servicer.py` (`SubscribeKvEvents`)
+- Shared ZMQ→proto conversion: `grpc_servicer/smg_grpc_servicer/kv_events.py` (engine-neutral; used by the vLLM and TokenSpeed bridges)
+- TokenSpeed servicer bridge: `grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py` (`SubscribeKvEvents`) + config resolver `grpc_servicer/smg_grpc_servicer/tokenspeed/kv_events.py`
 - SGLang upstream config: `python/sglang/srt/disaggregation/kv_events.py` (class `KVEventsConfig`)
+- TokenSpeed upstream config: `tokenspeed/runtime/pd/kv_events.py` (class `KVEventsConfig`)

--- a/docs/getting-started/kv-events-cache-aware.md
+++ b/docs/getting-started/kv-events-cache-aware.md
@@ -138,7 +138,7 @@ python -m smg_grpc_servicer.tokenspeed \
 |---|---|
 | `enable_kv_cache_events: true` | TokenSpeed master switch. Without it the scheduler records no events even if a publisher is set. |
 | `publisher: "zmq"` | Selects the ZMQ publisher the servicer bridges. Unset defaults to `"zmq"` when events are enabled; `"null"` (or any other value) disables bridging. |
-| `endpoint` / `topic` | ZMQ `PUB` address and topic prefix. The publisher binds in the scheduler subprocess; for data-parallel the port is `endpoint_port + dp_rank`, and SMG currently consumes rank 0. |
+| `endpoint` / `topic` | ZMQ `PUB` address and topic prefix. Use a **bind-style** endpoint (`tcp://*:PORT`) — TokenSpeed only *binds* when the endpoint contains `*`/`::`/`ipc://`/`inproc://`, so a concrete address like `tcp://127.0.0.1:PORT` makes it *connect* instead, leaving nothing bound and the stream idle. For data-parallel the port is `endpoint_port + dp_rank`, and SMG currently consumes rank 0. |
 
 `--kv-events-config` is parsed by TokenSpeed's `KVEventsConfig.from_cli`. SMG learns the block size from the `BlockStored` events themselves, so you needn't set it; pass TokenSpeed's `--page-size N` only to pin a non-default value. Everything downstream is identical to the SGLang and vLLM paths.
 

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -36,6 +36,9 @@ sglang = ["sglang>=0.5.10"]
 # without this floor, installing [mlx] against an older proto build would
 # crash at import time when smg_grpc_servicer.mlx.server runs.
 mlx = ["smg-grpc-proto>=0.4.7", "mlx>=0.22.0", "mlx-lm>=0.22.0"]
+# TokenSpeed itself is installed from source (no PyPI release); these are the
+# extra runtime deps the KV-event bridge needs on top of a TokenSpeed install.
+tokenspeed = ["pyzmq>=25.0.0", "msgspec>=0.18.0"]
 
 [project.urls]
 Homepage = "https://github.com/lightseekorg/smg"

--- a/grpc_servicer/smg_grpc_servicer/kv_events.py
+++ b/grpc_servicer/smg_grpc_servicer/kv_events.py
@@ -1,0 +1,164 @@
+"""Engine-neutral KV-cache-event → proto conversion and ZMQ streaming.
+
+Shared by every engine bridge (vLLM, TokenSpeed, ...). Imports only stdlib +
+the generated proto, and dispatches engine events by class name (BlockStored /
+BlockRemoved / AllBlocksCleared), so it needs no engine import and is
+unit-testable without any engine installed.
+
+Each engine package keeps its own ``resolve_kv_events_config`` (the only
+engine-specific seam); everything here is wire-format-only.
+"""
+
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+from smg_grpc_proto.generated import common_pb2
+
+logger = logging.getLogger(__name__)
+
+_U64_MASK = 0xFFFFFFFFFFFFFFFF
+_I64_SIGN_BIT = 0x8000000000000000
+_U64_MODULUS = 0x10000000000000000
+
+
+def to_int64(value: int | bytes) -> int:
+    """Reduce an engine block hash to a signed int64 for the proto block_hash field.
+
+    An engine's block hash may be ``int | bytes`` (sha256 bytes when int hashes
+    are disabled); bytes are read big-endian. SMG uses the hash only as a node
+    identity, so the 64-bit reduction is safe as long as it stays deterministic.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        value = int.from_bytes(value, "big")
+    masked = value & _U64_MASK
+    if masked >= _I64_SIGN_BIT:
+        masked -= _U64_MODULUS
+    return masked
+
+
+def endpoint_for_rank(endpoint: str, dp_rank: int) -> str:
+    """Resolve a KV-events PUB endpoint to a connectable SUB address.
+
+    Bind wildcards (``*``, ``0.0.0.0``) are rewritten to ``127.0.0.1`` (the
+    latter is not connectable on macOS/Windows). For data-parallel deployments
+    each rank publishes on ``base_port + dp_rank``; non-tcp endpoints (ipc://,
+    inproc://) get the wildcard substituted but no port arithmetic.
+    """
+    resolved = endpoint.replace("*", "127.0.0.1").replace("0.0.0.0", "127.0.0.1")
+    if resolved.startswith("tcp://") and dp_rank:
+        host, sep, port = resolved.rpartition(":")
+        if sep and port.isdigit():
+            return f"{host}:{int(port) + dp_rank}"
+    return resolved
+
+
+def convert_event(event: object, event_id: int) -> common_pb2.KvCacheEvent | None:
+    """Convert one decoded engine event to a proto KvCacheEvent (or None if unknown)."""
+    name = type(event).__name__
+
+    if name == "BlockStored":
+        block_size = int(event.block_size)
+        blocks = []
+        for i, block_hash in enumerate(event.block_hashes):
+            start = i * block_size
+            end = start + block_size
+            block = common_pb2.KvBlock(
+                block_hash=to_int64(block_hash),
+                token_ids=list(event.token_ids[start:end]),
+                block_size=block_size,
+            )
+            lora_id = getattr(event, "lora_id", None)
+            if lora_id is not None:
+                block.lora_id = to_int64(lora_id)
+            blocks.append(block)
+        stored = common_pb2.KvBlocksStored(blocks=blocks)
+        parent = getattr(event, "parent_block_hash", None)
+        if parent is not None:
+            stored.parent_block_hash = to_int64(parent)
+        return common_pb2.KvCacheEvent(event_id=event_id, stored=stored)
+
+    if name == "BlockRemoved":
+        return common_pb2.KvCacheEvent(
+            event_id=event_id,
+            removed=common_pb2.KvBlocksRemoved(
+                block_hashes=[to_int64(h) for h in event.block_hashes]
+            ),
+        )
+
+    if name == "AllBlocksCleared":
+        return common_pb2.KvCacheEvent(event_id=event_id, cleared=common_pb2.KvCacheCleared())
+
+    logger.debug("Unknown KV event type %r, skipping", name)
+    return None
+
+
+def convert_batch(
+    raw_batch: object, seq_num: int, event_id_start: int
+) -> tuple[common_pb2.KvEventBatch, int]:
+    """Convert a decoded engine KVEventBatch to a proto KvEventBatch.
+
+    Returns the proto batch and the new event-id counter. The counter advances
+    once per input event (even if unconvertible) so ids stay monotonic.
+
+    The DP rank is read from ``data_parallel_rank`` (vLLM) or ``attn_dp_rank``
+    (TokenSpeed); engines that carry neither leave the proto field unset.
+    """
+    proto = common_pb2.KvEventBatch(sequence_number=seq_num, timestamp=raw_batch.ts)
+    dp_rank = getattr(raw_batch, "data_parallel_rank", None)
+    if dp_rank is None:
+        dp_rank = getattr(raw_batch, "attn_dp_rank", None)
+    if dp_rank is not None:
+        proto.dp_rank = dp_rank
+
+    event_id = event_id_start
+    for event in raw_batch.events:
+        event_id += 1
+        proto_event = convert_event(event, event_id)
+        if proto_event is not None:
+            proto.events.append(proto_event)
+    return proto, event_id
+
+
+async def stream_kv_events(
+    sub_socket: object,
+    decode: Callable[[bytes], object],
+    send_initial_metadata: Callable[[], Awaitable[None]],
+    is_cancelled: Callable[[], bool],
+    *,
+    recv_timeout: float = 1.0,
+) -> AsyncIterator[common_pb2.KvEventBatch]:
+    """Core ZMQ→proto streaming loop, decoupled from any engine and gRPC types.
+
+    Args:
+        sub_socket: a connected ``zmq.asyncio`` SUB socket (duck-typed; only
+            ``poll()`` and ``recv_multipart()`` are used). The caller owns the
+            socket lifecycle (this function never closes it).
+        decode: bytes → decoded engine batch (e.g. ``msgspec.msgpack.Decoder(KVEventBatch).decode``).
+        send_initial_metadata: awaitable called once before the first recv so the
+            gRPC client's ``subscribe_kv_events().await`` resolves promptly.
+        is_cancelled: returns True when the RPC is cancelled; loop then exits.
+        recv_timeout: poll timeout so cancellation is observed even when idle.
+
+    Yields proto KvEventBatch using the ZMQ publisher's native sequence numbers.
+    """
+    await send_initial_metadata()
+    event_id = 0
+    while not is_cancelled():
+        # poll() before recv: cancelling a zmq.asyncio recv future does not
+        # cancel the in-flight ZMQ recv and can drop an already-dequeued message.
+        if not await sub_socket.poll(timeout=int(recv_timeout * 1000)):
+            continue
+        frames = await sub_socket.recv_multipart()
+
+        # ZMQ multipart: [topic, 8-byte big-endian seq, msgpack payload].
+        if len(frames) < 3:
+            continue
+        zmq_seq = int.from_bytes(frames[1], "big")
+        try:
+            raw_batch = decode(frames[2])
+        except Exception as e:  # noqa: BLE001 - one bad frame must not kill the stream
+            logger.warning("Failed to decode KV event batch: %s", e)
+            continue
+
+        proto_batch, event_id = convert_batch(raw_batch, zmq_seq, event_id)
+        yield proto_batch

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/kv_events.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/kv_events.py
@@ -1,0 +1,73 @@
+"""TokenSpeed-specific KV-events config resolution.
+
+The wire-format conversion + ZMQ streaming helpers live in the engine-neutral
+``smg_grpc_servicer.kv_events`` module; this module only resolves whether (and
+where) TokenSpeed is publishing ZMQ KV events.
+
+TokenSpeed's ``--kv-events-config`` is a raw JSON string on ``ServerArgs``
+(``server_args.kv_events_config``), unlike vLLM's already-parsed config object.
+We parse it with stdlib ``json`` (not TokenSpeed's pydantic ``KVEventsConfig``)
+so this resolver stays unit-testable without TokenSpeed installed; the defaults
+below mirror ``tokenspeed.runtime.pd.kv_events.KVEventsConfig``.
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Defaults mirror tokenspeed.runtime.pd.kv_events.KVEventsConfig.
+_DEFAULT_ENDPOINT = "tcp://*:5557"
+_DEFAULT_TOPIC = ""
+
+
+@dataclass(frozen=True)
+class ResolvedKvEventsConfig:
+    """The subset of KVEventsConfig the bridge needs to open a SUB socket."""
+
+    endpoint: str
+    topic: str
+
+
+def resolve_kv_events_config(server_args: object) -> ResolvedKvEventsConfig | None:
+    """Return the resolved ZMQ endpoint iff TokenSpeed KV events are enabled, else None.
+
+    Reads ``server_args.kv_events_config`` (a JSON string). Returns ``None`` —
+    leaving ``SubscribeKvEvents`` to report UNIMPLEMENTED — when events are
+    disabled, the publisher is not ``zmq``, or the config is absent/malformed.
+    """
+    raw = getattr(server_args, "kv_events_config", None)
+    if not raw:
+        return None
+
+    try:
+        cfg = json.loads(raw)
+    except (TypeError, ValueError) as e:
+        logger.warning("Could not parse --kv-events-config %r: %s", raw, e)
+        return None
+    if not isinstance(cfg, dict):
+        logger.warning("--kv-events-config did not decode to an object: %r", raw)
+        return None
+
+    if not cfg.get("enable_kv_cache_events", False):
+        logger.info("TokenSpeed KV cache events not enabled; SubscribeKvEvents disabled")
+        return None
+
+    # publisher unset → "zmq" when enabled (matches EventPublisherFactory.create).
+    publisher = cfg.get("publisher")
+    if publisher is None:
+        publisher = "zmq"
+    if publisher != "zmq":
+        logger.info(
+            "TokenSpeed KV events publisher is %r, not 'zmq'; SubscribeKvEvents disabled",
+            publisher,
+        )
+        return None
+
+    endpoint = cfg.get("endpoint") or _DEFAULT_ENDPOINT
+    topic = cfg.get("topic")
+    if topic is None:
+        topic = _DEFAULT_TOPIC
+    logger.info("TokenSpeed KV events enabled: endpoint=%s", endpoint)
+    return ResolvedKvEventsConfig(endpoint=endpoint, topic=topic)

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/kv_events.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/kv_events.py
@@ -69,5 +69,15 @@ def resolve_kv_events_config(server_args: object) -> ResolvedKvEventsConfig | No
     topic = cfg.get("topic")
     if topic is None:
         topic = _DEFAULT_TOPIC
+    # Guard against non-string values from arbitrary JSON; otherwise they fail
+    # later (e.g. topic.encode()) as opaque INTERNAL errors at subscribe time.
+    if not isinstance(endpoint, str) or not isinstance(topic, str):
+        logger.warning(
+            "TokenSpeed kv-events endpoint/topic must be strings (got endpoint=%r topic=%r); "
+            "SubscribeKvEvents disabled",
+            endpoint,
+            topic,
+        )
+        return None
     logger.info("TokenSpeed KV events enabled: endpoint=%s", endpoint)
     return ResolvedKvEventsConfig(endpoint=endpoint, topic=topic)

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -2,9 +2,9 @@
 
 Implements ``tokenspeed.grpc.scheduler.TokenSpeedScheduler`` on top of
 :class:`tokenspeed.runtime.engine.async_llm.AsyncLLM`. The proto field set
-is intentionally minimal — generative LLM serving plus precomputed multimodal;
-no Embed / GetTokenizer / SubscribeKvEvents / PD-disaggregated / LoRA /
-hidden states / classifier outputs.
+is intentionally minimal — generative LLM serving, precomputed multimodal, and
+KV-cache-event streaming for cache-aware routing; no Embed / GetTokenizer /
+PD-disaggregated / LoRA / hidden states / classifier outputs.
 """
 
 from __future__ import annotations
@@ -21,8 +21,11 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 import grpc
+import msgspec
 import numpy as np
 import torch
+import zmq
+import zmq.asyncio
 from google.protobuf.struct_pb2 import Struct
 from google.protobuf.timestamp_pb2 import Timestamp
 from smg_grpc_proto import tokenspeed_scheduler_pb2_grpc
@@ -32,8 +35,11 @@ from tokenspeed.runtime.multimodal.inputs import (
     MultimodalDataItem,
     MultimodalInputs,
 )
+from tokenspeed.runtime.pd.kv_events import KVEventBatch
 
+from smg_grpc_servicer.kv_events import endpoint_for_rank, stream_kv_events
 from smg_grpc_servicer.tokenspeed.health_servicer import TokenSpeedHealthServicer
+from smg_grpc_servicer.tokenspeed.kv_events import resolve_kv_events_config
 
 if TYPE_CHECKING:
     # Type-only — keeps these out of the cold-path graph when the servicer is
@@ -110,6 +116,10 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         self.scheduler_info = scheduler_info
         self.health_servicer = health_servicer
         self.start_time = time.time()
+
+        # Resolved ZMQ KV-events endpoint, or None when the worker was not
+        # launched with --kv-events-config (SubscribeKvEvents → UNIMPLEMENTED).
+        self._kv_events_config = resolve_kv_events_config(server_args)
 
         # Drive AsyncLLM's output-dispatch loop. This is idempotent — the
         # first caller creates the handle loop; subsequent callers (including
@@ -534,6 +544,67 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             loads=scheduler_loads,
             aggregate=aggregate,
         )
+
+    # ------------------------------------------------------------------
+    # SubscribeKvEvents (server-streaming) — feeds the gateway's
+    # cache-aware router the scheduler's actual KV-cache state.
+    # ------------------------------------------------------------------
+
+    async def SubscribeKvEvents(
+        self,
+        _request: common_pb2.SubscribeKvEventsRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncIterator[common_pb2.KvEventBatch]:
+        """Bridge TokenSpeed's in-process ZMQ KV cache events to a gRPC stream.
+
+        The scheduler subprocess publishes msgpack ``BlockStored`` /
+        ``BlockRemoved`` / ``AllBlocksCleared`` batches on a ZMQ PUB socket
+        (enabled via ``--kv-events-config``); we re-publish them as the
+        engine-neutral ``common.KvEventBatch`` stream SMG already consumes,
+        using the publisher's sequence numbers directly.
+
+        ``start_sequence_number`` (replay) is not honored — the stream starts
+        from the current ZMQ position, matching the other engine bridges.
+        """
+        if self._kv_events_config is None:
+            await context.abort(
+                grpc.StatusCode.UNIMPLEMENTED,
+                "KV cache events not enabled. Start TokenSpeed with "
+                "--kv-events-config "
+                '\'{"enable_kv_cache_events": true, "publisher": "zmq"}\'',
+            )
+
+        config = self._kv_events_config
+
+        # DP attention publishes one PUB socket per rank (port + rank) with
+        # independent sequence counters; subscribing to several on one socket
+        # interleaves them and breaks gap detection. Subscribe to rank 0 only.
+        pub_endpoint = endpoint_for_rank(config.endpoint, 0)
+
+        zmq_ctx = zmq.asyncio.Context.instance()
+        sub_socket = zmq_ctx.socket(zmq.SUB)
+        sub_socket.subscribe(config.topic.encode("utf-8"))
+        sub_socket.connect(pub_endpoint)
+        logger.info("SubscribeKvEvents: connected to ZMQ endpoint %s", pub_endpoint)
+
+        decoder = msgspec.msgpack.Decoder(KVEventBatch)
+
+        try:
+            async for proto_batch in stream_kv_events(
+                sub_socket,
+                decoder.decode,
+                lambda: context.send_initial_metadata(()),
+                context.cancelled,
+            ):
+                yield proto_batch
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:  # noqa: BLE001
+            logger.exception("SubscribeKvEvents failed")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+        finally:
+            sub_socket.close(linger=0)
+            logger.info("SubscribeKvEvents: stream closed")
 
     async def FlushCache(
         self,

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -573,6 +573,7 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
                 "--kv-events-config "
                 '\'{"enable_kv_cache_events": true, "publisher": "zmq"}\'',
             )
+            return  # defensive: context.abort() raises, but keep config non-None below
 
         config = self._kv_events_config
 
@@ -583,13 +584,14 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
 
         zmq_ctx = zmq.asyncio.Context.instance()
         sub_socket = zmq_ctx.socket(zmq.SUB)
-        sub_socket.subscribe(config.topic.encode("utf-8"))
-        sub_socket.connect(pub_endpoint)
-        logger.info("SubscribeKvEvents: connected to ZMQ endpoint %s", pub_endpoint)
-
-        decoder = msgspec.msgpack.Decoder(KVEventBatch)
-
         try:
+            # subscribe/connect can raise on a malformed endpoint; keep them in
+            # the try so the finally below always closes the socket.
+            sub_socket.subscribe(config.topic.encode("utf-8"))
+            sub_socket.connect(pub_endpoint)
+            logger.info("SubscribeKvEvents: connected to ZMQ endpoint %s", pub_endpoint)
+
+            decoder = msgspec.msgpack.Decoder(KVEventBatch)
             async for proto_batch in stream_kv_events(
                 sub_socket,
                 decoder.decode,
@@ -599,6 +601,8 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
                 yield proto_batch
         except asyncio.CancelledError:
             pass
+        except grpc.aio.AbortError:
+            raise
         except Exception as e:  # noqa: BLE001
             logger.exception("SubscribeKvEvents failed")
             await context.abort(grpc.StatusCode.INTERNAL, str(e))

--- a/grpc_servicer/smg_grpc_servicer/vllm/kv_events.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/kv_events.py
@@ -1,51 +1,30 @@
-"""vLLM KV-cache-event → proto conversion and ZMQ streaming.
+"""vLLM-specific KV-events config resolution.
 
-Engine-free: imports only stdlib + the generated proto, and dispatches vLLM
-events by class name (BlockStored / BlockRemoved / AllBlocksCleared), so it
-needs no vLLM import and is unit-testable without vLLM installed.
+The wire-format conversion + ZMQ streaming helpers live in the engine-neutral
+``smg_grpc_servicer.kv_events`` module and are re-exported here for backwards
+compatibility (existing imports and tests reference them via this module).
 """
 
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
 
-from smg_grpc_proto.generated import common_pb2
+from smg_grpc_servicer.kv_events import (
+    convert_batch,
+    convert_event,
+    endpoint_for_rank,
+    stream_kv_events,
+    to_int64,
+)
+
+__all__ = [
+    "convert_batch",
+    "convert_event",
+    "endpoint_for_rank",
+    "resolve_kv_events_config",
+    "stream_kv_events",
+    "to_int64",
+]
 
 logger = logging.getLogger(__name__)
-
-_U64_MASK = 0xFFFFFFFFFFFFFFFF
-_I64_SIGN_BIT = 0x8000000000000000
-_U64_MODULUS = 0x10000000000000000
-
-
-def to_int64(value: int | bytes) -> int:
-    """Reduce a vLLM block hash to a signed int64 for the proto block_hash field.
-
-    vLLM's block hash is ``int | bytes`` (sha256 bytes when int hashes are
-    disabled); bytes are read big-endian. SMG uses the hash only as a node
-    identity, so the 64-bit reduction is safe as long as it stays deterministic.
-    """
-    if isinstance(value, (bytes, bytearray)):
-        value = int.from_bytes(value, "big")
-    masked = value & _U64_MASK
-    if masked >= _I64_SIGN_BIT:
-        masked -= _U64_MODULUS
-    return masked
-
-
-def endpoint_for_rank(endpoint: str, dp_rank: int) -> str:
-    """Resolve a vLLM KV-events PUB endpoint to a connectable SUB address.
-
-    Bind wildcards (``*``, ``0.0.0.0``) are rewritten to ``127.0.0.1`` (the
-    latter is not connectable on macOS/Windows). For data-parallel deployments
-    each rank publishes on ``base_port + dp_rank``; non-tcp endpoints (ipc://,
-    inproc://) get the wildcard substituted but no port arithmetic.
-    """
-    resolved = endpoint.replace("*", "127.0.0.1").replace("0.0.0.0", "127.0.0.1")
-    if resolved.startswith("tcp://") and dp_rank:
-        host, sep, port = resolved.rpartition(":")
-        if sep and port.isdigit():
-            return f"{host}:{int(port) + dp_rank}"
-    return resolved
 
 
 def resolve_kv_events_config(engine: object):
@@ -69,110 +48,3 @@ def resolve_kv_events_config(engine: object):
         return None
     logger.info("vLLM KV events enabled: endpoint=%s", getattr(cfg, "endpoint", "?"))
     return cfg
-
-
-def convert_event(event: object, event_id: int) -> common_pb2.KvCacheEvent | None:
-    """Convert one decoded vLLM event to a proto KvCacheEvent (or None if unknown)."""
-    name = type(event).__name__
-
-    if name == "BlockStored":
-        block_size = int(event.block_size)
-        blocks = []
-        for i, block_hash in enumerate(event.block_hashes):
-            start = i * block_size
-            end = start + block_size
-            block = common_pb2.KvBlock(
-                block_hash=to_int64(block_hash),
-                token_ids=list(event.token_ids[start:end]),
-                block_size=block_size,
-            )
-            lora_id = getattr(event, "lora_id", None)
-            if lora_id is not None:
-                block.lora_id = to_int64(lora_id)
-            blocks.append(block)
-        stored = common_pb2.KvBlocksStored(blocks=blocks)
-        parent = getattr(event, "parent_block_hash", None)
-        if parent is not None:
-            stored.parent_block_hash = to_int64(parent)
-        return common_pb2.KvCacheEvent(event_id=event_id, stored=stored)
-
-    if name == "BlockRemoved":
-        return common_pb2.KvCacheEvent(
-            event_id=event_id,
-            removed=common_pb2.KvBlocksRemoved(
-                block_hashes=[to_int64(h) for h in event.block_hashes]
-            ),
-        )
-
-    if name == "AllBlocksCleared":
-        return common_pb2.KvCacheEvent(event_id=event_id, cleared=common_pb2.KvCacheCleared())
-
-    logger.debug("Unknown vLLM KV event type %r, skipping", name)
-    return None
-
-
-def convert_batch(
-    raw_batch: object, seq_num: int, event_id_start: int
-) -> tuple[common_pb2.KvEventBatch, int]:
-    """Convert a decoded vLLM KVEventBatch to a proto KvEventBatch.
-
-    Returns the proto batch and the new event-id counter. The counter advances
-    once per input event (even if unconvertible) so ids stay monotonic.
-    """
-    proto = common_pb2.KvEventBatch(sequence_number=seq_num, timestamp=raw_batch.ts)
-    dp_rank = getattr(raw_batch, "data_parallel_rank", None)
-    if dp_rank is not None:
-        proto.dp_rank = dp_rank
-
-    event_id = event_id_start
-    for event in raw_batch.events:
-        event_id += 1
-        proto_event = convert_event(event, event_id)
-        if proto_event is not None:
-            proto.events.append(proto_event)
-    return proto, event_id
-
-
-async def stream_kv_events(
-    sub_socket: object,
-    decode: Callable[[bytes], object],
-    send_initial_metadata: Callable[[], Awaitable[None]],
-    is_cancelled: Callable[[], bool],
-    *,
-    recv_timeout: float = 1.0,
-) -> AsyncIterator[common_pb2.KvEventBatch]:
-    """Core ZMQ→proto streaming loop, decoupled from vLLM and gRPC types.
-
-    Args:
-        sub_socket: a connected ``zmq.asyncio`` SUB socket (duck-typed; only
-            ``poll()`` and ``recv_multipart()`` are used). The caller owns the
-            socket lifecycle (this function never closes it).
-        decode: bytes → decoded vLLM batch (e.g. ``msgspec.msgpack.Decoder(KVEventBatch).decode``).
-        send_initial_metadata: awaitable called once before the first recv so the
-            gRPC client's ``subscribe_kv_events().await`` resolves promptly.
-        is_cancelled: returns True when the RPC is cancelled; loop then exits.
-        recv_timeout: poll timeout so cancellation is observed even when idle.
-
-    Yields proto KvEventBatch using the ZMQ publisher's native sequence numbers.
-    """
-    await send_initial_metadata()
-    event_id = 0
-    while not is_cancelled():
-        # poll() before recv: cancelling a zmq.asyncio recv future does not
-        # cancel the in-flight ZMQ recv and can drop an already-dequeued message.
-        if not await sub_socket.poll(timeout=int(recv_timeout * 1000)):
-            continue
-        frames = await sub_socket.recv_multipart()
-
-        # ZMQ multipart: [topic, 8-byte big-endian seq, msgpack payload].
-        if len(frames) < 3:
-            continue
-        zmq_seq = int.from_bytes(frames[1], "big")
-        try:
-            raw_batch = decode(frames[2])
-        except Exception as e:  # noqa: BLE001 - one bad frame must not kill the stream
-            logger.warning("Failed to decode vLLM KV event batch: %s", e)
-            continue
-
-        proto_batch, event_id = convert_batch(raw_batch, zmq_seq, event_id)
-        yield proto_batch

--- a/grpc_servicer/tests/conftest.py
+++ b/grpc_servicer/tests/conftest.py
@@ -1,12 +1,6 @@
-"""Pytest configuration for the gRPC servicer tests.
-
-Some tests load engine-free modules (e.g. ``vllm/kv_events.py``) by file path,
-and those modules re-export from the shared ``smg_grpc_servicer.kv_events``
-package module. Put this repo's ``grpc_servicer/`` directory at the front of
-``sys.path`` so that package import resolves to the in-repo source — without
-requiring an editable install, and taking precedence over any stale copy that
-might be installed elsewhere on the path. This lets the suite run from the repo
-root (as CI does) the same way it runs from inside ``grpc_servicer/``.
+"""Put this repo's ``grpc_servicer/`` at the front of ``sys.path`` so
+``smg_grpc_servicer`` imports resolve in-repo when tests run from the repo root
+(as CI does), without an editable install.
 """
 
 import sys

--- a/grpc_servicer/tests/conftest.py
+++ b/grpc_servicer/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Pytest configuration for the gRPC servicer tests.
+
+Some tests load engine-free modules (e.g. ``vllm/kv_events.py``) by file path,
+and those modules re-export from the shared ``smg_grpc_servicer.kv_events``
+package module. Put this repo's ``grpc_servicer/`` directory at the front of
+``sys.path`` so that package import resolves to the in-repo source — without
+requiring an editable install, and taking precedence over any stale copy that
+might be installed elsewhere on the path. This lets the suite run from the repo
+root (as CI does) the same way it runs from inside ``grpc_servicer/``.
+"""
+
+import sys
+from pathlib import Path
+
+_GRPC_SERVICER_ROOT = Path(__file__).resolve().parent.parent
+if sys.path[:1] != [str(_GRPC_SERVICER_ROOT)]:
+    sys.path.insert(0, str(_GRPC_SERVICER_ROOT))

--- a/grpc_servicer/tests/test_tokenspeed_kv_events.py
+++ b/grpc_servicer/tests/test_tokenspeed_kv_events.py
@@ -54,7 +54,8 @@ class TestResolveKvEventsConfig:
         cfg = _cfg(enable_kv_cache_events=False, publisher="zmq")
         assert ts_kv_events.resolve_kv_events_config(_Args(cfg)) is None
 
-    def test_none_when_publisher_null(self):
+    def test_none_when_publisher_non_zmq_string(self):
+        # Explicit non-zmq publisher (string "null") disables bridging.
         cfg = _cfg(enable_kv_cache_events=True, publisher="null")
         assert ts_kv_events.resolve_kv_events_config(_Args(cfg)) is None
 
@@ -76,6 +77,28 @@ class TestResolveKvEventsConfig:
         assert out is not None
         assert out.endpoint == "tcp://*:5557"  # KVEventsConfig default
         assert out.topic == ""  # KVEventsConfig default
+
+    def test_publisher_explicit_json_null_defaults_to_zmq(self):
+        # Explicit JSON ``null`` (not the string "null") → defaults to zmq when enabled.
+        cfg = _cfg(enable_kv_cache_events=True, publisher=None)
+        assert '"publisher": null' in cfg
+        out = ts_kv_events.resolve_kv_events_config(_Args(cfg))
+        assert out is not None
+
+    def test_none_when_endpoint_or_topic_not_string(self):
+        # Non-string endpoint/topic from arbitrary JSON → cleanly disabled (not a runtime crash).
+        assert (
+            ts_kv_events.resolve_kv_events_config(
+                _Args(_cfg(enable_kv_cache_events=True, endpoint=1234))
+            )
+            is None
+        )
+        assert (
+            ts_kv_events.resolve_kv_events_config(
+                _Args(_cfg(enable_kv_cache_events=True, topic=["x"]))
+            )
+            is None
+        )
 
     def test_malformed_json_returns_none(self):
         assert ts_kv_events.resolve_kv_events_config(_Args("{not json")) is None

--- a/grpc_servicer/tests/test_tokenspeed_kv_events.py
+++ b/grpc_servicer/tests/test_tokenspeed_kv_events.py
@@ -1,0 +1,164 @@
+"""Unit tests for the TokenSpeed KV-events config resolver + shared conversion.
+
+Engine-free: no TokenSpeed install required. Modules are loaded by file path so
+the ``tokenspeed`` package ``__init__`` (which imports the engine-bound
+servicer) is never triggered.
+
+Run with: pytest grpc_servicer/tests/test_tokenspeed_kv_events.py -v
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("smg_grpc_proto")
+
+_SERVICER_ROOT = Path(__file__).parents[1] / "smg_grpc_servicer"
+
+
+def _load(relpath: str, name: str):
+    spec = importlib.util.spec_from_file_location(name, _SERVICER_ROOT / relpath)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ts_kv_events = _load("tokenspeed/kv_events.py", "ts_kv_events")
+shared = _load("kv_events.py", "shared_kv_events")
+
+
+class _Args:
+    """Minimal stand-in for TokenSpeed's ServerArgs."""
+
+    def __init__(self, kv_events_config):
+        self.kv_events_config = kv_events_config
+
+
+def _cfg(**kw) -> str:
+    return json.dumps(kw)
+
+
+class TestResolveKvEventsConfig:
+    def test_none_when_attr_missing(self):
+        assert ts_kv_events.resolve_kv_events_config(object()) is None
+
+    def test_none_when_empty_string(self):
+        assert ts_kv_events.resolve_kv_events_config(_Args("")) is None
+
+    def test_none_when_none(self):
+        assert ts_kv_events.resolve_kv_events_config(_Args(None)) is None
+
+    def test_none_when_disabled(self):
+        cfg = _cfg(enable_kv_cache_events=False, publisher="zmq")
+        assert ts_kv_events.resolve_kv_events_config(_Args(cfg)) is None
+
+    def test_none_when_publisher_null(self):
+        cfg = _cfg(enable_kv_cache_events=True, publisher="null")
+        assert ts_kv_events.resolve_kv_events_config(_Args(cfg)) is None
+
+    def test_returns_config_when_enabled_zmq(self):
+        cfg = _cfg(
+            enable_kv_cache_events=True,
+            publisher="zmq",
+            endpoint="tcp://*:6000",
+            topic="kv",
+        )
+        out = ts_kv_events.resolve_kv_events_config(_Args(cfg))
+        assert out is not None
+        assert out.endpoint == "tcp://*:6000"
+        assert out.topic == "kv"
+
+    def test_publisher_defaults_to_zmq_when_enabled(self):
+        # publisher unset → "zmq" when enabled (matches EventPublisherFactory).
+        out = ts_kv_events.resolve_kv_events_config(_Args(_cfg(enable_kv_cache_events=True)))
+        assert out is not None
+        assert out.endpoint == "tcp://*:5557"  # KVEventsConfig default
+        assert out.topic == ""  # KVEventsConfig default
+
+    def test_malformed_json_returns_none(self):
+        assert ts_kv_events.resolve_kv_events_config(_Args("{not json")) is None
+
+    def test_non_object_json_returns_none(self):
+        assert ts_kv_events.resolve_kv_events_config(_Args("[1, 2, 3]")) is None
+
+
+# --- TokenSpeed-shaped fake events (dispatch is by class name) ---
+# TokenSpeed's BlockStored has no lora_id; its batch carries attn_dp_rank.
+class BlockStored:
+    def __init__(self, block_hashes, parent_block_hash, token_ids, block_size):
+        self.block_hashes = block_hashes
+        self.parent_block_hash = parent_block_hash
+        self.token_ids = token_ids
+        self.block_size = block_size
+
+
+class BlockRemoved:
+    def __init__(self, block_hashes):
+        self.block_hashes = block_hashes
+
+
+class AllBlocksCleared:
+    pass
+
+
+class KVEventBatch:
+    def __init__(self, ts, events, attn_dp_rank=None):
+        self.ts = ts
+        self.events = events
+        self.attn_dp_rank = attn_dp_rank
+
+
+class TestConvertEventTokenSpeedShape:
+    def test_block_stored_without_lora(self):
+        ev = BlockStored(
+            block_hashes=[111], parent_block_hash=None, token_ids=[1, 2, 3, 4], block_size=4
+        )
+        out = shared.convert_event(ev, event_id=1)
+        assert out.WhichOneof("data") == "stored"
+        assert out.stored.blocks[0].block_hash == 111
+        assert list(out.stored.blocks[0].token_ids) == [1, 2, 3, 4]
+        assert not out.stored.blocks[0].HasField("lora_id")
+        assert not out.stored.HasField("parent_block_hash")
+
+    def test_block_stored_multi_block_with_parent(self):
+        ev = BlockStored(
+            block_hashes=[10, 20],
+            parent_block_hash=9,
+            token_ids=[1, 2, 3, 4, 5, 6, 7, 8],
+            block_size=4,
+        )
+        out = shared.convert_event(ev, event_id=1)
+        assert [b.block_hash for b in out.stored.blocks] == [10, 20]
+        assert list(out.stored.blocks[1].token_ids) == [5, 6, 7, 8]
+        assert out.stored.parent_block_hash == 9
+
+    def test_block_removed(self):
+        out = shared.convert_event(BlockRemoved(block_hashes=[1, 2]), event_id=2)
+        assert out.WhichOneof("data") == "removed"
+        assert list(out.removed.block_hashes) == [1, 2]
+
+    def test_all_blocks_cleared(self):
+        out = shared.convert_event(AllBlocksCleared(), event_id=3)
+        assert out.WhichOneof("data") == "cleared"
+
+
+class TestConvertBatchAttnDpRank:
+    def test_attn_dp_rank_maps_to_proto_dp_rank(self):
+        batch = KVEventBatch(ts=1.0, events=[], attn_dp_rank=2)
+        proto, _ = shared.convert_batch(batch, seq_num=5, event_id_start=0)
+        assert proto.sequence_number == 5
+        assert proto.dp_rank == 2
+
+    def test_no_dp_rank_when_attn_dp_rank_none(self):
+        batch = KVEventBatch(ts=1.0, events=[], attn_dp_rank=None)
+        proto, _ = shared.convert_batch(batch, seq_num=1, event_id_start=0)
+        assert not proto.HasField("dp_rank")
+
+    def test_attn_dp_rank_zero_is_set(self):
+        # rank 0 is a valid rank, not "unset" — it must still be encoded.
+        batch = KVEventBatch(ts=1.0, events=[], attn_dp_rank=0)
+        proto, _ = shared.convert_batch(batch, seq_num=1, event_id_start=0)
+        assert proto.HasField("dp_rank")
+        assert proto.dp_rank == 0

--- a/grpc_servicer/tests/test_tokenspeed_kv_events_stream.py
+++ b/grpc_servicer/tests/test_tokenspeed_kv_events_stream.py
@@ -1,0 +1,116 @@
+"""Integration test: TokenSpeed-shaped ZMQ KV events → proto via stream_kv_events.
+
+No TokenSpeed required — batches are encoded with local ``msgspec`` structs that
+mirror ``tokenspeed.runtime.pd.kv_events`` (array_like + tagged union), and the
+shared streaming loop runs with a real ``msgspec`` decoder, exactly as the
+servicer does. This exercises the full ZMQ-frame → msgpack-decode → proto path.
+
+Run with: pytest grpc_servicer/tests/test_tokenspeed_kv_events_stream.py -v
+"""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("smg_grpc_proto")
+zmq = pytest.importorskip("zmq")
+msgspec = pytest.importorskip("msgspec")
+import zmq.asyncio  # noqa: E402, F811
+
+_MODULE_PATH = Path(__file__).parents[1] / "smg_grpc_servicer" / "kv_events.py"
+_spec = importlib.util.spec_from_file_location("shared_kv_events", _MODULE_PATH)
+kv_events = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(kv_events)
+
+
+# Mirror tokenspeed.runtime.pd.kv_events wire structs (array_like + tagged
+# union); the class names double as the union tags and the convert_event
+# dispatch keys.
+class KVCacheEvent(msgspec.Struct, array_like=True, omit_defaults=True, tag=True):
+    pass
+
+
+class BlockStored(KVCacheEvent):
+    block_hashes: list[int]
+    parent_block_hash: int | None
+    token_ids: list[int]
+    block_size: int
+
+
+class BlockRemoved(KVCacheEvent):
+    block_hashes: list[int]
+
+
+class AllBlocksCleared(KVCacheEvent):
+    pass
+
+
+class KVEventBatch(msgspec.Struct, array_like=True, omit_defaults=True):
+    ts: float
+    events: list[BlockStored | BlockRemoved | AllBlocksCleared]
+    attn_dp_rank: int | None = None
+
+
+def _seq_bytes(n: int) -> bytes:
+    return n.to_bytes(8, "big")
+
+
+@pytest.mark.asyncio
+async def test_stream_decodes_tokenspeed_batches():
+    encoder = msgspec.msgpack.Encoder()
+    decoder = msgspec.msgpack.Decoder(KVEventBatch)
+    ctx = zmq.asyncio.Context.instance()
+    pub = ctx.socket(zmq.PUB)
+    sub = ctx.socket(zmq.SUB)
+    collected = []
+    try:
+        port = pub.bind_to_random_port("tcp://127.0.0.1")
+        sub.subscribe(b"")
+        sub.connect(f"tcp://127.0.0.1:{port}")
+        await asyncio.sleep(0.2)  # allow SUB connection before publishing
+
+        batches = [
+            KVEventBatch(
+                ts=1.0,
+                events=[
+                    BlockStored(
+                        block_hashes=[111],
+                        parent_block_hash=None,
+                        token_ids=[1, 2],
+                        block_size=2,
+                    )
+                ],
+                attn_dp_rank=0,
+            ),
+            KVEventBatch(ts=2.0, events=[BlockRemoved(block_hashes=[111])]),
+        ]
+
+        async def _noop():
+            return None
+
+        async def consume():
+            async for batch in kv_events.stream_kv_events(
+                sub,
+                decoder.decode,
+                send_initial_metadata=_noop,
+                is_cancelled=lambda: len(collected) >= 2,
+            ):
+                collected.append(batch)
+
+        consumer = asyncio.create_task(consume())
+        for seq, batch in enumerate(batches):
+            await pub.send_multipart([b"", _seq_bytes(seq), encoder.encode(batch)])
+            await asyncio.sleep(0.05)
+        await asyncio.wait_for(consumer, timeout=5)
+    finally:
+        pub.close(linger=0)
+        sub.close(linger=0)
+
+    assert [b.sequence_number for b in collected] == [0, 1]
+    stored = collected[0].events[0].stored
+    assert stored.blocks[0].block_hash == 111
+    assert list(stored.blocks[0].token_ids) == [1, 2]
+    assert collected[0].dp_rank == 0  # attn_dp_rank 0 → proto dp_rank 0
+    assert collected[1].events[0].WhichOneof("data") == "removed"


### PR DESCRIPTION
## Description

### Problem

KV-event-driven cache-aware routing — where the gateway routes each request to the worker whose KV cache already holds the longest prefix, using the worker's **actual** cache state — worked for SGLang and vLLM but **not** for TokenSpeed. TokenSpeed gRPC workers silently fell back to the *approximate* token tree because `TokenSpeedSchedulerServicer` never implemented `SubscribeKvEvents` (the RPC returned `UNIMPLEMENTED`, so SMG's `KvEventMonitor` disabled the subscription for that worker).

The **entire Rust/SMG side is already engine-agnostic** — the proto RPC (`common.proto` `SubscribeKvEvents`/`KvEventBatch`), the TokenSpeed gRPC client (`impl_subscribe_kv_events!`), `GrpcClient::TokenSpeed` dispatch, `KvEventMonitor`, the `PositionalIndexer`, and the `cache_aware` policy. The only missing piece was the Python servicer bridge.

### Solution

Implement `SubscribeKvEvents` on `TokenSpeedSchedulerServicer`, bridging TokenSpeed's in-process ZMQ KV-cache events (msgpack `BlockStored`/`BlockRemoved`/`AllBlocksCleared`) to the engine-neutral `common.proto` `KvEventBatch` stream SMG already consumes. **No Rust, proto, or TokenSpeed-engine changes.**

The ZMQ→proto conversion is engine-neutral, so it is promoted to a shared module reused by both the vLLM and TokenSpeed bridges; each engine keeps only its own config resolver.

## Changes

- **`grpc_servicer/smg_grpc_servicer/kv_events.py`** (new): engine-neutral ZMQ→proto helpers (`to_int64`, `endpoint_for_rank`, `convert_event`, `convert_batch`, `stream_kv_events`), promoted from `vllm/kv_events.py`. `convert_batch` reads the DP rank from `data_parallel_rank` (vLLM) or `attn_dp_rank` (TokenSpeed).
- **`grpc_servicer/smg_grpc_servicer/vllm/kv_events.py`**: re-exports the shared helpers; keeps the vLLM-specific resolver.
- **`grpc_servicer/smg_grpc_servicer/tokenspeed/kv_events.py`** (new): TokenSpeed config resolver — parses `server_args.kv_events_config` and returns the ZMQ endpoint iff events are enabled with `publisher=zmq`.
- **`grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py`**: implement `SubscribeKvEvents` (rank-0 subscription, no replay), mirroring the vLLM bridge.
- **`grpc_servicer/pyproject.toml`**: add the `[tokenspeed]` extra (`pyzmq`, `msgspec`).
- **Tests**: engine-free unit tests for the resolver + shared conversion, and an in-process ZMQ PUB/SUB integration test using msgspec structs that mirror the TokenSpeed wire layout.
- **Docs**: TokenSpeed worker launch section in `docs/getting-started/kv-events-cache-aware.md`.

## Test Plan

`cargo +nightly fmt`, `ruff check`/`ruff format`, and `pytest grpc_servicer/tests/` pass for the new/changed files. Existing `test_vllm_kv_events*.py` remain green (the shared-module refactor is import-compatible).

### Manual E2E (H100)

Built SMG + the servicer from this branch, ran live TokenSpeed gRPC workers (`DeepSeek-R1-Distill-Qwen-32B`) under SMG `--policy cache_aware`:
- gateway logs `Starting KV event subscription` → `KV event stream connected start_seq=0` per worker (RPC streams instead of `UNIMPLEMENTED`)
- `Learned block_size from KV event ... block_size=64` (block size learned from real `BlockStored` events through the bridge)
- repeated-prefix requests route stickily to the worker holding the prefix
- a worker launched **without** `--kv-events-config` → `Backend does not implement SubscribeKvEvents, disabling KV event subscription` (graceful fallback)

### Benchmark (event-driven vs approximate token tree)

`vllm bench serve --dataset-name prefix_repetition` (600 prefixes × 1000-token shared prefix + 50-token suffix, 128-token output, 3000 requests, open-loop Poisson, saturating rate 32), through **4 SMG gateways** (nginx round-robin, no mesh) in front of **3 TokenSpeed workers** (`DeepSeek-R1-Distill-Qwen-32B`, TP=2). TokenSpeed workers launched with `--disable-kvstore` and `--kv-events-config '{"enable_kv_cache_events": true, "publisher": "zmq", ...}'`. 8×H100, 3000/3000 successful per run.

| metric | approximate tree (events off) | **event-driven (this PR)** | delta |
|---|--:|--:|--:|
| prefix-cache hit rate | 24.4% | **48.5%** | **+24 pts (~2×)** |
| Mean TTFT | 1699 ms | **923 ms** | **−46%** |
| Median TTFT | 258 ms | **141 ms** | **−45%** |
| P95 TTFT | 10256 ms | **4724 ms** | **−54%** |
| P99 TTFT | 23227 ms | 19396 ms | −16% |
| Request throughput | 29.3 req/s | 30.3 req/s | +3.4% |

Event-driven cache-aware routing roughly **doubles the prefix-cache hit rate and halves TTFT** versus the approximate token tree for TokenSpeed workers. The win is concentrated in prefill/TTFT (expected — prefix-cache reuse cuts prefill work); end-to-end latency converges at this scale since the 128-token decode dominates.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TokenSpeed KV-cache event streaming via a new gRPC subscription RPC for cache-aware routing.

* **Documentation**
  * Added setup guidance for TokenSpeed KV-event publishing and updated KV-events reference links.

* **Enhancements**
  * Added a shared KV-events conversion/streaming layer and refactored vLLM integration to reuse it.
  * Introduced optional TokenSpeed dependencies needed for KV-event bridging.

* **Tests**
  * Added unit and end-to-end tests covering KV-events config resolution, conversion, and stream decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->