### PR TITLE
chore(deps): bump wasmtime and wasmtime-wasi 41->45

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ tokio = { version = "1.42.0" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "chrono"] }
 uuid = { version = "1.10", features = ["v7", "serde"] }
-wasmtime = { version = "41.0", features = ["component-model", "async"] }
-wasmtime-wasi = "41.0"
+wasmtime = { version = "45.0", features = ["component-model", "async"] }
+wasmtime-wasi = "45.0"
 tokio-util = { version = "0.7", features = ["rt"] }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 webpki-roots = "1.0"

--- a/crates/wasm/src/runtime.rs
+++ b/crates/wasm/src/runtime.rs
@@ -260,7 +260,8 @@ impl WasmThreadPool {
         wasmtime_config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool_config));
 
         wasmtime_config.async_stack_size(config.max_stack_size);
-        wasmtime_config.async_support(true);
+        // wasmtime 45+ enables async via the `async` crate feature; Config::async_support
+        // is a deprecated no-op.
         wasmtime_config.wasm_component_model(true);
         wasmtime_config.epoch_interruption(true); // Enable epoch-based timeout interruption
 

--- a/crates/wasm/src/storage_hook.rs
+++ b/crates/wasm/src/storage_hook.rs
@@ -59,7 +59,6 @@ impl WasmStorageHook {
     /// Use `wasm-tools component new` to wrap a core module if needed.
     pub fn new(wasm_bytes: &[u8]) -> Result<Self, String> {
         let mut config = Config::new();
-        config.async_support(true);
         config.wasm_component_model(true);
         config.epoch_interruption(true);
 

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -152,7 +152,7 @@ tokio = { workspace = true, features = ["test-util"] }
 kv-index.workspace = true
 wasmtime-wasi = { workspace = true }
 lru = { workspace = true }
-wat = "1.244"
+wat = "1.252"
 zip = "8.1"
 
 [[bench]]

--- a/model_gateway/benches/wasm_instantiation.rs
+++ b/model_gateway/benches/wasm_instantiation.rs
@@ -68,7 +68,6 @@ fn make_pooling_engine() -> Engine {
     let mut config = Config::new();
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool_config));
     config.async_stack_size(1024 * 1024); // 1MB (default)
-    config.async_support(true);
     config.wasm_component_model(true);
     config.epoch_interruption(true);
     Engine::new(&config).expect("Failed to create pooling engine")
@@ -76,7 +75,6 @@ fn make_pooling_engine() -> Engine {
 
 fn make_standard_engine() -> Engine {
     let mut config = Config::new();
-    config.async_support(true);
     config.wasm_component_model(true);
     config.epoch_interruption(true);
     Engine::new(&config).expect("Failed to create standard engine")

--- a/model_gateway/src/workflow/wasm_module_registration.rs
+++ b/model_gateway/src/workflow/wasm_module_registration.rs
@@ -401,7 +401,6 @@ impl StepExecutor<WasmRegistrationWorkflowData> for ValidateWasmComponentStep {
 
         // Create a temporary engine to validate the component
         let mut config = Config::new();
-        config.async_support(true);
         config.wasm_component_model(true);
 
         let engine = Engine::new(&config).map_err(|e| WorkflowError::StepFailed {


### PR DESCRIPTION
## Bumps
- `wasmtime` 41.0 -> 45.0 (root `[workspace.dependencies]`, keeps `component-model` + `async` features)
- `wasmtime-wasi` 41.0 -> 45.0 (root `[workspace.dependencies]`)
- `wat` 1.244 -> 1.252 (`model_gateway`, dev/bench dep)

Resolved versions: wasmtime 45.0.2, wasmtime-wasi 45.0.2, wat 1.252.0.

## Breaking changes fixed
The only source-level break in 41 -> 45 affecting this codebase is that **`wasmtime::Config::async_support` is now a deprecated no-op** ("no longer has any effect"). In wasmtime 45 async is enabled solely by the `async` crate feature (retained in the root manifest), so the explicit `async_support(true)` calls now trip `#[deprecated]` under `-D warnings`. Removed all 5 call sites:
- `crates/wasm/src/runtime.rs` (worker engine config)
- `crates/wasm/src/storage_hook.rs` (storage-hook engine config)
- `model_gateway/src/workflow/wasm_module_registration.rs` (component validation engine)
- `model_gateway/benches/wasm_instantiation.rs` (pooling + standard bench engines)

Everything else is source-compatible. Verified against the 45.0.2 crate source that the embedder APIs in use are unchanged: `component::{Component, Linker, ResourceTable}`, `Component::new` / `instantiate_async`, the `bindgen!` macro `imports`/`exports` `default: async | trappable` options, `wasmtime_wasi::p2::add_to_linker_async`, `WasiCtx`/`WasiCtxView`/`WasiView`, `Config`/`PoolingAllocationConfig`/`StoreLimitsBuilder`, the epoch APIs (`set_epoch_deadline`, `epoch_deadline_callback`, `increment_epoch`), and `wasmtime::Error`/`Trap` (note: `wasmtime::Error` is now a custom type that is API-compatible with `anyhow::Error`, retaining `msg`/`downcast_ref`; `Trap` still derives `PartialEq` and exposes `Trap::Interrupt`).

## Verification (sccache off, default features)
All run with `RUSTC_WRAPPER=""`, targets `-p smg-wasm -p smg`:
- `cargo build -p smg-wasm -p smg` — clean (after removals)
- `cargo +nightly fmt --all` — clean
- `cargo clippy -p smg-wasm -p smg --all-targets -- -D warnings` — 0 warnings
- `cargo test -p smg-wasm -p smg` — pass: `smg` lib 1092 passed / 4 ignored, `smg_wasm` lib 24 passed, `storage_hook_integration` 9 passed, all other `smg` integration binaries green
- `cargo build --workspace` — clean, incl. `smg-python` / `smg-golang` bindings

No AI attribution. DCO signed off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Wasmtime runtime from version 41.0 to 45.0
  * Upgraded Wasmtime WASI support and WAT dependencies
  * Updated internal Wasmtime configuration for version compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->