### PR TITLE
build(deps): bump reqwest 0.12 -> 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ lru = "0.18.0"
 num-traits = "0.2"
 parking_lot = "0.12.4"
 rand = "0.10.1"
-reqwest = { version = "0.12.8", default-features = false }
+reqwest = { version = "0.13.4", default-features = false }
 serde = { version = "1.0" }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["macros"] }

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = "0.3"
 tracing = "0.1"
 libc = "0.2.179"
 async-trait = "0.1"
-reqwest = { version = "0.12", default-features = false }
+reqwest = { version = "0.13", default-features = false }
 
 [dependencies.smg]
 path = "../../model_gateway"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 
 [features]
 default = ["rustls"]
-rustls = ["reqwest/rustls-tls"]
+rustls = ["reqwest/rustls"]
 native-tls = ["reqwest/native-tls"]
 
 [dependencies]

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -22,7 +22,7 @@ chrono = { workspace = true, features = ["serde"] }
 http.workspace = true
 lru.workspace = true
 parking_lot.workspace = true
-reqwest = { workspace = true, features = ["rustls-tls", "json"] }
+reqwest = { workspace = true, features = ["rustls", "json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 subtle.workspace = true

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -24,9 +24,7 @@ futures.workspace = true
 dashmap.workspace = true
 lru.workspace = true
 parking_lot.workspace = true
-# rmcp 1.7 requires reqwest 0.13 (its `StreamableHttpClient` impl is on
-# reqwest 0.13's `Client`); pin here rather than via the workspace 0.12.
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
+reqwest = { workspace = true, features = ["rustls", "json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml = "0.9"

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -57,7 +57,7 @@ tracing-subscriber.workspace = true
 # Workspace dependencies (with extra features)
 axum = { workspace = true, features = ["macros", "multipart", "ws", "tracing"] }
 bytemuck = { workspace = true, features = ["derive"] }
-reqwest = { workspace = true, features = ["stream", "blocking", "json", "rustls-tls", "multipart"] }
+reqwest = { workspace = true, features = ["stream", "blocking", "json", "rustls", "multipart"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true


### PR DESCRIPTION
## Summary

Bumps **reqwest 0.12 -> 0.13.4** across the workspace.

reqwest 0.13's only API-relevant change for this repo is the **TLS feature rename `rustls-tls` -> `rustls`**. Every consumer was updated accordingly. No `.rs` source changes were needed: the public `Client` / `ClientBuilder` / `Body` / `multipart` / `Proxy` / `Identity` / `Certificate` / header APIs used in this repo are unchanged across the bump.

### Bumps
- `Cargo.toml` `[workspace.dependencies]`: `reqwest 0.12.8 -> 0.13.4`
- `bindings/golang/Cargo.toml`: `reqwest 0.12 -> 0.13`
- `crates/auth`, `crates/mcp`, `model_gateway`: feature `rustls-tls -> rustls`
- `clients/rust` feature passthrough: `reqwest/rustls-tls -> reqwest/rustls`

(`crates/tokenizer` dev-dep and `crates/multimodal` use reqwest via the workspace dep; `hf-hub`'s own `rustls-tls` feature is unrelated and left untouched.)

### Breaking changes fixed
- TLS feature rename `rustls-tls` -> `rustls` in all 5 reqwest declarations + 1 feature passthrough.

### Verification
- `cargo build -p llm-multimodal -p smg-auth -p smg-client -p llm-tokenizer` (RUSTC_WRAPPER="", default features): **clean, exit 0**.
- `cargo build -p smg-auth`: **clean**.
- model_gateway reqwest call sites reviewed (`bytes_stream`, `client.request`, `reqwest::Body::from`, `multipart::{Form,Part}`, `Part::stream_with_length`, `use_rustls_tls`, `Identity::from_pem`, `Certificate::from_pem`, `Proxy::{http,https}`, `NoProxy::from_string`) — all stable in 0.13.

## :no_entry: Blocked — needs the rmcp upgrade first

`crates/mcp` does **not** compile on reqwest 0.13 (34 `E0277` errors), and this transitively blocks `model_gateway` and the `golang`/`python` bindings.

**Root cause:** `rmcp 0.8.5` hard-pins `reqwest = "0.12"` and its `SseClient` / `StreamableHttpClient` trait impls are written for **reqwest 0.12's** `Client` type. The orchestrator (`crates/mcp/src/core/orchestrator.rs`) builds a reqwest **0.13** `Client` and passes it to rmcp transports:

```
let transport = SseClientTransport::start_with_client(http_client, sse_config)?;        // SSE
let transport = StreamableHttpClientTransport::with_client(http_client, cfg);            // streamable HTTP
```

Because reqwest 0.12 and 0.13 are distinct crate versions, the 0.13 `Client` does not satisfy rmcp 0.8's bounds:

```
error[E0277]: the trait bound `reqwest::Client: SseClient` is not satisfied
error[E0277]: the trait bound `reqwest::Client: StreamableHttpClient` is not satisfied
error[E0277]: the trait bound `SseClientTransport<reqwest::Client>: IntoTransport<RoleClient, _, _>` is not satisfied
error[E0277]: the trait bound `WorkerTransport<StreamableHttpClientWorker<reqwest::Client>>: IntoTransport<RoleClient, _, _>` is not satisfied
... (34 total)
error: could not compile `smg-mcp` (lib) due to 34 previous errors
```

**Why this can't be fixed inside the reqwest unit:** reqwest 0.13 support requires **rmcp >= 1.x** (rmcp 1.7.0 depends on `reqwest 0.13.2` and maps its `reqwest` feature to `reqwest?/rustls`). But rmcp 0.8 -> 1.7 is a **major breaking bump** beyond a feature rename:
- the **SSE client transport is removed entirely** in rmcp 1.7 (no `sse_client` module, `SseClientTransport`, `SseClientConfig`, or `start_with_client`), so the `McpTransport::Sse` code path must be removed or reimplemented;
- model/type renames (e.g. `CallToolRequestParam` -> `CallToolRequestParams`).

That migration is the scope of the separate **rmcp upgrade unit**, not the reqwest bump. Per repo policy I did **not** pin reqwest back to 0.12 to dodge this.

### Path to unblock / merge
- Land the rmcp 0.8 -> 1.x upgrade (which itself moves the workspace to reqwest 0.13.x), **then** rebase this branch; `crates/mcp` and the rest of the workspace should compile, after which I'll run the full pre-commit (`cargo +nightly fmt --all`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`) and the final `cargo build --workspace` and flip this out of draft.
- Alternatively, fold this bump into the rmcp upgrade PR, since the two are coupled.

> Draft + `[blocked]` because the workspace does not build standalone yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP client library to the latest version across multiple components
  * Updated TLS encryption backend configuration for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->