### PR TITLE
chore(deps): bump str0m 0.19 -> 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 webpki-roots = "1.0"
 multer = "3"
-str0m = { version = "0.19", default-features = false, features = ["openssl"] }
+str0m = { version = "0.20", default-features = false, features = ["openssl"] }
 scopeguard = "1.2"
 bitflags = "2.10.0"
 schemars = "0.8"

--- a/model_gateway/src/routers/openai/realtime/webrtc_bridge.rs
+++ b/model_gateway/src/routers/openai/realtime/webrtc_bridge.rs
@@ -16,7 +16,7 @@ use str0m::{
     channel::{ChannelData, ChannelId},
     media::{Direction, MediaKind, Mid},
     net::{Protocol, Receive},
-    rtp::RtpPacket,
+    rtp::{RtpPacket, RtpWrite},
     Candidate, Event, Input, Output, Rtc, RtcConfig,
 };
 use tokio::net::UdpSocket;
@@ -685,15 +685,20 @@ impl WebRtcBridge {
         };
         let Some(mid) = mid else { return };
         if let Some(tx) = rtc.direct_api().stream_tx_by_mid(mid, None) {
-            let _ = tx.write_rtp(
-                pkt.header.payload_type,
-                pkt.seq_no,
-                pkt.header.timestamp,
-                pkt.timestamp,
-                pkt.header.marker,
-                pkt.header.ext_vals.clone(),
-                true,
-                pkt.payload.clone(),
+            // str0m 0.20 replaced the positional write_rtp args with an
+            // RtpWrite builder; optional fields default off, so marker/
+            // ext_vals/nackable must be set explicitly to preserve behavior.
+            tx.write_rtp(
+                RtpWrite::new(
+                    pkt.header.payload_type,
+                    pkt.seq_no,
+                    pkt.header.timestamp,
+                    pkt.timestamp,
+                    pkt.payload.clone(),
+                )
+                .marker(pkt.header.marker)
+                .ext_vals(pkt.header.ext_vals.clone())
+                .nackable(true),
             );
         }
     }


### PR DESCRIPTION
## Summary

Bumps `str0m` from **0.19** to **0.20** (root `[workspace.dependencies]`, `default-features = false`, `features = ["openssl"]`).

str0m 0.20 split its crypto backends into separate crates (`str0m-openssl`, `str0m-aws-lc-rs`, `str0m-rust-crypto`). The `openssl` cargo feature is retained and now selects the `str0m-openssl` backend internally, so the workspace dependency declaration is unchanged apart from the version. The resolved tree pulls `str0m-openssl 0.4.1` + `str0m-proto 0.5.1` and no rustls/aws-lc/ring crypto crates — the OpenSSL backend is preserved as required.

## Breaking changes fixed

- **`StreamTx::write_rtp` signature change** (`model_gateway/src/routers/openai/realtime/webrtc_bridge.rs`): in 0.19 it took 8 positional arguments and returned `Result<(), PacketError>`; in 0.20 it takes a single `RtpWrite` builder and returns `()`. Migrated the RTP relay call site in `forward_rtp` to:
  ```rust
  tx.write_rtp(
      RtpWrite::new(pt, seq_no, time, wallclock, payload)
          .marker(marker)
          .ext_vals(ext_vals)
          .nackable(true),
  );
  ```
  `RtpWrite`'s optional fields default off, so `marker` / `ext_vals` / `nackable` are set explicitly to preserve the previous behavior. The previously-ignored `Result` (`let _ =`) is dropped since the method now returns `()`. Added `RtpWrite` to the `str0m::rtp` import.

No other str0m API in use (`Rtc`, `RtcConfig`, `SdpOffer`/`SdpAnswer`, `Candidate`, `Input`/`Output`/`Event`, `channel`, `direct_api`, error types) changed.

## Verification (sccache OFF, default features, `-p smg`)

- `cargo build -p smg` — clean (exit 0)
- `cargo +nightly fmt --all` — clean
- `cargo clippy -p smg --all-targets -- -D warnings` — clean (exit 0)
- `cargo test -p smg` — all binaries pass (lib 1092 passed; integration binaries incl. spec_test 105/93/95/... all 0 failed; doc-tests ok)
- `cargo build --workspace` — clean (exit 0)
- `cargo build -p smg-python -p smg-golang` — clean (exit 0)
