### PR TITLE
Cache env lookups off request hot paths

### DIFF
--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -3,7 +3,7 @@ use std::{
     io::Write,
     path::PathBuf,
     process::{Output, Stdio},
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -18,6 +18,10 @@ use url::Url;
 
 const DEFAULT_VIDEO_PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_VIDEO_MAX_DECODED_BYTES: usize = 1024 * 1024 * 1024;
+static VIDEO_DECODE_BACKEND: OnceLock<Option<String>> = OnceLock::new();
+static LOG_VIDEO_DECODE_TIMING: OnceLock<bool> = OnceLock::new();
+static VIDEO_PROCESS_TIMEOUT: OnceLock<Duration> = OnceLock::new();
+static VIDEO_MAX_DECODED_BYTES: OnceLock<usize> = OnceLock::new();
 
 use super::{
     error::MediaConnectorError,
@@ -394,7 +398,7 @@ async fn decode_video_frames(
             .map_err(MediaConnectorError::Blocking)??
     };
     let input_path = input_file.path().to_path_buf();
-    match video_decode_backend_override().as_deref() {
+    match video_decode_backend_override() {
         Some("ffmpeg") => decode_video_with_ffmpeg(&input_path, input_bytes, cfg).await,
         Some("opencv") => {
             #[cfg(feature = "opencv-video")]
@@ -473,26 +477,32 @@ fn decode_video_with_opencv_logged(
     result
 }
 
-fn video_decode_backend_override() -> Option<String> {
-    let backend = std::env::var("SMG_VIDEO_DECODE_BACKEND")
-        .ok()?
-        .trim()
-        .to_ascii_lowercase();
-    match backend.as_str() {
-        "" | "auto" => None,
-        _ => Some(backend),
-    }
+fn video_decode_backend_override() -> Option<&'static str> {
+    VIDEO_DECODE_BACKEND
+        .get_or_init(|| {
+            let backend = std::env::var("SMG_VIDEO_DECODE_BACKEND")
+                .ok()?
+                .trim()
+                .to_ascii_lowercase();
+            match backend.as_str() {
+                "" | "auto" => None,
+                _ => Some(backend),
+            }
+        })
+        .as_deref()
 }
 
 fn log_video_decode_timing_enabled() -> bool {
-    std::env::var("SMG_LOG_MM_TIMING")
-        .map(|value| {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
-        .unwrap_or(false)
+    *LOG_VIDEO_DECODE_TIMING.get_or_init(|| {
+        std::env::var("SMG_LOG_MM_TIMING")
+            .map(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false)
+    })
 }
 
 fn log_video_decode_backend_timing(
@@ -827,20 +837,24 @@ fn video_temp_suffix(bytes: &[u8]) -> &'static str {
 }
 
 fn video_process_timeout() -> Duration {
-    std::env::var("SMG_VIDEO_PROCESS_TIMEOUT_SECS")
-        .ok()
-        .and_then(|value| value.parse::<f64>().ok())
-        .filter(|seconds| seconds.is_finite() && *seconds > 0.0)
-        .map(Duration::from_secs_f64)
-        .unwrap_or(DEFAULT_VIDEO_PROCESS_TIMEOUT)
+    *VIDEO_PROCESS_TIMEOUT.get_or_init(|| {
+        std::env::var("SMG_VIDEO_PROCESS_TIMEOUT_SECS")
+            .ok()
+            .and_then(|value| value.parse::<f64>().ok())
+            .filter(|seconds| seconds.is_finite() && *seconds > 0.0)
+            .map(Duration::from_secs_f64)
+            .unwrap_or(DEFAULT_VIDEO_PROCESS_TIMEOUT)
+    })
 }
 
 fn video_max_decoded_bytes() -> usize {
-    std::env::var("SMG_VIDEO_MAX_DECODED_BYTES")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .filter(|bytes| *bytes > 0)
-        .unwrap_or(DEFAULT_VIDEO_MAX_DECODED_BYTES)
+    *VIDEO_MAX_DECODED_BYTES.get_or_init(|| {
+        std::env::var("SMG_VIDEO_MAX_DECODED_BYTES")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|bytes| *bytes > 0)
+            .unwrap_or(DEFAULT_VIDEO_MAX_DECODED_BYTES)
+    })
 }
 
 fn ensure_decoded_byte_limit(bytes: usize) -> Result<(), MediaConnectorError> {

--- a/grpc_servicer/smg_grpc_servicer/sglang/utils.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/utils.py
@@ -1,5 +1,7 @@
 """gRPC utility functions."""
 
+from __future__ import annotations
+
 import os
 from array import array
 from collections.abc import Iterable
@@ -14,11 +16,12 @@ import grpc
 # ``array("q")``, which current SGLang requires (see ``to_token_id_array``).
 _TOKEN_ID_ARRAY_ENV = "SGLANG_GRPC_TOKEN_ID_ARRAY"
 _TRUTHY = ("1", "true", "yes")
+_USE_TOKEN_ID_ARRAY = os.getenv(_TOKEN_ID_ARRAY_ENV, "false").strip().lower() in _TRUTHY
 
 
 def _use_token_id_array() -> bool:
     """Whether to emit ``array("q")`` (new contract) vs ``list`` (old contract)."""
-    return os.getenv(_TOKEN_ID_ARRAY_ENV, "false").strip().lower() in _TRUTHY
+    return _USE_TOKEN_ID_ARRAY
 
 
 def to_token_id_array(token_ids: Iterable[int] | None) -> array | list | None:

--- a/grpc_servicer/tests/test_token_id_array.py
+++ b/grpc_servicer/tests/test_token_id_array.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib.util
 from array import array
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -30,13 +31,21 @@ import pytest
 # helper itself is stdlib + grpc only, so a direct file load keeps this test
 # runnable without the full inference stack.
 _UTILS_PATH = Path(__file__).resolve().parent.parent / "smg_grpc_servicer" / "sglang" / "utils.py"
-_spec = importlib.util.spec_from_file_location("_smg_sglang_utils_under_test", _UTILS_PATH)
-_utils = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_utils)
-to_token_id_array = _utils.to_token_id_array
+
+
+def _load_utils() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_smg_sglang_utils_under_test", _UTILS_PATH)
+    utils = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(utils)
+    return utils
+
+
+def to_token_id_array(token_ids):
+    return _load_utils().to_token_id_array(token_ids)
 
 # Env var that toggles the array("q") (new) vs list (old) SGLang contract.
-_TOKEN_ID_ARRAY_ENV = _utils._TOKEN_ID_ARRAY_ENV
+_TOKEN_ID_ARRAY_ENV = "SGLANG_GRPC_TOKEN_ID_ARRAY"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

- Cache multimodal video decode env knobs with `OnceLock` so video request processing no longer re-reads process env for backend, timing, timeout, and decoded-byte limits.
- Cache the SGLang gRPC token-id array toggle at module import so request conversion avoids per-request `os.getenv`.
- Update token-id tests to reload the lightweight utility module when asserting different startup env values.

## Validation

- `cargo fmt --package llm-multimodal`
- `cargo test -p llm-multimodal`
- `python3 -m pytest grpc_servicer/tests/test_token_id_array.py`