### PR TITLE
feat(discovery): discover local HTTP model ids from /v1/models

### DIFF
--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -54,6 +54,7 @@ use crate::{
         },
         error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},
+        openai::strip_default_sglang_fields,
         RouterTrait,
     },
     worker::{AttachedBody, ConnectionMode, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType},
@@ -899,7 +900,7 @@ impl Router {
             }
         };
 
-        let json_val = match worker.prepare_request(json_val) {
+        let mut json_val = match worker.prepare_request(json_val) {
             Ok(prepared) => prepared,
             Err(e) => {
                 return error::bad_request(
@@ -908,6 +909,7 @@ impl Router {
                 );
             }
         };
+        strip_default_sglang_fields(&mut json_val);
 
         let mut request_builder = self.client.post(&endpoint_url).json(&json_val);
 

--- a/model_gateway/src/routers/openai/mod.rs
+++ b/model_gateway/src/routers/openai/mod.rs
@@ -15,4 +15,5 @@ mod provider;
 pub mod responses;
 mod router;
 
+pub(crate) use provider::strip_default_sglang_fields;
 pub use router::OpenAIRouter;

--- a/model_gateway/src/routers/openai/provider/mod.rs
+++ b/model_gateway/src/routers/openai/provider/mod.rs
@@ -17,5 +17,6 @@ pub use openai::OpenAIProvider;
 pub use provider_trait::Provider;
 pub use registry::ProviderRegistry;
 pub use sglang::SGLangProvider;
+pub(crate) use types::strip_default_sglang_fields;
 pub use types::ProviderError;
 pub use xai::XAIProvider;

--- a/model_gateway/src/routers/openai/provider/tests.rs
+++ b/model_gateway/src/routers/openai/provider/tests.rs
@@ -13,7 +13,7 @@ use openai_protocol::{
 };
 use serde_json::{json, to_value, Value};
 
-use super::{OpenAIProvider, Provider, XAIProvider};
+use super::{types::strip_default_sglang_fields, OpenAIProvider, Provider, XAIProvider};
 use crate::worker::Endpoint;
 
 /// Build a `ResponsesRequest` whose single input message carries every
@@ -65,6 +65,28 @@ fn first_content_array(payload: &Value) -> &Vec<Value> {
     payload["input"][0]["content"]
         .as_array()
         .expect("content array present on first input item")
+}
+
+#[test]
+fn strip_default_sglang_fields_removes_false_and_null_values() {
+    let mut payload = json!({
+        "continue_final_message": false,
+        "messages": [],
+        "model": "test-model",
+        "no_stop_trim": true,
+        "return_hidden_states": null,
+        "separate_reasoning": true,
+        "stream_reasoning": true
+    });
+
+    strip_default_sglang_fields(&mut payload);
+
+    assert_eq!(payload.get("continue_final_message"), None);
+    assert_eq!(payload.get("return_hidden_states"), None);
+    assert_eq!(payload.get("separate_reasoning"), None);
+    assert_eq!(payload.get("stream_reasoning"), None);
+    assert_eq!(payload.get("no_stop_trim"), Some(&json!(true)));
+    assert_eq!(payload.get("model"), Some(&json!("test-model")));
 }
 
 #[test]

--- a/model_gateway/src/routers/openai/provider/types.rs
+++ b/model_gateway/src/routers/openai/provider/types.rs
@@ -37,6 +37,21 @@ pub(crate) fn strip_sglang_fields(payload: &mut Value) {
     }
 }
 
+pub(crate) fn strip_default_sglang_fields(payload: &mut Value) {
+    if let Some(obj) = payload.as_object_mut() {
+        for field in SGLANG_FIELDS {
+            if obj.get(*field).is_some_and(|value| {
+                value.is_null()
+                    || value == false
+                    || (matches!(*field, "separate_reasoning" | "stream_reasoning")
+                        && value == true)
+            }) {
+                obj.remove(*field);
+            }
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum ProviderError {
     #[error("Unsupported endpoint: {0:?}")]

--- a/model_gateway/src/workflow/steps/classify.rs
+++ b/model_gateway/src/workflow/steps/classify.rs
@@ -25,7 +25,7 @@ use crate::{
 const CLASSIFY_PROBE_TIMEOUT_SECS: u64 = 2;
 
 /// Known local backend `owned_by` values returned by `/v1/models`.
-const LOCAL_OWNED_BY: &[&str] = &["sglang", "vllm", "trtllm"];
+const LOCAL_OWNED_BY: &[&str] = &["sglang", "vllm", "trtllm", "nvidia"];
 
 /// Fetch `/v1/models` and check the `owned_by` field of the first model.
 /// Returns `Some("sglang")`, `Some("vllm")`, etc. if recognized as a local
@@ -161,5 +161,48 @@ impl StepExecutor<WorkerWorkflowData> for ClassifyWorkerTypeStep {
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{routing::get, Json, Router};
+    use reqwest::Client;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+
+    use super::probe_models_owned_by;
+
+    #[tokio::test]
+    async fn probe_models_owned_by_accepts_nvidia_as_local() {
+        async fn models() -> Json<serde_json::Value> {
+            Json(json!({
+                "data": [{
+                    "id": "test-model",
+                    "object": "model",
+                    "owned_by": "nvidia"
+                }],
+                "object": "list"
+            }))
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test-only mock /v1/models server; handle is aborted at test end"
+        )]
+        let server = tokio::spawn(async move {
+            axum::serve(listener, Router::new().route("/v1/models", get(models)))
+                .await
+                .unwrap();
+        });
+
+        let owned_by = probe_models_owned_by(&format!("http://{addr}"), 5, &Client::new(), None)
+            .await
+            .unwrap();
+        server.abort();
+
+        assert_eq!(owned_by, "nvidia");
     }
 }

--- a/model_gateway/src/workflow/steps/local/detect_backend.rs
+++ b/model_gateway/src/workflow/steps/local/detect_backend.rs
@@ -103,7 +103,7 @@ async fn detect_via_models_endpoint(
         .ok_or_else(|| format!("/v1/models returned empty data array from {models_url}"))?;
 
     match first_model.owned_by.as_deref() {
-        Some("sglang") => Ok("sglang".to_string()),
+        Some("sglang" | "nvidia") => Ok("sglang".to_string()),
         Some("vllm") => Ok("vllm".to_string()),
         other => Err(format!("Unrecognized owned_by value: {other:?}")),
     }
@@ -297,5 +297,49 @@ impl StepExecutor<WorkerWorkflowData> for DetectBackendStep {
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{routing::get, Json, Router};
+    use reqwest::Client;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+
+    use super::detect_via_models_endpoint;
+
+    #[tokio::test]
+    async fn detect_via_models_endpoint_maps_nvidia_to_sglang() {
+        async fn models() -> Json<serde_json::Value> {
+            Json(json!({
+                "data": [{
+                    "id": "test-model",
+                    "object": "model",
+                    "owned_by": "nvidia"
+                }],
+                "object": "list"
+            }))
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test-only mock /v1/models server; handle is aborted at test end"
+        )]
+        let server = tokio::spawn(async move {
+            axum::serve(listener, Router::new().route("/v1/models", get(models)))
+                .await
+                .unwrap();
+        });
+
+        let runtime =
+            detect_via_models_endpoint(&format!("http://{addr}"), 5, &Client::new(), None)
+                .await
+                .unwrap();
+        server.abort();
+
+        assert_eq!(runtime, "sglang");
     }
 }

--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -187,10 +187,21 @@ async fn fetch_sglang_http_metadata(url: &str, api_key: Option<&str>) -> HashMap
         labels.extend(flat_labels(&info));
     }
 
-    // /v1/models gives us max_model_len (fills context_length when /server_info returns null)
+    // /v1/models gives us model identity and max_model_len when a compatible
+    // local frontend does not expose the SGLang-specific metadata endpoints.
     if let Ok(models) = http_get_json::<ModelsResponse>(&format!("{base}/v1/models"), api_key).await
     {
         if let Some(m) = models.data.first() {
+            if let Some(id) = m.id.as_ref().filter(|id| !id.is_empty()) {
+                labels
+                    .entry("served_model_name".to_string())
+                    .or_insert_with(|| id.clone());
+            }
+            if let Some(root) = m.root.as_ref().filter(|root| !root.is_empty()) {
+                labels
+                    .entry("model_path".to_string())
+                    .or_insert_with(|| root.clone());
+            }
             if let Some(len) = m.max_model_len.filter(|&n| n > 0) {
                 labels
                     .entry("max_model_len".to_string())
@@ -472,5 +483,53 @@ mod tests {
 
         let labels = flat_labels(&info);
         assert!(!labels.contains_key("max_running_requests"));
+    }
+
+    #[tokio::test]
+    async fn test_sglang_http_metadata_uses_models_identity() {
+        use axum::{routing::get, Json, Router};
+        use serde_json::json;
+        use tokio::net::TcpListener;
+
+        async fn models() -> Json<serde_json::Value> {
+            Json(json!({
+                "data": [{
+                    "id": "test-model",
+                    "max_model_len": 4096,
+                    "object": "model",
+                    "owned_by": "nvidia",
+                    "root": "test-root"
+                }],
+                "object": "list"
+            }))
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test-only mock /v1/models server; handle is aborted at test end"
+        )]
+        let server = tokio::spawn(async move {
+            axum::serve(listener, Router::new().route("/v1/models", get(models)))
+                .await
+                .unwrap();
+        });
+
+        let labels = fetch_sglang_http_metadata(&format!("http://{addr}"), None).await;
+        server.abort();
+
+        assert_eq!(
+            labels.get("served_model_name").map(String::as_str),
+            Some("test-model")
+        );
+        assert_eq!(
+            labels.get("model_path").map(String::as_str),
+            Some("test-root")
+        );
+        assert_eq!(
+            labels.get("max_model_len").map(String::as_str),
+            Some("4096")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- classify OpenAI-compatible local frontends with `/v1/models.data[0].owned_by: nvidia` as local workers
- map `owned_by: nvidia` to the SGLang-compatible local HTTP metadata path
- use `/v1/models.data[0].id` as `served_model_name` and `.root` as `model_path` when stronger metadata did not provide them
- strip default SMG/SGLang-only request fields before generic HTTP forwarding, including true-by-default `separate_reasoning` and `stream_reasoning`
- add focused unit coverage for NVIDIA-owned local model discovery, backend detection, metadata identity, and default SGLang-field stripping

## Why

A Dynamo Frontend service can expose a healthy OpenAI-compatible `/v1/models` response with `owned_by: nvidia` while not populating SGLang-specific metadata endpoints. Before this change, SMG could classify/detect the worker incorrectly or register the model as `unknown`, so SMG `/v1/models` did not expose the real model id and real-model chat requests failed even though direct backend chat succeeded.

Dynamo Frontend also rejects SMG/SGLang-only request fields on its strict OpenAI-compatible HTTP surface. The pass-through HTTP router now removes unset/default SGLang-only fields before forwarding so strict local frontends accept the request, while preserving non-default fields such as `no_stop_trim: true`.

## Verification

On Linux VM, upstream-main PR worktree:

- `cargo fmt --all -- --check`
- `git diff --check`
- `timeout 900s cargo test -p smg --lib probe_models_owned_by_accepts_nvidia_as_local`
- `timeout 900s cargo test -p smg --lib detect_via_models_endpoint_maps_nvidia_to_sglang`
- `timeout 900s cargo test -p smg --lib strip_default_sglang_fields_removes_false_and_null_values`

Production compatibility was also validated on the v1.4.1-compatible branch with A4 Dynamo/SMG: SMG `/health` returned OK, `/v1/models` exposed `BlaiseAI/DeepSeek-V3.2-REAP-345B-SpinQuant-ActKV-NVFP4-NextN-Graft`, and `/v1/chat/completions` through SMG returned HTTP 200 `chat.completion` for that real model.
