### PR TITLE
build(deps): bump rand 0.9 -> 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ http = "1.1.0"
 lru = "0.18.0"
 num-traits = "0.2"
 parking_lot = "0.12.4"
-rand = "0.9.2"
+rand = "0.10.1"
 reqwest = { version = "0.12.8", default-features = false }
 serde = { version = "1.0" }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1217,7 +1217,7 @@ impl Router {
                     .map(|c| c.to_auth_control_plane_config()),
                 mesh_server_config: if self.enable_mesh {
                     let self_name = self.mesh_server_name.clone().unwrap_or_else(|| {
-                        use rand::{distr::Alphanumeric, Rng};
+                        use rand::{distr::Alphanumeric, RngExt};
                         let random_string: String = (0..4)
                             .map(|_| rand::rng().sample(Alphanumeric) as char)
                             .collect();

--- a/crates/data_connector/src/core.rs
+++ b/crates/data_connector/src/core.rs
@@ -8,7 +8,7 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use rand::RngCore;
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value};
 

--- a/crates/kv_index/benches/throughput_bench.rs
+++ b/crates/kv_index/benches/throughput_bench.rs
@@ -30,7 +30,7 @@ use kv_index::{
     compute_content_hash, ContentHash, OverlapScores, PositionalIndexer, SequenceHash, StoredBlock,
     WorkerBlockMap,
 };
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt, SeedableRng};
 
 // ---------------------------------------------------------------------------
 // CLI

--- a/crates/kv_index/src/string_tree.rs
+++ b/crates/kv_index/src/string_tree.rs
@@ -1830,7 +1830,7 @@ mod tests {
 
     use rand::{
         distr::{Alphanumeric, SampleString},
-        rng as thread_rng, Rng,
+        rng as thread_rng, RngExt,
     };
 
     use super::*;

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -807,7 +807,7 @@ fn get_random_values_refs<K, V>(map: &BTreeMap<K, V>, k: usize) -> Vec<&V> {
 
     let mut rng = rand::rng();
 
-    values.choose_multiple(&mut rng, k).copied().collect()
+    values.sample(&mut rng, k).copied().collect()
 }
 
 /// Exponential backoff calculator used by the per-peer reconnect loop.

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -3623,7 +3623,7 @@ pub fn normalize_input_item(item: &ResponseInputOutputItem) -> ResponseInputOutp
 }
 
 pub fn generate_id(prefix: &str) -> String {
-    use rand::RngCore;
+    use rand::Rng;
     let mut rng = rand::rng();
     // Generate exactly 50 hex characters (25 bytes) for the part after the underscore
     let mut bytes = [0u8; 25];

--- a/model_gateway/benches/manual_policy_benchmark.rs
+++ b/model_gateway/benches/manual_policy_benchmark.rs
@@ -214,7 +214,7 @@ fn bench_cache_size_impact(c: &mut Criterion) {
 }
 
 fn bench_comparison_baseline(c: &mut Criterion) {
-    use rand::Rng;
+    use rand::RngExt;
 
     let mut group = c.benchmark_group("manual_policy/vs_baseline");
     let workers = create_workers(16);

--- a/model_gateway/benches/radix_tree_benchmark.rs
+++ b/model_gateway/benches/radix_tree_benchmark.rs
@@ -32,7 +32,7 @@ use kv_index::{
 };
 use rand::{
     distr::{Alphanumeric, SampleString},
-    rng as thread_rng, Rng,
+    rng as thread_rng, RngExt,
 };
 
 // Global results storage for summary

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
-use rand::{distr::Alphanumeric, Rng};
+use rand::{distr::Alphanumeric, RngExt};
 use smg::{
     config::{
         validate_mesh_server_name, CircuitBreakerConfig, ConfigError, ConfigResult,

--- a/model_gateway/src/middleware/request_id.rs
+++ b/model_gateway/src/middleware/request_id.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use axum::{extract::Request, http::HeaderValue, response::Response};
-use rand::Rng;
+use rand::RngExt;
 // Re-export RequestId from auth crate for backward compatibility
 pub use smg_auth::RequestId;
 use tower::{Layer, Service};

--- a/model_gateway/src/policies/bucket.rs
+++ b/model_gateway/src/policies/bucket.rs
@@ -6,7 +6,7 @@ use std::{
 
 use dashmap::DashMap;
 use parking_lot::{Mutex, RwLock};
-use rand::Rng;
+use rand::RngExt;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -53,7 +53,7 @@ use dashmap::DashMap;
 use kv_index::{compute_request_content_hashes, PositionalIndexer, TokenTree, Tree};
 use openai_protocol::worker::WorkerLoadResponse;
 use parking_lot::RwLock;
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use tracing::{debug, warn};

--- a/model_gateway/src/policies/consistent_hashing.rs
+++ b/model_gateway/src/policies/consistent_hashing.rs
@@ -18,7 +18,7 @@
 
 use std::sync::Arc;
 
-use rand::Rng as _;
+use rand::RngExt as _;
 
 use super::{LoadBalancingPolicy, SelectWorkerInfo};
 use crate::{

--- a/model_gateway/src/policies/manual.rs
+++ b/model_gateway/src/policies/manual.rs
@@ -16,7 +16,7 @@
 use std::{sync::Arc, time::Instant};
 
 use dashmap::{mapref::entry::Entry, DashMap};
-use rand::Rng;
+use rand::RngExt;
 use tracing::info;
 
 use super::{

--- a/model_gateway/src/policies/power_of_two.rs
+++ b/model_gateway/src/policies/power_of_two.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use openai_protocol::worker::WorkerLoadResponse;
-use rand::Rng;
+use rand::RngExt;
 use tracing::debug;
 
 use super::{get_healthy_worker_indices, LoadBalancingPolicy, SelectWorkerInfo};

--- a/model_gateway/src/policies/random.rs
+++ b/model_gateway/src/policies/random.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use rand::Rng;
+use rand::RngExt;
 
 use super::{get_healthy_worker_indices, LoadBalancingPolicy, SelectWorkerInfo};
 use crate::worker::Worker;

--- a/model_gateway/src/routers/common/retry.rs
+++ b/model_gateway/src/routers/common/retry.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use axum::{http::StatusCode, response::Response};
-use rand::Rng;
+use rand::RngExt;
 use tracing::debug;
 
 use crate::config::types::RetryConfig;

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use rand::Rng;
+use rand::RngExt;
 use smg_grpc_client::{
     mlx_proto,
     sglang_proto::{self, DisaggregatedParams},


### PR DESCRIPTION
## Summary

Bumps `rand` from **0.9.2 to 0.10.1** (root `[workspace.dependencies]`) and migrates all call sites to the reworked 0.10 API.

## Bump
- `rand` 0.9.2 -> 0.10.1 (`Cargo.toml`)

## Breaking changes fixed

rand 0.10 reworked the RNG traits (rust-random/rand#1717): upstream `rand_core::RngCore` was renamed to `rand_core::Rng` (re-exported as `rand::Rng`), and the old `rand::Rng` extension trait (with `random`/`random_range`/`random_bool`/`sample`) was renamed to `rand::RngExt`.

- **`use rand::RngCore` -> `use rand::Rng`** (the byte-source trait carrying `fill_bytes`):
  - `crates/data_connector/src/core.rs`
  - `crates/protocols/src/responses.rs`
- **`use rand::Rng` -> `use rand::RngExt`** (the extension trait carrying `random`/`random_range`/`random_bool`/`sample`): 15 sites across `model_gateway/src/{main.rs, middleware/request_id.rs, routers/common/retry.rs, routers/grpc/common/stages/helpers.rs, policies/{random,cache_aware,consistent_hashing,power_of_two,manual,bucket}.rs}`, `model_gateway/benches/{manual_policy_benchmark,radix_tree_benchmark}.rs`, `crates/kv_index/{src/string_tree.rs, benches/throughput_bench.rs}`, and `bindings/python/src/lib.rs`.
- **`IndexedRandom::choose_multiple` -> `sample`** (renamed in 0.10, rust-random/rand#1632): `crates/mesh/src/gossip_controller.rs`.

Unchanged APIs confirmed still valid in 0.10 and left as-is: `rand::random::<T>()`, `rand::rng()`, `SliceRandom::shuffle`, and `IndexedRandom::choose`.

## Verification (sccache off, default features)
- `cargo build --workspace` -> exit 0 (includes `smg-python` / `smg-golang` bindings)
- `cargo +nightly fmt --all` -> clean
- `cargo clippy --workspace --all-targets -- -D warnings` -> exit 0 (no deprecation warnings)
- `cargo test --workspace` -> all suites `ok`, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `rand` dependency to version 0.10.1 and adjusted internal code compatibility across multiple modules to support the updated library's trait interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->