### PR TITLE
chore(deps): bump jsonwebtoken 9.3 -> 10.4

### DIFF
--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -29,7 +29,9 @@ subtle.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 # Only used by auth
-jsonwebtoken = { version = "9.3", default-features = false, features = ["use_pem"] }
+# jsonwebtoken 10 decouples crypto behind a provider trait; `rust_crypto` selects the
+# RustCrypto backend (matches the workspace's pure-Rust stack, no aws-lc-sys C build).
+jsonwebtoken = { version = "10.4", default-features = false, features = ["use_pem", "rust_crypto"] }
 sha2 = "0.11"
 url = "2.5"
 

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -145,7 +145,7 @@ npyz = { version = "0.9", features = ["npz"] }
 opentelemetry-proto = { version = "0.32", features = ["gen-tonic"] }
 serial_test = "3.0"
 rsa = { version = "0.9", features = ["sha2"] }
-jsonwebtoken = "9.3"
+jsonwebtoken = { version = "10.4", features = ["rust_crypto"] }
 validator = "0.20.0"
 tracing-test = "0.2"
 tokio = { workspace = true, features = ["test-util"] }


### PR DESCRIPTION
## Bump

- `jsonwebtoken` **9.3 -> 10.4** in `crates/auth` and `model_gateway` (dev-dep).

## Breaking change fixed

jsonwebtoken 10.0 [decoupled its cryptography behind `CryptoProvider` traits](https://github.com/Keats/jsonwebtoken/blob/master/CHANGELOG.md#1000-2025-09-29) and no longer bundles a crypto backend. You must enable exactly one of the `rust_crypto` / `aws_lc_rs` features; otherwise the auto-selected provider **panics at runtime** when signing/verifying (it is not a compile error).

Fix: enable the **`rust_crypto`** backend (RustCrypto: rsa/p256/p384/ed25519-dalek/hmac/sha2). Chosen over `aws_lc_rs` to match the workspace's existing pure-Rust crypto stack (uses `ring`, not `aws-lc-rs`) and avoid pulling the `aws-lc-sys` C build toolchain.

- `crates/auth`: `default-features = false, features = ["use_pem", "rust_crypto"]`
- `model_gateway` (dev-dep): `features = ["rust_crypto"]`

No call-site changes were required: the `encode` / `decode` / `decode_header` / `Validation` / `Algorithm` / `Jwk` / `DecodingKey::{from_rsa_components, from_ec_components}` / `EncodingKey::from_rsa_pem` APIs used in `jwt.rs`, `jwks.rs`, and the security integration tests are source-compatible across 9 -> 10.

## Verification (RUSTC_WRAPPER="", default features)

- `cargo +nightly fmt --all` — clean (no source changes)
- `cargo clippy -p smg-auth -p smg --all-targets -- -D warnings` — passed, no warnings
- `cargo test -p smg-auth -p smg` — passed (smg-auth lib: 25/25)
- `cargo test -p smg --test security_tests` — **48/48 passed**, including the JWT tests that exercise the runtime crypto provider end-to-end (`test_jwt_valid_token_with_admin_role`, `test_jwt_jti_replay_protection`, `test_jwt_expired_token`, `test_jwt_wrong_audience`, `test_jwt_wrong_issuer`, `test_jwt_role_extraction_from_groups_claim`, `test_jwt_malformed_token`, `test_jwt_missing_kid_in_header`, ...). This confirms `rust_crypto` is correctly selected — no not-installed-provider panic.
- `cargo build --workspace` — passed, including `smg-python` and `smg-golang` bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the `jsonwebtoken` library to version 10.4 across authentication services.
  * Adjusted JWT configuration to use the Rust crypto backend for improved consistency with the app’s existing pure-Rust cryptography stack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->