### PR TITLE
chore(deps): bump sha2 0.10 -> 0.11

### DIFF
--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -30,7 +30,7 @@ thiserror.workspace = true
 tracing.workspace = true
 # Only used by auth
 jsonwebtoken = { version = "9.3", default-features = false, features = ["use_pem"] }
-sha2 = "0.10"
+sha2 = "0.11"
 url = "2.5"
 
 [dev-dependencies]

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -33,7 +33,7 @@ prost-types.workspace = true
 futures.workspace = true
 
 # Archive validation
-sha2 = "0.10"
+sha2 = "0.11"
 zip = "8.1"
 tempfile = "3.8"
 

--- a/crates/grpc_client/src/tokenizer_bundle.rs
+++ b/crates/grpc_client/src/tokenizer_bundle.rs
@@ -143,12 +143,23 @@ where
 
 // ── Validation ───────────────────────────────────────────────────────────────
 
+// digest 0.11's `Output` is a `hybrid_array::Array` without `LowerHex`, so format bytes ourselves.
+fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut acc, b| {
+            let _ = write!(acc, "{b:02x}");
+            acc
+        })
+}
+
 pub fn validate_bundle_sha256(bundle: &StreamBundle) -> Result<(), String> {
     if bundle.sha256.is_empty() {
         return Ok(());
     }
 
-    let computed = format!("{:x}", Sha256::digest(&bundle.compressed_data));
+    let computed = hex_lower(&Sha256::digest(&bundle.compressed_data));
     if !computed.eq_ignore_ascii_case(&bundle.sha256) {
         return Err(format!(
             "Bundle fingerprint mismatch: expected {}, got {}",
@@ -361,7 +372,7 @@ mod tests {
     #[test]
     fn validate_sha256_accepts_matching_fingerprint() {
         let compressed_data = b"test-bundle".to_vec();
-        let sha256 = format!("{:x}", Sha256::digest(&compressed_data));
+        let sha256 = hex_lower(&Sha256::digest(&compressed_data));
         let bundle = make_bundle(compressed_data, sha256);
 
         validate_bundle_sha256(&bundle).unwrap();
@@ -370,7 +381,7 @@ mod tests {
     #[test]
     fn validate_sha256_accepts_uppercase_fingerprint() {
         let compressed_data = b"test-bundle".to_vec();
-        let sha256 = format!("{:x}", Sha256::digest(&compressed_data)).to_uppercase();
+        let sha256 = hex_lower(&Sha256::digest(&compressed_data)).to_uppercase();
         let bundle = make_bundle(compressed_data, sha256);
 
         validate_bundle_sha256(&bundle).unwrap();
@@ -437,7 +448,7 @@ mod tests {
     #[test]
     fn extract_bundle_extracts_files() {
         let zip_bytes = build_test_zip(1, b"hello");
-        let sha256 = format!("{:x}", Sha256::digest(&zip_bytes));
+        let sha256 = hex_lower(&Sha256::digest(&zip_bytes));
         let bundle = make_bundle(zip_bytes, sha256);
 
         let extracted = extract_bundle_to_tempdir(&bundle).unwrap();

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -27,7 +27,7 @@ chrono = { workspace = true, features = ["serde"] }
 lru = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
-sha2 = "0.10"
+sha2 = "0.11"
 smg-data-connector = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt-multi-thread", "time"] }

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -116,7 +116,7 @@ openmetrics-parser = "0.4.4"
 arc-swap = "1.7.1"
 bitflags.workspace = true
 once_cell = "1.21.3"
-sha2 = "0.10"
+sha2 = "0.11"
 base64 = "0.22"
 image = { version = "0.25.4", default-features = false }
 tokio-tungstenite = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps the per-crate `sha2` dependency from `0.10` to `0.11` across the workspace. sha2 0.11 rides the RustCrypto `digest` 0.11 release.

### Bumps
- `sha2` 0.10 -> 0.11 in `crates/auth` (smg-auth)
- `sha2` 0.10 -> 0.11 in `crates/grpc_client` (smg-grpc-client)
- `sha2` 0.10 -> 0.11 in `crates/wasm` (smg-wasm)
- `sha2` 0.10 -> 0.11 in `model_gateway` (smg)

### Breaking changes fixed
The only source break in digest 0.11 is that the digest `Output` type is now a `hybrid_array::Array` instead of `generic_array::GenericArray`, and `Array` does **not** implement `LowerHex`. This broke the `format!("{:x}", Sha256::digest(..))` calls in `crates/grpc_client/src/tokenizer_bundle.rs`.

- Replaced those with a small `hex_lower(&[u8]) -> String` helper that produces byte-identical lowercase-hex output (production `validate_bundle_sha256` site + 3 test sites).
- All other call sites are source-compatible and required no changes:
  - `Sha256::new()` / `.update(..)` / `.finalize().into()` (`crates/auth/src/config.rs`, `model_gateway/src/workflow/wasm_module_registration.rs`) — `From<Array<u8, U32>> for [u8; 32]` still holds.
  - `Sha256::digest(..).into()` (`model_gateway/src/middleware/auth.rs`).

Note: `smg-wasm` declares `sha2` but does not reference it in source; the version was bumped for consistency. `Cargo.lock` is gitignored in this repo, so it is not part of the diff. The transitive `sha2` 0.10.9 brought in by `rsa` is unaffected and coexists.

### Verification (sccache off, default features, isolated target dir)
- `cargo build -p smg-auth -p smg-grpc-client -p smg-wasm -p smg` — Finished, 0 errors
- `cargo clippy -p smg-auth -p smg-grpc-client -p smg-wasm -p smg --all-targets -- -D warnings` — Finished, 0 warnings
- `cargo test -p smg-auth -p smg-grpc-client -p smg-wasm -p smg` — all suites pass (smg lib 1092 passed; grpc_client tokenizer_bundle 18 passed incl. the SHA-256 validation tests). One integration test (`queue_full_returns_429`) timed out once under heavy concurrent machine load (load avg ~147) waiting for mock workers to become healthy; it passes in isolation and does not touch sha2.
- `cargo build --workspace` — Finished, 0 errors (includes `smg-python` / `smg-golang` bindings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated cryptographic library dependencies across authentication, gRPC client, WebAssembly, and model gateway modules.
  * Adjusted internal validation logic and tests to maintain compatibility with updated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->