### PR TITLE
feat(observability): re-export engine load signals as smg_engine_* gauges

### DIFF
--- a/crates/grpc_client/src/sglang_scheduler.rs
+++ b/crates/grpc_client/src/sglang_scheduler.rs
@@ -700,6 +700,10 @@ impl SglangSchedulerClient {
 
 impl From<proto::SchedulerLoad> for openai_protocol::worker::SchedulerLoadSnapshot {
     fn from(load: proto::SchedulerLoad) -> Self {
+        // Disaggregation queue depths roll the per-stage SGLang counters into
+        // the two canonical totals: prefill = prealloc + inflight, decode =
+        // prealloc + transfer + retracted.
+        let disagg = load.disaggregation;
         Self {
             dp_rank: load.dp_rank,
             num_running_reqs: load.num_running_reqs,
@@ -713,6 +717,17 @@ impl From<proto::SchedulerLoad> for openai_protocol::worker::SchedulerLoadSnapsh
             cache_hit_rate: load.cache_hit_rate,
             utilization: load.utilization,
             max_running_requests: load.max_running_requests,
+            kv_transfer_latency_ms: disagg.as_ref().map(|d| d.kv_transfer_latency_ms),
+            kv_transfer_speed_gb_s: disagg.as_ref().map(|d| d.kv_transfer_speed_gb_s),
+            prefill_queue_reqs: disagg
+                .as_ref()
+                .map(|d| d.prefill_prealloc_queue_reqs + d.prefill_inflight_queue_reqs),
+            decode_queue_reqs: disagg.as_ref().map(|d| {
+                d.decode_prealloc_queue_reqs
+                    + d.decode_transfer_queue_reqs
+                    + d.decode_retracted_queue_reqs
+            }),
+            disagg_mode: disagg.map(|d| d.mode),
         }
     }
 }
@@ -735,6 +750,46 @@ mod tests {
     fn test_proto_types_compilation() {
         let _health_req = proto::HealthCheckRequest {};
         // HealthCheckRequest is now empty - no fields to test
+    }
+
+    #[test]
+    fn test_scheduler_load_maps_disagg_section() {
+        let load = proto::SchedulerLoad {
+            dp_rank: 0,
+            num_running_reqs: 3,
+            disaggregation: Some(proto::DisaggregationMetrics {
+                mode: "prefill".to_string(),
+                prefill_prealloc_queue_reqs: 2,
+                prefill_inflight_queue_reqs: 5,
+                decode_prealloc_queue_reqs: 1,
+                decode_transfer_queue_reqs: 4,
+                decode_retracted_queue_reqs: 7,
+                kv_transfer_speed_gb_s: 12.5,
+                kv_transfer_latency_ms: 3.25,
+            }),
+            ..Default::default()
+        };
+
+        let snap = openai_protocol::worker::SchedulerLoadSnapshot::from(load);
+
+        assert_eq!(snap.disagg_mode.as_deref(), Some("prefill"));
+        assert_eq!(snap.kv_transfer_latency_ms, Some(3.25));
+        assert_eq!(snap.kv_transfer_speed_gb_s, Some(12.5));
+        assert_eq!(snap.prefill_queue_reqs, Some(7)); // 2 + 5
+        assert_eq!(snap.decode_queue_reqs, Some(12)); // 1 + 4 + 7
+    }
+
+    #[test]
+    fn test_scheduler_load_disagg_absent_is_none() {
+        let snap = openai_protocol::worker::SchedulerLoadSnapshot::from(proto::SchedulerLoad {
+            num_running_reqs: 1,
+            ..Default::default()
+        });
+
+        assert!(snap.disagg_mode.is_none());
+        assert!(snap.kv_transfer_latency_ms.is_none());
+        assert!(snap.prefill_queue_reqs.is_none());
+        assert!(snap.decode_queue_reqs.is_none());
     }
 
     #[test]

--- a/crates/grpc_client/src/sglang_scheduler.rs
+++ b/crates/grpc_client/src/sglang_scheduler.rs
@@ -719,13 +719,14 @@ impl From<proto::SchedulerLoad> for openai_protocol::worker::SchedulerLoadSnapsh
             max_running_requests: load.max_running_requests,
             kv_transfer_latency_ms: disagg.as_ref().map(|d| d.kv_transfer_latency_ms),
             kv_transfer_speed_gb_s: disagg.as_ref().map(|d| d.kv_transfer_speed_gb_s),
-            prefill_queue_reqs: disagg
-                .as_ref()
-                .map(|d| d.prefill_prealloc_queue_reqs + d.prefill_inflight_queue_reqs),
+            prefill_queue_reqs: disagg.as_ref().map(|d| {
+                d.prefill_prealloc_queue_reqs
+                    .saturating_add(d.prefill_inflight_queue_reqs)
+            }),
             decode_queue_reqs: disagg.as_ref().map(|d| {
                 d.decode_prealloc_queue_reqs
-                    + d.decode_transfer_queue_reqs
-                    + d.decode_retracted_queue_reqs
+                    .saturating_add(d.decode_transfer_queue_reqs)
+                    .saturating_add(d.decode_retracted_queue_reqs)
             }),
             disagg_mode: disagg.map(|d| d.mode),
         }

--- a/crates/grpc_client/src/tokenspeed_scheduler.rs
+++ b/crates/grpc_client/src/tokenspeed_scheduler.rs
@@ -683,6 +683,8 @@ impl From<tokenspeed_proto::SchedulerLoad> for openai_protocol::worker::Schedule
             cache_hit_rate: load.cache_hit_rate,
             utilization: load.utilization,
             max_running_requests: load.max_running_requests,
+            // TokenSpeed has no disagg section; canonical PD fields stay None.
+            ..Default::default()
         }
     }
 }

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -730,6 +730,9 @@ impl From<proto::SchedulerLoad> for openai_protocol::worker::SchedulerLoadSnapsh
             cache_hit_rate: load.cache_hit_rate,
             utilization: load.utilization,
             max_running_requests: load.max_running_requests,
+            // vLLM disagg mapping is out of scope here; canonical PD fields
+            // stay None until the vLLM proto exposes them.
+            ..Default::default()
         }
     }
 }

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -1099,6 +1099,21 @@ pub struct SchedulerLoadSnapshot {
     pub cache_hit_rate: f64,
     pub utilization: f64,
     pub max_running_requests: i32,
+    /// PD disaggregation signals, populated only when the backend reports a
+    /// `disagg` section. `None` for HTTP or older engines. Canonical schema
+    /// other engines map into; SGLang derives the queue depths from its
+    /// per-stage DisaggregationMetrics counters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kv_transfer_latency_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kv_transfer_speed_gb_s: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prefill_queue_reqs: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decode_queue_reqs: Option<i32>,
+    /// "prefill", "decode", or "null" as reported by the backend.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disagg_mode: Option<String>,
 }
 
 /// Full load response for a single worker across all DP ranks.

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -584,6 +584,7 @@ impl AppContextBuilder {
                 .clone(),
             client.clone(),
             config.load_monitor_interval_secs,
+            config.engine_metrics,
         )));
         Ok(self)
     }

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -202,6 +202,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn engine_metrics(mut self, enabled: bool) -> Self {
+        self.config.engine_metrics = enabled;
+        self
+    }
+
     // ==================== Rate Limiting ====================
 
     pub fn max_concurrent_requests(mut self, max: i32) -> Self {

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -30,6 +30,11 @@ pub struct RouterConfig {
     pub worker_startup_check_interval_secs: u64,
     #[serde(default = "default_load_monitor_interval_secs")]
     pub load_monitor_interval_secs: u64,
+    /// Re-export engine `GetLoads` signals as `smg_engine_*` gauges, polling
+    /// even when no load-aware routing policy is active. Decouples engine
+    /// observability from routing.
+    #[serde(default)]
+    pub engine_metrics: bool,
     pub dp_aware: bool,
     #[serde(default)]
     pub dp_minimum_tokens_scheduler: bool,
@@ -650,6 +655,7 @@ impl Default for RouterConfig {
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
             worker_startup_check_interval_secs: 30,
             load_monitor_interval_secs: 10,
+            engine_metrics: false,
             dp_aware: false,
             dp_minimum_tokens_scheduler: false,
             api_key: None,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -274,6 +274,11 @@ struct CliArgs {
     #[arg(long, default_value_t = 10, help_heading = "Load Monitoring")]
     load_monitor_interval: u64,
 
+    /// Re-export engine GetLoads signals (incl. PD) as smg_engine_* Prometheus
+    /// gauges, polling even without a load-aware routing policy.
+    #[arg(long, default_value_t = false, help_heading = "Load Monitoring")]
+    engine_metrics: bool,
+
     // ==================== Service Discovery (Kubernetes) ====================
     /// Enable Kubernetes service discovery
     #[arg(
@@ -1258,6 +1263,7 @@ impl CliArgs {
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
             .load_monitor_interval_secs(self.load_monitor_interval)
+            .engine_metrics(self.engine_metrics)
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
             .queue_timeout_secs(self.queue_timeout_secs)
@@ -1570,6 +1576,39 @@ mod tests {
 
         let server_config = cli.to_server_config(router_config).unwrap();
         assert_eq!(server_config.health_check_port, None);
+    }
+
+    /// `--engine-metrics` must flow into `RouterConfig` and survive nesting
+    /// into `ServerConfig.router_config` — the consumer (load monitor) reads it
+    /// off `RouterConfig`. Two-path config-plumbing guard.
+    #[test]
+    fn engine_metrics_flows_into_both_configs() {
+        let cli = cli_args_from(&["--engine-metrics"]);
+
+        let router_config = cli.to_router_config(vec![]).unwrap();
+        assert!(
+            router_config.engine_metrics,
+            "engine_metrics must reach RouterConfig via to_router_config"
+        );
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert!(
+            server_config.router_config.engine_metrics,
+            "engine_metrics must survive into ServerConfig via to_server_config"
+        );
+    }
+
+    /// Default is off: the flag stays false through both conversions so
+    /// existing deployments keep the routing-gated polling behavior.
+    #[test]
+    fn engine_metrics_defaults_to_false_in_both_configs() {
+        let cli = cli_args_from(&[]);
+
+        let router_config = cli.to_router_config(vec![]).unwrap();
+        assert!(!router_config.engine_metrics);
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert!(!server_config.router_config.engine_metrics);
     }
 
     /// clap rejects out-of-range probe ports at parse time (the `u16`

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -1380,7 +1380,7 @@ impl Metrics {
     /// convention we set each to -1 (an impossible value for these gauges, whose
     /// 0 is meaningful) until <https://github.com/metrics-rs/metrics/issues/653>.
     /// `dp_size` bounds the rank labels; the role label is unknown at teardown,
-    /// so both PD roles are cleared. The label set must exactly match
+    /// so all PD roles (prefill/decode/null) are cleared. The label set must exactly match
     /// `record_engine_load` (including `model`) or a fresh series is created
     /// instead of overwriting the live one.
     pub fn remove_engine_load_metrics(worker_url: &str, model_id: &str, dp_size: usize) {
@@ -1406,7 +1406,7 @@ impl Metrics {
             }
         }
 
-        for role in ["prefill", "decode"] {
+        for role in ["prefill", "decode", "null"] {
             for name in [
                 "smg_engine_pd_kv_transfer_latency_ms",
                 "smg_engine_pd_kv_transfer_speed_gb_s",

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -276,6 +276,44 @@ pub(crate) fn init_metrics() {
         "Retry backoff duration by attempt number"
     );
 
+    // Layer 3: Engine load re-export (from the GetLoads poll loop)
+    describe_gauge!(
+        "smg_engine_running_requests",
+        "Engine-reported running requests by worker, model, dp_rank"
+    );
+    describe_gauge!(
+        "smg_engine_waiting_requests",
+        "Engine-reported waiting requests by worker, model, dp_rank"
+    );
+    describe_gauge!(
+        "smg_engine_token_usage",
+        "Engine-reported KV token usage ratio (0.0-1.0) by worker, model, dp_rank"
+    );
+    describe_gauge!(
+        "smg_engine_gen_throughput",
+        "Engine-reported generation throughput (tokens/s) by worker, model, dp_rank"
+    );
+    describe_gauge!(
+        "smg_engine_cache_hit_rate",
+        "Engine-reported prefix cache hit rate (0.0-1.0) by worker, model, dp_rank"
+    );
+    describe_gauge!(
+        "smg_engine_pd_kv_transfer_latency_ms",
+        "Engine-reported PD KV transfer latency (ms) by worker, role"
+    );
+    describe_gauge!(
+        "smg_engine_pd_kv_transfer_speed_gb_s",
+        "Engine-reported PD KV transfer speed (GB/s) by worker, role"
+    );
+    describe_gauge!(
+        "smg_engine_pd_prefill_queue_reqs",
+        "Engine-reported PD prefill queue depth by worker, role"
+    );
+    describe_gauge!(
+        "smg_engine_pd_decode_queue_reqs",
+        "Engine-reported PD decode queue depth by worker, role"
+    );
+
     // Layer 4: Discovery metrics
     describe_counter!(
         "smg_discovery_registrations_total",
@@ -1223,6 +1261,102 @@ impl Metrics {
     }
 
     // ========================================================================
+    // Layer 3: Engine load re-export
+    // ========================================================================
+
+    /// Re-export a worker's `GetLoads` snapshot as `smg_engine_*` gauges.
+    ///
+    /// Core gauges are per DP rank (`dp_rank` bounded by dp_size). PD gauges
+    /// are emitted only for ranks that carry a `disagg` section, labeled by the
+    /// engine-reported role (`prefill`/`decode`/`null`).
+    pub fn record_engine_load(
+        worker_url: &str,
+        model_id: &str,
+        response: &openai_protocol::worker::WorkerLoadResponse,
+    ) {
+        let worker = intern_string(worker_url);
+        let model = intern_string(model_id);
+
+        for load in &response.loads {
+            let dp_rank = intern_string(&load.dp_rank.to_string());
+
+            gauge!(
+                "smg_engine_running_requests",
+                "worker" => Arc::clone(&worker),
+                "model" => Arc::clone(&model),
+                "dp_rank" => Arc::clone(&dp_rank),
+            )
+            .set(load.num_running_reqs as f64);
+            gauge!(
+                "smg_engine_waiting_requests",
+                "worker" => Arc::clone(&worker),
+                "model" => Arc::clone(&model),
+                "dp_rank" => Arc::clone(&dp_rank),
+            )
+            .set(load.num_waiting_reqs as f64);
+            gauge!(
+                "smg_engine_token_usage",
+                "worker" => Arc::clone(&worker),
+                "model" => Arc::clone(&model),
+                "dp_rank" => Arc::clone(&dp_rank),
+            )
+            .set(load.token_usage);
+            gauge!(
+                "smg_engine_gen_throughput",
+                "worker" => Arc::clone(&worker),
+                "model" => Arc::clone(&model),
+                "dp_rank" => Arc::clone(&dp_rank),
+            )
+            .set(load.gen_throughput);
+            gauge!(
+                "smg_engine_cache_hit_rate",
+                "worker" => Arc::clone(&worker),
+                "model" => Arc::clone(&model),
+                "dp_rank" => dp_rank,
+            )
+            .set(load.cache_hit_rate);
+
+            // PD gauges only when the engine reported a disagg section.
+            let Some(role) = load.disagg_mode.as_deref() else {
+                continue;
+            };
+            let role = intern_string(role);
+            if let Some(latency) = load.kv_transfer_latency_ms {
+                gauge!(
+                    "smg_engine_pd_kv_transfer_latency_ms",
+                    "worker" => Arc::clone(&worker),
+                    "role" => Arc::clone(&role),
+                )
+                .set(latency);
+            }
+            if let Some(speed) = load.kv_transfer_speed_gb_s {
+                gauge!(
+                    "smg_engine_pd_kv_transfer_speed_gb_s",
+                    "worker" => Arc::clone(&worker),
+                    "role" => Arc::clone(&role),
+                )
+                .set(speed);
+            }
+            if let Some(reqs) = load.prefill_queue_reqs {
+                gauge!(
+                    "smg_engine_pd_prefill_queue_reqs",
+                    "worker" => Arc::clone(&worker),
+                    "role" => Arc::clone(&role),
+                )
+                .set(reqs as f64);
+            }
+            if let Some(reqs) = load.decode_queue_reqs {
+                gauge!(
+                    "smg_engine_pd_decode_queue_reqs",
+                    "worker" => Arc::clone(&worker),
+                    "role" => role,
+                )
+                .set(reqs as f64);
+            }
+        }
+    }
+
+    // ========================================================================
     // Worker cleanup
     // ========================================================================
 
@@ -1239,13 +1373,163 @@ impl Metrics {
         gauge!("smg_worker_cb_state", "worker" => Arc::clone(&worker)).set(-1.0);
         gauge!("smg_worker_health", "worker" => worker).set(-1.0);
     }
+
+    /// Sentinel-out `smg_engine_*` series for a removed worker.
+    ///
+    /// metrics-rs cannot delete series, so per the `remove_worker_metrics`
+    /// convention we set each to -1 (an impossible value for these gauges, whose
+    /// 0 is meaningful) until <https://github.com/metrics-rs/metrics/issues/653>.
+    /// `dp_size` bounds the rank labels; the role label is unknown at teardown,
+    /// so both PD roles are cleared. The label set must exactly match
+    /// `record_engine_load` (including `model`) or a fresh series is created
+    /// instead of overwriting the live one.
+    pub fn remove_engine_load_metrics(worker_url: &str, model_id: &str, dp_size: usize) {
+        let worker = intern_string(worker_url);
+        let model = intern_string(model_id);
+
+        for rank in 0..dp_size.max(1) {
+            let dp_rank = intern_string(&rank.to_string());
+            for name in [
+                "smg_engine_running_requests",
+                "smg_engine_waiting_requests",
+                "smg_engine_token_usage",
+                "smg_engine_gen_throughput",
+                "smg_engine_cache_hit_rate",
+            ] {
+                gauge!(
+                    name,
+                    "worker" => Arc::clone(&worker),
+                    "model" => Arc::clone(&model),
+                    "dp_rank" => Arc::clone(&dp_rank),
+                )
+                .set(-1.0);
+            }
+        }
+
+        for role in ["prefill", "decode"] {
+            for name in [
+                "smg_engine_pd_kv_transfer_latency_ms",
+                "smg_engine_pd_kv_transfer_speed_gb_s",
+                "smg_engine_pd_prefill_queue_reqs",
+                "smg_engine_pd_decode_queue_reqs",
+            ] {
+                gauge!(name, "worker" => Arc::clone(&worker), "role" => role).set(-1.0);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::net::TcpListener;
 
+    use metrics_exporter_prometheus::PrometheusBuilder;
+    use openai_protocol::worker::{SchedulerLoadSnapshot, WorkerLoadResponse};
+
     use super::*;
+
+    /// Run `f` under a thread-local Prometheus recorder and return the
+    /// rendered `/metrics` text — the same scrape output the :29000 endpoint
+    /// serves in production.
+    fn render_with_recorder(f: impl FnOnce()) -> String {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, f);
+        handle.render()
+    }
+
+    /// Core engine gauges share these labels for the snapshot fixtures.
+    const CORE_LABELS: [&str; 3] = ["dp_rank=\"2\"", "model=\"m\"", "worker=\"http://w:1\""];
+
+    /// Assert the rendered scrape has a line for `name` carrying every label in
+    /// `labels` and ending in `value`. Label order is exporter-defined, so this
+    /// matches on substrings rather than a fixed label set.
+    fn assert_metric(rendered: &str, name: &str, labels: &[&str], value: &str) {
+        let line = rendered
+            .lines()
+            .find(|l| l.starts_with(&format!("{name}{{")))
+            .unwrap_or_else(|| panic!("metric {name} missing; rendered:\n{rendered}"));
+        for label in labels {
+            assert!(line.contains(label), "{name} missing label {label}: {line}");
+        }
+        assert!(
+            line.ends_with(&format!(" {value}")),
+            "{name} expected value {value}: {line}"
+        );
+    }
+
+    #[test]
+    fn record_engine_load_sets_core_gauges_per_dp_rank() {
+        let response = WorkerLoadResponse {
+            timestamp: "t".to_string(),
+            dp_rank_count: 1,
+            loads: vec![SchedulerLoadSnapshot {
+                dp_rank: 2,
+                num_running_reqs: 7,
+                num_waiting_reqs: 3,
+                token_usage: 0.5,
+                gen_throughput: 42.0,
+                cache_hit_rate: 0.25,
+                ..Default::default()
+            }],
+        };
+
+        let rendered = render_with_recorder(|| {
+            Metrics::record_engine_load("http://w:1", "m", &response);
+        });
+
+        // The exporter renders labels in insertion order, so assert on the
+        // metric line's components rather than a fixed label ordering.
+        assert_metric(&rendered, "smg_engine_running_requests", &CORE_LABELS, "7");
+        assert_metric(&rendered, "smg_engine_waiting_requests", &CORE_LABELS, "3");
+        assert_metric(&rendered, "smg_engine_gen_throughput", &CORE_LABELS, "42");
+        // PD gauges absent when no disagg section was reported.
+        assert!(
+            !rendered.contains("smg_engine_pd_"),
+            "PD gauges must not appear without a disagg section; rendered:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn record_engine_load_sets_pd_gauges_when_disagg_present() {
+        let response = WorkerLoadResponse {
+            timestamp: "t".to_string(),
+            dp_rank_count: 1,
+            loads: vec![SchedulerLoadSnapshot {
+                dp_rank: 0,
+                disagg_mode: Some("prefill".to_string()),
+                kv_transfer_latency_ms: Some(3.5),
+                kv_transfer_speed_gb_s: Some(12.0),
+                prefill_queue_reqs: Some(9),
+                decode_queue_reqs: Some(4),
+                ..Default::default()
+            }],
+        };
+
+        let rendered = render_with_recorder(|| {
+            Metrics::record_engine_load("http://w:1", "m", &response);
+        });
+
+        let pd_labels = ["role=\"prefill\"", "worker=\"http://w:1\""];
+        assert_metric(
+            &rendered,
+            "smg_engine_pd_kv_transfer_latency_ms",
+            &pd_labels,
+            "3.5",
+        );
+        assert_metric(
+            &rendered,
+            "smg_engine_pd_prefill_queue_reqs",
+            &pd_labels,
+            "9",
+        );
+        assert_metric(
+            &rendered,
+            "smg_engine_pd_decode_queue_reqs",
+            &pd_labels,
+            "4",
+        );
+    }
 
     #[test]
     fn test_prometheus_config_default() {

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -299,19 +299,19 @@ pub(crate) fn init_metrics() {
     );
     describe_gauge!(
         "smg_engine_pd_kv_transfer_latency_ms",
-        "Engine-reported PD KV transfer latency (ms) by worker, role"
+        "Engine-reported PD KV transfer latency (ms) by worker, role, dp_rank"
     );
     describe_gauge!(
         "smg_engine_pd_kv_transfer_speed_gb_s",
-        "Engine-reported PD KV transfer speed (GB/s) by worker, role"
+        "Engine-reported PD KV transfer speed (GB/s) by worker, role, dp_rank"
     );
     describe_gauge!(
         "smg_engine_pd_prefill_queue_reqs",
-        "Engine-reported PD prefill queue depth by worker, role"
+        "Engine-reported PD prefill queue depth by worker, role, dp_rank"
     );
     describe_gauge!(
         "smg_engine_pd_decode_queue_reqs",
-        "Engine-reported PD decode queue depth by worker, role"
+        "Engine-reported PD decode queue depth by worker, role, dp_rank"
     );
 
     // Layer 4: Discovery metrics
@@ -1312,11 +1312,12 @@ impl Metrics {
                 "smg_engine_cache_hit_rate",
                 "worker" => Arc::clone(&worker),
                 "model" => Arc::clone(&model),
-                "dp_rank" => dp_rank,
+                "dp_rank" => Arc::clone(&dp_rank),
             )
             .set(load.cache_hit_rate);
 
-            // PD gauges only when the engine reported a disagg section.
+            // PD gauges only when the engine reported a disagg section. Labeled
+            // by dp_rank too, so DP ranks sharing a role don't overwrite.
             let Some(role) = load.disagg_mode.as_deref() else {
                 continue;
             };
@@ -1326,6 +1327,7 @@ impl Metrics {
                     "smg_engine_pd_kv_transfer_latency_ms",
                     "worker" => Arc::clone(&worker),
                     "role" => Arc::clone(&role),
+                    "dp_rank" => Arc::clone(&dp_rank),
                 )
                 .set(latency);
             }
@@ -1334,6 +1336,7 @@ impl Metrics {
                     "smg_engine_pd_kv_transfer_speed_gb_s",
                     "worker" => Arc::clone(&worker),
                     "role" => Arc::clone(&role),
+                    "dp_rank" => Arc::clone(&dp_rank),
                 )
                 .set(speed);
             }
@@ -1342,6 +1345,7 @@ impl Metrics {
                     "smg_engine_pd_prefill_queue_reqs",
                     "worker" => Arc::clone(&worker),
                     "role" => Arc::clone(&role),
+                    "dp_rank" => Arc::clone(&dp_rank),
                 )
                 .set(reqs as f64);
             }
@@ -1350,6 +1354,7 @@ impl Metrics {
                     "smg_engine_pd_decode_queue_reqs",
                     "worker" => Arc::clone(&worker),
                     "role" => role,
+                    "dp_rank" => dp_rank,
                 )
                 .set(reqs as f64);
             }
@@ -1380,9 +1385,9 @@ impl Metrics {
     /// convention we set each to -1 (an impossible value for these gauges, whose
     /// 0 is meaningful) until <https://github.com/metrics-rs/metrics/issues/653>.
     /// `dp_size` bounds the rank labels; the role label is unknown at teardown,
-    /// so all PD roles (prefill/decode/null) are cleared. The label set must exactly match
-    /// `record_engine_load` (including `model`) or a fresh series is created
-    /// instead of overwriting the live one.
+    /// so the full `dp_rank` × role (prefill/decode/null) space is cleared. The
+    /// label set must exactly match `record_engine_load` (including `model` and
+    /// `dp_rank`) or a fresh series is created instead of overwriting the live one.
     pub fn remove_engine_load_metrics(worker_url: &str, model_id: &str, dp_size: usize) {
         let worker = intern_string(worker_url);
         let model = intern_string(model_id);
@@ -1404,16 +1409,24 @@ impl Metrics {
                 )
                 .set(-1.0);
             }
-        }
 
-        for role in ["prefill", "decode", "null"] {
-            for name in [
-                "smg_engine_pd_kv_transfer_latency_ms",
-                "smg_engine_pd_kv_transfer_speed_gb_s",
-                "smg_engine_pd_prefill_queue_reqs",
-                "smg_engine_pd_decode_queue_reqs",
-            ] {
-                gauge!(name, "worker" => Arc::clone(&worker), "role" => role).set(-1.0);
+            // PD gauges are labeled {worker, role, dp_rank}; the role is unknown
+            // at teardown, so clear every role for this rank.
+            for role in ["prefill", "decode", "null"] {
+                for name in [
+                    "smg_engine_pd_kv_transfer_latency_ms",
+                    "smg_engine_pd_kv_transfer_speed_gb_s",
+                    "smg_engine_pd_prefill_queue_reqs",
+                    "smg_engine_pd_decode_queue_reqs",
+                ] {
+                    gauge!(
+                        name,
+                        "worker" => Arc::clone(&worker),
+                        "role" => role,
+                        "dp_rank" => Arc::clone(&dp_rank),
+                    )
+                    .set(-1.0);
+                }
             }
         }
     }
@@ -1510,7 +1523,7 @@ mod tests {
             Metrics::record_engine_load("http://w:1", "m", &response);
         });
 
-        let pd_labels = ["role=\"prefill\"", "worker=\"http://w:1\""];
+        let pd_labels = ["role=\"prefill\"", "worker=\"http://w:1\"", "dp_rank=\"0\""];
         assert_metric(
             &rendered,
             "smg_engine_pd_kv_transfer_latency_ms",

--- a/model_gateway/src/policies/least_load.rs
+++ b/model_gateway/src/policies/least_load.rs
@@ -335,6 +335,7 @@ mod tests {
                 cache_hit_rate: 0.0,
                 utilization: 0.0,
                 max_running_requests: 0,
+                ..Default::default()
             }],
         }
     }

--- a/model_gateway/src/policies/power_of_two.rs
+++ b/model_gateway/src/policies/power_of_two.rs
@@ -168,6 +168,7 @@ mod tests {
                 cache_hit_rate: 0.0,
                 utilization: 0.0,
                 max_running_requests: 0,
+                ..Default::default()
             }],
         }
     }

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -244,17 +244,26 @@ impl GrpcClient {
     /// Get the full load response from the backend.
     /// Returns `Unimplemented` for backends without scheduler load metrics.
     pub async fn get_loads(&self) -> Result<WorkerLoadResponse, tonic::Status> {
+        // Optional sections beyond `core` (disagg/queues/memory) are dropped by
+        // engines that do not report them, so requesting them is always safe and
+        // leaves routing consumers, which only read `core`, unaffected.
+        let include = || {
+            ["core", "disagg", "queues", "memory"]
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>()
+        };
         match self {
             Self::Sglang(client) => {
-                let resp = client.get_loads(vec!["core".to_string()]).await?;
+                let resp = client.get_loads(include()).await?;
                 Ok(WorkerLoadResponse::from(resp))
             }
             Self::TokenSpeed(client) => {
-                let resp = client.get_loads(vec!["core".to_string()]).await?;
+                let resp = client.get_loads(include()).await?;
                 Ok(WorkerLoadResponse::from(resp))
             }
             Self::Vllm(client) => {
-                let resp = client.get_loads(vec!["core".to_string()]).await?;
+                let resp = client.get_loads(include()).await?;
                 Ok(WorkerLoadResponse::from(resp))
             }
             _ => Err(tonic::Status::unimplemented(

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -61,6 +61,7 @@ use tokio::{
 use tracing::{debug, info, warn};
 
 use crate::{
+    observability::metrics::Metrics,
     policies::PolicyRegistry,
     worker::{event::WorkerEvent, ConnectionMode, Worker, WorkerRegistry},
 };
@@ -141,6 +142,9 @@ pub struct WorkerMonitor {
     pub worker_load_manager: Arc<WorkerLoadManager>,
     client: reqwest::Client,
     default_interval: Duration,
+    /// When set, poll loads and re-export `smg_engine_*` gauges even if no
+    /// load-aware routing policy is active (`--engine-metrics`).
+    engine_metrics: bool,
     load_tx: watch::Sender<HashMap<String, WorkerLoadResponse>>,
     load_rx: watch::Receiver<HashMap<String, WorkerLoadResponse>>,
     group_handles: Mutex<HashMap<WorkerGroupKey, GroupState>>,
@@ -166,6 +170,7 @@ impl WorkerMonitor {
         policy_registry: Arc<PolicyRegistry>,
         client: reqwest::Client,
         default_interval_secs: u64,
+        engine_metrics: bool,
     ) -> Self {
         let (load_tx, load_rx) = watch::channel(HashMap::new());
         Self {
@@ -174,6 +179,7 @@ impl WorkerMonitor {
             worker_load_manager: Arc::new(WorkerLoadManager::new()),
             client,
             default_interval: Duration::from_secs(default_interval_secs.max(1)),
+            engine_metrics,
             load_tx,
             load_rx,
             group_handles: Mutex::new(HashMap::new()),
@@ -350,11 +356,22 @@ impl WorkerMonitor {
     /// Evict a single worker's cached loads from both the watch
     /// channel snapshot and the DP cache. Used by the event loop on
     /// `Removed`, `Replaced`, and `StatusChanged` away from `Ready`.
-    fn evict_worker_loads(&self, url: &str) {
+    ///
+    /// Also sentinels the worker's `smg_engine_*` series when engine-metrics
+    /// re-export is on, since metrics-rs cannot delete series.
+    fn evict_worker_loads(&self, worker: &Arc<dyn Worker>) {
+        let url = worker.url();
         self.load_tx.send_modify(|map| {
             map.remove(url);
         });
         self.worker_load_manager.remove_worker(url);
+        if self.engine_metrics {
+            Metrics::remove_engine_load_metrics(
+                url,
+                worker.model_id(),
+                worker.dp_size().unwrap_or(1),
+            );
+        }
     }
 
     /// Spawn the polling loop for a single group.
@@ -379,7 +396,10 @@ impl WorkerMonitor {
         handles.insert(key, GroupState { handle, interval });
     }
 
-    /// Fetch load via HTTP `GET /v1/loads?include=core`.
+    /// Fetch load via HTTP `GET /v1/loads?include=core,disagg,queues,memory`.
+    ///
+    /// Extra sections beyond `core` degrade gracefully: engines that do not
+    /// report them simply omit the fields, which deserialize to `None`.
     ///
     /// Returns `None` on transport failure, non-success status, JSON
     /// parse failure, or an empty `loads` array.
@@ -388,7 +408,7 @@ impl WorkerMonitor {
         worker: &Arc<dyn Worker>,
     ) -> Option<WorkerLoadResponse> {
         let url = worker.url();
-        let load_url = format!("{url}/v1/loads?include=core");
+        let load_url = format!("{url}/v1/loads?include=core,disagg,queues,memory");
         let mut req = client.get(&load_url).timeout(REQUEST_TIMEOUT);
         if let Some(key) = worker.api_key() {
             req = req.bearer_auth(key);
@@ -510,7 +530,7 @@ async fn run_event_loop(
                 // `reconcile_group` will stop the polling loop, and a
                 // stopped loop cannot prune the stale entry on a later
                 // tick — it would persist forever otherwise.
-                monitor.evict_worker_loads(worker.url());
+                monitor.evict_worker_loads(&worker);
                 for key in group_keys_for_worker(&worker) {
                     monitor.reconcile_group(&key);
                 }
@@ -522,7 +542,7 @@ async fn run_event_loop(
                 // from caches before reconciling so the disappearing
                 // groups do not leak the entry; the surviving / new
                 // groups will repopulate it on their next poll tick.
-                monitor.evict_worker_loads(old.url());
+                monitor.evict_worker_loads(&old);
                 let mut keys = group_keys_for_worker(&old);
                 keys.extend(group_keys_for_worker(&new));
                 keys.sort_by(|a, b| {
@@ -543,7 +563,7 @@ async fn run_event_loop(
                 ..
             }) => {
                 if new_status != WorkerStatus::Ready {
-                    monitor.evict_worker_loads(worker.url());
+                    monitor.evict_worker_loads(&worker);
                 }
                 // No action needed when transitioning *into* Ready: the
                 // group's polling loop reads from the registry on every
@@ -588,10 +608,13 @@ async fn group_monitor_loop(
             return;
         };
 
+        // Poll when a load-aware policy needs the data OR engine-metrics
+        // re-export is on; the latter decouples observability from routing.
         let load_aware_policies = monitor.policy_registry.get_all_load_aware_policies();
-        if load_aware_policies.is_empty() && monitor.policy_registry.get_dp_rank_policy().is_none()
-        {
-            debug!("No load-aware policies, skipping load fetch for group {group_key}");
+        let routing_needs_load = !load_aware_policies.is_empty()
+            || monitor.policy_registry.get_dp_rank_policy().is_some();
+        if !routing_needs_load && !monitor.engine_metrics {
+            debug!("No load-aware policies and engine metrics off, skipping load fetch for group {group_key}");
             drop(monitor);
             continue;
         }
@@ -678,6 +701,14 @@ async fn group_monitor_loop(
             policy.update_loads(&group_loads);
         }
         monitor.worker_load_manager.update_dp_loads(&group_dp_loads);
+
+        // Re-export the freshly fetched loads as `smg_engine_*` gauges. Reuses
+        // this poll's data; no extra fetch. Model label comes from the group.
+        if monitor.engine_metrics {
+            for (url, load) in &group_loads {
+                Metrics::record_engine_load(url, &group_key.model_id, load);
+            }
+        }
 
         // Atomically merge into the shared watch channel: clear stale
         // entries for *this group's* URLs first, then insert the fresh
@@ -805,6 +836,7 @@ mod worker_monitor_tests {
             policy_registry,
             reqwest::Client::new(),
             5,
+            false,
         ));
         (registry, monitor)
     }

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -366,11 +366,12 @@ impl WorkerMonitor {
         });
         self.worker_load_manager.remove_worker(url);
         if self.engine_metrics {
-            Metrics::remove_engine_load_metrics(
-                url,
-                worker.model_id(),
-                worker.dp_size().unwrap_or(1),
-            );
+            // A worker can serve multiple models (one load group per model),
+            // so sentinel every model's series — not just the primary.
+            let dp_size = worker.dp_size().unwrap_or(1);
+            for model_id in WorkerRegistry::worker_model_ids(worker) {
+                Metrics::remove_engine_load_metrics(url, &model_id, dp_size);
+            }
         }
     }
 

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -350,6 +350,7 @@ pub fn create_test_context(
             policy_registry.clone(),
             client.clone(),
             config.load_monitor_interval_secs,
+            config.engine_metrics,
         )));
 
         // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator
@@ -492,6 +493,7 @@ pub fn create_test_context_with_parsers(
             policy_registry.clone(),
             client.clone(),
             config.load_monitor_interval_secs,
+            config.engine_metrics,
         )));
 
         // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator
@@ -641,6 +643,7 @@ pub fn create_test_context_with_mcp_config(
             policy_registry.clone(),
             client.clone(),
             config.load_monitor_interval_secs,
+            config.engine_metrics,
         )));
 
         // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator

--- a/model_gateway/tests/common/test_app.rs
+++ b/model_gateway/tests/common/test_app.rs
@@ -63,6 +63,7 @@ pub fn create_test_app(
         policy_registry.clone(),
         client.clone(),
         router_config.load_monitor_interval_secs,
+        router_config.engine_metrics,
     )));
 
     // Create empty OnceLock for worker job queue and workflow engines

--- a/model_gateway/tests/engine_metrics_test.rs
+++ b/model_gateway/tests/engine_metrics_test.rs
@@ -53,16 +53,19 @@ async fn engine_pd_gauge_appears_on_metrics_endpoint() {
         .await
         .expect("metrics body");
 
+    // Match the metric name AND its labels on the SAME rendered line, so the
+    // name and the role/dp_rank labels can't be satisfied by different samples.
+    let pd_latency_line = body
+        .lines()
+        .find(|l| l.starts_with("smg_engine_pd_kv_transfer_latency_ms{"))
+        .unwrap_or_else(|| panic!("PD KV transfer latency sample missing from /metrics:\n{body}"));
     assert!(
-        body.contains("smg_engine_pd_kv_transfer_latency_ms"),
-        "PD KV transfer latency gauge missing from /metrics:\n{body}"
+        pd_latency_line.contains("role=\"prefill\"") && pd_latency_line.contains("dp_rank=\"0\""),
+        "PD latency sample missing role/dp_rank labels: {pd_latency_line}"
     );
     assert!(
-        body.contains("role=\"prefill\""),
-        "PD role label missing from /metrics:\n{body}"
-    );
-    assert!(
-        body.contains("smg_engine_running_requests"),
-        "core engine gauge missing from /metrics:\n{body}"
+        body.lines()
+            .any(|l| l.starts_with("smg_engine_running_requests{")),
+        "core engine sample missing from /metrics:\n{body}"
     );
 }

--- a/model_gateway/tests/engine_metrics_test.rs
+++ b/model_gateway/tests/engine_metrics_test.rs
@@ -1,0 +1,68 @@
+//! Integration test for the `smg_engine_*` re-export (W2).
+//!
+//! Drives the real Prometheus exporter and the :29000-style metrics HTTP
+//! server end to end: a worker load snapshot carrying a `disagg` section is
+//! recorded through the same `Metrics::record_engine_load` call the load
+//! monitor makes, then scraped over HTTP to assert the PD gauge is exposed.
+//!
+//! This file is its own test binary (process), so installing the global
+//! Prometheus recorder here is safe and does not collide with other suites.
+
+use openai_protocol::worker::{SchedulerLoadSnapshot, WorkerLoadResponse};
+use smg::observability::{
+    metrics::{start_prometheus, Metrics, PrometheusConfig},
+    metrics_server::start_metrics_server,
+};
+
+#[tokio::test]
+async fn engine_pd_gauge_appears_on_metrics_endpoint() {
+    // Reserve a free port, then start the metrics server on it. The recorder is
+    // global and may only be installed once per process; `start_prometheus`
+    // does that install and hands back the handle the server renders.
+    let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = probe.local_addr().unwrap().port();
+    drop(probe);
+
+    let handle = start_prometheus(PrometheusConfig {
+        port,
+        host: "127.0.0.1".to_string(),
+        duration_buckets: None,
+    });
+    let _server = start_metrics_server(handle, "127.0.0.1".to_string(), port).await;
+
+    let response = WorkerLoadResponse {
+        timestamp: "t".to_string(),
+        dp_rank_count: 1,
+        loads: vec![SchedulerLoadSnapshot {
+            dp_rank: 0,
+            num_running_reqs: 5,
+            disagg_mode: Some("prefill".to_string()),
+            kv_transfer_latency_ms: Some(2.5),
+            kv_transfer_speed_gb_s: Some(8.0),
+            prefill_queue_reqs: Some(6),
+            decode_queue_reqs: Some(2),
+            ..Default::default()
+        }],
+    };
+    Metrics::record_engine_load("grpc://prefill-0:30000", "test-model", &response);
+
+    let body = reqwest::get(format!("http://127.0.0.1:{port}/metrics"))
+        .await
+        .expect("metrics endpoint reachable")
+        .text()
+        .await
+        .expect("metrics body");
+
+    assert!(
+        body.contains("smg_engine_pd_kv_transfer_latency_ms"),
+        "PD KV transfer latency gauge missing from /metrics:\n{body}"
+    );
+    assert!(
+        body.contains("role=\"prefill\""),
+        "PD role label missing from /metrics:\n{body}"
+    );
+    assert!(
+        body.contains("smg_engine_running_requests"),
+        "core engine gauge missing from /metrics:\n{body}"
+    );
+}

--- a/model_gateway/tests/routing/test_pd_routing.rs
+++ b/model_gateway/tests/routing/test_pd_routing.rs
@@ -244,6 +244,7 @@ mod pd_routing_unit_tests {
                     policy_registry.clone(),
                     client.clone(),
                     config.load_monitor_interval_secs,
+                    config.engine_metrics,
                 )));
 
                 // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator

--- a/model_gateway/tests/wasm_test.rs
+++ b/model_gateway/tests/wasm_test.rs
@@ -69,6 +69,7 @@ async fn create_test_context_with_wasm() -> Arc<AppContext> {
         policy_registry.clone(),
         client.clone(),
         config.load_monitor_interval_secs,
+        config.engine_metrics,
     )));
 
     // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator


### PR DESCRIPTION
Part of #1773. Closes #1775.

## What
Re-export the `GetLoads` data SMG already polls as `smg_engine_*` Prometheus gauges on `:29000` — uniform engine + PD observability for any backend with `GetLoads`, no HTTP endpoint required.

- Request `core,disagg,queues,memory` from `GetLoads` (gRPC `client.rs`) and HTTP `/v1/loads` (`monitor.rs`); the extra sections are additive/optional, so routing consumers (which read only `core`) are unaffected.
- Canonical schema: `SchedulerLoadSnapshot` (crates/protocols) gains `Option<>` disagg fields (`kv_transfer_latency_ms`, `kv_transfer_speed_gb_s`, `prefill_queue_reqs`, `decode_queue_reqs`, `disagg_mode`). SGLang `From<proto>` rolls the per-stage counters into the two canonical queue totals. Other engines map in via W5 (#1778).
- Emit from the existing monitor poll loop (no new polling) via `Metrics::record_engine_load`: core gauges `{worker,model,dp_rank}` + PD gauges `{worker,role}` (only when a `disagg` section is present). `remove_engine_load_metrics` sentinel on teardown (metrics-rs can't delete series).
- `--engine-metrics` decouples the poll from load-aware routing, wired through **both** config conversion paths.

## Tests
Unit (`From` maps disagg; `record_engine_load` sets gauges) + integration (`engine_metrics_test.rs`: a `disagg` section surfaces `smg_engine_pd_kv_transfer_latency_ms` on the metrics endpoint). `smg-python`/`smg-golang` build-checked for the `crates/protocols` change. Verified green in an isolated target dir; **CI is authoritative**.

## Cross-workstream notes
- `WorkerMonitor::new` gains a 5th arg and `evict_worker_loads` now takes `&Arc<dyn Worker>` — siblings adding monitor call sites must match.
- Shares `observability/metrics.rs` and `routers/grpc/client.rs` with W1 (#1774) / W3 (#1776) — additive; expect merge conflicts when stacking.
- The canonical `SchedulerLoadSnapshot` disagg fields are the contract W5 (#1778) maps vLLM into (currently `None` for vLLM/TokenSpeed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus engine-load gauges (`smg_engine_*`), with PD/disaggregation metrics (KV transfer latency/speed and prefill/decode queue depths) surfaced when the backend reports disaggregation.
  * Expanded load polling to request additional engine sections (disagg, queues, memory) where supported.
* **Configuration**
  * Added `--engine-metrics` CLI flag and `engine_metrics` config option (default: disabled).
* **Bug Fixes**
  * Cleared engine-load gauge series on worker removal to avoid stale metric values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->