### PR TITLE
chore(deps): bump schemars 0.8 -> 1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ multer = "3"
 str0m = { version = "0.19", default-features = false, features = ["openssl"] }
 scopeguard = "1.2"
 bitflags = "2.10.0"
-schemars = "0.8"
+schemars = "1.2"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/clients/openapi-gen/src/main.rs
+++ b/clients/openapi-gen/src/main.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, io::Write};
 
-use schemars::{schema::RootSchema, schema_for};
+use schemars::{schema_for, Schema};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -91,12 +91,12 @@ struct Response {
 // ============================================================================
 
 /// Post-process a JSON value tree to fix schemars output for OpenAPI compatibility:
-/// 1. Rewrite `#/definitions/X` → `#/components/schemas/X`
+/// 1. Rewrite `#/$defs/X` → `#/components/schemas/X`
 /// 2. Replace boolean `true` in `anyOf`/`oneOf`/`allOf` arrays with `{}` (empty = any)
 fn fixup_schema(value: &mut Value) {
     match value {
         Value::String(s) => {
-            if let Some(rest) = s.strip_prefix("#/definitions/") {
+            if let Some(rest) = s.strip_prefix("#/$defs/") {
                 *s = format!("#/components/schemas/{rest}");
             }
         }
@@ -128,29 +128,35 @@ fn fixup_schema(value: &mut Value) {
 
 /// Collect a root schema and all its definitions into the schemas map.
 /// Returns the top-level schema name.
-fn collect_schema(
-    root: &RootSchema,
-    schemas: &mut BTreeMap<String, Value>,
-) -> anyhow::Result<String> {
-    let title = root
-        .schema
-        .metadata
-        .as_ref()
-        .and_then(|m| m.title.clone())
-        .unwrap_or_else(|| "Unknown".to_string());
+///
+/// schemars 1.0 returns a single `Schema` (a JSON object) holding the root
+/// schema inline, plus `$defs` for referenced subschemas and a `$schema`
+/// meta-schema key.
+fn collect_schema(root: Schema, schemas: &mut BTreeMap<String, Value>) -> anyhow::Result<String> {
+    let mut root_value = root.to_value();
+    let Value::Object(map) = &mut root_value else {
+        anyhow::bail!("expected schema object, got {root_value}");
+    };
+
+    let title = match map.get("title") {
+        Some(Value::String(t)) => t.clone(),
+        _ => "Unknown".to_string(),
+    };
+
+    // Pull out the referenced subschemas and the meta-schema key so only the
+    // root schema body remains.
+    let defs = map.remove("$defs");
+    map.remove("$schema");
 
     // Add all definitions (sub-schemas referenced by the root)
-    for (name, schema) in &root.definitions {
-        let mut value = serde_json::to_value(schema)?;
-        fixup_schema(&mut value);
-        schemas.insert(name.clone(), value);
+    if let Some(Value::Object(defs)) = defs {
+        for (name, mut value) in defs {
+            fixup_schema(&mut value);
+            schemas.insert(name, value);
+        }
     }
 
-    // Add the root schema itself (strip definitions to avoid duplication)
-    let mut root_value = serde_json::to_value(&root.schema)?;
-    if let Value::Object(ref mut map) = root_value {
-        map.remove("definitions");
-    }
+    // Add the root schema itself
     fixup_schema(&mut root_value);
     schemas.insert(title.clone(), root_value);
 
@@ -273,9 +279,9 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Chat Completions ----
     use openai_protocol::chat::*;
-    let req_name = collect_schema(&schema_for!(ChatCompletionRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(ChatCompletionResponse), &mut schemas)?;
-    collect_schema(&schema_for!(ChatCompletionStreamResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(ChatCompletionRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(ChatCompletionResponse), &mut schemas)?;
+    collect_schema(schema_for!(ChatCompletionStreamResponse), &mut schemas)?;
     paths.insert(
         "/v1/chat/completions".to_string(),
         post_endpoint(
@@ -288,9 +294,9 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Completions ----
     use openai_protocol::completion::*;
-    let req_name = collect_schema(&schema_for!(CompletionRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(CompletionResponse), &mut schemas)?;
-    collect_schema(&schema_for!(CompletionStreamResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(CompletionRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(CompletionResponse), &mut schemas)?;
+    collect_schema(schema_for!(CompletionStreamResponse), &mut schemas)?;
     paths.insert(
         "/v1/completions".to_string(),
         post_endpoint(
@@ -303,8 +309,8 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Embeddings ----
     use openai_protocol::embedding::*;
-    let req_name = collect_schema(&schema_for!(EmbeddingRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(EmbeddingResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(EmbeddingRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(EmbeddingResponse), &mut schemas)?;
     paths.insert(
         "/v1/embeddings".to_string(),
         post_endpoint("createEmbedding", "Create embedding", &req_name, &resp_name),
@@ -312,8 +318,8 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Rerank ----
     use openai_protocol::rerank::*;
-    let req_name = collect_schema(&schema_for!(RerankRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(RerankResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(RerankRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(RerankResponse), &mut schemas)?;
     paths.insert(
         "/v1/rerank".to_string(),
         post_endpoint("createRerank", "Rerank documents", &req_name, &resp_name),
@@ -321,9 +327,9 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Messages (Anthropic) ----
     use openai_protocol::messages::*;
-    let req_name = collect_schema(&schema_for!(CreateMessageRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(Message), &mut schemas)?;
-    collect_schema(&schema_for!(MessageStreamEvent), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(CreateMessageRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(Message), &mut schemas)?;
+    collect_schema(schema_for!(MessageStreamEvent), &mut schemas)?;
     paths.insert(
         "/v1/messages".to_string(),
         post_endpoint(
@@ -336,8 +342,8 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Responses API ----
     use openai_protocol::responses::*;
-    let req_name = collect_schema(&schema_for!(ResponsesRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(ResponsesResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(ResponsesRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(ResponsesResponse), &mut schemas)?;
     paths.insert(
         "/v1/responses".to_string(),
         post_endpoint("createResponse", "Create response", &req_name, &resp_name),
@@ -413,9 +419,9 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Classify ----
     use openai_protocol::classify::*;
-    let req_name = collect_schema(&schema_for!(ClassifyRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(ClassifyResponse), &mut schemas)?;
-    collect_schema(&schema_for!(ClassifyData), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(ClassifyRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(ClassifyResponse), &mut schemas)?;
+    collect_schema(schema_for!(ClassifyData), &mut schemas)?;
     paths.insert(
         "/v1/classify".to_string(),
         post_endpoint("classify", "Classify text", &req_name, &resp_name),
@@ -423,8 +429,8 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Parser ----
     use openai_protocol::parser::*;
-    let req_name = collect_schema(&schema_for!(ParseFunctionCallRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(ParseFunctionCallResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(ParseFunctionCallRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(ParseFunctionCallResponse), &mut schemas)?;
     paths.insert(
         "/parse/function_call".to_string(),
         post_endpoint(
@@ -434,8 +440,8 @@ fn main() -> anyhow::Result<()> {
             &resp_name,
         ),
     );
-    let req_name = collect_schema(&schema_for!(SeparateReasoningRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(SeparateReasoningResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(SeparateReasoningRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(SeparateReasoningResponse), &mut schemas)?;
     paths.insert(
         "/parse/reasoning".to_string(),
         post_endpoint(
@@ -451,9 +457,9 @@ fn main() -> anyhow::Result<()> {
     // (not WorkerApiResponse), and list returns a different stats shape than
     // WorkerListResponse. We use inline schemas matching the actual server responses.
     use openai_protocol::worker::*;
-    let worker_spec_name = collect_schema(&schema_for!(WorkerSpec), &mut schemas)?;
-    let worker_info_name = collect_schema(&schema_for!(WorkerInfo), &mut schemas)?;
-    let worker_update_name = collect_schema(&schema_for!(WorkerUpdateRequest), &mut schemas)?;
+    let worker_spec_name = collect_schema(schema_for!(WorkerSpec), &mut schemas)?;
+    let worker_info_name = collect_schema(schema_for!(WorkerInfo), &mut schemas)?;
+    let worker_update_name = collect_schema(schema_for!(WorkerUpdateRequest), &mut schemas)?;
 
     // Inline schema for 202 Accepted mutation responses
     let worker_accepted_schema = serde_json::json!({
@@ -575,8 +581,8 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Generate (SGLang native) ----
     use openai_protocol::generate::*;
-    let req_name = collect_schema(&schema_for!(GenerateRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(GenerateResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(GenerateRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(GenerateResponse), &mut schemas)?;
     paths.insert(
         "/generate".to_string(),
         post_endpoint(
@@ -589,15 +595,15 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Tokenize / Detokenize ----
     use openai_protocol::tokenize::*;
-    let req_name = collect_schema(&schema_for!(TokenizeRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(TokenizeResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(TokenizeRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(TokenizeResponse), &mut schemas)?;
     paths.insert(
         "/v1/tokenize".to_string(),
         post_endpoint("tokenize", "Tokenize text", &req_name, &resp_name),
     );
 
-    let req_name = collect_schema(&schema_for!(DetokenizeRequest), &mut schemas)?;
-    let resp_name = collect_schema(&schema_for!(DetokenizeResponse), &mut schemas)?;
+    let req_name = collect_schema(schema_for!(DetokenizeRequest), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(DetokenizeResponse), &mut schemas)?;
     paths.insert(
         "/v1/detokenize".to_string(),
         post_endpoint("detokenize", "Detokenize tokens", &req_name, &resp_name),
@@ -605,7 +611,7 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Models ----
     use openai_protocol::models::ListModelsResponse as OpenAIListModelsResponse;
-    let resp_name = collect_schema(&schema_for!(OpenAIListModelsResponse), &mut schemas)?;
+    let resp_name = collect_schema(schema_for!(OpenAIListModelsResponse), &mut schemas)?;
     paths.insert(
         "/v1/models".to_string(),
         get_endpoint("listModels", "List available models", &resp_name),
@@ -613,9 +619,9 @@ fn main() -> anyhow::Result<()> {
 
     // ---- Shared types (not tied to a specific endpoint) ----
     use openai_protocol::common::{Detail, ErrorDetail, ErrorResponse};
-    collect_schema(&schema_for!(ErrorResponse), &mut schemas)?;
-    collect_schema(&schema_for!(ErrorDetail), &mut schemas)?;
-    collect_schema(&schema_for!(Detail), &mut schemas)?;
+    collect_schema(schema_for!(ErrorResponse), &mut schemas)?;
+    collect_schema(schema_for!(ErrorDetail), &mut schemas)?;
+    collect_schema(schema_for!(Detail), &mut schemas)?;
 
     // ---- Assemble OpenAPI document ----
     let doc = OpenApiDoc {

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -469,42 +469,25 @@ impl<'de> Deserialize<'de> for FunctionCall {
 }
 
 impl schemars::JsonSchema for FunctionCall {
-    fn schema_name() -> String {
-        "FunctionCall".to_string()
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "FunctionCall".into()
     }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        use schemars::schema::*;
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
         // FunctionCall is either "none", "auto", or {"name": "..."}
-        let string_schema = SchemaObject {
-            instance_type: Some(InstanceType::String.into()),
-            enum_values: Some(vec!["none".into(), "auto".into()]),
-            ..Default::default()
-        };
-        let object_schema = SchemaObject {
-            instance_type: Some(InstanceType::Object.into()),
-            object: Some(Box::new(ObjectValidation {
-                properties: {
-                    let mut map = schemars::Map::new();
-                    map.insert("name".to_string(), gen.subschema_for::<String>());
-                    map
+        let name_schema = generator.subschema_for::<String>();
+        schemars::json_schema!({
+            "anyOf": [
+                {
+                    "type": "string",
+                    "enum": ["none", "auto"]
                 },
-                required: {
-                    let mut set = std::collections::BTreeSet::new();
-                    set.insert("name".to_string());
-                    set
-                },
-                ..Default::default()
-            })),
-            ..Default::default()
-        };
-        SchemaObject {
-            subschemas: Some(Box::new(SubschemaValidation {
-                any_of: Some(vec![string_schema.into(), object_schema.into()]),
-                ..Default::default()
-            })),
-            ..Default::default()
-        }
-        .into()
+                {
+                    "type": "object",
+                    "properties": { "name": name_schema },
+                    "required": ["name"]
+                }
+            ]
+        })
     }
 }
 

--- a/crates/protocols/src/model_type.rs
+++ b/crates/protocols/src/model_type.rs
@@ -3,8 +3,10 @@
 //! Defines [`ModelType`] using bitflags to represent which endpoints a model
 //! can support, and [`Endpoint`] for routing decisions.
 
+use std::borrow::Cow;
+
 use bitflags::bitflags;
-use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
+use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Serialize};
 
 bitflags! {
@@ -288,45 +290,32 @@ impl<'de> Deserialize<'de> for ModelType {
 
 /// Manual JsonSchema impl for `ModelType` — serialized as an array of capability name strings.
 impl JsonSchema for ModelType {
-    fn schema_name() -> String {
-        "ModelType".to_string()
+    fn schema_name() -> Cow<'static, str> {
+        "ModelType".into()
     }
 
-    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
-        use schemars::schema::*;
-        let items = SchemaObject {
-            instance_type: Some(InstanceType::String.into()),
-            enum_values: Some(vec![
-                "chat".into(),
-                "completions".into(),
-                "responses".into(),
-                "embeddings".into(),
-                "rerank".into(),
-                "generate".into(),
-                "vision".into(),
-                "tools".into(),
-                "reasoning".into(),
-                "image_gen".into(),
-                "audio".into(),
-                "moderation".into(),
-            ]),
-            ..Default::default()
-        };
-        SchemaObject {
-            instance_type: Some(InstanceType::Array.into()),
-            array: Some(Box::new(ArrayValidation {
-                items: Some(SingleOrVec::Single(Box::new(items.into()))),
-                ..Default::default()
-            })),
-            metadata: Some(Box::new(Metadata {
-                description: Some(
-                    "Bitflag capabilities serialized as an array of capability names".to_string(),
-                ),
-                ..Default::default()
-            })),
-            ..Default::default()
-        }
-        .into()
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "array",
+            "description": "Bitflag capabilities serialized as an array of capability names",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "chat",
+                    "completions",
+                    "responses",
+                    "embeddings",
+                    "rerank",
+                    "generate",
+                    "vision",
+                    "tools",
+                    "reasoning",
+                    "image_gen",
+                    "audio",
+                    "moderation"
+                ]
+            }
+        })
     }
 }
 

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -543,12 +543,12 @@ impl<'de> Deserialize<'de> for WorkerModels {
 
 /// JsonSchema: wire format is `Vec<ModelCard>`.
 impl JsonSchema for WorkerModels {
-    fn schema_name() -> String {
-        "WorkerModels".to_string()
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "WorkerModels".into()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        Vec::<ModelCard>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        Vec::<ModelCard>::json_schema(generator)
     }
 }
 


### PR DESCRIPTION
## Bump

- `schemars` **0.8 → 1.2** (root `[workspace.dependencies]`, resolved to 1.2.1)

## Breaking changes fixed

schemars 1.0 dropped the typed `schema::{SchemaObject, InstanceType, ...}` model in favor of a `Schema` newtype wrapping `serde_json::Value`, and reworked the `JsonSchema` trait.

**Manual `JsonSchema` impls** (`crates/protocols`): `FunctionCall` (common.rs), `ModelType` (model_type.rs), `WorkerModels` (worker.rs)
- `schema_name()` now returns `Cow<'static, str>` (was `String`).
- `json_schema(generator: &mut SchemaGenerator) -> Schema` (was `&mut gen::SchemaGenerator -> schema::Schema`).
- Rebuilt the schema bodies with the `json_schema!` macro instead of hand-constructing `SchemaObject`/`InstanceType`/`SubschemaValidation`. Output is semantically identical (verified against the generated spec).

**openapi-gen** (`clients/openapi-gen`):
- `schema_for!(T)` now returns a single `Schema` (root schema inline + `$defs` + `$schema` meta key) rather than a `RootSchema` with `.schema`/`.definitions`/`.metadata`.
- Rewrote `collect_schema` to take `Schema` by value, pull `title` and `$defs` out of the JSON object, and drop the `$schema` key.
- Updated the ref fixup from `#/definitions/` → `#/$defs/` (schemars 1.0 default draft-2020-12 definitions path).

## Verification

All run with `RUSTC_WRAPPER=""` (sccache off), default features:
- `cargo +nightly fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0, no warnings
- `cargo test --workspace` — exit 0 (openai-protocol: 76 lib + 126 responses passed; full workspace green)
- `cargo build --workspace` — exit 0 (incl. smg, smg-python, smg-golang)
- Ran `openapi-gen` end-to-end: emits valid YAML, 260 schemas, **0** dangling refs, **0** leftover `#/$defs/` refs, **0** leaked `$defs`/`$schema` keys.

Note: `Cargo.lock` is gitignored in this repo, so the lock change isn't committed.