### PR TITLE
fix(messages): accept system role in messages[] and forward in place (/v1/messages)

### DIFF
--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -279,6 +279,17 @@ pub struct InputMessage {
 pub enum Role {
     User,
     Assistant,
+    /// `system` role inside `messages[]`.
+    ///
+    /// The Anthropic Messages API carries the system prompt in the top-level
+    /// `system` field, but some clients (e.g. Claude Code) additionally send a
+    /// `system`-role message *in the array* — often mid-conversation. Accepting
+    /// it (instead of 400ing) lets those requests through; the message is
+    /// forwarded to the chat template **in place**, so backends that render
+    /// `system` inline (e.g. GLM-4.5+/5.x) keep its position, while backends
+    /// that only read a leading system (e.g. MiniMax-M2) handle it per their
+    /// own template. See https://github.com/lightseekorg/smg/issues/1795
+    System,
 }
 
 /// Input content can be a string or an array of content blocks
@@ -2423,5 +2434,25 @@ mod tests {
             ContentBlock::ToolSearchToolResult { .. }
         ));
         assert!(matches!(msg.content[2], ContentBlock::ToolUse { .. }));
+    }
+
+    #[test]
+    fn test_system_role_in_messages_is_accepted_and_preserved() {
+        // Claude Code sends a `system`-role message in `messages[]` (in addition
+        // to the top-level `system`). It must parse (not 400) and stay in place
+        // so inline-`system` templates render it where it was sent.
+        let body = json!({
+            "model": "m",
+            "max_tokens": 16,
+            "system": "main prompt",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "mid-conversation system"}
+            ]
+        });
+        let req: CreateMessageRequest = serde_json::from_value(body).unwrap();
+        assert_eq!(req.messages.len(), 2);
+        assert_eq!(req.messages[0].role, Role::User);
+        assert_eq!(req.messages[1].role, Role::System); // preserved in place
     }
 }

--- a/model_gateway/src/routers/grpc/utils/message_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/message_utils.rs
@@ -155,9 +155,34 @@ pub(crate) fn process_message_content_format(
             messages::Role::Assistant => {
                 result.push(convert_assistant_message(&message.content, content_format));
             }
+            // A `system`-role message in `messages[]` (e.g. from Claude Code) is
+            // forwarded in place, preserving its position in the conversation so
+            // inline-`system` chat templates render it where it was sent.
+            // See https://github.com/lightseekorg/smg/issues/1795
+            messages::Role::System => {
+                result.push(convert_system_message(&message.content));
+            }
         }
         Ok(result)
     })
+}
+
+/// Convert a `system`-role message's content to a chat-template JSON value,
+/// preserving its position in `messages[]`. System content is text; text blocks
+/// are concatenated.
+fn convert_system_message(content: &InputContent) -> Value {
+    let text = match content {
+        InputContent::String(text) => text.clone(),
+        InputContent::Blocks(blocks) => blocks
+            .iter()
+            .filter_map(|block| match block {
+                InputContentBlock::Text(t) => Some(t.text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+    };
+    json!({"role": "system", "content": text})
 }
 
 /// Convert a user message content to JSON values.


### PR DESCRIPTION
Closes #1795.

## Problem

`POST /v1/messages` returns **400** when a request includes a `system`-role message inside `messages[]` (`messages[1].role: unknown variant 'system'`). Real clients — notably **Claude Code** — send this: a top-level `system` (main prompt) **plus** a `system` message in the array carrying its sub-agent/skill registry, often mid-conversation. The strict `Role { User, Assistant }` enum rejects it at deserialization. (Exact captured request in #1795.)

## Fix — accept `system` in `messages[]` and forward it **in place**

A faithful pass-through (an earlier "hoist to top-level `system`" draft was dropped — it would front-load *mid-conversation* system messages and rewrite the conversation for backends that render `system` **inline**, e.g. GLM-4.5+/5.x):

- **`crates/protocols/src/messages.rs`** — add `Role::System`, so a `system`-role message deserializes (no more 400). Strict types otherwise unchanged.
- **`model_gateway/src/routers/grpc/utils/message_utils.rs`** — add a `Role::System` arm in `process_message_content_format` that emits `{"role":"system","content":…}` **at the message's position** (text-only, via the typed `InputContentBlock::Text` variant). The top-level Anthropic `system` field is still prepended as `messages[0]` (Step 2, unchanged).

Net: the conversation structure the client sent is preserved. **GLM-4.5+/5.x** render the inline `<|system|>` block where it was sent; **MiniMax-M2** (whose template only reads a leading system) handles it per its own template. The gateway no longer rewrites message order.

## Why pass-through, not hoist
Hoisting is required for MiniMax (template ignores non-`messages[0]` system) but **wrong for GLM** (inline `system` at any position). Pass-through preserves position and lets each model's chat template decide.

## Cascade check
The only exhaustive match on the messages `Role` was `process_message_content_format` (handled). `multimodal.rs` uses `!= Role::User`, so a `system` message is correctly treated as non-user. The control-plane `Role` in `main.rs` is a different enum.

## Verification (built + tested locally, rustc 1.96.0)
- `cargo test -p openai-protocol` → **126 passed; 0 failed**, including the new `test_system_role_in_messages_is_accepted_and_preserved` (a `system`-role message in `messages[]` now deserializes and is preserved in place).
- `cargo check -p smg` → **clean** (compiles the `message_utils` forwarding arm; finished, 0 errors/warnings).
- `cargo fmt --check` → clean for the changed files.
