### PR TITLE
feat(metrics): add smg_pd_* PD disaggregation metrics

### DIFF
--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -218,7 +218,7 @@ impl RuntimeType {
 
     /// Static string form, identical to `Display`. For hot-path metric labels
     /// that must avoid per-call allocation/interning.
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             RuntimeType::Unspecified => "unspecified",
             RuntimeType::Sglang => "sglang",

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -215,19 +215,25 @@ impl RuntimeType {
     pub fn is_specified(self) -> bool {
         !matches!(self, RuntimeType::Unspecified)
     }
+
+    /// Static string form, identical to `Display`. For hot-path metric labels
+    /// that must avoid per-call allocation/interning.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RuntimeType::Unspecified => "unspecified",
+            RuntimeType::Sglang => "sglang",
+            RuntimeType::Vllm => "vllm",
+            RuntimeType::Trtllm => "trtllm",
+            RuntimeType::Mlx => "mlx",
+            RuntimeType::TokenSpeed => "tokenspeed",
+            RuntimeType::External => "external",
+        }
+    }
 }
 
 impl std::fmt::Display for RuntimeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RuntimeType::Unspecified => write!(f, "unspecified"),
-            RuntimeType::Sglang => write!(f, "sglang"),
-            RuntimeType::Vllm => write!(f, "vllm"),
-            RuntimeType::Trtllm => write!(f, "trtllm"),
-            RuntimeType::Mlx => write!(f, "mlx"),
-            RuntimeType::TokenSpeed => write!(f, "tokenspeed"),
-            RuntimeType::External => write!(f, "external"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -133,6 +133,10 @@ toml = "1.0"
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 tower = { version = "0.5", features = ["util"] }
+# Used by PD metrics integration tests to capture metric emission via a
+# thread-local Prometheus recorder (same versions as the runtime deps above).
+metrics = "0.24.2"
+metrics-exporter-prometheus = { version = "0.18.1", default-features = false }
 http-body-util = "0.1"
 portpicker = "0.1"
 lazy_static = "1.4"

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -201,6 +201,33 @@ pub(crate) fn init_metrics() {
         "Total generation time by router_type, backend_type, model, endpoint (gRPC only)"
     );
 
+    // Layer 2: PD disaggregation metrics (signals only SMG can measure — it is the
+    // only component that observes both the prefill and decode legs of a request).
+    describe_histogram!(
+        "smg_pd_prefill_duration_seconds",
+        "Prefill-leg RPC duration by backend_type, model, runtime"
+    );
+    describe_histogram!(
+        "smg_pd_kv_transfer_duration_seconds",
+        "KV-transfer window (prefill drain to decode send) by backend_type, model, runtime (vLLM sequential PD)"
+    );
+    describe_histogram!(
+        "smg_pd_ttft_seconds",
+        "Honest end-to-end TTFT (prefill start to first decode token) by backend_type, model, runtime"
+    );
+    describe_counter!(
+        "smg_pd_kv_connector_mode_total",
+        "KV connector mode decisions by mode (mooncake/nixl/passthrough)"
+    );
+    describe_counter!(
+        "smg_pd_bootstrap_failures_total",
+        "PD bootstrap injection failures"
+    );
+    describe_counter!(
+        "smg_pd_kv_transfer_failures_total",
+        "PD KV-transfer failures (missing connector params at decode handoff)"
+    );
+
     // Layer 3: Worker metrics
     describe_gauge!(
         "smg_worker_pool_size",
@@ -429,6 +456,11 @@ pub mod metrics_labels {
     // Token types
     pub const TOKEN_INPUT: &str = "input";
     pub const TOKEN_OUTPUT: &str = "output";
+
+    // PD KV connector modes (smg_pd_kv_connector_mode_total)
+    pub const KV_CONNECTOR_MOONCAKE: &str = "mooncake";
+    pub const KV_CONNECTOR_NIXL: &str = "nixl";
+    pub const KV_CONNECTOR_PASSTHROUGH: &str = "passthrough";
 
     // Storage types
     pub const STORAGE_RESPONSE: &str = "response";
@@ -833,6 +865,96 @@ impl Metrics {
             "token_type" => metrics_labels::TOKEN_OUTPUT
         )
         .increment(output_tokens);
+    }
+
+    // ========================================================================
+    // Layer 2: PD disaggregation metrics
+    //
+    // Per-request, engine-agnostic signals that no backend can self-report: SMG
+    // is the only component that sees both the prefill and decode legs. All
+    // durations come from a monotonic clock and are recorded once per request
+    // (never per retry attempt).
+    // ========================================================================
+
+    /// Record prefill-leg RPC duration.
+    /// Uses string interning for model_id and runtime.
+    pub fn record_pd_prefill_duration(
+        backend_type: &'static str,
+        model_id: &str,
+        runtime: &str,
+        duration: Duration,
+    ) {
+        let model = intern_string(model_id);
+        let runtime = intern_string(runtime);
+        histogram!(
+            "smg_pd_prefill_duration_seconds",
+            "backend_type" => backend_type,
+            "model" => model,
+            "runtime" => runtime
+        )
+        .record(duration.as_secs_f64());
+    }
+
+    /// Record the KV-transfer window (prefill drain to decode send) for vLLM
+    /// sequential PD. Uses string interning for model_id and runtime.
+    pub fn record_pd_kv_transfer_duration(
+        backend_type: &'static str,
+        model_id: &str,
+        runtime: &str,
+        duration: Duration,
+    ) {
+        let model = intern_string(model_id);
+        let runtime = intern_string(runtime);
+        histogram!(
+            "smg_pd_kv_transfer_duration_seconds",
+            "backend_type" => backend_type,
+            "model" => model,
+            "runtime" => runtime
+        )
+        .record(duration.as_secs_f64());
+    }
+
+    /// Record honest end-to-end TTFT: prefill start to first decode token.
+    ///
+    /// INVARIANT: this is the user-facing complement to
+    /// `smg_router_ttft_seconds{backend_type="pd"}`, which measures only the
+    /// decode leg (first decode token minus decode-send). For sequential PD the
+    /// two differ by the prefill + KV-transfer time; both are kept on purpose.
+    /// Uses string interning for model_id and runtime.
+    pub fn record_pd_ttft(
+        backend_type: &'static str,
+        model_id: &str,
+        runtime: &str,
+        duration: Duration,
+    ) {
+        let model = intern_string(model_id);
+        let runtime = intern_string(runtime);
+        histogram!(
+            "smg_pd_ttft_seconds",
+            "backend_type" => backend_type,
+            "model" => model,
+            "runtime" => runtime
+        )
+        .record(duration.as_secs_f64());
+    }
+
+    /// Record a KV connector mode decision (mooncake/nixl/passthrough).
+    pub fn record_pd_kv_connector_mode(mode: &'static str) {
+        counter!(
+            "smg_pd_kv_connector_mode_total",
+            "mode" => mode
+        )
+        .increment(1);
+    }
+
+    /// Record a PD bootstrap injection failure.
+    pub fn record_pd_bootstrap_failure() {
+        counter!("smg_pd_bootstrap_failures_total").increment(1);
+    }
+
+    /// Record a PD KV-transfer failure (missing connector params at handoff).
+    pub fn record_pd_kv_transfer_failure() {
+        counter!("smg_pd_kv_transfer_failures_total").increment(1);
     }
 
     // ========================================================================
@@ -1560,5 +1682,104 @@ mod tests {
         assert_eq!(method_to_static_str("GET"), "GET");
         assert_eq!(method_to_static_str("POST"), "POST");
         assert_eq!(method_to_static_str("UNKNOWN"), "OTHER");
+    }
+
+    // ========================================================================
+    // PD disaggregation metric tests
+    // ========================================================================
+
+    /// Run `f` with a Prometheus recorder installed thread-locally and return
+    /// the rendered /metrics text. Mirrors the helper in `runtime_metrics`.
+    fn with_test_recorder<T>(f: impl FnOnce() -> T) -> (String, T) {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let result = metrics::with_local_recorder(&recorder, f);
+        (handle.render(), result)
+    }
+
+    #[test]
+    fn test_record_pd_prefill_duration_emits_histogram() {
+        let (rendered, ()) = with_test_recorder(|| {
+            Metrics::record_pd_prefill_duration(
+                metrics_labels::BACKEND_PD,
+                "test-model",
+                "vllm",
+                Duration::from_millis(42),
+            );
+        });
+        assert!(
+            rendered.contains("smg_pd_prefill_duration_seconds_count{")
+                && rendered.contains(r#"backend_type="pd""#)
+                && rendered.contains(r#"model="test-model""#)
+                && rendered.contains(r#"runtime="vllm""#),
+            "prefill duration histogram not emitted; rendered:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn test_record_pd_kv_transfer_duration_emits_histogram() {
+        let (rendered, ()) = with_test_recorder(|| {
+            Metrics::record_pd_kv_transfer_duration(
+                metrics_labels::BACKEND_PD,
+                "m",
+                "vllm",
+                Duration::from_millis(7),
+            );
+        });
+        assert!(
+            rendered.contains("smg_pd_kv_transfer_duration_seconds_count"),
+            "kv transfer histogram not emitted; rendered:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn test_record_pd_ttft_emits_histogram() {
+        let (rendered, ()) = with_test_recorder(|| {
+            Metrics::record_pd_ttft(
+                metrics_labels::BACKEND_PD,
+                "m",
+                "sglang",
+                Duration::from_millis(123),
+            );
+        });
+        assert!(
+            rendered.contains("smg_pd_ttft_seconds_count")
+                && rendered.contains(r#"runtime="sglang""#),
+            "pd ttft histogram not emitted; rendered:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn test_record_pd_kv_connector_mode_counts_by_mode() {
+        let (rendered, ()) = with_test_recorder(|| {
+            Metrics::record_pd_kv_connector_mode(metrics_labels::KV_CONNECTOR_MOONCAKE);
+            Metrics::record_pd_kv_connector_mode(metrics_labels::KV_CONNECTOR_MOONCAKE);
+            Metrics::record_pd_kv_connector_mode(metrics_labels::KV_CONNECTOR_NIXL);
+        });
+        assert!(
+            rendered.contains(r#"smg_pd_kv_connector_mode_total{mode="mooncake"} 2"#),
+            "mooncake connector counter wrong; rendered:\n{rendered}"
+        );
+        assert!(
+            rendered.contains(r#"smg_pd_kv_connector_mode_total{mode="nixl"} 1"#),
+            "nixl connector counter wrong; rendered:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn test_record_pd_failure_counters() {
+        let (rendered, ()) = with_test_recorder(|| {
+            Metrics::record_pd_bootstrap_failure();
+            Metrics::record_pd_kv_transfer_failure();
+            Metrics::record_pd_kv_transfer_failure();
+        });
+        assert!(
+            rendered.contains("smg_pd_bootstrap_failures_total 1"),
+            "bootstrap failure counter wrong; rendered:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("smg_pd_kv_transfer_failures_total 2"),
+            "kv transfer failure counter wrong; rendered:\n{rendered}"
+        );
     }
 }

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -877,15 +877,14 @@ impl Metrics {
     // ========================================================================
 
     /// Record prefill-leg RPC duration.
-    /// Uses string interning for model_id and runtime.
+    /// Uses string interning for model_id; runtime is a static label.
     pub fn record_pd_prefill_duration(
         backend_type: &'static str,
         model_id: &str,
-        runtime: &str,
+        runtime: &'static str,
         duration: Duration,
     ) {
         let model = intern_string(model_id);
-        let runtime = intern_string(runtime);
         histogram!(
             "smg_pd_prefill_duration_seconds",
             "backend_type" => backend_type,
@@ -896,15 +895,14 @@ impl Metrics {
     }
 
     /// Record the KV-transfer window (prefill drain to decode send) for vLLM
-    /// sequential PD. Uses string interning for model_id and runtime.
+    /// sequential PD. Uses string interning for model_id; runtime is a static label.
     pub fn record_pd_kv_transfer_duration(
         backend_type: &'static str,
         model_id: &str,
-        runtime: &str,
+        runtime: &'static str,
         duration: Duration,
     ) {
         let model = intern_string(model_id);
-        let runtime = intern_string(runtime);
         histogram!(
             "smg_pd_kv_transfer_duration_seconds",
             "backend_type" => backend_type,
@@ -920,15 +918,14 @@ impl Metrics {
     /// `smg_router_ttft_seconds{backend_type="pd"}`, which measures only the
     /// decode leg (first decode token minus decode-send). For sequential PD the
     /// two differ by the prefill + KV-transfer time; both are kept on purpose.
-    /// Uses string interning for model_id and runtime.
+    /// Uses string interning for model_id; runtime is a static label.
     pub fn record_pd_ttft(
         backend_type: &'static str,
         model_id: &str,
-        runtime: &str,
+        runtime: &'static str,
         duration: Duration,
     ) {
         let model = intern_string(model_id);
-        let runtime = intern_string(runtime);
         histogram!(
             "smg_pd_ttft_seconds",
             "backend_type" => backend_type,

--- a/model_gateway/src/routers/grpc/common/response_collection.rs
+++ b/model_gateway/src/routers/grpc/common/response_collection.rs
@@ -39,6 +39,7 @@ pub(crate) async fn collect_responses(
         ExecutionResult::Dual {
             mut prefill,
             decode,
+            ..
         } => {
             // Collect prefill for input_logprobs (don't mark completed yet)
             let prefill_responses = collect_stream_responses(&mut prefill, "Prefill").await?;

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -452,7 +452,9 @@ impl RequestExecutionStage {
             })
             .unwrap_or(KvConnectorMode::Passthrough);
 
-        Metrics::record_pd_kv_connector_mode(mode.metrics_label());
+        // Recorded on the success path (after decode established) so failed
+        // requests don't pollute success metrics; captured here before use of mode.
+        let kv_connector_label = mode.metrics_label();
 
         match &mode {
             KvConnectorMode::Mooncake {
@@ -566,12 +568,8 @@ impl RequestExecutionStage {
         }
         prefill_stream.mark_completed();
         workers.record_outcome_prefill(200);
-        Metrics::record_pd_prefill_duration(
-            metrics_labels::BACKEND_PD,
-            model,
-            runtime,
-            prefill_start.elapsed(),
-        );
+        // Captured at drain; recorded below only once decode is established.
+        let prefill_duration = prefill_start.elapsed();
 
         // KV-transfer window: prefill drain complete to decode send complete.
         let kv_window_start = Instant::now();
@@ -654,6 +652,14 @@ impl RequestExecutionStage {
         })?;
 
         workers.record_outcome_decode(200);
+        // Decode established: record the success-only PD metrics here.
+        Metrics::record_pd_kv_connector_mode(kv_connector_label);
+        Metrics::record_pd_prefill_duration(
+            metrics_labels::BACKEND_PD,
+            model,
+            runtime,
+            prefill_duration,
+        );
         Metrics::record_pd_kv_transfer_duration(
             metrics_labels::BACKEND_PD,
             model,

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -206,8 +206,7 @@ impl PipelineStage for RequestExecutionStage {
                                     .await
                             }
                             Some(RuntimeType::Sglang) => {
-                                self.execute_dual_dispatch(req, clients, workers, model)
-                                    .await
+                                self.execute_dual_dispatch(req, clients, workers).await
                             }
                             Some(RuntimeType::Trtllm)
                             | Some(RuntimeType::Mlx)
@@ -325,12 +324,8 @@ impl RequestExecutionStage {
         proto_request: ProtoGenerateRequest,
         clients: &mut ClientSelection,
         workers: &WorkerSelection,
-        model: &str,
     ) -> Result<ExecutionResult, Response> {
-        let runtime = workers
-            .pd_runtime_type()
-            .map(RuntimeType::as_str)
-            .unwrap_or("");
+        let runtime = workers.pd_runtime_type().map(|r| r.as_str()).unwrap_or("");
         let (prefill_client, decode_client) = clients.dual_mut().ok_or_else(|| {
             error!(
                 function = "execute_dual_dispatch",
@@ -417,10 +412,7 @@ impl RequestExecutionStage {
         workers: &WorkerSelection,
         model: &str,
     ) -> Result<ExecutionResult, Response> {
-        let runtime = workers
-            .pd_runtime_type()
-            .map(RuntimeType::as_str)
-            .unwrap_or("");
+        let runtime = workers.pd_runtime_type().map(|r| r.as_str()).unwrap_or("");
         let (prefill_client, decode_client) = clients.dual_mut().ok_or_else(|| {
             error!(
                 function = "execute_sequential_pd",

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error, info_span, Instrument};
 
 use super::PipelineStage;
 use crate::{
-    observability::metrics::{intern_string, metrics_labels, Metrics},
+    observability::metrics::{metrics_labels, Metrics},
     routers::{
         error,
         grpc::{
@@ -329,8 +329,8 @@ impl RequestExecutionStage {
     ) -> Result<ExecutionResult, Response> {
         let runtime = workers
             .pd_runtime_type()
-            .map(RuntimeType::to_string)
-            .unwrap_or_default();
+            .map(RuntimeType::as_str)
+            .unwrap_or("");
         let (prefill_client, decode_client) = clients.dual_mut().ok_or_else(|| {
             error!(
                 function = "execute_dual_dispatch",
@@ -354,21 +354,13 @@ impl RequestExecutionStage {
             decode_request.set_data_parallel_rank(rank as i32);
         }
 
-        // Time the prefill RPC on its own even though both legs are dispatched
-        // concurrently: wrap the prefill future so it records its own elapsed.
+        // `generate` only establishes the prefill stream here (SMG does not drain
+        // it on this path), so prefill duration cannot be measured — only TTFT,
+        // recorded at the first decode token in streaming. prefill_start anchors it.
         let prefill_start = Instant::now();
-        let prefill_fut = async {
-            let result: StreamResult = prefill_client.generate(prefill_request).await;
-            (prefill_start.elapsed(), result)
-        };
-        let ((prefill_elapsed, prefill_result), decode_result): ((_, StreamResult), StreamResult) =
-            tokio::join!(prefill_fut, decode_client.generate(decode_request));
-
-        Metrics::record_pd_prefill_duration(
-            metrics_labels::BACKEND_PD,
-            model,
-            &runtime,
-            prefill_elapsed,
+        let (prefill_result, decode_result): (StreamResult, StreamResult) = tokio::join!(
+            prefill_client.generate(prefill_request),
+            decode_client.generate(decode_request)
         );
 
         // Record circuit breaker outcomes (client errors don't count as failures)
@@ -407,7 +399,7 @@ impl RequestExecutionStage {
             decode: Box::new(decode_stream),
             pd_timing: PdTiming {
                 prefill_start,
-                runtime: intern_string(&runtime),
+                runtime,
             },
         })
     }
@@ -427,8 +419,8 @@ impl RequestExecutionStage {
     ) -> Result<ExecutionResult, Response> {
         let runtime = workers
             .pd_runtime_type()
-            .map(RuntimeType::to_string)
-            .unwrap_or_default();
+            .map(RuntimeType::as_str)
+            .unwrap_or("");
         let (prefill_client, decode_client) = clients.dual_mut().ok_or_else(|| {
             error!(
                 function = "execute_sequential_pd",
@@ -577,7 +569,7 @@ impl RequestExecutionStage {
         Metrics::record_pd_prefill_duration(
             metrics_labels::BACKEND_PD,
             model,
-            &runtime,
+            runtime,
             prefill_start.elapsed(),
         );
 
@@ -665,7 +657,7 @@ impl RequestExecutionStage {
         Metrics::record_pd_kv_transfer_duration(
             metrics_labels::BACKEND_PD,
             model,
-            &runtime,
+            runtime,
             kv_window_start.elapsed(),
         );
 

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -1,16 +1,20 @@
 //! Request execution stage: Execute gRPC requests (single or dual dispatch)
 
+use std::time::Instant;
+
 use async_trait::async_trait;
 use axum::response::Response;
 use tracing::{debug, error, info_span, Instrument};
 
 use super::PipelineStage;
 use crate::{
+    observability::metrics::{intern_string, metrics_labels, Metrics},
     routers::{
         error,
         grpc::{
             context::{
-                ClientSelection, ExecutionResult, LoadGuards, RequestContext, WorkerSelection,
+                ClientSelection, ExecutionResult, LoadGuards, PdTiming, RequestContext,
+                WorkerSelection,
             },
             proto_wrapper::{
                 ProtoEmbedRequest, ProtoGenerateRequest, ProtoRequest, ProtoResponseVariant,
@@ -43,6 +47,16 @@ enum KvConnectorMode {
     Nixl,
     /// Unknown/absent connector: relay returned params opportunistically.
     Passthrough,
+}
+
+impl KvConnectorMode {
+    fn metrics_label(&self) -> &'static str {
+        match self {
+            Self::Mooncake { .. } => metrics_labels::KV_CONNECTOR_MOONCAKE,
+            Self::Nixl => metrics_labels::KV_CONNECTOR_NIXL,
+            Self::Passthrough => metrics_labels::KV_CONNECTOR_PASSTHROUGH,
+        }
+    }
 }
 
 fn kv_connector_mode(
@@ -188,10 +202,12 @@ impl PipelineStage for RequestExecutionStage {
                         let runtime_type = workers.pd_runtime_type();
                         match runtime_type {
                             Some(RuntimeType::Vllm) => {
-                                self.execute_sequential_pd(req, clients, workers).await
+                                self.execute_sequential_pd(req, clients, workers, model)
+                                    .await
                             }
                             Some(RuntimeType::Sglang) => {
-                                self.execute_dual_dispatch(req, clients, workers).await
+                                self.execute_dual_dispatch(req, clients, workers, model)
+                                    .await
                             }
                             Some(RuntimeType::Trtllm)
                             | Some(RuntimeType::Mlx)
@@ -309,7 +325,12 @@ impl RequestExecutionStage {
         proto_request: ProtoGenerateRequest,
         clients: &mut ClientSelection,
         workers: &WorkerSelection,
+        model: &str,
     ) -> Result<ExecutionResult, Response> {
+        let runtime = workers
+            .pd_runtime_type()
+            .map(RuntimeType::to_string)
+            .unwrap_or_default();
         let (prefill_client, decode_client) = clients.dual_mut().ok_or_else(|| {
             error!(
                 function = "execute_dual_dispatch",
@@ -333,9 +354,21 @@ impl RequestExecutionStage {
             decode_request.set_data_parallel_rank(rank as i32);
         }
 
-        let (prefill_result, decode_result): (StreamResult, StreamResult) = tokio::join!(
-            prefill_client.generate(prefill_request),
-            decode_client.generate(decode_request)
+        // Time the prefill RPC on its own even though both legs are dispatched
+        // concurrently: wrap the prefill future so it records its own elapsed.
+        let prefill_start = Instant::now();
+        let prefill_fut = async {
+            let result: StreamResult = prefill_client.generate(prefill_request).await;
+            (prefill_start.elapsed(), result)
+        };
+        let ((prefill_elapsed, prefill_result), decode_result): ((_, StreamResult), StreamResult) =
+            tokio::join!(prefill_fut, decode_client.generate(decode_request));
+
+        Metrics::record_pd_prefill_duration(
+            metrics_labels::BACKEND_PD,
+            model,
+            &runtime,
+            prefill_elapsed,
         );
 
         // Record circuit breaker outcomes (client errors don't count as failures)
@@ -346,12 +379,22 @@ impl RequestExecutionStage {
 
         // Handle prefill result
         let prefill_stream = prefill_result.map_err(|e| {
+            Metrics::record_worker_error(
+                metrics_labels::WORKER_PREFILL,
+                metrics_labels::CONNECTION_GRPC,
+                metrics_labels::ERROR_BACKEND,
+            );
             error!(function = "execute_dual_dispatch", error = %e, "Prefill worker failed to start");
             e.to_http_error("prefill_worker_failed_to_start", format!("Prefill worker failed to start: {}", e.message()))
         })?;
 
         // Handle decode result
         let decode_stream = decode_result.map_err(|e| {
+            Metrics::record_worker_error(
+                metrics_labels::WORKER_DECODE,
+                metrics_labels::CONNECTION_GRPC,
+                metrics_labels::ERROR_BACKEND,
+            );
             error!(function = "execute_dual_dispatch", error = %e, "Decode worker failed to start");
             e.to_http_error(
                 "decode_worker_failed_to_start",
@@ -362,6 +405,10 @@ impl RequestExecutionStage {
         Ok(ExecutionResult::Dual {
             prefill: prefill_stream,
             decode: Box::new(decode_stream),
+            pd_timing: PdTiming {
+                prefill_start,
+                runtime: intern_string(&runtime),
+            },
         })
     }
 
@@ -376,7 +423,12 @@ impl RequestExecutionStage {
         proto_request: ProtoGenerateRequest,
         clients: &mut ClientSelection,
         workers: &WorkerSelection,
+        model: &str,
     ) -> Result<ExecutionResult, Response> {
+        let runtime = workers
+            .pd_runtime_type()
+            .map(RuntimeType::to_string)
+            .unwrap_or_default();
         let (prefill_client, decode_client) = clients.dual_mut().ok_or_else(|| {
             error!(
                 function = "execute_sequential_pd",
@@ -407,6 +459,8 @@ impl RequestExecutionStage {
                 )
             })
             .unwrap_or(KvConnectorMode::Passthrough);
+
+        Metrics::record_pd_kv_connector_mode(mode.metrics_label());
 
         match &mode {
             KvConnectorMode::Mooncake {
@@ -477,11 +531,17 @@ impl RequestExecutionStage {
         );
 
         // Send to prefill, wait for completion
+        let prefill_start = Instant::now();
         let mut prefill_stream = prefill_client
             .generate(prefill_request)
             .await
             .map_err(|e| {
                 workers.record_outcome_prefill(e.http_status().as_u16());
+                Metrics::record_worker_error(
+                    metrics_labels::WORKER_PREFILL,
+                    metrics_labels::CONNECTION_GRPC,
+                    metrics_labels::ERROR_BACKEND,
+                );
                 error!(function = "execute_sequential_pd", error = %e, "Prefill worker failed to start");
                 e.to_http_error("prefill_worker_failed_to_start", format!("Prefill worker failed to start: {}", e.message()))
             })?;
@@ -499,6 +559,11 @@ impl RequestExecutionStage {
                 }
                 Err(e) => {
                     workers.record_outcome_prefill(e.http_status().as_u16());
+                    Metrics::record_worker_error(
+                        metrics_labels::WORKER_PREFILL,
+                        metrics_labels::CONNECTION_GRPC,
+                        metrics_labels::ERROR_BACKEND,
+                    );
                     error!(function = "execute_sequential_pd", error = %e, "Prefill stream error");
                     return Err(e.to_http_error(
                         "prefill_stream_error",
@@ -509,6 +574,15 @@ impl RequestExecutionStage {
         }
         prefill_stream.mark_completed();
         workers.record_outcome_prefill(200);
+        Metrics::record_pd_prefill_duration(
+            metrics_labels::BACKEND_PD,
+            model,
+            &runtime,
+            prefill_start.elapsed(),
+        );
+
+        // KV-transfer window: prefill drain complete to decode send complete.
+        let kv_window_start = Instant::now();
 
         debug!("vLLM PD: prefill completed, sending decode request");
 
@@ -561,6 +635,7 @@ impl RequestExecutionStage {
                 decode_request.set_kv_transfer_params_json(json);
             }
             (KvConnectorMode::Nixl, None) if relay_kv_params => {
+                Metrics::record_pd_kv_transfer_failure();
                 tracing::warn!(
                     request_id = %decode_request.request_id(),
                     "vLLM PD (NIXL): prefill returned no kv_transfer_params; decode will \
@@ -574,6 +649,11 @@ impl RequestExecutionStage {
         // Send request to decode
         let decode_stream = decode_client.generate(decode_request).await.map_err(|e| {
             workers.record_outcome_decode(e.http_status().as_u16());
+            Metrics::record_worker_error(
+                metrics_labels::WORKER_DECODE,
+                metrics_labels::CONNECTION_GRPC,
+                metrics_labels::ERROR_BACKEND,
+            );
             error!(function = "execute_sequential_pd", error = %e, "Decode worker failed to start");
             e.to_http_error(
                 "decode_worker_failed_to_start",
@@ -582,6 +662,12 @@ impl RequestExecutionStage {
         })?;
 
         workers.record_outcome_decode(200);
+        Metrics::record_pd_kv_transfer_duration(
+            metrics_labels::BACKEND_PD,
+            model,
+            &runtime,
+            kv_window_start.elapsed(),
+        );
 
         Ok(ExecutionResult::Single {
             stream: decode_stream,

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -723,7 +723,7 @@ pub(crate) struct PdTiming {
     /// Monotonic instant the prefill RPC was dispatched.
     pub prefill_start: std::time::Instant,
     /// Backend runtime label (e.g. "sglang", "vllm") for the PD metric set.
-    pub runtime: Arc<str>,
+    pub runtime: &'static str,
 }
 
 /// Final processed response

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -707,11 +707,23 @@ pub(crate) enum ExecutionResult {
     Dual {
         prefill: ProtoStream,
         decode: Box<ProtoStream>,
+        /// PD timing context, for honest PD TTFT (prefill start to first decode token).
+        pd_timing: PdTiming,
     },
     /// Embedding requests return a single response, not a stream
     Embedding {
         response: ProtoEmbedComplete,
     },
+}
+
+/// Timing context threaded from PD execution into the streaming layer so the
+/// first decode token can be measured against prefill start.
+#[derive(Clone)]
+pub(crate) struct PdTiming {
+    /// Monotonic instant the prefill RPC was dispatched.
+    pub prefill_start: std::time::Instant,
+    /// Backend runtime label (e.g. "sglang", "vllm") for the PD metric set.
+    pub runtime: Arc<str>,
 }
 
 /// Final processed response

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -119,7 +119,9 @@ impl HarmonyStreamingProcessor {
                     let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
                 });
             }
-            context::ExecutionResult::Dual { prefill, decode } => {
+            context::ExecutionResult::Dual {
+                prefill, decode, ..
+            } => {
                 tokio::spawn(async move {
                     let result =
                         Self::process_dual_stream(prefill, *decode, dispatch, chat_request, &tx)
@@ -507,7 +509,9 @@ impl HarmonyStreamingProcessor {
                 debug!("Processing Responses API single stream mode");
                 Self::process_decode_stream(stream, emitter, tx, session, format_registry, 0).await
             }
-            context::ExecutionResult::Dual { prefill, decode } => {
+            context::ExecutionResult::Dual {
+                prefill, decode, ..
+            } => {
                 debug!("Processing Responses API dual stream mode");
                 Self::process_responses_dual_stream(
                     prefill,

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -120,7 +120,10 @@ impl HarmonyStreamingProcessor {
                 });
             }
             context::ExecutionResult::Dual {
-                prefill, decode, ..
+                // TODO(#1781 follow-up): thread pd_timing for honest PD TTFT
+                prefill,
+                decode,
+                ..
             } => {
                 tokio::spawn(async move {
                     let result =
@@ -510,7 +513,10 @@ impl HarmonyStreamingProcessor {
                 Self::process_decode_stream(stream, emitter, tx, session, format_registry, 0).await
             }
             context::ExecutionResult::Dual {
-                prefill, decode, ..
+                // TODO(#1781 follow-up): thread pd_timing for honest PD TTFT
+                prefill,
+                decode,
+                ..
             } => {
                 debug!("Processing Responses API dual stream mode");
                 Self::process_responses_dual_stream(

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -140,7 +140,11 @@ impl StreamingProcessor {
                     let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
                 });
             }
-            context::ExecutionResult::Dual { prefill, decode } => {
+            context::ExecutionResult::Dual {
+                prefill,
+                decode,
+                pd_timing,
+            } => {
                 let processor = self.clone();
                 let tokenizer_clone = tokenizer.clone();
                 #[expect(
@@ -157,6 +161,7 @@ impl StreamingProcessor {
                             stop_params,
                             chat_request,
                             &tx,
+                            pd_timing,
                         )
                         .await;
 
@@ -184,12 +189,38 @@ impl StreamingProcessor {
     /// Process streaming chunks from a single stream (Regular mode)
     pub async fn process_streaming_chunks(
         &self,
+        grpc_stream: ProtoStream,
+        dispatch: context::DispatchMetadata,
+        tokenizer: Arc<dyn Tokenizer>,
+        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
+        original_request: Arc<ChatCompletionRequest>,
+        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+    ) -> Result<(), String> {
+        self.process_streaming_chunks_inner(
+            grpc_stream,
+            dispatch,
+            tokenizer,
+            stop_params,
+            original_request,
+            tx,
+            None,
+        )
+        .await
+    }
+
+    /// Inner implementation shared by single-mode and PD-dual streaming.
+    /// `pd_timing` is `Some` only in PD mode and yields honest PD TTFT
+    /// (prefill start to first decode token).
+    #[expect(clippy::too_many_arguments)]
+    async fn process_streaming_chunks_inner(
+        &self,
         mut grpc_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        pd_timing: Option<context::PdTiming>,
     ) -> Result<(), String> {
         // Metrics timing
         let start_time = Instant::now();
@@ -303,6 +334,14 @@ impl StreamingProcessor {
                     // Track TTFT immediately on first chunk received from backend
                     if first_token_time.is_none() {
                         first_token_time = Some(Instant::now());
+                        if let Some(timing) = &pd_timing {
+                            Metrics::record_pd_ttft(
+                                self.backend_type,
+                                model,
+                                &timing.runtime,
+                                timing.prefill_start.elapsed(),
+                            );
+                        }
                     }
 
                     let index = chunk.index();
@@ -610,6 +649,7 @@ impl StreamingProcessor {
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        pd_timing: context::PdTiming,
     ) -> Result<(), String> {
         // Phase 1.5: Collect input_logprobs from prefill stream if requested
         if original_request.logprobs {
@@ -627,16 +667,18 @@ impl StreamingProcessor {
             }
         }
 
-        // Phase 2-5: Process decode stream (same as single mode)
+        // Phase 2-5: Process decode stream (same as single mode). Pass pd_timing
+        // so the first decode token yields honest PD TTFT.
         // Note: decode_stream will be marked completed inside process_streaming_chunks
         let result = self
-            .process_streaming_chunks(
+            .process_streaming_chunks_inner(
                 decode_stream,
                 dispatch,
                 tokenizer,
                 stop_params,
                 original_request,
                 tx,
+                Some(pd_timing),
             )
             .await;
 
@@ -696,7 +738,11 @@ impl StreamingProcessor {
                     let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
                 });
             }
-            context::ExecutionResult::Dual { prefill, decode } => {
+            context::ExecutionResult::Dual {
+                prefill,
+                decode,
+                pd_timing,
+            } => {
                 // For PD mode, need to handle prefill stream for input_logprobs
                 let tokenizer = tokenizer.clone();
                 #[expect(
@@ -705,7 +751,7 @@ impl StreamingProcessor {
                 )]
                 tokio::spawn(async move {
                     let result = Self::process_generate_streaming_dual(
-                        tokenizer, prefill, *decode, ctx, &tx,
+                        tokenizer, prefill, *decode, ctx, &tx, pd_timing,
                     )
                     .await;
 
@@ -846,6 +892,7 @@ impl StreamingProcessor {
         decode_stream: ProtoStream,
         ctx: GenerateStreamContext,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        pd_timing: context::PdTiming,
     ) -> Result<(), String> {
         // Collect input_logprobs from prefill stream if requested
         let input_token_logprobs = if ctx.return_logprob {
@@ -870,7 +917,8 @@ impl StreamingProcessor {
             None
         };
 
-        // Process decode stream with input_logprobs prepended
+        // Process decode stream with input_logprobs prepended. Pass pd_timing so
+        // the first decode token yields honest PD TTFT.
         // Note: decode_stream will be marked completed inside the function
         let result = Self::process_generate_streaming_with_input_logprobs(
             tokenizer,
@@ -878,6 +926,7 @@ impl StreamingProcessor {
             ctx,
             input_token_logprobs,
             tx,
+            Some(pd_timing),
         )
         .await;
 
@@ -897,6 +946,7 @@ impl StreamingProcessor {
         ctx: GenerateStreamContext,
         input_token_logprobs: Option<Vec<Vec<Option<f64>>>>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        pd_timing: Option<context::PdTiming>,
     ) -> Result<(), String> {
         let start_time = Instant::now();
         let mut first_token_time: Option<Instant> = None;
@@ -915,6 +965,14 @@ impl StreamingProcessor {
                     // Track TTFT immediately on first chunk received from backend
                     if first_token_time.is_none() {
                         first_token_time = Some(Instant::now());
+                        if let Some(timing) = &pd_timing {
+                            Metrics::record_pd_ttft(
+                                ctx.backend_type,
+                                &ctx.model,
+                                &timing.runtime,
+                                timing.prefill_start.elapsed(),
+                            );
+                        }
                     }
 
                     let index = chunk.index();
@@ -1501,7 +1559,9 @@ impl StreamingProcessor {
                     // No data: [DONE] — Anthropic uses message_stop instead
                 });
             }
-            context::ExecutionResult::Dual { prefill, decode } => {
+            context::ExecutionResult::Dual {
+                prefill, decode, ..
+            } => {
                 let processor = self.clone();
                 let tokenizer_clone = tokenizer.clone();
                 #[expect(
@@ -2259,7 +2319,9 @@ impl StreamingProcessor {
                     let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
                 });
             }
-            context::ExecutionResult::Dual { prefill, decode } => {
+            context::ExecutionResult::Dual {
+                prefill, decode, ..
+            } => {
                 let processor = self.clone();
                 #[expect(
                     clippy::disallowed_methods,

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -1560,7 +1560,10 @@ impl StreamingProcessor {
                 });
             }
             context::ExecutionResult::Dual {
-                prefill, decode, ..
+                // TODO(#1781 follow-up): thread pd_timing for honest PD TTFT
+                prefill,
+                decode,
+                ..
             } => {
                 let processor = self.clone();
                 let tokenizer_clone = tokenizer.clone();
@@ -2320,7 +2323,10 @@ impl StreamingProcessor {
                 });
             }
             context::ExecutionResult::Dual {
-                prefill, decode, ..
+                // TODO(#1781 follow-up): thread pd_timing for honest PD TTFT
+                prefill,
+                decode,
+                ..
             } => {
                 let processor = self.clone();
                 #[expect(

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -338,7 +338,7 @@ impl StreamingProcessor {
                             Metrics::record_pd_ttft(
                                 self.backend_type,
                                 model,
-                                &timing.runtime,
+                                timing.runtime,
                                 timing.prefill_start.elapsed(),
                             );
                         }
@@ -969,7 +969,7 @@ impl StreamingProcessor {
                             Metrics::record_pd_ttft(
                                 ctx.backend_type,
                                 &ctx.model,
-                                &timing.runtime,
+                                timing.runtime,
                                 timing.prefill_start.elapsed(),
                             );
                         }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -352,7 +352,10 @@ impl PDRouter {
                             context.batch_size,
                         ) {
                             Ok(v) => v,
-                            Err(e) => return Self::handle_serialization_error(e),
+                            Err(e) => {
+                                Metrics::record_pd_bootstrap_failure();
+                                return Self::handle_serialization_error(e);
+                            }
                         };
 
                         let mut prefill_json_request = json_request.clone();
@@ -648,6 +651,10 @@ impl PDRouter {
         // hits a transport error, the other is cancelled immediately — otherwise
         // the surviving request hangs waiting for a PD bootstrap that will never
         // come (see #831).
+        // PD timing uses a monotonic clock from dispatch; the recorders below sit
+        // on the success path only, so retried attempts never double-count.
+        let runtime = prefill.metadata().spec.runtime_type.to_string();
+        let prefill_start = Instant::now();
         let pd_result = tokio::try_join!(prefill_request.send(), decode_request.send());
 
         events::RequestReceivedEvent {}.emit();
@@ -682,6 +689,18 @@ impl PDRouter {
                 .await;
         }
 
+        // Honest PD TTFT (prefill start to first decode output): the decode
+        // response head is the first user-visible decode output, since the
+        // gateway forwards the decode body unbuffered. Complements the
+        // decode-only `smg_router_ttft_seconds`, which PD never narrows to a
+        // single leg.
+        Metrics::record_pd_ttft(
+            metrics_labels::BACKEND_PD,
+            context.model_id,
+            &runtime,
+            prefill_start.elapsed(),
+        );
+
         // Process prefill response
         let prefill_body = match self
             .process_prefill_response(prefill_response, prefill.url(), context.return_logprob)
@@ -690,6 +709,14 @@ impl PDRouter {
             Ok((_, body)) => body,
             Err(error_response) => return error_response,
         };
+
+        // Prefill RPC duration: dispatch to fully-drained prefill body.
+        Metrics::record_pd_prefill_duration(
+            metrics_labels::BACKEND_PD,
+            context.model_id,
+            &runtime,
+            prefill_start.elapsed(),
+        );
 
         if context.is_stream {
             // Streaming response

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -651,33 +651,38 @@ impl PDRouter {
         // hits a transport error, the other is cancelled immediately — otherwise
         // the surviving request hangs waiting for a PD bootstrap that will never
         // come (see #831).
-        // Time each leg from its own dispatch on a monotonic clock. The decode
-        // future captures its own head-arrival elapsed so TTFT is not conflated
-        // with the prefill-head wait; prefill duration is measured below, after
-        // its body is drained. All recorders sit on the success path only, so
-        // failed/retried attempts never pollute or double-count the signal.
+        // Each leg captures its own head-arrival elapsed when its `send()`
+        // resolves, so the two are independent even though `try_join!` returns
+        // only once both heads arrive: decode TTFT isn't conflated with the
+        // prefill-head wait, and prefill duration isn't conflated with a slower
+        // decode head. Recorded on the success path only.
         let runtime = prefill.metadata().spec.runtime_type.as_str();
         let dispatch_start = Instant::now();
+        let prefill_fut = async {
+            let resp = prefill_request.send().await?;
+            Ok::<_, reqwest::Error>((dispatch_start.elapsed(), resp))
+        };
         let decode_fut = async {
             let resp = decode_request.send().await?;
             Ok::<_, reqwest::Error>((dispatch_start.elapsed(), resp))
         };
-        let pd_result = tokio::try_join!(prefill_request.send(), decode_fut);
+        let pd_result = tokio::try_join!(prefill_fut, decode_fut);
 
         events::RequestReceivedEvent {}.emit();
 
-        let (prefill_response, (decode_head_elapsed, decode_response)) = match pd_result {
-            Ok(pair) => pair,
-            Err(e) => {
-                error!("PD request transport error, both sides aborted: {e}");
-                // Don't record_outcome here — the caller (execute_dual_dispatch)
-                // records outcomes from the response status after we return.
-                return error::bad_gateway(
-                    "PD disaggregation request failed",
-                    format!("Transport error: {e}"),
-                );
-            }
-        };
+        let ((prefill_head_elapsed, prefill_response), (decode_head_elapsed, decode_response)) =
+            match pd_result {
+                Ok(pair) => pair,
+                Err(e) => {
+                    error!("PD request transport error, both sides aborted: {e}");
+                    // Don't record_outcome here — the caller (execute_dual_dispatch)
+                    // records outcomes from the response status after we return.
+                    return error::bad_gateway(
+                        "PD disaggregation request failed",
+                        format!("Transport error: {e}"),
+                    );
+                }
+            };
 
         // Process decode response
         let status = StatusCode::from_u16(decode_response.status().as_u16())
@@ -708,6 +713,7 @@ impl PDRouter {
         );
 
         // Process prefill response
+        let prefill_drain_start = Instant::now();
         let prefill_body = match self
             .process_prefill_response(prefill_response, prefill.url(), context.return_logprob)
             .await
@@ -716,12 +722,13 @@ impl PDRouter {
             Err(error_response) => return error_response,
         };
 
-        // Prefill RPC duration: dispatch to fully-drained prefill body.
+        // Prefill RPC duration: prefill-head elapsed + body drain, independent
+        // of decode so a slower decode head never inflates it.
         Metrics::record_pd_prefill_duration(
             metrics_labels::BACKEND_PD,
             context.model_id,
             runtime,
-            dispatch_start.elapsed(),
+            prefill_head_elapsed + prefill_drain_start.elapsed(),
         );
 
         if context.is_stream {

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -651,16 +651,23 @@ impl PDRouter {
         // hits a transport error, the other is cancelled immediately — otherwise
         // the surviving request hangs waiting for a PD bootstrap that will never
         // come (see #831).
-        // PD timing uses a monotonic clock from dispatch; the recorders below sit
-        // on the success path only, so retried attempts never double-count.
-        let runtime = prefill.metadata().spec.runtime_type.to_string();
-        let prefill_start = Instant::now();
-        let pd_result = tokio::try_join!(prefill_request.send(), decode_request.send());
+        // Time each leg from its own dispatch on a monotonic clock. The decode
+        // future captures its own head-arrival elapsed so TTFT is not conflated
+        // with the prefill-head wait; prefill duration is measured below, after
+        // its body is drained. All recorders sit on the success path only, so
+        // failed/retried attempts never pollute or double-count the signal.
+        let runtime = prefill.metadata().spec.runtime_type.as_str();
+        let dispatch_start = Instant::now();
+        let decode_fut = async {
+            let resp = decode_request.send().await?;
+            Ok::<_, reqwest::Error>((dispatch_start.elapsed(), resp))
+        };
+        let pd_result = tokio::try_join!(prefill_request.send(), decode_fut);
 
         events::RequestReceivedEvent {}.emit();
 
-        let (prefill_response, decode_response) = match pd_result {
-            Ok((prefill_resp, decode_resp)) => (prefill_resp, decode_resp),
+        let (prefill_response, (decode_head_elapsed, decode_response)) = match pd_result {
+            Ok(pair) => pair,
             Err(e) => {
                 error!("PD request transport error, both sides aborted: {e}");
                 // Don't record_outcome here — the caller (execute_dual_dispatch)
@@ -689,16 +696,15 @@ impl PDRouter {
                 .await;
         }
 
-        // Honest PD TTFT (prefill start to first decode output): the decode
-        // response head is the first user-visible decode output, since the
-        // gateway forwards the decode body unbuffered. Complements the
-        // decode-only `smg_router_ttft_seconds`, which PD never narrows to a
-        // single leg.
+        // Honest PD TTFT: dispatch to the decode response head — the first
+        // user-visible decode output, since the gateway forwards the decode body
+        // unbuffered. Complements the decode-only `smg_router_ttft_seconds`,
+        // which PD never narrows to a single leg.
         Metrics::record_pd_ttft(
             metrics_labels::BACKEND_PD,
             context.model_id,
-            &runtime,
-            prefill_start.elapsed(),
+            runtime,
+            decode_head_elapsed,
         );
 
         // Process prefill response
@@ -714,8 +720,8 @@ impl PDRouter {
         Metrics::record_pd_prefill_duration(
             metrics_labels::BACKEND_PD,
             context.model_id,
-            &runtime,
-            prefill_start.elapsed(),
+            runtime,
+            dispatch_start.elapsed(),
         );
 
         if context.is_stream {

--- a/model_gateway/tests/routing/pd_routing_test.rs
+++ b/model_gateway/tests/routing/pd_routing_test.rs
@@ -151,6 +151,75 @@ mod pd_routing_tests {
         ctx.shutdown().await;
     }
 
+    /// A non-streaming PD request must emit the SMG-only PD metrics, including
+    /// the honest `smg_pd_ttft_seconds`. Runs on a current-thread runtime so the
+    /// thread-local Prometheus recorder captures emissions from the request path.
+    #[test]
+    fn test_pd_metrics_emitted_on_request() {
+        use metrics_exporter_prometheus::PrometheusBuilder;
+
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let mut config = RouterConfig::builder()
+                    .prefill_decode_mode(
+                        vec![("http://127.0.0.1:19830".to_string(), None)],
+                        vec!["http://127.0.0.1:19831".to_string()],
+                    )
+                    .round_robin_policy()
+                    .host("127.0.0.1")
+                    .port(3803)
+                    .max_payload_size(256 * 1024 * 1024)
+                    .request_timeout_secs(600)
+                    .worker_startup_timeout_secs(5)
+                    .worker_startup_check_interval_secs(1)
+                    .max_concurrent_requests(64)
+                    .queue_timeout_secs(60)
+                    .build_unchecked();
+                config.health_check.disable_health_check = true;
+
+                let ctx = AppTestContext::new_with_config(
+                    config,
+                    vec![
+                        TestWorkerConfig::prefill(19830),
+                        TestWorkerConfig::decode(19831),
+                    ],
+                )
+                .await;
+
+                let app = ctx.create_app();
+                let payload = json!({ "text": "PD metrics request", "stream": false });
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/generate")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&payload).unwrap()))
+                    .unwrap();
+
+                let resp = app.oneshot(req).await.unwrap();
+                assert_eq!(resp.status(), StatusCode::OK, "PD request should succeed");
+
+                ctx.shutdown().await;
+            });
+        });
+
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("smg_pd_prefill_duration_seconds_count"),
+            "smg_pd_prefill_duration_seconds not emitted; rendered:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("smg_pd_ttft_seconds_count"),
+            "smg_pd_ttft_seconds not emitted; rendered:\n{rendered}"
+        );
+    }
+
     /// Test PD mode handles worker failures gracefully
     #[tokio::test]
     async fn test_pd_mode_with_failing_decode_worker() {


### PR DESCRIPTION
Part of #1773. Closes #1776.

## What
SMG-measured PD metrics — per-request, user-facing, engine-agnostic signals no backend can report (only SMG sees both legs of a request):

- `smg_pd_prefill_duration_seconds`, `smg_pd_kv_transfer_duration_seconds`, `smg_pd_ttft_seconds` (honest TTFT = prefill start → first decode token). The existing decode-only `smg_router_ttft_seconds{backend_type=pd}` is **kept** unchanged.
- `smg_pd_kv_connector_mode_total{mode}`, `smg_pd_bootstrap_failures_total`, `smg_pd_kv_transfer_failures_total`.
- Per-leg gRPC worker errors (`record_worker_error` for prefill/decode) — parity with the HTTP PD path.
- `PdTiming` threaded through `ExecutionResult::Dual` into the streaming layer; timing uses a monotonic clock and records on success paths only (retries never double-count).

## Tests
Unit recorders + integration (`pd_routing_test.rs`: a PD request emits `smg_pd_prefill_duration_seconds` + `smg_pd_ttft_seconds`). Verified green in an isolated target dir; **CI is authoritative**.

## Review notes / scope
- gRPC PD `smg_pd_ttft_seconds` covers chat + generate streaming dual; messages/completion/harmony PD paths thread the field but don't emit TTFT yet (straightforward follow-up via the same `PdTiming`).
- vLLM sequential PD returns `ExecutionResult::Single`, so its end-to-end TTFT isn't emitted directly — reconstruct from `prefill_duration` + `kv_transfer_duration` + decode TTFT.
- `smg_pd_bootstrap_failures_total` sits at the recoverable HTTP bootstrap-injection failure; the gRPC SGLang injection is infallible (runtime-guarded), so no counter there.
- Shares `observability/metrics.rs` with W1 (#1774) / W2 (#1775) — additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for PD (prefill+decode) disaggregation, including prefill duration, KV-transfer duration, PD TTFT, KV connector mode tracking (Mooncake/Nixl/Passthrough), and PD failure counters.

* **Bug Fixes**
  * Improved dual-dispatch handling so added PD timing context is correctly propagated through streaming, ensuring TTFT metrics are recorded at the right moment.

* **Tests**
  * Added an integration test that captures Prometheus output and verifies PD metrics are emitted on PD `/generate` requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->