### PR TITLE
perf(grpc-harmony): use shared SseEncoder for streaming SSE output

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -31,7 +31,10 @@ use super::{
 use crate::{
     observability::metrics::{metrics_labels, Metrics, StreamingMetricsParams},
     routers::{
-        common::openai_bridge::{self, descriptor, FormatRegistry, ResponseFormat},
+        common::{
+            openai_bridge::{self, descriptor, FormatRegistry, ResponseFormat},
+            sse::SseEncoder,
+        },
         grpc::{
             common::{
                 response_formatting::CompletionTokenTracker,
@@ -116,7 +119,7 @@ impl HarmonyStreamingProcessor {
                         utils::send_error_sse(&tx, &e, "internal_error");
                     }
 
-                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                    let _ = tx.send(Ok(SseEncoder::done()));
                 });
             }
             context::ExecutionResult::Dual { prefill, decode } => {
@@ -130,7 +133,7 @@ impl HarmonyStreamingProcessor {
                         utils::send_error_sse(&tx, &e, "internal_error");
                     }
 
-                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                    let _ = tx.send(Ok(SseEncoder::done()));
                 });
             }
             context::ExecutionResult::Embedding { .. } => {
@@ -140,7 +143,7 @@ impl HarmonyStreamingProcessor {
                     "Embeddings not supported in Harmony streaming",
                     "invalid_request_error",
                 );
-                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                let _ = tx.send(Ok(SseEncoder::done()));
             }
         }
 
@@ -229,6 +232,8 @@ impl HarmonyStreamingProcessor {
         let mut is_firsts: HashMap<u32, bool> = HashMap::new();
         let mut matched_stops: HashMap<u32, Option<serde_json::Value>> = HashMap::new();
         let mut completion_tokens = CompletionTokenTracker::new();
+        // Reusable SSE encoder shared across every chunk emitted for this stream.
+        let mut encoder = SseEncoder::new();
 
         let stream_options = &original_request.stream_options;
 
@@ -284,6 +289,7 @@ impl HarmonyStreamingProcessor {
                             dispatch,
                             original_request,
                             tx,
+                            &mut encoder,
                             chunk_logprobs,
                         )?;
 
@@ -319,6 +325,7 @@ impl HarmonyStreamingProcessor {
                             dispatch,
                             original_request,
                             tx,
+                            &mut encoder,
                         )?;
                     }
                 }
@@ -343,6 +350,7 @@ impl HarmonyStreamingProcessor {
                 dispatch,
                 original_request,
                 tx,
+                &mut encoder,
             )?;
         }
 
@@ -362,6 +370,7 @@ impl HarmonyStreamingProcessor {
     }
 
     /// Emit a chunk delta from Harmony channels
+    #[expect(clippy::too_many_arguments)]
     fn emit_chunk_delta(
         delta: &HarmonyChannelDelta,
         index: u32,
@@ -369,6 +378,7 @@ impl HarmonyStreamingProcessor {
         dispatch: &context::DispatchMetadata,
         original_request: &ChatCompletionRequest,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        encoder: &mut SseEncoder,
         logprobs: Option<ChatLogProbs>,
     ) -> Result<(), String> {
         // On first chunk, emit role announcement separately
@@ -382,11 +392,11 @@ impl HarmonyStreamingProcessor {
             .maybe_system_fingerprint(dispatch.weight_version.as_deref())
             .build();
 
-            let chunk_json = serde_json::to_string(&role_chunk)
+            let sse_data = encoder
+                .encode_data(&role_chunk)
                 .map_err(|e| format!("JSON serialization error: {e}"))?;
-            let sse_data = format!("data: {chunk_json}\n\n");
 
-            tx.send(Ok(Bytes::from(sse_data)))
+            tx.send(Ok(sse_data))
                 .map_err(|_| "Failed to send role chunk".to_string())?;
         }
 
@@ -422,11 +432,11 @@ impl HarmonyStreamingProcessor {
                 .maybe_system_fingerprint(dispatch.weight_version.as_deref())
                 .build();
 
-        let chunk_json =
-            serde_json::to_string(&chunk).map_err(|e| format!("JSON serialization error: {e}"))?;
-        let sse_data = format!("data: {chunk_json}\n\n");
+        let sse_data = encoder
+            .encode_data(&chunk)
+            .map_err(|e| format!("JSON serialization error: {e}"))?;
 
-        tx.send(Ok(Bytes::from(sse_data)))
+        tx.send(Ok(sse_data))
             .map_err(|_| "Failed to send chunk".to_string())?;
 
         Ok(())
@@ -440,6 +450,7 @@ impl HarmonyStreamingProcessor {
         dispatch: &context::DispatchMetadata,
         original_request: &ChatCompletionRequest,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        encoder: &mut SseEncoder,
     ) -> Result<(), String> {
         let chunk =
             ChatCompletionStreamResponse::builder(&dispatch.request_id, &original_request.model)
@@ -448,11 +459,11 @@ impl HarmonyStreamingProcessor {
                 .maybe_system_fingerprint(dispatch.weight_version.as_deref())
                 .build();
 
-        let chunk_json =
-            serde_json::to_string(&chunk).map_err(|e| format!("JSON serialization error: {e}"))?;
-        let sse_data = format!("data: {chunk_json}\n\n");
+        let sse_data = encoder
+            .encode_data(&chunk)
+            .map_err(|e| format!("JSON serialization error: {e}"))?;
 
-        tx.send(Ok(Bytes::from(sse_data)))
+        tx.send(Ok(sse_data))
             .map_err(|_| "Failed to send final chunk".to_string())?;
 
         Ok(())
@@ -466,6 +477,7 @@ impl HarmonyStreamingProcessor {
         dispatch: &context::DispatchMetadata,
         original_request: &ChatCompletionRequest,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        encoder: &mut SseEncoder,
     ) -> Result<(), String> {
         let usage_chunk =
             ChatCompletionStreamResponse::builder(&dispatch.request_id, &original_request.model)
@@ -477,11 +489,11 @@ impl HarmonyStreamingProcessor {
                 .maybe_system_fingerprint(dispatch.weight_version.as_deref())
                 .build();
 
-        let chunk_json = serde_json::to_string(&usage_chunk)
+        let sse_data = encoder
+            .encode_data(&usage_chunk)
             .map_err(|e| format!("JSON serialization error: {e}"))?;
-        let sse_data = format!("data: {chunk_json}\n\n");
 
-        tx.send(Ok(Bytes::from(sse_data)))
+        tx.send(Ok(sse_data))
             .map_err(|_| "Failed to send usage chunk".to_string())?;
 
         Ok(())


### PR DESCRIPTION
## Description

### Problem

The Harmony chat streaming path re-encoded every chunk with `serde_json::to_string` + `format!("data: …\n\n")` — two heap allocations per chunk on the streaming hot path.

### Solution

Replace that pair with the shared `common::sse::SseEncoder`. A single encoder is created once per stream in `process_chat_decode_stream` and threaded through the emit helpers, so the serialization buffer is reused across chunks (1 allocation per chunk instead of 2).

## Changes

- `emit_chunk_delta` / `emit_final_chunk` / `emit_usage_chunk` serialize through a per-stream `SseEncoder`.
- The three `[DONE]` sentinels now use `SseEncoder::done()` (`Bytes::from_static`, zero allocation).
- No behavior change — identical wire output.

## Test Plan

- `cargo +nightly fmt` ✅ and `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -p smg --lib grpc::harmony` ✅ (8 passed)

Part of the shared SSE codec rollout (codec landed in #987). Sibling of #1633/#1634 (anthropic), #1759/#1760 (openai), #1768 (http-pd), #1772 (grpc-regular).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the internal encoding mechanism for streaming responses to improve code consistency and maintainability across chat operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->