### PR TITLE
chore(deps): bump redis 0.27->1.2 (+ deadpool 0.13, deadpool-redis 0.23)

### DIFF
--- a/crates/data_connector/Cargo.toml
+++ b/crates/data_connector/Cargo.toml
@@ -27,11 +27,11 @@ ulid = "1.2.1"
 url = "2.5"
 
 # Database backends
-deadpool = { version = "0.12", features = ["managed", "rt_tokio_1"] }
+deadpool = { version = "0.13", features = ["managed", "rt_tokio_1"] }
 deadpool-postgres = "0.14.1"
-deadpool-redis = "0.18.0"
+deadpool-redis = "0.23.0"
 oracle = { version = "0.6.3", features = ["chrono"] }
-redis = { version = "0.27.6", features = ["tokio-comp", "json", "connection-manager"] }
+redis = { version = "1.2.0", features = ["tokio-comp", "json", "connection-manager"] }
 tokio-postgres = { version = "0.7.15", features = ["runtime", "with-chrono-0_4", "with-serde_json-1", "array-impls"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Upgrades the Redis storage backend stack in `crates/data_connector`:

- `redis` 0.27.6 -> 1.2 (resolves 1.2.4)
- `deadpool` 0.12 -> 0.13 (resolves 0.13.0)
- `deadpool-redis` 0.18.0 -> 0.23.0

These are the only declarations of these crates in the workspace (all in `crates/data_connector/Cargo.toml`); all Redis usage lives in `crates/data_connector/src/redis.rs`.

## Breaking changes fixed

None required at the call sites. Despite the redis 0.27 -> 1.x major bump, the APIs this crate uses are source-compatible:

- The `redis::AsyncCommands` trait and its methods (`hset`, `hget`, `hgetall`, `hdel`, `exists`, `del`, `expire`, `zadd`, `zrem`, `zscore`, `zrange`/`zrevrange`, `zrangebyscore_limit`/`zrevrangebyscore_limit`) keep the same signatures, including the explicit turbofish return-type annotations already in use (e.g. `hset::<_, _, _, ()>`).
- `redis::pipe()` builder and `query_async::<T>(&mut conn)` are unchanged.
- `deadpool_redis::{Config, Pool, Runtime, PoolConfig}` — `Config::from_url`, `cfg.pool`, and `create_pool(Some(Runtime::Tokio1))` are unchanged, so `RedisStore::new` needed no edits.

`deadpool-redis` 0.23 pulls `deadpool` 0.13, matching the direct bump. (`deadpool-postgres` 0.14.1 still pulls `deadpool` 0.12, which coexists fine.)

The public crate API (`RedisConfig`) is unchanged, so no downstream crate edits were needed.

## Verification (sccache off, default features)

- `cargo build -p data-connector` — Finished, clean
- `cargo +nightly fmt --all` — no code changes (only the Cargo.toml version edits)
- `cargo clippy -p data-connector --all-targets -- -D warnings` — clean
- `cargo test -p data-connector` — 215 passed; 0 failed (+ 0 doctests)
- `cargo build --workspace` (default features) — Finished; includes `smg`, `smg-python`, `smg-golang` bindings consuming the new stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connection and caching library dependencies to newer stable versions for improved compatibility and long-term support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->