### PR TITLE
chore(deps): bump opentelemetry 0.27->0.32 stack

### DIFF
--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -93,10 +93,10 @@ futures-util = "0.3"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 tracing-log = "0.2"
 tracing-appender = "0.2.3"
-opentelemetry = "0.27"
-opentelemetry_sdk = { version = "0.27", features = ["trace", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.27", features = ["trace", "grpc-tonic"] }
-tracing-opentelemetry = "0.28"
+opentelemetry = "0.32"
+opentelemetry_sdk = { version = "0.32", features = ["trace"] }
+opentelemetry-otlp = { version = "0.32", features = ["trace", "grpc-tonic"] }
+tracing-opentelemetry = "0.33"
 kube = { version = "3.0.1", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.27.0", features = ["v1_33"] }
 metrics = "0.24.2"

--- a/model_gateway/src/middleware/logging.rs
+++ b/model_gateway/src/middleware/logging.rs
@@ -42,7 +42,8 @@ impl<B> MakeSpan<B> for RequestSpan {
             module = "smg"
         );
 
-        span.set_parent(parent_cx);
+        // 0.33 returns a Result; a missing/empty parent context is not actionable here.
+        let _ = span.set_parent(parent_cx);
         span
     }
 }

--- a/model_gateway/src/observability/otel_trace.rs
+++ b/model_gateway/src/observability/otel_trace.rs
@@ -14,8 +14,7 @@ use opentelemetry::{global, trace::TracerProvider as _, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     propagation::TraceContextPropagator,
-    runtime,
-    trace::{BatchConfigBuilder, BatchSpanProcessor, Tracer as SdkTracer, TracerProvider},
+    trace::{BatchConfigBuilder, BatchSpanProcessor, SdkTracer, SdkTracerProvider},
     Resource,
 };
 use tokio::task::spawn_blocking;
@@ -36,7 +35,7 @@ use super::events::get_module_path as events_module_path;
 /// happen-before the Release store, and Acquire loads happen-before reads.
 static ENABLED: AtomicBool = AtomicBool::new(false);
 static TRACER: OnceLock<SdkTracer> = OnceLock::new();
-static PROVIDER: OnceLock<TracerProvider> = OnceLock::new();
+static PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
 static ALLOWED_TARGETS: OnceLock<[&'static str; 3]> = OnceLock::new();
 
 #[inline]
@@ -122,14 +121,15 @@ pub fn otel_tracing_init(enable: bool, otlp_endpoint: Option<&str>) -> Result<()
         .with_max_export_batch_size(64)
         .build();
 
-    let span_processor = BatchSpanProcessor::builder(exporter, runtime::Tokio)
+    let span_processor = BatchSpanProcessor::builder(exporter)
         .with_batch_config(batch_config)
         .build();
 
-    let resource =
-        Resource::default().merge(&Resource::new(vec![KeyValue::new("service.name", "smg")]));
+    let resource = Resource::builder()
+        .with_attribute(KeyValue::new("service.name", "smg"))
+        .build();
 
-    let provider = TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_span_processor(span_processor)
         .with_resource(resource)
         .build();
@@ -144,7 +144,7 @@ pub fn otel_tracing_init(enable: bool, otlp_endpoint: Option<&str>) -> Result<()
         .set(tracer)
         .map_err(|_| anyhow::anyhow!("Tracer already initialized"))?;
 
-    let _ = global::set_tracer_provider(provider);
+    global::set_tracer_provider(provider);
 
     // Use Release ordering: all writes to TRACER/PROVIDER happen-before this store,
     // so any thread that loads ENABLED with Acquire will see the initialized state.
@@ -200,6 +200,7 @@ pub async fn flush_spans_async() -> Result<()> {
 
     spawn_blocking(move || provider.force_flush())
         .await
+        .map_err(|e| anyhow::anyhow!("Failed to join flush task: {e}"))?
         .map_err(|e| anyhow::anyhow!("Failed to flush spans: {e}"))?;
 
     Ok(())
@@ -208,7 +209,16 @@ pub async fn flush_spans_async() -> Result<()> {
 pub fn shutdown_otel() {
     // Use Acquire to ensure we see any prior OTEL operations
     if ENABLED.load(Ordering::Acquire) {
-        global::shutdown_tracer_provider();
+        // 0.32 removed `global::shutdown_tracer_provider`; shut down the stored
+        // provider directly (its inner state is shared with the global provider).
+        if let Some(provider) = PROVIDER.get() {
+            if let Err(e) = provider.shutdown() {
+                #[expect(clippy::print_stderr)]
+                {
+                    eprintln!("[tracing] Failed to shut down OpenTelemetry: {e}");
+                }
+            }
+        }
         // Use Release to ensure shutdown completes before flag is cleared
         ENABLED.store(false, Ordering::Release);
         // Logger may already be shut down during process teardown; use stderr


### PR DESCRIPTION
## Summary

Bumps the OpenTelemetry tracing stack in `model_gateway` and adopts the new 0.32-line APIs in `model_gateway/src/observability/otel_trace.rs`.

### Version bumps (`model_gateway/Cargo.toml`)
- `opentelemetry` 0.27 -> 0.32
- `opentelemetry_sdk` 0.27 -> 0.32 (dropped now-unused `rt-tokio` feature, see below)
- `opentelemetry-otlp` 0.27 -> 0.32
- `tracing-opentelemetry` 0.28 -> 0.33
- `opentelemetry-proto` was already at 0.32 (unchanged)

### Breaking changes fixed
- **`TracerProvider` -> `SdkTracerProvider`** (the SDK provider type was renamed; `Tracer` alias replaced with the canonical `SdkTracer`).
- **Batch span processor no longer takes an async runtime.** In 0.32 the default `BatchSpanProcessor` runs on a dedicated background thread, so `BatchSpanProcessor::builder(exporter, runtime::Tokio)` becomes `BatchSpanProcessor::builder(exporter)`. The `opentelemetry_sdk` `rt-tokio` feature is only needed for the experimental async-runtime processor and is no longer pulled by `opentelemetry-otlp`'s `grpc-tonic` feature, so it was dropped.
- **`Resource` construction** moved to a builder: `Resource::default().merge(&Resource::new(vec![...]))` -> `Resource::builder().with_attribute(KeyValue::new("service.name", "smg")).build()` (the builder still includes SDK default detectors).
- **`SdkTracerProvider::force_flush()` now returns `OTelSdkResult`** instead of `()`; the result is propagated through `flush_spans_async`.
- **`global::shutdown_tracer_provider()` was removed.** Shutdown now goes through the provider directly; `shutdown_otel()` calls `provider.shutdown()` on the stored `SdkTracerProvider` (its inner state is shared with the global provider).
- **`tracing-opentelemetry` 0.33: `Span::set_parent` now returns `Result<(), SetParentError>`.** The HTTP request span in `middleware/logging.rs` discards it (a missing/empty parent context is not actionable there).

The OTLP exporter builder (`SpanExporter::builder().with_tonic().with_endpoint().with_protocol().build()`) and the W3C propagation helpers are API-compatible and unchanged.

## Verification (sccache off, default features, target `-p smg`)
- `cargo build -p smg` — Finished, exit 0
- `cargo +nightly fmt --all` — clean (no changes)
- `cargo clippy -p smg --all-targets -- -D warnings` — exit 0, no warnings
- `cargo test -p smg --test otel_tracing_test` — 11 passed; 0 failed (exercises real OTLP span export to a collector + gRPC W3C trace-context injection)
- `cargo test -p smg --lib` — 1092 passed; 0 failed; 4 ignored
- `cargo build --workspace` (default features) — Finished, exit 0 (includes `smg-python` and `smg-golang` bindings)