### PR TITLE
perf(runtime): slim to --runtime-worker-threads override; rely on container-aware default (#1695)

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1198,6 +1198,7 @@ impl Router {
                 host: self.host.clone(),
                 port: self.port,
                 health_check_port: self.health_check_port,
+                runtime_worker_threads: None,
                 router_config,
                 max_payload_size: self.max_payload_size,
                 log_dir: self.log_dir.clone(),

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -517,6 +517,35 @@ headers can otherwise spoof storage hook request context values.
 
 ---
 
+## Runtime Configuration
+
+Controls the tokio async runtime that backs request handling.
+
+By default the runtime is **container-aware**. tokio sizes its worker pool to
+`std::thread::available_parallelism()`, which on Rust 1.95+ already reads the
+cgroup CPU quota — so under a Kubernetes `limits.cpu` the worker count matches
+the pod's quota, not the host's core count. No extra configuration is needed for
+the default to be right under a CPU limit.
+
+Do **not** set an inflated `TOKIO_WORKER_THREADS` (for example a fixed `32`).
+That overrides the container-aware default and oversubscribes worker threads
+against the cores the scheduler actually grants, causing scheduler thrash,
+tail-latency spikes, and `/health` starvation. Leaving it unset is the correct
+production configuration.
+
+### Worker Threads
+
+Explicit async runtime worker-thread count. Leave unset to use tokio's
+container-aware default above; set it only to pin an explicit count (overriding
+the cgroup-quota-derived default).
+
+| Option | `--runtime-worker-threads` |
+|--------|----------------------------|
+| Environment | - |
+| Default | tokio default (`available_parallelism()`, cgroup-quota-aware) |
+
+---
+
 ## Rate Limiting Configuration
 
 ### Concurrent Request Limit

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -175,6 +175,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn runtime_worker_threads(mut self, threads: Option<usize>) -> Self {
+        self.config.runtime_worker_threads = threads;
+        self
+    }
+
     // ==================== Request ====================
 
     pub fn max_payload_size(mut self, size: usize) -> Self {

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -24,6 +24,11 @@ pub struct RouterConfig {
     /// routes always remain available on the main `port` regardless.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health_check_port: Option<u16>,
+    /// Explicit async runtime worker-thread count. `None` uses tokio's default
+    /// (`available_parallelism()`), which already honors the cgroup CPU quota on
+    /// Rust 1.95+ and is therefore container-aware. `Some` pins a count.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_worker_threads: Option<usize>,
     pub max_payload_size: usize,
     pub request_timeout_secs: u64,
     pub worker_startup_timeout_secs: u64,
@@ -645,6 +650,7 @@ impl Default for RouterConfig {
             host: "0.0.0.0".to_string(),
             port: 3001,
             health_check_port: None,
+            runtime_worker_threads: None,
             max_payload_size: 536_870_912,     // 512MB
             request_timeout_secs: 1800,        // 30 minutes
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -20,6 +20,8 @@ use smg::{
 };
 use smg_auth::{ApiKeyEntry, ControlPlaneAuthConfig, JwtConfig, Role};
 use smg_mesh::MeshServerConfig;
+use tracing::info;
+
 fn parse_prefill_args() -> Vec<(String, Option<u16>)> {
     let args: Vec<String> = std::env::args().collect();
     let mut prefill_entries = Vec::new();
@@ -743,6 +745,13 @@ struct CliArgs {
     /// Defaults to `stun.l.google.com:19302`. Set to "none" to disable.
     #[arg(long, help_heading = "WebRTC")]
     webrtc_stun_server: Option<String>,
+
+    // ==================== Runtime ====================
+    /// Explicit async runtime worker-thread count. Leave unset to use tokio's
+    /// default (`available_parallelism()`), which already honors the cgroup CPU
+    /// quota on Rust 1.95+ and is therefore container-aware.
+    #[arg(long, help_heading = "Runtime")]
+    runtime_worker_threads: Option<usize>,
 }
 
 enum OracleConnectSource {
@@ -1253,6 +1262,7 @@ impl CliArgs {
             .host(&self.host)
             .port(self.port)
             .health_check_port(self.health_check_port)
+            .runtime_worker_threads(self.runtime_worker_threads)
             .max_payload_size(self.max_payload_size)
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
@@ -1411,6 +1421,7 @@ impl CliArgs {
             host: self.host.clone(),
             port: self.port,
             health_check_port: self.health_check_port,
+            runtime_worker_threads: self.runtime_worker_threads,
             router_config,
             max_payload_size: self.max_payload_size,
             log_dir: self.log_dir.clone(),
@@ -1515,7 +1526,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     router_config.validate()?;
 
     let server_config = cli_args.to_server_config(router_config)?;
-    let runtime = tokio::runtime::Runtime::new()?;
+    // tokio's default worker-thread count is `available_parallelism()`, which on
+    // Rust 1.95+ already honors the cgroup CPU quota, so the default is
+    // container-aware. Only build the runtime explicitly when an operator pins a
+    // worker-thread count.
+    let runtime = match server_config.runtime_worker_threads {
+        Some(n) => {
+            info!(
+                worker_threads = n,
+                "Sizing tokio runtime (explicit override)"
+            );
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(n)
+                .enable_all()
+                .build()?
+        }
+        None => {
+            info!("Sizing tokio runtime (default, container-aware)");
+            tokio::runtime::Runtime::new()?
+        }
+    };
     runtime.block_on(Box::pin(server::startup(server_config)))?;
     if is_otel_enabled() {
         shutdown_otel();
@@ -1581,5 +1611,36 @@ mod tests {
             Cli::try_parse_from(argv).is_err(),
             "a port above u16::MAX must fail clap parsing"
         );
+    }
+
+    /// The `--runtime-worker-threads` override must flow into BOTH conversion
+    /// paths (`to_router_config` and `to_server_config`); wiring only one path
+    /// would let the flag be silently ignored on the other (the two-path footgun).
+    #[test]
+    fn runtime_worker_threads_flows_into_both_configs() {
+        let cli = cli_args_from(&["--runtime-worker-threads", "3"]);
+
+        let router_config = cli.to_router_config(vec![]).unwrap();
+        assert_eq!(router_config.runtime_worker_threads, Some(3));
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert_eq!(
+            server_config.runtime_worker_threads,
+            Some(3),
+            "runtime_worker_threads must reach ServerConfig via to_server_config"
+        );
+    }
+
+    /// Unset, the flag propagates as `None` through both conversions, so the
+    /// runtime uses tokio's container-aware default.
+    #[test]
+    fn runtime_worker_threads_default_to_none_in_both_configs() {
+        let cli = cli_args_from(&[]);
+
+        let router_config = cli.to_router_config(vec![]).unwrap();
+        assert_eq!(router_config.runtime_worker_threads, None);
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert_eq!(server_config.runtime_worker_threads, None);
     }
 }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -689,6 +689,9 @@ pub struct ServerConfig {
     /// leaves the dedicated listener off; probe routes always stay on the
     /// main `port` regardless.
     pub health_check_port: Option<u16>,
+    /// Explicit async runtime worker-thread count. `None` uses tokio's
+    /// container-aware default (`available_parallelism()`).
+    pub runtime_worker_threads: Option<usize>,
     pub router_config: RouterConfig,
     pub max_payload_size: usize,
     pub log_dir: Option<String>,


### PR DESCRIPTION
## Summary

This PR is now a thin override flag plus corrected docs. The original version added a custom cgroup-detection module to size the tokio runtime; that turned out to be **redundant**.

Rust 1.95's `std::thread::available_parallelism()` already reads the cgroup CPU quota (cgroup v2 `cpu.max`, v1 `cpu.cfs_quota_us`/`cpu.cfs_period_us`, returning `count.min(quota)`), and tokio's default worker-thread count **is** `available_parallelism()`. So `tokio::runtime::Runtime::new()` is **already container-aware** under a Kubernetes `limits.cpu` — the custom module merely reimplemented std.

The instability in #1685 came from a manual `TOKIO_WORKER_THREADS=32` override that oversubscribed the pod, **not** from a deficiency in the default. The right fix is to *not* set that inflated override.

Closes #1695

## What changed (slimmed)

- **Removed `model_gateway/src/runtime_sizing.rs`** and its parser unit tests — it duplicated std's cgroup-quota logic.
- **Removed `--runtime-max-blocking-threads`** entirely (CLI arg, config fields, wiring, bindings literal). It was a no-op at tokio's default of 512.
- **Kept `--runtime-worker-threads`** (`Option<usize>`, "Runtime" help heading) as an explicit override, wired through **both** conversion paths (`to_router_config` **and** `to_server_config`) so it can't be silently dropped.
- **Thin runtime build** in `main.rs`:
  - `Some(n)` → `Builder::new_multi_thread().worker_threads(n).enable_all().build()`
  - `None` → `Runtime::new()` (the container-aware default)
  - One `info!` logs the chosen worker count or the container-aware default.
- **Corrected docs** (`docs/reference/configuration.md` "Runtime Configuration"): the default already honors the cgroup CPU quota (k8s `limits.cpu`), so it is container-aware out of the box. Operators should **not** set an inflated `TOKIO_WORKER_THREADS` (that overrides the default and oversubscribes — the cause of #1685). `--runtime-worker-threads` is only for an explicit override. Removed the prior claim that `available_parallelism()` reports host cores / ignores the quota.
- **Python bindings**: `ServerConfig` literal keeps `runtime_worker_threads: None`; binding runtime creation is unchanged (it already gets the container-aware default via `Runtime::new()`).

## Tests

Kept the two-path config-flow guards in `main.rs` (`runtime_worker_threads_flows_into_both_configs`, `..._default_to_none_in_both_configs`), mirroring the existing `health_check_port` two-path guard. The cgroup-parser unit tests were removed with the module.

## Verification (isolated `CARGO_TARGET_DIR`, default features)

- `cargo +nightly fmt --all` — clean
- `cargo clippy -p smg --all-targets -- -D warnings` — clean (exit 0)
- `cargo test -p smg --bins --lib` — **1076 lib + 5+5 bin tests pass, 0 failed**
- `cargo build -p smg-python` — compiles (bindings still build after the config-field removal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--runtime-worker-threads` CLI flag to explicitly configure the Tokio async runtime worker-thread count.
  * Runtime now defaults to Tokio's container-aware detection when left unset.

* **Documentation**
  * Added Runtime Configuration section covering worker-thread sizing and the new `--runtime-worker-threads` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
