### PR TITLE
perf(grpc-regular): use shared SseEncoder for inline SSE framing

### DIFF
--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -35,12 +35,15 @@ use tracing::{debug, error, warn};
 
 use crate::{
     observability::metrics::{metrics_labels, Metrics, StreamingMetricsParams},
-    routers::grpc::{
-        common::{response_formatting::CompletionTokenTracker, responses::build_sse_response},
-        context,
-        proto_wrapper::{ProtoResponseVariant, ProtoStream},
-        utils,
-        utils::message_utils,
+    routers::{
+        common::sse::SseEncoder,
+        grpc::{
+            common::{response_formatting::CompletionTokenTracker, responses::build_sse_response},
+            context,
+            proto_wrapper::{ProtoResponseVariant, ProtoStream},
+            utils,
+            utils::message_utils,
+        },
     },
 };
 
@@ -224,6 +227,9 @@ impl StreamingProcessor {
 
         // Reusable SSE formatting buffer to avoid allocations per chunk
         let mut sse_buffer = Vec::with_capacity(512);
+        // Reusable SSE encoder for the post-loop flush / tool / finish / usage
+        // chunks, which previously each did `to_string` + `format!`.
+        let mut sse_encoder = SseEncoder::new();
 
         // Use dispatch metadata for consistent response fields
         let request_id = &dispatch.request_id;
@@ -475,10 +481,10 @@ impl StreamingProcessor {
                                         .build();
 
                                 let sse_chunk =
-                                    serde_json::to_string(&content_chunk).map_err(|e| {
+                                    sse_encoder.encode_data(&content_chunk).map_err(|e| {
                                         format!("Failed to serialize content chunk: {e}")
                                     })?;
-                                tx.send(Ok(Bytes::from(format!("data: {sse_chunk}\n\n"))))
+                                tx.send(Ok(sse_chunk))
                                     .map_err(|_| "Failed to send flushed content".to_string())?;
                             }
                         }
@@ -525,9 +531,10 @@ impl StreamingProcessor {
                         .maybe_system_fingerprint(system_fingerprint)
                         .build();
 
-                    let sse_chunk = serde_json::to_string(&tool_chunk)
+                    let sse_chunk = sse_encoder
+                        .encode_data(&tool_chunk)
                         .map_err(|e| format!("Failed to serialize tool chunk: {e}"))?;
-                    tx.send(Ok(Bytes::from(format!("data: {sse_chunk}\n\n"))))
+                    tx.send(Ok(sse_chunk))
                         .map_err(|_| "Failed to send unstreamed tool args".to_string())?;
                 }
             }
@@ -550,9 +557,10 @@ impl StreamingProcessor {
                 .maybe_system_fingerprint(system_fingerprint)
                 .build();
 
-            let sse_chunk = serde_json::to_string(&finish_chunk)
+            let sse_chunk = sse_encoder
+                .encode_data(&finish_chunk)
                 .map_err(|e| format!("Failed to serialize finish chunk: {e}"))?;
-            tx.send(Ok(Bytes::from(format!("data: {sse_chunk}\n\n"))))
+            tx.send(Ok(sse_chunk))
                 .map_err(|_| "Failed to send finish chunk".to_string())?;
         }
 
@@ -572,9 +580,10 @@ impl StreamingProcessor {
                     .maybe_system_fingerprint(system_fingerprint)
                     .build();
 
-                let sse_chunk = serde_json::to_string(&usage_chunk)
+                let sse_chunk = sse_encoder
+                    .encode_data(&usage_chunk)
                     .map_err(|e| format!("Failed to serialize usage chunk: {e}"))?;
-                tx.send(Ok(Bytes::from(format!("data: {sse_chunk}\n\n"))))
+                tx.send(Ok(sse_chunk))
                     .map_err(|_| "Failed to send usage chunk".to_string())?;
             }
         }
@@ -744,6 +753,8 @@ impl StreamingProcessor {
         // Track state per index for n>1 case
         let mut accumulated_texts: HashMap<u32, String> = HashMap::new();
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
+        // Reusable SSE encoder shared across every chunk emitted for this stream.
+        let mut sse_encoder = SseEncoder::new();
 
         while let Some(response) = stream.next().await {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
@@ -789,9 +800,10 @@ impl StreamingProcessor {
                         "index": index
                     });
 
-                    let sse_data = serde_json::to_string(&chunk_response)
+                    let sse_data = sse_encoder
+                        .encode_data(&chunk_response)
                         .map_err(|e| format!("Failed to serialize generate chunk: {e}"))?;
-                    tx.send(Ok(Bytes::from(format!("data: {sse_data}\n\n"))))
+                    tx.send(Ok(sse_data))
                         .map_err(|_| "Failed to send chunk".to_string())?;
                 }
                 ProtoResponseVariant::Complete(complete) => {
@@ -818,9 +830,10 @@ impl StreamingProcessor {
                         "index": index
                     });
 
-                    let sse_data = serde_json::to_string(&finish_response)
+                    let sse_data = sse_encoder
+                        .encode_data(&finish_response)
                         .map_err(|e| format!("Failed to serialize generate finish: {e}"))?;
-                    tx.send(Ok(Bytes::from(format!("data: {sse_data}\n\n"))))
+                    tx.send(Ok(sse_data))
                         .map_err(|_| "Failed to send finish chunk".to_string())?;
 
                     // Continue to process all completions if n>1
@@ -906,6 +919,8 @@ impl StreamingProcessor {
         let mut accumulated_output_logprobs: HashMap<u32, Option<Vec<Vec<Option<f64>>>>> =
             HashMap::new();
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
+        // Reusable SSE encoder shared across every chunk emitted for this stream.
+        let mut sse_encoder = SseEncoder::new();
 
         while let Some(response) = stream.next().await {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
@@ -977,9 +992,10 @@ impl StreamingProcessor {
                         "index": index
                     });
 
-                    let sse_data = serde_json::to_string(&chunk_response)
+                    let sse_data = sse_encoder
+                        .encode_data(&chunk_response)
                         .map_err(|e| format!("Failed to serialize generate chunk: {e}"))?;
-                    tx.send(Ok(Bytes::from(format!("data: {sse_data}\n\n"))))
+                    tx.send(Ok(sse_data))
                         .map_err(|_| "Failed to send chunk".to_string())?;
                 }
                 ProtoResponseVariant::Complete(complete) => {
@@ -1020,9 +1036,10 @@ impl StreamingProcessor {
                         "index": index
                     });
 
-                    let sse_data = serde_json::to_string(&finish_response)
+                    let sse_data = sse_encoder
+                        .encode_data(&finish_response)
                         .map_err(|e| format!("Failed to serialize generate finish: {e}"))?;
-                    tx.send(Ok(Bytes::from(format!("data: {sse_data}\n\n"))))
+                    tx.send(Ok(sse_data))
                         .map_err(|_| "Failed to send finish chunk".to_string())?;
 
                     // Continue to process all completions if n>1


### PR DESCRIPTION
## Description

### Problem

`grpc/regular/streaming.rs` had several inline `serde_json::to_string` + `format!("data: …\n\n")` pairs (chat completions tool-args / finish-reason / usage / flushed-content chunks, and both generate-streaming paths) — two heap allocations per chunk on the streaming hot path.

### Solution

Replace those inline pairs with the shared `common::sse::SseEncoder`, instantiated once per stream and reused, so the serialization buffer is shared across chunks (1 allocation per chunk instead of 2).

## Changes

- Chat completions tool-args / finish-reason / usage / flushed-content chunks serialize through a per-stream `SseEncoder`.
- Both generate paths (`process_generate_streaming`, `process_generate_streaming_with_input_logprobs`) reuse an encoder for their chunk / finish frames.
- The already-optimal hot-loop helper (`format_sse_chunk_into`, which writes into a reused `Vec` via `to_writer`) and the messages/completions buffer helpers are left untouched. No behavior change — identical wire output.

## Test Plan

- `cargo +nightly fmt` ✅ and `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -p smg --lib grpc::regular` ✅ (16 passed)

Part of the shared SSE codec rollout (codec landed in #987). Sibling of #1633/#1634 (anthropic), #1759/#1760 (openai), #1768 (http-pd).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code efficiency for streaming message handling through refactored serialization utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->