### PR TITLE
chore(deps): bump tiktoken-rs 0.9->0.12

### DIFF
--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -30,12 +30,12 @@ futures.workspace = true
 # Only used by tokenizer
 aho-corasick = "1.1"
 base64 = "0.22"
-rustc-hash = "1.1"
+rustc-hash = "2"
 hf-hub = { version = "0.5.0", default-features = false, features = ["tokio", "rustls-tls"] }
 minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }
 minijinja-contrib = { version = "2.0", features = ["pycompat"] }
 rayon = "1.10"
-tiktoken-rs = "0.9.1"
+tiktoken-rs = "0.12"
 tokenizers = "0.23.1"
 
 [dev-dependencies]

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap;
 use tiktoken_rs::{
     cl100k_base, o200k_base, p50k_base, p50k_edit, r50k_base,
     tokenizer::{get_tokenizer, Tokenizer},
-    CoreBPE,
+    CoreBPE, DecodeKeyError,
 };
 
 use crate::{
@@ -480,7 +480,7 @@ impl Encoder for TiktokenTokenizer {
 
 impl Decoder for TiktokenTokenizer {
     fn decode(&self, token_ids: &[TokenIdType], _skip_special_tokens: bool) -> Result<String> {
-        match self.tokenizer.decode(token_ids.to_vec()) {
+        match self.tokenizer.decode(token_ids) {
             Ok(text) => Ok(text),
             Err(err) if is_unknown_tiktoken_decode_error(&err) => Err(Error::msg(format!(
                 "tiktoken decode failed for unknown token id: {err}"
@@ -506,12 +506,11 @@ impl Decoder for TiktokenTokenizer {
 /// Detect tiktoken's "unknown token id" error so we can surface a clean error
 /// instead of letting the lossy-decode fallback panic on a missing key.
 ///
-/// We match on the `Display` string because tiktoken-rs's `DecodeKeyError` lives
-/// in a private `vendor_tiktoken` module and isn't re-exported (as of 0.9.1),
-/// so a typed `downcast_ref` is not available. The message format is stable —
-/// see `vendor_tiktoken::DecodeKeyError::fmt` upstream.
+/// `CoreBPE::decode` surfaces a missing-token id as a `DecodeKeyError` (now
+/// re-exported as of tiktoken-rs 0.12), while UTF-8 failures arrive as a plain
+/// string error — so a typed `downcast_ref` cleanly separates the two cases.
 fn is_unknown_tiktoken_decode_error(err: &Error) -> bool {
-    err.to_string().starts_with("Invalid token for decoding:")
+    err.downcast_ref::<DecodeKeyError>().is_some()
 }
 
 impl TokenizerTrait for TiktokenTokenizer {


### PR DESCRIPTION
## Bumps
- `tiktoken-rs` 0.9.1 -> 0.12 (`crates/tokenizer/Cargo.toml`)
- `rustc-hash` 1.1 -> 2 (`crates/tokenizer/Cargo.toml`) — required transitively: tiktoken-rs 0.12 switched to `rustc-hash` 2.x, so `CoreBPE::new` now expects `HashMap<_, _, FxBuildHasher>`. Our `FxHashMap` alias had to move to the matching 2.x type.

## Breaking changes fixed (`crates/tokenizer/src/tiktoken.rs`)
1. **`CoreBPE::decode` signature**: `Vec<Rank>` -> `&[Rank]`. The call now passes the `&[TokenIdType]` slice directly instead of `token_ids.to_vec()`, dropping an allocation. (`_decode_native_and_split` still takes `Vec<Rank>`, so the lossy-fallback path keeps its `.to_vec()`.)
2. **`CoreBPE::new` hasher type**: the `encoder` / `special_tokens_encoder` maps must now use `rustc_hash::FxBuildHasher` (rustc-hash 2.x). Resolved by the `rustc-hash` 1->2 bump; no call-site code change needed since rustc-hash 2's `FxHashMap`/`FxBuildHasher` satisfy our existing `with_capacity_and_hasher(..., Default::default())` and `FxHashMap::default()` usage.
3. **`DecodeKeyError` now re-exported**: replaced the brittle `err.to_string().starts_with("Invalid token for decoding:")` check with a typed `err.downcast_ref::<DecodeKeyError>()`. The old string match was an explicit workaround for 0.9.1 not re-exporting the type; 0.12 exports it, so the unknown-token-id case is now distinguished from UTF-8 errors by type. Behavior is unchanged (UTF-8 failures still fall through to the lossy-decode path).

The built-in constructors (`cl100k_base`, `o200k_base`, `p50k_base`, `p50k_edit`, `r50k_base`) and the `tokenizer::{get_tokenizer, Tokenizer}` enum variants we match on are unchanged in 0.12.

## Verification (sccache OFF, default features)
- `cargo build -p llm-tokenizer` — Finished, 0 errors
- `cargo +nightly fmt --all` — clean
- `cargo clippy -p llm-tokenizer --all-targets -- -D warnings` — 0 warnings
- `cargo test -p llm-tokenizer` — all passed, 0 failed (lib unit tests + tokenizer integration 16 passed + cache-correctness 2 passed; the HF-download `tiktoken_integration` tests are `#[ignore]`-gated as before)
- `cargo build --workspace` — Finished, 0 errors (includes `smg`, `smg-python`, `smg-golang`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded tokenizer library dependencies to latest versions for improved stability.

* **Bug Fixes**
  * Enhanced error detection and classification for decode failures, especially unknown token scenarios.
  * Improved decode operation efficiency through optimized memory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->