### PR TITLE
feat(bfcl): multi-model nightly A/B matrix on per-model runners

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -22,30 +22,34 @@ on:
       - ".github/workflows/nightly-bfcl.yml"
   workflow_dispatch:
     inputs:
+      only:
+        description: "Run only this matrix leg (qwen3.6|gpt-oss|deepseek-v4|minimax-m2.7|kimi-k2.6); empty = all"
+        required: false
+        default: ""
       model:
-        description: "HF model id (weights) served on both arms"
+        description: "Override HF model id (weights) for the selected leg; empty = matrix default"
         required: false
-        default: "Qwen/Qwen3.6-27B"
+        default: ""
       bfcl_model:
-        description: "BFCL FC handler name (must end in -FC; auto-registered if new)"
+        description: "Override BFCL FC handler name (must end in -FC); empty = matrix default"
         required: false
-        default: "Qwen/Qwen3.6-27B-FC"
+        default: ""
       categories:
         description: "Comma-separated BFCL test categories"
         required: false
         default: "simple_python,simple_java,simple_javascript,multiple,parallel,parallel_multiple,irrelevance,live_simple,live_multiple,live_parallel,live_parallel_multiple,live_irrelevance,live_relevance,multi_turn_base,multi_turn_miss_func,multi_turn_miss_param,multi_turn_long_context"
       vllm_tool_parser:
-        description: "pure-vLLM --tool-call-parser"
+        description: "Override pure-vLLM --tool-call-parser; empty = matrix default"
         required: false
-        default: "qwen3_xml"
+        default: ""
       smg_tool_parser:
-        description: "SMG --tool-call-parser"
+        description: "Override SMG --tool-call-parser; empty = matrix default (empty also = SMG auto-detect)"
         required: false
-        default: "qwen_xml"
+        default: ""
       reasoning_parser:
-        description: "reasoning parser for both arms (empty for non-thinking SKUs)"
+        description: "Override reasoning parser for BOTH arms; empty = matrix defaults"
         required: false
-        default: "qwen3"
+        default: ""
 
 concurrency:
   group: nightly-bfcl-${{ github.event_name }}-${{ github.ref }}
@@ -93,18 +97,94 @@ jobs:
 
   bfcl-ab:
     needs: build-wheel
-    if: ${{ !cancelled() && needs.build-wheel.result == 'success' }}
-    runs-on: 4-gpu-h100 # TP=2 per arm, both arms concurrent (GPUs 0,1 + 2,3)
-    # Generous: the nightly set adds multi_turn (multi-turn state simulation),
-    # which is much slower than the single-turn AST/live categories.
+    if: >-
+      ${{ !cancelled() && needs.build-wheel.result == 'success'
+          && (github.event.inputs.only == '' || github.event.inputs.only == matrix.name)
+          && (github.event_name != 'pull_request' || matrix.runner == '4-gpu-h100') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # H100 legs (TP=2 per arm, both arms concurrent: GPUs 0,1 + 2,3).
+          - name: qwen3.6
+            runner: 4-gpu-h100
+            tp: 2
+            gpu_a: "0,1"
+            gpu_b: "2,3"
+            model: Qwen/Qwen3.6-27B
+            bfcl_model: Qwen/Qwen3.6-27B-FC
+            vllm_tool: qwen3_xml
+            vllm_reason: qwen3
+            smg_tool: qwen_xml
+            smg_reason: qwen3
+            vllm_extra: ""
+            gpu_mem: "0.85"
+          # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
+          - name: gpt-oss
+            runner: 4-gpu-h100
+            tp: 2
+            gpu_a: "0,1"
+            gpu_b: "2,3"
+            model: openai/gpt-oss-120b
+            bfcl_model: openai/gpt-oss-120b-FC
+            vllm_tool: openai
+            vllm_reason: ""
+            smg_tool: ""
+            smg_reason: ""
+            vllm_extra: ""
+            gpu_mem: "0.85"
+          # Blackwell legs (8xB300, TP=4 per arm, both arms concurrent: 0-3 + 4-7).
+          - name: deepseek-v4
+            runner: blackwell
+            tp: 4
+            gpu_a: "0,1,2,3"
+            gpu_b: "4,5,6,7"
+            model: deepseek-ai/DeepSeek-V4-Flash
+            bfcl_model: deepseek-ai/DeepSeek-V4-Flash-FC
+            vllm_tool: deepseek_v4
+            vllm_reason: deepseek_v4
+            smg_tool: deepseek_v4
+            smg_reason: deepseek_v31 # TODO(confirm): no deepseek_v4 SMG reasoning parser yet
+            vllm_extra: "--tokenizer-mode deepseek_v4 --trust-remote-code"
+            gpu_mem: "0.90"
+          - name: minimax-m2.7
+            runner: blackwell
+            tp: 4
+            gpu_a: "0,1,2,3"
+            gpu_b: "4,5,6,7"
+            model: MiniMaxAI/MiniMax-M2.7
+            bfcl_model: MiniMaxAI/MiniMax-M2.7-FC
+            vllm_tool: minimax_m2
+            vllm_reason: minimax_m2
+            smg_tool: minimax_m2
+            smg_reason: minimax
+            vllm_extra: "--trust-remote-code"
+            gpu_mem: "0.90"
+          # Kimi-K2.6 loads native int4 weights (~500GB) -> fits TP=4 half-node.
+          - name: kimi-k2.6
+            runner: blackwell
+            tp: 4
+            gpu_a: "0,1,2,3"
+            gpu_b: "4,5,6,7"
+            model: moonshotai/Kimi-K2.6
+            bfcl_model: moonshotai/Kimi-K2.6-FC
+            vllm_tool: kimi_k2
+            vllm_reason: kimi_k2
+            smg_tool: kimik2
+            smg_reason: kimi_k25 # TODO(confirm): no kimi_k2 SMG reasoning parser yet
+            vllm_extra: "--trust-remote-code"
+            gpu_mem: "0.90"
+    runs-on: ${{ matrix.runner }}
+    # Generous: the nightly set adds multi_turn (state simulation), much slower
+    # than the single-turn AST/live categories.
     timeout-minutes: 240
     permissions:
       contents: read
     env:
       ROUTER_LOCAL_MODEL_PATH: /models
       HF_HOME: /models
-      MODEL: ${{ github.event.inputs.model || 'Qwen/Qwen3.6-27B' }}
-      BFCL_MODEL_FC: ${{ github.event.inputs.bfcl_model || 'Qwen/Qwen3.6-27B-FC' }}
+      MODEL: ${{ github.event.inputs.model || matrix.model }}
+      BFCL_MODEL_FC: ${{ github.event.inputs.bfcl_model || matrix.bfcl_model }}
       # PR = quick non-live sanity subset; schedule/dispatch = non_live + live + multi_turn.
       CATEGORIES: ${{ github.event.inputs.categories || (github.event_name == 'pull_request' && 'simple_python,irrelevance' || 'simple_python,simple_java,simple_javascript,multiple,parallel,parallel_multiple,irrelevance,live_simple,live_multiple,live_parallel,live_parallel_multiple,live_irrelevance,live_relevance,multi_turn_base,multi_turn_miss_func,multi_turn_miss_param,multi_turn_long_context') }}
     steps:
@@ -130,20 +210,21 @@ jobs:
           VLLM_BIN: vllm
           VLLM_PYTHON: python
           SMG_LAUNCH: "python -m smg.launch_router"
-          BFCL_VLLM_TOOL_PARSER: ${{ github.event.inputs.vllm_tool_parser || 'qwen3_xml' }}
-          BFCL_SMG_TOOL_PARSER: ${{ github.event.inputs.smg_tool_parser || 'qwen_xml' }}
-          BFCL_VLLM_REASONING_PARSER: ${{ github.event.inputs.reasoning_parser || 'qwen3' }}
-          BFCL_SMG_REASONING_PARSER: ${{ github.event.inputs.reasoning_parser || 'qwen3' }}
-          BFCL_TP: "2"
+          BFCL_VLLM_TOOL_PARSER: ${{ github.event.inputs.vllm_tool_parser || matrix.vllm_tool }}
+          BFCL_SMG_TOOL_PARSER: ${{ github.event.inputs.smg_tool_parser || matrix.smg_tool }}
+          BFCL_VLLM_REASONING_PARSER: ${{ github.event.inputs.reasoning_parser || matrix.vllm_reason }}
+          BFCL_SMG_REASONING_PARSER: ${{ github.event.inputs.reasoning_parser || matrix.smg_reason }}
+          BFCL_VLLM_EXTRA: ${{ matrix.vllm_extra }}
+          BFCL_TP: ${{ matrix.tp }}
           BFCL_MAX_MODEL_LEN: "16384"
-          BFCL_GPU_MEM_UTIL: "0.85"
+          BFCL_GPU_MEM_UTIL: ${{ matrix.gpu_mem }}
         run: |
           set -euo pipefail
-          # TP=2 per arm: Arm A (pure vLLM) on GPUs 0,1; Arm B (SMG -> vLLM gRPC) on GPUs 2,3.
-          # Ports are left unset so launch_arm.sh picks free ones — lets two bfcl
-          # runners share a node (bin-packed, hostNetwork) without port collisions.
-          A_URL=$(BFCL_GPU=0,1 bash scripts/bfcl/launch_arm.sh a)
-          B_URL=$(BFCL_GPU=2,3 bash scripts/bfcl/launch_arm.sh b)
+          # Both arms concurrent: arm A (pure vLLM) on the first GPU half, arm B
+          # (SMG -> vLLM gRPC) on the second. Ports left unset so launch_arm.sh
+          # picks free ones (lets bin-packed runners share a node).
+          A_URL=$(BFCL_GPU=${{ matrix.gpu_a }} bash scripts/bfcl/launch_arm.sh a)
+          B_URL=$(BFCL_GPU=${{ matrix.gpu_b }} bash scripts/bfcl/launch_arm.sh b)
           echo "arm A: $A_URL   arm B: $B_URL"
           python scripts/bfcl/run_ab.py \
             --baseline  "vllm=$A_URL" \
@@ -157,12 +238,16 @@ jobs:
             --tolerance 0.02 || echo "BFCL_AB_REGRESSION=1" >> "$GITHUB_ENV"
       - name: Render summary
         if: always()
-        run: cat "$RUNNER_TEMP/bfcl_ab.md" >> "$GITHUB_STEP_SUMMARY" || echo "no report produced" >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          {
+            echo "## BFCL A/B — ${{ matrix.name }} (${{ matrix.model }})"
+            cat "$RUNNER_TEMP/bfcl_ab.md"
+          } >> "$GITHUB_STEP_SUMMARY" || echo "no report produced for ${{ matrix.name }}" >> "$GITHUB_STEP_SUMMARY"
       - name: Upload comparison
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: bfcl-ab-${{ github.run_id }}
+          name: bfcl-ab-${{ matrix.name }}-${{ github.run_id }}
           path: |
             ${{ runner.temp }}/bfcl_ab.md
             ${{ runner.temp }}/bfcl_ab.json

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -130,15 +130,18 @@ jobs:
                "model": "Qwen/Qwen3.6-27B", "bfcl_model": "Qwen/Qwen3.6-27B-FC",
                "vllm_tool": "qwen3_xml", "vllm_reason": "qwen3",
                "smg_tool": "qwen_xml", "smg_reason": "qwen3",
-               "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600"},
+               "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
+               "model_cache": "/models"},
               # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
               {"name": "gpt-oss", "runner": "4-gpu-h100", "tp": 2,
                "gpu_a": "0,1", "gpu_b": "2,3",
                "model": "openai/gpt-oss-120b", "bfcl_model": "openai/gpt-oss-120b-FC",
                "vllm_tool": "openai", "vllm_reason": "",
                "smg_tool": "", "smg_reason": "",
-               "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600"},
-              # Blackwell legs (8xB300, TP=4 per arm, both arms concurrent: 0-3 + 4-7).
+               "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
+               "model_cache": "/models"},
+              # Blackwell legs (B200, TP=4 per arm, both arms concurrent: 0-3 + 4-7).
+              # Models are pre-staged on NVMe at /raid/models/<id> (no download).
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "deepseek-ai/DeepSeek-V4-Flash", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-FC",
@@ -148,13 +151,14 @@ jobs:
                # --kv-cache-dtype fp8 + --block-size 256 REQUIRED: V4's FlashMLA fp8
                # kernel asserts fp8 kv-cache (else EngineCore dies at startup).
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
-               "gpu_mem": "0.90", "startup_timeout": "2400"},
+               "gpu_mem": "0.90", "startup_timeout": "2400", "model_cache": "/raid/models"},
               {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "MiniMaxAI/MiniMax-M2.7", "bfcl_model": "MiniMaxAI/MiniMax-M2.7-FC",
                "vllm_tool": "minimax_m2", "vllm_reason": "minimax_m2",
                "smg_tool": "minimax_m2", "smg_reason": "minimax",
-               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400"},
+               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
+               "model_cache": "/raid/models"},
               # Kimi-K2.6 loads native int4 weights (~500GB) -> fits TP=4 half-node.
               {"name": "kimi-k2.6", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
@@ -163,7 +167,8 @@ jobs:
                "smg_tool": "kimik2",
                "smg_reason": "kimi_k25",  # TODO(confirm): no kimi_k2 SMG reasoning parser yet
                # Generous startup: 1T MoE at TP=4 needs minutes for load+compile+quant (420s timed out).
-               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400"},
+               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
+               "model_cache": "/raid/models"},
           ]
           only = os.environ.get("ONLY", "")
           valid_names = [l["name"] for l in legs]
@@ -191,8 +196,11 @@ jobs:
     permissions:
       contents: read
     env:
-      ROUTER_LOCAL_MODEL_PATH: /models
-      HF_HOME: /models
+      # Per-runner model store: /models on h100, /raid/models (NVMe) on blackwell.
+      # Models pre-staged at <cache>/<id> load locally; anything missing downloads
+      # into the same dir's HF cache.
+      ROUTER_LOCAL_MODEL_PATH: ${{ matrix.model_cache }}
+      HF_HOME: ${{ matrix.model_cache }}
       MODEL: ${{ github.event.inputs.model || matrix.model }}
       BFCL_MODEL_FC: ${{ github.event.inputs.bfcl_model || matrix.bfcl_model }}
       # Auth for gated/private HF repos + higher download rate limits.
@@ -215,9 +223,15 @@ jobs:
       - name: Register model in bfcl (no-op if bfcl already ships a handler)
         run: python scripts/bfcl/register_bfcl_model.py --model-id "$MODEL" || true
       - name: Stage model weights
-        # Only this leg's model — not the whole GPU tier (which pulls unrelated,
-        # sometimes-gated repos this A/B never serves).
-        run: bash scripts/ci_download_model.sh "$MODEL"
+        # Skip if pre-staged locally at <cache>/<id> (e.g. blackwell NVMe); else
+        # download just this leg's model (not the whole GPU tier, which pulls
+        # unrelated, sometimes-gated repos this A/B never serves).
+        run: |
+          if [ -d "$ROUTER_LOCAL_MODEL_PATH/$MODEL" ]; then
+            echo "model present at $ROUTER_LOCAL_MODEL_PATH/$MODEL — skipping download"
+          else
+            bash scripts/ci_download_model.sh "$MODEL"
+          fi
       - name: Launch arms + run official BFCL A/B
         env:
           BFCL_MODEL: ${{ env.MODEL }}

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -27,11 +27,11 @@ on:
         required: false
         default: ""
       model:
-        description: "Override HF model id (weights) for the selected leg; empty = matrix default"
+        description: "Override HF model id (weights) for the selected leg; empty = matrix default. Override model and bfcl_model together — mismatched weights/handler pair if only one is overridden."
         required: false
         default: ""
       bfcl_model:
-        description: "Override BFCL FC handler name (must end in -FC); empty = matrix default"
+        description: "Override BFCL FC handler name (must end in -FC); empty = matrix default. Override model and bfcl_model together — mismatched weights/handler pair if only one is overridden."
         required: false
         default: ""
       categories:
@@ -99,6 +99,8 @@ jobs:
   # excluding the scarce Blackwell legs on PRs) can depend on event/inputs —
   # the `matrix` context is not available in a job-level `if`.
   setup:
+    # No needs: build-wheel — this job is pure CPU JSON generation with no wheel
+    # dependency. bfcl-ab still gates on build-wheel.result == 'success'.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -152,11 +154,16 @@ jobs:
           ]
           only = os.environ.get("ONLY", "")
           event = os.environ.get("EVENT", "")
+          valid_names = [l["name"] for l in legs]
           if only:
               legs = [l for l in legs if l["name"] == only]
+          # `only` and `pull_request` can't co-occur: PRs carry no workflow_dispatch
+          # inputs, so the two filters never conflict.
           if event == "pull_request":
               # PR sanity = cheap H100 legs only; don't queue scarce Blackwell capacity.
               legs = [l for l in legs if l["runner"] == "4-gpu-h100"]
+          if only and not legs:
+              raise SystemExit(f"unknown leg {only!r}; valid: {valid_names}")
           print("matrix=" + json.dumps({"include": legs}))
           PY
 

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -237,6 +237,9 @@ jobs:
           BFCL_GPU_MEM_UTIL: ${{ matrix.gpu_mem }}
           # Per-leg health-wait budget: big MoEs need minutes for load + compile + quant.
           BFCL_STARTUP_TIMEOUT: ${{ matrix.startup_timeout }}
+          # Keep arm logs + pidfiles under RUNNER_TEMP (per-job, and uploadable as
+          # artifacts) instead of the shared /tmp default.
+          BFCL_RUN_DIR: ${{ runner.temp }}/bfcl_run
         run: |
           set -euo pipefail
           # Both arms concurrent: arm A (pure vLLM) on the first GPU half, arm B
@@ -262,15 +265,31 @@ jobs:
             echo "## BFCL A/B — ${{ matrix.name }} (${{ matrix.model }})"
             cat "$RUNNER_TEMP/bfcl_ab.md"
           } >> "$GITHUB_STEP_SUMMARY" || echo "no report produced for ${{ matrix.name }}" >> "$GITHUB_STEP_SUMMARY"
-      - name: Upload comparison
+      - name: Upload results (summary + per-case scores)
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: bfcl-ab-${{ matrix.name }}-${{ github.run_id }}
+          # Summary table + the per-category score files, which list the exact
+          # failed cases (id, model output, expected, error) for both arms — enough
+          # to trace any vLLM-vs-SMG divergence. The bulky raw generate dumps
+          # (bfcl_ab/<arm>/result/**) are intentionally excluded.
           path: |
             ${{ runner.temp }}/bfcl_ab.md
             ${{ runner.temp }}/bfcl_ab.json
+            ${{ runner.temp }}/bfcl_ab/*/score/**
+          if-no-files-found: warn
           retention-days: 30
+      - name: Upload arm logs (failure only)
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bfcl-ab-${{ matrix.name }}-logs-${{ github.run_id }}
+          # vLLM/SMG startup+serve logs — only useful when a leg crashed or timed
+          # out; huge and noise-only on success, so gated on failure.
+          path: ${{ runner.temp }}/bfcl_run/*.log
+          if-no-files-found: ignore
+          retention-days: 14
       - name: Teardown arms
         if: always()
         run: bash scripts/bfcl/launch_arm.sh stop || true

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -252,9 +252,21 @@ jobs:
           BFCL_RUN_DIR: ${{ runner.temp }}/bfcl_run
         run: |
           set -euo pipefail
-          # Both arms concurrent: arm A (pure vLLM) on the first GPU half, arm B
-          # (SMG -> vLLM gRPC) on the second. Ports left unset so launch_arm.sh
-          # picks free ones (lets bin-packed runners share a node).
+          # Serialize the heavy launch->serve->teardown phase PER HOST. Multiple
+          # Blackwell runner agents share one bare-metal machine (host network +
+          # the same 8 GPUs), so two legs at once collide: on ports (free_port
+          # picks a port, frees it, then vLLM binds it ~40s later — another leg
+          # grabs it meanwhile) and on GPU memory. A host-wide flock runs them one
+          # at a time; the lock releases when this step's shell exits.
+          exec 9>/tmp/bfcl-host.lock
+          echo "waiting for host lock..."; flock 9; echo "acquired host lock"
+          # Tear this leg's servers down before releasing the lock, so the next
+          # leg starts on a clean host (the always() steps below are backstops).
+          cleanup() { bash scripts/bfcl/launch_arm.sh stop || true; }
+          trap cleanup EXIT
+          trap 'cleanup; exit 143' INT TERM
+          # Arm A (pure vLLM) on the first GPU half, arm B (SMG -> vLLM gRPC) on
+          # the second; ports left unset so launch_arm.sh picks free ones.
           A_URL=$(BFCL_GPU=${{ matrix.gpu_a }} bash scripts/bfcl/launch_arm.sh a)
           B_URL=$(BFCL_GPU=${{ matrix.gpu_b }} bash scripts/bfcl/launch_arm.sh b)
           echo "arm A: $A_URL   arm B: $B_URL"
@@ -297,15 +309,9 @@ jobs:
           path: ${{ runner.temp }}/bfcl_run/*.log
           if-no-files-found: ignore
           retention-days: 14
-      - name: Teardown arms
+      - name: Teardown arms (leg-scoped backstop)
         if: always()
+        # Backstop to the in-step trap: kill THIS leg's process groups via its
+        # pidfiles. NOT a node-wide GPU nuke — these hosts run other orgs' runner
+        # agents, so killing by GPU occupancy would take down their jobs too.
         run: bash scripts/bfcl/launch_arm.sh stop || true
-      - name: Release GPUs (nuke + verify, same util as nightly-benchmark)
-        if: always()
-        # Backstop the pidfile teardown above: kill ANY process still holding the
-        # GPUs (by occupancy, not name) and assert the node is actually free. This
-        # catches root-owned, setsid-detached vLLM workers that survive a
-        # hard-killed launch step — exactly the leak that pinned ~250 GiB/GPU
-        # across jobs. Each bfcl leg uses the whole node (TP fills it), so no
-        # co-tenant job shares these GPUs.
-        run: bash scripts/ci_killall_sglang.sh nuke_gpus || true

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -95,85 +95,77 @@ jobs:
           path: bindings/python/dist/*.whl
           retention-days: 7
 
+  # Compute the model matrix as JSON so leg-filtering (dispatch `only`, and
+  # excluding the scarce Blackwell legs on PRs) can depend on event/inputs —
+  # the `matrix` context is not available in a job-level `if`.
+  setup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - id: build
+        env:
+          ONLY: ${{ github.event.inputs.only }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          legs = [
+              # H100 legs (TP=2 per arm, both arms concurrent: GPUs 0,1 + 2,3).
+              {"name": "qwen3.6", "runner": "4-gpu-h100", "tp": 2,
+               "gpu_a": "0,1", "gpu_b": "2,3",
+               "model": "Qwen/Qwen3.6-27B", "bfcl_model": "Qwen/Qwen3.6-27B-FC",
+               "vllm_tool": "qwen3_xml", "vllm_reason": "qwen3",
+               "smg_tool": "qwen_xml", "smg_reason": "qwen3",
+               "vllm_extra": "", "gpu_mem": "0.85"},
+              # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
+              {"name": "gpt-oss", "runner": "4-gpu-h100", "tp": 2,
+               "gpu_a": "0,1", "gpu_b": "2,3",
+               "model": "openai/gpt-oss-120b", "bfcl_model": "openai/gpt-oss-120b-FC",
+               "vllm_tool": "openai", "vllm_reason": "",
+               "smg_tool": "", "smg_reason": "",
+               "vllm_extra": "", "gpu_mem": "0.85"},
+              # Blackwell legs (8xB300, TP=4 per arm, both arms concurrent: 0-3 + 4-7).
+              {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
+               "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
+               "model": "deepseek-ai/DeepSeek-V4-Flash", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-FC",
+               "vllm_tool": "deepseek_v4", "vllm_reason": "deepseek_v4",
+               "smg_tool": "deepseek_v4",
+               "smg_reason": "deepseek_v31",  # TODO(confirm): no deepseek_v4 SMG reasoning parser yet
+               "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code", "gpu_mem": "0.90"},
+              {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,
+               "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
+               "model": "MiniMaxAI/MiniMax-M2.7", "bfcl_model": "MiniMaxAI/MiniMax-M2.7-FC",
+               "vllm_tool": "minimax_m2", "vllm_reason": "minimax_m2",
+               "smg_tool": "minimax_m2", "smg_reason": "minimax",
+               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90"},
+              # Kimi-K2.6 loads native int4 weights (~500GB) -> fits TP=4 half-node.
+              {"name": "kimi-k2.6", "runner": "blackwell", "tp": 4,
+               "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
+               "model": "moonshotai/Kimi-K2.6", "bfcl_model": "moonshotai/Kimi-K2.6-FC",
+               "vllm_tool": "kimi_k2", "vllm_reason": "kimi_k2",
+               "smg_tool": "kimik2",
+               "smg_reason": "kimi_k25",  # TODO(confirm): no kimi_k2 SMG reasoning parser yet
+               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90"},
+          ]
+          only = os.environ.get("ONLY", "")
+          event = os.environ.get("EVENT", "")
+          if only:
+              legs = [l for l in legs if l["name"] == only]
+          if event == "pull_request":
+              # PR sanity = cheap H100 legs only; don't queue scarce Blackwell capacity.
+              legs = [l for l in legs if l["runner"] == "4-gpu-h100"]
+          print("matrix=" + json.dumps({"include": legs}))
+          PY
+
   bfcl-ab:
-    needs: build-wheel
-    if: >-
-      ${{ !cancelled() && needs.build-wheel.result == 'success'
-          && (github.event.inputs.only == '' || github.event.inputs.only == matrix.name)
-          && (github.event_name != 'pull_request' || matrix.runner == '4-gpu-h100') }}
+    needs: [build-wheel, setup]
+    if: ${{ !cancelled() && needs.build-wheel.result == 'success' && needs.setup.result == 'success' }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # H100 legs (TP=2 per arm, both arms concurrent: GPUs 0,1 + 2,3).
-          - name: qwen3.6
-            runner: 4-gpu-h100
-            tp: 2
-            gpu_a: "0,1"
-            gpu_b: "2,3"
-            model: Qwen/Qwen3.6-27B
-            bfcl_model: Qwen/Qwen3.6-27B-FC
-            vllm_tool: qwen3_xml
-            vllm_reason: qwen3
-            smg_tool: qwen_xml
-            smg_reason: qwen3
-            vllm_extra: ""
-            gpu_mem: "0.85"
-          # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
-          - name: gpt-oss
-            runner: 4-gpu-h100
-            tp: 2
-            gpu_a: "0,1"
-            gpu_b: "2,3"
-            model: openai/gpt-oss-120b
-            bfcl_model: openai/gpt-oss-120b-FC
-            vllm_tool: openai
-            vllm_reason: ""
-            smg_tool: ""
-            smg_reason: ""
-            vllm_extra: ""
-            gpu_mem: "0.85"
-          # Blackwell legs (8xB300, TP=4 per arm, both arms concurrent: 0-3 + 4-7).
-          - name: deepseek-v4
-            runner: blackwell
-            tp: 4
-            gpu_a: "0,1,2,3"
-            gpu_b: "4,5,6,7"
-            model: deepseek-ai/DeepSeek-V4-Flash
-            bfcl_model: deepseek-ai/DeepSeek-V4-Flash-FC
-            vllm_tool: deepseek_v4
-            vllm_reason: deepseek_v4
-            smg_tool: deepseek_v4
-            smg_reason: deepseek_v31 # TODO(confirm): no deepseek_v4 SMG reasoning parser yet
-            vllm_extra: "--tokenizer-mode deepseek_v4 --trust-remote-code"
-            gpu_mem: "0.90"
-          - name: minimax-m2.7
-            runner: blackwell
-            tp: 4
-            gpu_a: "0,1,2,3"
-            gpu_b: "4,5,6,7"
-            model: MiniMaxAI/MiniMax-M2.7
-            bfcl_model: MiniMaxAI/MiniMax-M2.7-FC
-            vllm_tool: minimax_m2
-            vllm_reason: minimax_m2
-            smg_tool: minimax_m2
-            smg_reason: minimax
-            vllm_extra: "--trust-remote-code"
-            gpu_mem: "0.90"
-          # Kimi-K2.6 loads native int4 weights (~500GB) -> fits TP=4 half-node.
-          - name: kimi-k2.6
-            runner: blackwell
-            tp: 4
-            gpu_a: "0,1,2,3"
-            gpu_b: "4,5,6,7"
-            model: moonshotai/Kimi-K2.6
-            bfcl_model: moonshotai/Kimi-K2.6-FC
-            vllm_tool: kimi_k2
-            vllm_reason: kimi_k2
-            smg_tool: kimik2
-            smg_reason: kimi_k25 # TODO(confirm): no kimi_k2 SMG reasoning parser yet
-            vllm_extra: "--trust-remote-code"
-            gpu_mem: "0.90"
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     # Generous: the nightly set adds multi_turn (state simulation), much slower
     # than the single-turn AST/live categories.

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -119,14 +119,14 @@ jobs:
                "model": "Qwen/Qwen3.6-27B", "bfcl_model": "Qwen/Qwen3.6-27B-FC",
                "vllm_tool": "qwen3_xml", "vllm_reason": "qwen3",
                "smg_tool": "qwen_xml", "smg_reason": "qwen3",
-               "vllm_extra": "", "gpu_mem": "0.85"},
+               "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600"},
               # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
               {"name": "gpt-oss", "runner": "4-gpu-h100", "tp": 2,
                "gpu_a": "0,1", "gpu_b": "2,3",
                "model": "openai/gpt-oss-120b", "bfcl_model": "openai/gpt-oss-120b-FC",
                "vllm_tool": "openai", "vllm_reason": "",
                "smg_tool": "", "smg_reason": "",
-               "vllm_extra": "", "gpu_mem": "0.85"},
+               "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600"},
               # Blackwell legs (8xB300, TP=4 per arm, both arms concurrent: 0-3 + 4-7).
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
@@ -134,13 +134,16 @@ jobs:
                "vllm_tool": "deepseek_v4", "vllm_reason": "deepseek_v4",
                "smg_tool": "deepseek_v4",
                "smg_reason": "deepseek_v31",  # TODO(confirm): no deepseek_v4 SMG reasoning parser yet
-               "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code", "gpu_mem": "0.90"},
+               # --kv-cache-dtype fp8 + --block-size 256 are REQUIRED: V4 auto-quantizes to
+               # deepseek_v4_fp8 and its FlashMLA kernel asserts fp8 kv-cache (else EngineCore dies).
+               "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
+               "gpu_mem": "0.90", "startup_timeout": "2400"},
               {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "MiniMaxAI/MiniMax-M2.7", "bfcl_model": "MiniMaxAI/MiniMax-M2.7-FC",
                "vllm_tool": "minimax_m2", "vllm_reason": "minimax_m2",
                "smg_tool": "minimax_m2", "smg_reason": "minimax",
-               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90"},
+               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400"},
               # Kimi-K2.6 loads native int4 weights (~500GB) -> fits TP=4 half-node.
               {"name": "kimi-k2.6", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
@@ -148,7 +151,9 @@ jobs:
                "vllm_tool": "kimi_k2", "vllm_reason": "kimi_k2",
                "smg_tool": "kimik2",
                "smg_reason": "kimi_k25",  # TODO(confirm): no kimi_k2 SMG reasoning parser yet
-               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90"},
+               # Generous startup: 1T MoE at TP=4 spends minutes on load + torch.compile +
+               # weight quant; the default 420s timed out mid-compile.
+               "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400"},
           ]
           only = os.environ.get("ONLY", "")
           valid_names = [l["name"] for l in legs]
@@ -219,6 +224,8 @@ jobs:
           BFCL_TP: ${{ matrix.tp }}
           BFCL_MAX_MODEL_LEN: "16384"
           BFCL_GPU_MEM_UTIL: ${{ matrix.gpu_mem }}
+          # Per-leg health-wait budget: big MoEs need minutes for load + compile + quant.
+          BFCL_STARTUP_TIMEOUT: ${{ matrix.startup_timeout }}
         run: |
           set -euo pipefail
           # Both arms concurrent: arm A (pure vLLM) on the first GPU half, arm B

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -181,6 +181,9 @@ jobs:
       HF_HOME: /models
       MODEL: ${{ github.event.inputs.model || matrix.model }}
       BFCL_MODEL_FC: ${{ github.event.inputs.bfcl_model || matrix.bfcl_model }}
+      # Auth for gated/private HF repos + higher download rate limits (used by the
+      # weight-staging step and by vLLM/SMG at serve time).
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
       # PR = quick non-live sanity subset; schedule/dispatch = non_live + live + multi_turn.
       CATEGORIES: ${{ github.event.inputs.categories || (github.event_name == 'pull_request' && 'simple_python,irrelevance' || 'simple_python,simple_java,simple_javascript,multiple,parallel,parallel_multiple,irrelevance,live_simple,live_multiple,live_parallel,live_parallel_multiple,live_irrelevance,live_relevance,multi_turn_base,multi_turn_miss_func,multi_turn_miss_param,multi_turn_long_context') }}
     steps:
@@ -199,7 +202,9 @@ jobs:
       - name: Register model in bfcl (no-op if bfcl already ships a handler)
         run: python scripts/bfcl/register_bfcl_model.py --model-id "$MODEL" || true
       - name: Stage model weights
-        run: bash scripts/ci_download_model.sh --gpu-tier 2
+        # Only this leg's model — not the whole GPU tier (which pulls unrelated,
+        # sometimes-gated repos this A/B never serves).
+        run: bash scripts/ci_download_model.sh "$MODEL"
       - name: Launch arms + run official BFCL A/B
         env:
           BFCL_MODEL: ${{ env.MODEL }}

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -263,3 +263,12 @@ jobs:
       - name: Teardown arms
         if: always()
         run: bash scripts/bfcl/launch_arm.sh stop || true
+      - name: Release GPUs (nuke + verify, same util as nightly-benchmark)
+        if: always()
+        # Backstop the pidfile teardown above: kill ANY process still holding the
+        # GPUs (by occupancy, not name) and assert the node is actually free. This
+        # catches root-owned, setsid-detached vLLM workers that survive a
+        # hard-killed launch step — exactly the leak that pinned ~250 GiB/GPU
+        # across jobs. Each bfcl leg uses the whole node (TP fills it), so no
+        # co-tenant job shares these GPUs.
+        run: bash scripts/ci_killall_sglang.sh nuke_gpus || true

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -109,7 +109,18 @@ jobs:
       - id: build
         env:
           ONLY: ${{ github.event.inputs.only }}
+          MODEL_OVERRIDE: ${{ github.event.inputs.model }}
+          BFCL_OVERRIDE: ${{ github.event.inputs.bfcl_model }}
         run: |
+          set -euo pipefail
+          # Enforce the paired-override contract: `model` and `bfcl_model` must be
+          # given together or not at all (an overridden model with the default FC
+          # handler — or vice versa — is a mismatched weights/handler pair).
+          if { [ -n "$MODEL_OVERRIDE" ] && [ -z "$BFCL_OVERRIDE" ]; } || \
+             { [ -z "$MODEL_OVERRIDE" ] && [ -n "$BFCL_OVERRIDE" ]; }; then
+            echo "::error::Set BOTH 'model' and 'bfcl_model' (or neither): model='$MODEL_OVERRIDE' bfcl_model='$BFCL_OVERRIDE'"
+            exit 1
+          fi
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json, os
           legs = [

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -145,8 +145,8 @@ jobs:
                "vllm_tool": "deepseek_v4", "vllm_reason": "deepseek_v4",
                "smg_tool": "deepseek_v4",
                "smg_reason": "deepseek_v31",  # TODO(confirm): no deepseek_v4 SMG reasoning parser yet
-               # --kv-cache-dtype fp8 + --block-size 256 are REQUIRED: V4 auto-quantizes to
-               # deepseek_v4_fp8 and its FlashMLA kernel asserts fp8 kv-cache (else EngineCore dies).
+               # --kv-cache-dtype fp8 + --block-size 256 REQUIRED: V4's FlashMLA fp8
+               # kernel asserts fp8 kv-cache (else EngineCore dies at startup).
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
                "gpu_mem": "0.90", "startup_timeout": "2400"},
               {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,
@@ -162,17 +162,15 @@ jobs:
                "vllm_tool": "kimi_k2", "vllm_reason": "kimi_k2",
                "smg_tool": "kimik2",
                "smg_reason": "kimi_k25",  # TODO(confirm): no kimi_k2 SMG reasoning parser yet
-               # Generous startup: 1T MoE at TP=4 spends minutes on load + torch.compile +
-               # weight quant; the default 420s timed out mid-compile.
+               # Generous startup: 1T MoE at TP=4 needs minutes for load+compile+quant (420s timed out).
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400"},
           ]
           only = os.environ.get("ONLY", "")
           valid_names = [l["name"] for l in legs]
           if only:
               legs = [l for l in legs if l["name"] == only]
-          # All legs (H100 + Blackwell) run on PRs as a sanity check; the run stays
-          # cheap because the PR CATEGORIES below are a tiny non-live subset
-          # (simple_python,irrelevance) for every leg regardless of runner.
+          # All legs (incl. Blackwell) run on PRs; cheap because the PR CATEGORIES
+          # below are a tiny non-live subset for every leg.
           if only and not legs:
               raise SystemExit(f"unknown leg {only!r}; valid: {valid_names}")
           print("matrix=" + json.dumps({"include": legs}))
@@ -197,8 +195,7 @@ jobs:
       HF_HOME: /models
       MODEL: ${{ github.event.inputs.model || matrix.model }}
       BFCL_MODEL_FC: ${{ github.event.inputs.bfcl_model || matrix.bfcl_model }}
-      # Auth for gated/private HF repos + higher download rate limits (used by the
-      # weight-staging step and by vLLM/SMG at serve time).
+      # Auth for gated/private HF repos + higher download rate limits.
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       # PR = quick non-live sanity subset; schedule/dispatch = non_live + live + multi_turn.
       CATEGORIES: ${{ github.event.inputs.categories || (github.event_name == 'pull_request' && 'simple_python,irrelevance' || 'simple_python,simple_java,simple_javascript,multiple,parallel,parallel_multiple,irrelevance,live_simple,live_multiple,live_parallel,live_parallel_multiple,live_irrelevance,live_relevance,multi_turn_base,multi_turn_miss_func,multi_turn_miss_param,multi_turn_long_context') }}
@@ -237,8 +234,7 @@ jobs:
           BFCL_GPU_MEM_UTIL: ${{ matrix.gpu_mem }}
           # Per-leg health-wait budget: big MoEs need minutes for load + compile + quant.
           BFCL_STARTUP_TIMEOUT: ${{ matrix.startup_timeout }}
-          # Keep arm logs + pidfiles under RUNNER_TEMP (per-job, and uploadable as
-          # artifacts) instead of the shared /tmp default.
+          # Arm logs + pidfiles under RUNNER_TEMP (per-job, uploadable) not /tmp.
           BFCL_RUN_DIR: ${{ runner.temp }}/bfcl_run
         run: |
           set -euo pipefail
@@ -270,10 +266,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: bfcl-ab-${{ matrix.name }}-${{ github.run_id }}
-          # Summary table + the per-category score files, which list the exact
-          # failed cases (id, model output, expected, error) for both arms — enough
-          # to trace any vLLM-vs-SMG divergence. The bulky raw generate dumps
-          # (bfcl_ab/<arm>/result/**) are intentionally excluded.
+          # Summary + per-category score files (which list each failed case for
+          # both arms). Raw generate dumps (bfcl_ab/<arm>/result/**) excluded as bulky.
           path: |
             ${{ runner.temp }}/bfcl_ab.md
             ${{ runner.temp }}/bfcl_ab.json
@@ -285,8 +279,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: bfcl-ab-${{ matrix.name }}-logs-${{ github.run_id }}
-          # vLLM/SMG startup+serve logs — only useful when a leg crashed or timed
-          # out; huge and noise-only on success, so gated on failure.
+          # vLLM/SMG logs — only useful on crash/timeout; noise on success.
           path: ${{ runner.temp }}/bfcl_run/*.log
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -95,9 +95,8 @@ jobs:
           path: bindings/python/dist/*.whl
           retention-days: 7
 
-  # Compute the model matrix as JSON so leg-filtering (dispatch `only`, and
-  # excluding the scarce Blackwell legs on PRs) can depend on event/inputs —
-  # the `matrix` context is not available in a job-level `if`.
+  # Compute the model matrix as JSON so the dispatch `only` leg-filter can depend
+  # on inputs — the `matrix` context is not available in a job-level `if`.
   setup:
     # No needs: build-wheel — this job is pure CPU JSON generation with no wheel
     # dependency. bfcl-ab still gates on build-wheel.result == 'success'.
@@ -110,7 +109,6 @@ jobs:
       - id: build
         env:
           ONLY: ${{ github.event.inputs.only }}
-          EVENT: ${{ github.event_name }}
         run: |
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json, os
@@ -153,21 +151,20 @@ jobs:
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90"},
           ]
           only = os.environ.get("ONLY", "")
-          event = os.environ.get("EVENT", "")
           valid_names = [l["name"] for l in legs]
           if only:
               legs = [l for l in legs if l["name"] == only]
-          # `only` and `pull_request` can't co-occur: PRs carry no workflow_dispatch
-          # inputs, so the two filters never conflict.
-          if event == "pull_request":
-              # PR sanity = cheap H100 legs only; don't queue scarce Blackwell capacity.
-              legs = [l for l in legs if l["runner"] == "4-gpu-h100"]
+          # All legs (H100 + Blackwell) run on PRs as a sanity check; the run stays
+          # cheap because the PR CATEGORIES below are a tiny non-live subset
+          # (simple_python,irrelevance) for every leg regardless of runner.
           if only and not legs:
               raise SystemExit(f"unknown leg {only!r}; valid: {valid_names}")
           print("matrix=" + json.dumps({"include": legs}))
           PY
 
   bfcl-ab:
+    # Concise leg label (default would list every matrix field): model + runner + TP.
+    name: bfcl-ab ${{ matrix.model }} (${{ matrix.runner }} TP${{ matrix.tp }})
     needs: [build-wheel, setup]
     if: ${{ !cancelled() && needs.build-wheel.result == 'success' && needs.setup.result == 'success' }}
     strategy:

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -71,7 +71,9 @@ Key env knobs for `launch_arm.sh`: `BFCL_GPU` (CUDA_VISIBLE_DEVICES, e.g. `0,1`)
 > **gpt-oss has no SMG tool-call-parser.** SMG handles gpt-oss through its harmony
 > pipeline (`model_gateway/src/routers/grpc/harmony/`), auto-activated by
 > `HarmonyDetector` on a `gpt-oss` model id / `GptOssForCausalLM` architecture. So
-> the SMG arm passes **no** `--tool-call-parser` (`BFCL_SMG_TOOL_PARSER=""`).
+> the SMG arm passes **no** `--tool-call-parser` (`BFCL_SMG_TOOL_PARSER=""`). The
+> `—` in **both** reasoning-parser columns for gpt-oss is likewise intentional:
+> harmony carries its own reasoning channel, so neither arm sets a reasoning parser.
 >
 > **† Reasoning-parser fallbacks.** SMG's reasoning registry has no `deepseek_v4` or
 > `kimi_k2` entry yet; the closest existing parsers (`deepseek_v31`, `kimi_k25`) are

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -58,19 +58,47 @@ Key env knobs for `launch_arm.sh`: `BFCL_GPU` (CUDA_VISIBLE_DEVICES, e.g. `0,1`)
 
 `run_ab.py` exits non-zero if the candidate's overall accuracy drops more than `--tolerance` (default 2pp) below the baseline.
 
-## Per-model parser flags (vLLM ~0.22.x)
+## Per-model parser flags (the nightly matrix)
 
-| model family | pure-vLLM `--tool-call-parser` / `--reasoning-parser` | SMG `--tool-call-parser` / `--reasoning-parser` |
-|---|---|---|
-| Qwen3 dense Instruct (e.g. Qwen3-4B-Instruct-2507) | `hermes` / — | `qwen` / — |
-| Qwen3 thinking | `hermes` / `qwen3` | `qwen` / `qwen3` |
-| Qwen3-Coder / 3.5 / 3.6 | `qwen3_coder` / `qwen3` | `qwen_xml` / `qwen3` |
-| DeepSeek V3/R1 | `deepseek_v3` / `deepseek_r1` | `deepseek` / `deepseek_r1` |
-| DeepSeek V3.1/V3.2/V4 | `deepseek_v31` / `deepseek_v3` | `deepseek31` / `deepseek_v4` (DSML) / … |
-| Kimi K2 | `kimi_k2` / — | `kimik2` / `kimi` |
-| MiniMax M2 | `minimax_m2` / `minimax_m2` | `minimax_m2` / `minimax` |
+| model (matrix leg) | runner | TP/arm | pure-vLLM `--tool-call-parser` / `--reasoning-parser` | SMG `--tool-call-parser` / `--reasoning-parser` |
+|---|---|---|---|---|
+| Qwen3.6-27B (`qwen3.6`) | `4-gpu-h100` | 2 | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
+| gpt-oss-120b (`gpt-oss`) | `4-gpu-h100` | 2 | `openai` / — | _(none — SMG auto-routes harmony)_ / — |
+| DeepSeek-V4-Flash (`deepseek-v4`) | `blackwell` | 4 | `deepseek_v4` / `deepseek_v4` (+`--tokenizer-mode deepseek_v4 --trust-remote-code`) | `deepseek_v4` / `deepseek_v31`† |
+| MiniMax-M2.7 (`minimax-m2.7`) | `blackwell` | 4 | `minimax_m2` / `minimax_m2` (+`--trust-remote-code`) | `minimax_m2` / `minimax` |
+| Kimi-K2.6 int4 (`kimi-k2.6`) | `blackwell` | 4 | `kimi_k2` / `kimi_k2` (+`--trust-remote-code`) | `kimik2` / `kimi_k25`† |
 
-> The mid-2026 SKUs (DeepSeek V4, Kimi K2.6, Qwen3.6, MiniMax M2.7) may use newer parser names; confirm against the installed vLLM build: `vllm serve --help | grep -A40 tool-call-parser`.
+> **gpt-oss has no SMG tool-call-parser.** SMG handles gpt-oss through its harmony
+> pipeline (`model_gateway/src/routers/grpc/harmony/`), auto-activated by
+> `HarmonyDetector` on a `gpt-oss` model id / `GptOssForCausalLM` architecture. So
+> the SMG arm passes **no** `--tool-call-parser` (`BFCL_SMG_TOOL_PARSER=""`).
+>
+> **† Reasoning-parser fallbacks.** SMG's reasoning registry has no `deepseek_v4` or
+> `kimi_k2` entry yet; the closest existing parsers (`deepseek_v31`, `kimi_k25`) are
+> used. Confirm on the first nightly; adding exact parsers to `crates/reasoning_parser`
+> is a follow-up if outputs diverge.
+>
+> The mid-2026 SKU ids and a couple of vLLM parser names may shift; confirm against
+> the installed vLLM build: `vllm serve --help | grep -A40 tool-call-parser`.
+
+## Matrix & runners
+
+The nightly (`.github/workflows/nightly-bfcl.yml`) runs the A/B as a GitHub Actions
+matrix — one leg per model, `fail-fast: false`, each on its own runner:
+
+- `4-gpu-h100` — Qwen3.6-27B and gpt-oss-120b, TP=2 per arm (GPUs 0,1 + 2,3).
+- `blackwell` (8×B300) — DeepSeek-V4-Flash, MiniMax-M2.7, Kimi-K2.6, TP=4 per arm
+  (GPUs 0-3 + 4-7).
+
+All legs run **both arms concurrently**; no sequential path is needed because the
+"flash"/int4 checkpoints fit half a node. Per the A/B's premise, model size is
+irrelevant — a smaller same-family checkpoint exercises the identical parser, so the
+matrix uses DeepSeek-V4-Flash and int4 Kimi-K2.6 to validate the `deepseek_v4` /
+`kimi_k2` parsers without paying for the full production weights.
+
+`workflow_dispatch` can target one leg via the `only` input and override
+`model`/`bfcl_model`/parsers per run. PRs touching this pipeline run only the cheap
+`4-gpu-h100` legs as an end-to-end sanity check.
 
 ## Gotchas discovered while bringing this up (read before debugging)
 

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -97,8 +97,9 @@ matrix uses DeepSeek-V4-Flash and int4 Kimi-K2.6 to validate the `deepseek_v4` /
 `kimi_k2` parsers without paying for the full production weights.
 
 `workflow_dispatch` can target one leg via the `only` input and override
-`model`/`bfcl_model`/parsers per run. PRs touching this pipeline run only the cheap
-`4-gpu-h100` legs as an end-to-end sanity check.
+`model`/`bfcl_model`/parsers per run. PRs touching this pipeline run **all** legs
+(H100 + Blackwell) as an end-to-end sanity check, but cheaply — the PR category set
+is a tiny non-live subset (`simple_python,irrelevance`) for every leg.
 
 ## Gotchas discovered while bringing this up (read before debugging)
 

--- a/scripts/bfcl/launch_arm.sh
+++ b/scripts/bfcl/launch_arm.sh
@@ -64,6 +64,12 @@ start() {
   echo "[launch_arm] started $name (pid $(cat "$RUN_DIR/$name.pid")) -> $log" >&2
 }
 
+# Tail a logfile to stderr for real-time startup visibility in CI. Stdout is
+# reserved for the base_url (captured by the caller's $(...)), so logs must go to
+# stderr — which still streams live to the CI console. Prints the tail pid so the
+# caller can stop it once the server is healthy.
+stream_log() { tail -n +1 -F "$1" >&2 & echo $!; }
+
 wait_http() {  # wait_http <url> <timeout_s>
   local url="$1" timeout="${2:-300}" waited=0
   until curl -sf -m 3 "$url" >/dev/null 2>&1; do
@@ -100,7 +106,9 @@ case "$ARM" in
     # shellcheck disable=SC2206  # intentional word-split of optional extra flags
     [ -n "$VLLM_EXTRA" ] && cmd+=($VLLM_EXTRA)
     start arm_a "$RUN_DIR/arm_a_vllm.log" "${cmd[@]}"
+    log_tail=$(stream_log "$RUN_DIR/arm_a_vllm.log")
     wait_http "http://127.0.0.1:$ARM_A_PORT/health" "${BFCL_STARTUP_TIMEOUT:-420}"
+    kill "$log_tail" 2>/dev/null || true
     echo "http://127.0.0.1:$ARM_A_PORT"
     ;;
 
@@ -117,7 +125,9 @@ case "$ARM" in
     # shellcheck disable=SC2206  # intentional word-split of optional extra flags
     [ -n "$VLLM_EXTRA" ] && wcmd+=($VLLM_EXTRA)
     start arm_b_worker "$RUN_DIR/arm_b_worker.log" "${wcmd[@]}"
+    log_tail=$(stream_log "$RUN_DIR/arm_b_worker.log")
     wait_grpc "$ARM_B_GRPC_PORT" "${BFCL_STARTUP_TIMEOUT:-420}"
+    kill "$log_tail" 2>/dev/null || true
     # 2) SMG gateway in front, exposing the OpenAI API.
     # shellcheck disable=SC2206  # intentional word-split of SMG_LAUNCH
     declare -a smg_cmd=(
@@ -131,7 +141,9 @@ case "$ARM" in
     [ -n "$SMG_TOOL_PARSER" ] && smg_cmd+=(--tool-call-parser "$SMG_TOOL_PARSER")
     [ -n "$SMG_REASONING_PARSER" ] && smg_cmd+=(--reasoning-parser "$SMG_REASONING_PARSER")
     start arm_b_gateway "$RUN_DIR/arm_b_gateway.log" "${smg_cmd[@]}"
+    log_tail=$(stream_log "$RUN_DIR/arm_b_gateway.log")
     wait_http "http://127.0.0.1:$ARM_B_GW_PORT/health" "${BFCL_STARTUP_TIMEOUT:-420}"
+    kill "$log_tail" 2>/dev/null || true
     echo "http://127.0.0.1:$ARM_B_GW_PORT"
     ;;
 

--- a/scripts/bfcl/launch_arm.sh
+++ b/scripts/bfcl/launch_arm.sh
@@ -33,9 +33,8 @@ RUN_DIR="${BFCL_RUN_DIR:-/tmp/bfcl_ab}"
 VLLM_TOOL_PARSER="${BFCL_VLLM_TOOL_PARSER:-hermes}"
 VLLM_REASONING_PARSER="${BFCL_VLLM_REASONING_PARSER:-}"   # empty = none (non-thinking SKU)
 # SMG (arm B) parser flags — SMG registry names, NOT vLLM's.
-# Use `-` (not `:-`) so an explicit empty value passes through unchanged (omits
-# --tool-call-parser → SMG auto-detect, e.g. harmony for gpt-oss); only a fully
-# UNSET var falls back to the qwen default for standalone/manual use.
+# `-` not `:-`: an explicit empty value passes through (omits the flag → SMG
+# auto-detect, e.g. harmony for gpt-oss); only an unset var defaults to qwen.
 SMG_TOOL_PARSER="${BFCL_SMG_TOOL_PARSER-qwen}"
 SMG_REASONING_PARSER="${BFCL_SMG_REASONING_PARSER:-}"
 
@@ -67,10 +66,8 @@ start() {
   echo "[launch_arm] started $name (pid $(cat "$RUN_DIR/$name.pid")) -> $log" >&2
 }
 
-# Tail a logfile to stderr for real-time startup visibility in CI. Stdout is
-# reserved for the base_url (captured by the caller's $(...)), so logs must go to
-# stderr — which still streams live to the CI console. Prints the tail pid so the
-# caller can stop it once the server is healthy.
+# Tail a logfile to stderr (streams live in CI; stdout is reserved for the
+# base_url). Prints the tail pid so the caller can stop it once healthy.
 stream_log() { tail -n +1 -F "$1" >&2 & echo $!; }
 
 wait_http() {  # wait_http <url> <timeout_s>
@@ -139,8 +136,7 @@ case "$ARM" in
       --worker-urls "grpc://127.0.0.1:$ARM_B_GRPC_PORT"
       --host 0.0.0.0 --port "$ARM_B_GW_PORT"
     )
-    # Empty tool-call-parser => let SMG auto-detect (e.g. gpt-oss routes through
-    # the harmony pipeline via HarmonyDetector; passing a parser there is wrong).
+    # Empty => omit, so SMG auto-detects (e.g. gpt-oss → harmony pipeline).
     [ -n "$SMG_TOOL_PARSER" ] && smg_cmd+=(--tool-call-parser "$SMG_TOOL_PARSER")
     [ -n "$SMG_REASONING_PARSER" ] && smg_cmd+=(--reasoning-parser "$SMG_REASONING_PARSER")
     start arm_b_gateway "$RUN_DIR/arm_b_gateway.log" "${smg_cmd[@]}"
@@ -151,11 +147,9 @@ case "$ARM" in
     ;;
 
   stop)
-    # Collect recorded pids first, then kill the whole PROCESS GROUP of each.
-    # start() uses setsid, so the recorded pid is the session/group leader and
-    # vLLM's worker/engine children share its pgid. Killing only the leader (the
-    # old behavior) orphaned those children — they kept ~250 GiB pinned per GPU
-    # across jobs. Negative pid = "signal the process group".
+    # Kill each recorded pid's whole PROCESS GROUP (negative pid). start() uses
+    # setsid, so the pid is the group leader; killing only it orphaned vLLM's
+    # worker children, leaving ~250 GiB pinned per GPU across jobs.
     declare -a pids=()
     for pf in "$RUN_DIR"/*.pid; do
       [ -e "$pf" ] || continue

--- a/scripts/bfcl/launch_arm.sh
+++ b/scripts/bfcl/launch_arm.sh
@@ -58,6 +58,7 @@ VLLM_EXTRA="${BFCL_VLLM_EXTRA:-}"
 ARM_A_PORT="${BFCL_ARM_A_PORT:-}"          # pure-vLLM OpenAI port
 ARM_B_GRPC_PORT="${BFCL_ARM_B_GRPC_PORT:-}" # vLLM gRPC worker port
 ARM_B_GW_PORT="${BFCL_ARM_B_GW_PORT:-}"     # SMG OpenAI gateway port
+ARM_B_METRICS_PORT="${BFCL_ARM_B_METRICS_PORT:-}" # SMG Prometheus port (defaults to 29000 — collides when arms/legs share a host)
 
 # Executables (override for venv / box paths).
 VLLM_BIN="${VLLM_BIN:-vllm}"                      # `vllm serve` console script
@@ -123,6 +124,7 @@ case "$ARM" in
   b)
     ARM_B_GRPC_PORT="${ARM_B_GRPC_PORT:-$(free_port)}"
     ARM_B_GW_PORT="${ARM_B_GW_PORT:-$(free_port)}"
+    ARM_B_METRICS_PORT="${ARM_B_METRICS_PORT:-$(free_port)}"
     # 1) vLLM gRPC worker (raw-token; SMG will own template+parsing).
     declare -a wcmd=(
       CUDA_VISIBLE_DEVICES="$GPU" "$VLLM_PYTHON" -m vllm.entrypoints.grpc_server
@@ -144,6 +146,9 @@ case "$ARM" in
       --model-path "$MODEL_SRC"
       --worker-urls "grpc://127.0.0.1:$ARM_B_GRPC_PORT"
       --host 0.0.0.0 --port "$ARM_B_GW_PORT"
+      # Free port, not the fixed 29000 default — else a second SMG on the same
+      # host (concurrent arm/leg) panics with "metrics server bind failed".
+      --prometheus-port "$ARM_B_METRICS_PORT"
     )
     # Empty => omit, so SMG auto-detects (e.g. gpt-oss → harmony pipeline).
     [ -n "$SMG_TOOL_PARSER" ] && smg_cmd+=(--tool-call-parser "$SMG_TOOL_PARSER")

--- a/scripts/bfcl/launch_arm.sh
+++ b/scripts/bfcl/launch_arm.sh
@@ -23,6 +23,14 @@ set -euo pipefail
 ARM="${1:?usage: launch_arm.sh <a|b|stop>}"
 
 MODEL="${BFCL_MODEL:-Qwen/Qwen3-4B-Instruct-2507}"
+# Load source: prefer a pre-staged local copy at $ROUTER_LOCAL_MODEL_PATH/<id>
+# (e.g. NVMe /raid/models on the Blackwell node — no download); else the HF repo
+# id, which vLLM/HF downloads into HF_HOME. The canonical served name stays
+# $MODEL (passed as --served-model-name) so the BFCL handler + requests match.
+MODEL_SRC="$MODEL"
+if [ -n "${ROUTER_LOCAL_MODEL_PATH:-}" ] && [ -d "$ROUTER_LOCAL_MODEL_PATH/$MODEL" ]; then
+  MODEL_SRC="$ROUTER_LOCAL_MODEL_PATH/$MODEL"
+fi
 GPU="${BFCL_GPU:-0}"                              # CUDA_VISIBLE_DEVICES (e.g. "0" or "0,1")
 TP="${BFCL_TP:-1}"                               # tensor-parallel size (match GPU count)
 MAX_MODEL_LEN="${BFCL_MAX_MODEL_LEN:-16384}"
@@ -95,7 +103,7 @@ case "$ARM" in
   a)
     ARM_A_PORT="${ARM_A_PORT:-$(free_port)}"
     declare -a cmd=(
-      CUDA_VISIBLE_DEVICES="$GPU" "$VLLM_BIN" serve "$MODEL"
+      CUDA_VISIBLE_DEVICES="$GPU" "$VLLM_BIN" serve "$MODEL_SRC"
       --served-model-name "$MODEL"
       --enable-auto-tool-choice --tool-call-parser "$VLLM_TOOL_PARSER"
       --host 0.0.0.0 --port "$ARM_A_PORT"
@@ -118,7 +126,8 @@ case "$ARM" in
     # 1) vLLM gRPC worker (raw-token; SMG will own template+parsing).
     declare -a wcmd=(
       CUDA_VISIBLE_DEVICES="$GPU" "$VLLM_PYTHON" -m vllm.entrypoints.grpc_server
-      --model "$MODEL" --host 0.0.0.0 --port "$ARM_B_GRPC_PORT"
+      --model "$MODEL_SRC" --served-model-name "$MODEL"
+      --host 0.0.0.0 --port "$ARM_B_GRPC_PORT"
       --tensor-parallel-size "$TP" --max-model-len "$MAX_MODEL_LEN"
       --gpu-memory-utilization "$GPU_MEM_UTIL"
     )
@@ -132,7 +141,7 @@ case "$ARM" in
     # shellcheck disable=SC2206  # intentional word-split of SMG_LAUNCH
     declare -a smg_cmd=(
       $SMG_LAUNCH
-      --model-path "$MODEL"
+      --model-path "$MODEL_SRC"
       --worker-urls "grpc://127.0.0.1:$ARM_B_GRPC_PORT"
       --host 0.0.0.0 --port "$ARM_B_GW_PORT"
     )

--- a/scripts/bfcl/launch_arm.sh
+++ b/scripts/bfcl/launch_arm.sh
@@ -33,7 +33,10 @@ RUN_DIR="${BFCL_RUN_DIR:-/tmp/bfcl_ab}"
 VLLM_TOOL_PARSER="${BFCL_VLLM_TOOL_PARSER:-hermes}"
 VLLM_REASONING_PARSER="${BFCL_VLLM_REASONING_PARSER:-}"   # empty = none (non-thinking SKU)
 # SMG (arm B) parser flags — SMG registry names, NOT vLLM's.
-SMG_TOOL_PARSER="${BFCL_SMG_TOOL_PARSER:-qwen}"
+# Use `-` (not `:-`) so an explicit empty value passes through unchanged (omits
+# --tool-call-parser → SMG auto-detect, e.g. harmony for gpt-oss); only a fully
+# UNSET var falls back to the qwen default for standalone/manual use.
+SMG_TOOL_PARSER="${BFCL_SMG_TOOL_PARSER-qwen}"
 SMG_REASONING_PARSER="${BFCL_SMG_REASONING_PARSER:-}"
 
 # Extra args appended to every vLLM process (both arms). e.g.

--- a/scripts/bfcl/launch_arm.sh
+++ b/scripts/bfcl/launch_arm.sh
@@ -119,13 +119,16 @@ case "$ARM" in
     start arm_b_worker "$RUN_DIR/arm_b_worker.log" "${wcmd[@]}"
     wait_grpc "$ARM_B_GRPC_PORT" "${BFCL_STARTUP_TIMEOUT:-420}"
     # 2) SMG gateway in front, exposing the OpenAI API.
+    # shellcheck disable=SC2206  # intentional word-split of SMG_LAUNCH
     declare -a smg_cmd=(
       $SMG_LAUNCH
       --model-path "$MODEL"
       --worker-urls "grpc://127.0.0.1:$ARM_B_GRPC_PORT"
-      --tool-call-parser "$SMG_TOOL_PARSER"
       --host 0.0.0.0 --port "$ARM_B_GW_PORT"
     )
+    # Empty tool-call-parser => let SMG auto-detect (e.g. gpt-oss routes through
+    # the harmony pipeline via HarmonyDetector; passing a parser there is wrong).
+    [ -n "$SMG_TOOL_PARSER" ] && smg_cmd+=(--tool-call-parser "$SMG_TOOL_PARSER")
     [ -n "$SMG_REASONING_PARSER" ] && smg_cmd+=(--reasoning-parser "$SMG_REASONING_PARSER")
     start arm_b_gateway "$RUN_DIR/arm_b_gateway.log" "${smg_cmd[@]}"
     wait_http "http://127.0.0.1:$ARM_B_GW_PORT/health" "${BFCL_STARTUP_TIMEOUT:-420}"

--- a/scripts/bfcl/launch_arm.sh
+++ b/scripts/bfcl/launch_arm.sh
@@ -148,11 +148,25 @@ case "$ARM" in
     ;;
 
   stop)
+    # Collect recorded pids first, then kill the whole PROCESS GROUP of each.
+    # start() uses setsid, so the recorded pid is the session/group leader and
+    # vLLM's worker/engine children share its pgid. Killing only the leader (the
+    # old behavior) orphaned those children — they kept ~250 GiB pinned per GPU
+    # across jobs. Negative pid = "signal the process group".
+    declare -a pids=()
     for pf in "$RUN_DIR"/*.pid; do
       [ -e "$pf" ] || continue
-      pid="$(cat "$pf")"
-      kill "$pid" 2>/dev/null && echo "[launch_arm] killed $(basename "$pf" .pid) (pid $pid)" >&2 || true
+      pids+=("$(cat "$pf")")
       rm -f "$pf"
+    done
+    [ "${#pids[@]}" -eq 0 ] && exit 0
+    for pid in "${pids[@]}"; do
+      kill -TERM -- -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+    done
+    sleep 5  # let them drain on SIGTERM before the hard kill
+    for pid in "${pids[@]}"; do
+      kill -KILL -- -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+      echo "[launch_arm] stopped process group $pid" >&2
     done
     ;;
 


### PR DESCRIPTION
## Description

### Problem

The nightly BFCL A/B (`scripts/bfcl/`) — the parser-parity comparison of pure vLLM vs SMG→vLLM gRPC — only exercised a single model (`Qwen/Qwen3.6-27B`) on one `4-gpu-h100` node. We want coverage of the mid-2026 target SKUs (Kimi K2.6, DeepSeek V4, MiniMax M2.7, gpt-oss-120b) and the ability to run the large models on Blackwell (B300) hardware.

### Solution

Convert the single A/B job into a **5-model matrix**, each leg on its own runner with its own parser config. Because the A/B isolates the *parser frontend* (model size is irrelevant — a smaller same-family checkpoint exercises the identical parse path), the large legs use flash/int4 checkpoints that fit half a B300 node at TP=4, so every leg runs both arms concurrently with no perf tuning. gpt-oss needs no SMG tool-call-parser — SMG's `HarmonyDetector` auto-routes it through the harmony pipeline — so `launch_arm.sh` now omits the flag when unset.

| leg | runner | TP/arm | vLLM tool/reason | SMG tool/reason |
|---|---|---|---|---|
| qwen3.6 | `4-gpu-h100` | 2 | `qwen3_xml`/`qwen3` | `qwen_xml`/`qwen3` |
| gpt-oss | `4-gpu-h100` | 2 | `openai`/— | _(none → harmony auto)_/— |
| deepseek-v4 (Flash) | `blackwell` | 4 | `deepseek_v4`/`deepseek_v4` | `deepseek_v4`/`deepseek_v31`† |
| minimax-m2.7 | `blackwell` | 4 | `minimax_m2`/`minimax_m2` | `minimax_m2`/`minimax` |
| kimi-k2.6 (int4) | `blackwell` | 4 | `kimi_k2`/`kimi_k2` | `kimik2`/`kimi_k25`† |

## Changes

- `scripts/bfcl/launch_arm.sh`: make the SMG arm's `--tool-call-parser` conditional (omit when `BFCL_SMG_TOOL_PARSER` is empty → gpt-oss harmony auto-detect).
- `.github/workflows/nightly-bfcl.yml`: convert `bfcl-ab` to a 5-leg matrix on per-model runners (`4-gpu-h100`, `blackwell`); leg filtering (dispatch `only`, PR-runs-H100-only) lives in a new `setup` job that emits the matrix as JSON, since the `matrix` context isn't allowed in a job-level `if`.
- `scripts/bfcl/README.md`: per-model parser table + matrix/runner docs.
- `run_ab.py` is unchanged — it already loops over both arms.

**† To confirm on the first nightly:** SMG has no exact `deepseek_v4`/`kimi_k2` *reasoning* parser yet (using closest `deepseek_v31`/`kimi_k25`, marked `TODO(confirm)`); the new model IDs and the int4 Kimi invocation should be verified against the installed vLLM build.

## Test Plan

- `shellcheck scripts/bfcl/launch_arm.sh` passes; behavioral check confirms the SMG tool-call-parser is omitted when empty and included when set.
- `actionlint .github/workflows/nightly-bfcl.yml` clean (only pre-existing custom-runner-label warnings); matrix parses to the 5 expected legs; `setup` filter logic verified for schedule / PR / dispatch-`only` / unknown-leg (guarded) cases.
- PR trigger runs the quick non-live subset on the `4-gpu-h100` legs only as an end-to-end pipeline sanity check; full validation is the scheduled nightly on real runners.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly BFCL workflow can run a single selected matrix leg; the matrix is generated dynamically and dispatch overrides now fall back to leg defaults.
* **Bug Fixes**
  * SMG gateway only applies the tool-call parser when explicitly provided, otherwise it auto-detects routing.
* **Documentation**
  * Updated BFCL nightly documentation with the new per-model parser flags and clearer matrix/runner behavior.
* **Chores**
  * Improved arm startup logging with live log streaming; updated teardown to reliably stop full process groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->