### PR TITLE
chore(deps): bump rmcp 0.8 -> 1.7

### DIFF
--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -24,7 +24,9 @@ futures.workspace = true
 dashmap.workspace = true
 lru.workspace = true
 parking_lot.workspace = true
-reqwest = { workspace = true, features = ["rustls-tls", "json"] }
+# rmcp 1.7 requires reqwest 0.13 (its `StreamableHttpClient` impl is on
+# reqwest 0.13's `Client`); pin here rather than via the workspace 0.12.
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_yaml = "0.9"
@@ -32,9 +34,11 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt-multi-thread", "macros", "time"] }
 tracing.workspace = true
 url = "2.5"
-rmcp = { version = "0.8.3", features = ["client", "server",
+# rmcp 1.7 dropped the standalone SSE client transport
+# (`transport-sse-client-reqwest`); the MCP spec superseded HTTP+SSE with
+# Streamable HTTP, which is still here.
+rmcp = { version = "1.7", features = ["client", "server",
     "transport-child-process",
-    "transport-sse-client-reqwest",
     "transport-streamable-http-client-reqwest",
     "transport-streamable-http-server",
     "transport-streamable-http-server-session",

--- a/crates/mcp/src/annotations.rs
+++ b/crates/mcp/src/annotations.rs
@@ -85,13 +85,13 @@ mod tests {
 
     #[test]
     fn test_from_rmcp() {
-        let rmcp = RmcpToolAnnotations {
-            read_only_hint: Some(true),
-            destructive_hint: Some(false),
-            idempotent_hint: Some(true),
-            open_world_hint: Some(false),
-            title: None,
-        };
+        // `RmcpToolAnnotations` is `#[non_exhaustive]` in rmcp 1.7; build via
+        // the chained setters instead of a struct literal.
+        let rmcp = RmcpToolAnnotations::new()
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false);
         let ann = ToolAnnotations::from_rmcp(&rmcp);
         assert!(ann.read_only);
         assert!(!ann.destructive);
@@ -99,13 +99,7 @@ mod tests {
 
     #[test]
     fn test_conservative_defaults() {
-        let rmcp = RmcpToolAnnotations {
-            read_only_hint: None,
-            destructive_hint: None,
-            idempotent_hint: None,
-            open_world_hint: None,
-            title: None,
-        };
+        let rmcp = RmcpToolAnnotations::new();
         let ann = ToolAnnotations::from_rmcp(&rmcp);
         assert!(!ann.read_only); // assume writes
         assert!(ann.destructive); // assume dangerous

--- a/crates/mcp/src/core/handler.rs
+++ b/crates/mcp/src/core/handler.rs
@@ -10,8 +10,8 @@ use std::{collections::HashMap, sync::Arc};
 use parking_lot::RwLock;
 use rmcp::{
     model::{
-        CancelledNotificationParam, ClientInfo, CreateElicitationRequestParam,
-        CreateElicitationResult, LoggingLevel, LoggingMessageNotificationParam,
+        CancelledNotificationParam, ClientInfo, CreateElicitationRequestParams,
+        CreateElicitationResult, ElicitationAction, LoggingLevel, LoggingMessageNotificationParam,
         ProgressNotificationParam, ResourceUpdatedNotificationParam,
     },
     service::{NotificationContext, RequestContext},
@@ -136,7 +136,7 @@ impl SmgClientHandler {
 impl ClientHandler for SmgClientHandler {
     async fn create_elicitation(
         &self,
-        request: CreateElicitationRequestParam,
+        request: CreateElicitationRequestParams,
         context: RequestContext<RoleClient>,
     ) -> Result<CreateElicitationResult, rmcp::ErrorData> {
         use crate::annotations::ToolAnnotations;
@@ -151,8 +151,13 @@ impl ClientHandler for SmgClientHandler {
             rmcp::ErrorData::internal_error("No request context set for elicitation", None)
         })?;
 
-        // Use message as the tool identifier (elicitation doesn't have tool name directly)
-        let message = &request.message;
+        // rmcp 1.7 split elicitation params into form/url variants; both carry a
+        // user-facing message, which we use as the tool identifier (elicitation
+        // doesn't have a tool name directly).
+        let message = match &request {
+            CreateElicitationRequestParams::FormElicitationParams { message, .. }
+            | CreateElicitationRequestParams::UrlElicitationParams { message, .. } => message,
+        };
 
         // Default annotations (conservative - not read-only, potentially destructive)
         let hints = ToolAnnotations::default();
@@ -173,36 +178,20 @@ impl ClientHandler for SmgClientHandler {
             .await
             .map_err(|e| rmcp::ErrorData::internal_error(e.to_string(), None))?;
 
+        let result_for = |allowed: bool| {
+            CreateElicitationResult::new(if allowed {
+                ElicitationAction::Accept
+            } else {
+                ElicitationAction::Decline
+            })
+        };
+
         match outcome {
-            ApprovalOutcome::Decided(decision) => {
-                if decision.is_allowed() {
-                    Ok(CreateElicitationResult {
-                        action: rmcp::model::ElicitationAction::Accept,
-                        content: None,
-                    })
-                } else {
-                    Ok(CreateElicitationResult {
-                        action: rmcp::model::ElicitationAction::Decline,
-                        content: None,
-                    })
-                }
-            }
+            ApprovalOutcome::Decided(decision) => Ok(result_for(decision.is_allowed())),
             ApprovalOutcome::Pending { rx, .. } => {
                 // Wait for user response
                 match rx.await {
-                    Ok(decision) => {
-                        if decision.is_approved() {
-                            Ok(CreateElicitationResult {
-                                action: rmcp::model::ElicitationAction::Accept,
-                                content: None,
-                            })
-                        } else {
-                            Ok(CreateElicitationResult {
-                                action: rmcp::model::ElicitationAction::Decline,
-                                content: None,
-                            })
-                        }
-                    }
+                    Ok(decision) => Ok(result_for(decision.is_approved())),
                     Err(_) => Err(rmcp::ErrorData::internal_error(
                         "Approval channel closed",
                         None,

--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -38,7 +38,7 @@ use std::{
 
 use dashmap::DashMap;
 use rmcp::{
-    model::{CallToolRequestParam, CallToolResult},
+    model::{CallToolRequestParams, CallToolResult},
     service::{RunningService, ServiceError},
     RoleClient,
 };
@@ -116,6 +116,16 @@ fn build_http_client(
     builder
         .build()
         .map_err(|e| McpError::Transport(format!("build HTTP client: {e}")))
+}
+
+/// rmcp 1.7 dropped the standalone SSE client transport (HTTP+SSE was
+/// superseded by Streamable HTTP in the MCP spec). Servers still configured
+/// with `protocol: sse` get a clear error pointing at the replacement.
+fn sse_unsupported(server_name: &str) -> McpError {
+    McpError::Transport(format!(
+        "server '{server_name}': the SSE client transport was removed in rmcp 1.7; \
+         use 'protocol: streamable' instead"
+    ))
 }
 
 /// Type alias for MCP client with handler.
@@ -517,9 +527,8 @@ impl McpOrchestrator {
     ) -> McpResult<McpClientWithHandler> {
         use rmcp::{
             transport::{
-                sse_client::SseClientConfig,
                 streamable_http_client::StreamableHttpClientTransportConfig, ConfigureCommandExt,
-                SseClientTransport, StreamableHttpClientTransport, TokioChildProcess,
+                StreamableHttpClientTransport, TokioChildProcess,
             },
             ServiceExt,
         };
@@ -544,30 +553,7 @@ impl McpOrchestrator {
                 })
             }
 
-            McpTransport::Sse {
-                url,
-                token,
-                headers: custom_headers,
-            } => {
-                let proxy_config =
-                    super::proxy::resolve_proxy_config(config, self.config.proxy.as_ref());
-                let http_client =
-                    build_http_client(proxy_config, token.as_deref(), custom_headers)?;
-
-                let sse_config = SseClientConfig {
-                    sse_endpoint: url.clone().into(),
-                    ..Default::default()
-                };
-
-                let transport = SseClientTransport::start_with_client(http_client, sse_config)
-                    .await
-                    .map_err(|e| McpError::Transport(format!("create SSE transport: {e}")))?;
-
-                handler
-                    .serve(transport)
-                    .await
-                    .map_err(|e| McpError::ConnectionFailed(format!("initialize SSE client: {e}")))
-            }
+            McpTransport::Sse { .. } => Err(sse_unsupported(&config.name)),
 
             McpTransport::Streamable {
                 url,
@@ -1075,17 +1061,12 @@ impl McpOrchestrator {
         // LLMs often return numbers as strings (e.g., "5" instead of 5)
         Self::coerce_arg_types(&mut arguments, &entry.tool.input_schema);
 
-        // Build request
-        let args_map = if let Value::Object(map) = arguments {
-            Some(map)
-        } else {
-            None
-        };
-
-        let request = CallToolRequestParam {
-            name: Cow::Owned(target_tool),
-            arguments: args_map,
-        };
+        // Build request. `CallToolRequestParams` is `#[non_exhaustive]` in rmcp
+        // 1.7 (added `meta`/`task`), so construct via the builder.
+        let mut request = CallToolRequestParams::new(Cow::Owned(target_tool));
+        if let Value::Object(map) = arguments {
+            request = request.with_arguments(map);
+        }
 
         // Execute on server
         self.execute_on_server(&target_server, request).await
@@ -1160,7 +1141,7 @@ impl McpOrchestrator {
     async fn execute_on_server(
         &self,
         server_key: &str,
-        request: CallToolRequestParam,
+        request: CallToolRequestParams,
     ) -> McpResult<CallToolResult> {
         if let Some(entry) = self.static_servers.get(server_key) {
             return entry.client.call_tool(request).await.map_err(|e| match e {
@@ -1321,8 +1302,7 @@ impl McpOrchestrator {
     ) -> McpResult<String> {
         use rmcp::{
             transport::{
-                sse_client::SseClientConfig,
-                streamable_http_client::StreamableHttpClientTransportConfig, SseClientTransport,
+                streamable_http_client::StreamableHttpClientTransportConfig,
                 StreamableHttpClientTransport,
             },
             ServiceExt,
@@ -1364,32 +1344,7 @@ impl McpOrchestrator {
                             .await
                             .map_err(|e| McpError::ConnectionFailed(format!("streamable: {e}")))
                     }
-                    McpTransport::Sse {
-                        url,
-                        token,
-                        headers: custom_headers,
-                    } => {
-                        let proxy_config =
-                            super::proxy::resolve_proxy_config(&cfg, global_proxy.as_ref());
-                        let http_client =
-                            build_http_client(proxy_config, token.as_deref(), custom_headers)?;
-
-                        let sse_config = SseClientConfig {
-                            sse_endpoint: url.clone().into(),
-                            ..Default::default()
-                        };
-
-                        let transport =
-                            SseClientTransport::start_with_client(http_client, sse_config)
-                                .await
-                                .map_err(|e| {
-                                    McpError::Transport(format!("create SSE transport: {e}"))
-                                })?;
-
-                        ().serve(transport)
-                            .await
-                            .map_err(|e| McpError::ConnectionFailed(format!("SSE: {e}")))
-                    }
+                    McpTransport::Sse { .. } => Err(sse_unsupported(&cfg.name)),
                     McpTransport::Stdio { .. } => Err(McpError::Transport(
                         "Stdio not supported for dynamic connections".to_string(),
                     )),
@@ -1755,15 +1710,11 @@ mod tests {
     fn create_test_tool(name: &str) -> McpTool {
         use std::sync::Arc;
 
-        McpTool {
-            name: Cow::Owned(name.to_string()),
-            title: None,
-            description: Some(Cow::Owned(format!("Test tool: {name}"))),
-            input_schema: Arc::new(serde_json::Map::new()),
-            output_schema: None,
-            annotations: None,
-            icons: None,
-        }
+        McpTool::new(
+            Cow::Owned(name.to_string()),
+            Cow::Owned(format!("Test tool: {name}")),
+            Arc::new(serde_json::Map::new()),
+        )
     }
     #[tokio::test]
     async fn test_orchestrator_graceful_shutdown_flow() {

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -718,15 +718,11 @@ mod tests {
     fn create_test_tool(name: &str) -> McpTool {
         use std::{borrow::Cow, sync::Arc};
 
-        McpTool {
-            name: Cow::Owned(name.to_string()),
-            title: None,
-            description: Some(Cow::Owned(format!("Test tool: {name}"))),
-            input_schema: Arc::new(serde_json::Map::new()),
-            output_schema: None,
-            annotations: None,
-            icons: None,
-        }
+        McpTool::new(
+            Cow::Owned(name.to_string()),
+            Cow::Owned(format!("Test tool: {name}")),
+            Arc::new(serde_json::Map::new()),
+        )
     }
 
     #[test]

--- a/crates/mcp/src/inventory/index.rs
+++ b/crates/mcp/src/inventory/index.rs
@@ -429,39 +429,23 @@ mod tests {
             serde_json::Map::new()
         };
 
-        Tool {
-            name: Cow::Owned(name.to_string()),
-            title: None,
-            description: Some(Cow::Owned(format!("Test tool: {name}"))),
-            input_schema: Arc::new(schema_map),
-            output_schema: None,
-            annotations: None,
-            icons: None,
-        }
+        Tool::new(
+            Cow::Owned(name.to_string()),
+            Cow::Owned(format!("Test tool: {name}")),
+            Arc::new(schema_map),
+        )
     }
 
     // Helper to create a test prompt
     fn create_test_prompt(name: &str) -> Prompt {
-        Prompt {
-            name: name.to_string(),
-            title: None,
-            description: Some(format!("Test prompt: {name}")),
-            arguments: None,
-            icons: None,
-        }
+        Prompt::new(name, Some(format!("Test prompt: {name}")), None)
     }
 
     // Helper to create a test resource
     fn create_test_resource(uri: &str) -> RawResource {
-        RawResource {
-            uri: uri.to_string(),
-            name: uri.to_string(),
-            title: None,
-            description: Some(format!("Test resource: {uri}")),
-            mime_type: Some("text/plain".to_string()),
-            size: None,
-            icons: None,
-        }
+        RawResource::new(uri, uri)
+            .with_description(format!("Test resource: {uri}"))
+            .with_mime_type("text/plain")
     }
 
     #[test]

--- a/crates/mcp/src/inventory/types.rs
+++ b/crates/mcp/src/inventory/types.rs
@@ -233,15 +233,11 @@ mod tests {
             serde_json::Map::new()
         };
 
-        Tool {
-            name: Cow::Owned(name.to_string()),
-            title: None,
-            description: Some(Cow::Owned(format!("Test tool: {name}"))),
-            input_schema: Arc::new(schema_map),
-            output_schema: None,
-            annotations: None,
-            icons: None,
-        }
+        Tool::new(
+            Cow::Owned(name.to_string()),
+            Cow::Owned(format!("Test tool: {name}")),
+            Arc::new(schema_map),
+        )
     }
 
     #[test]

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -109,7 +109,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls-pemfile = "2.2"
 openssl = "0.10.73"
-rmcp = { version = "0.8.3", features = ["client"] }
+rmcp = { version = "1.7", features = ["client"] }
 serde_yaml = "0.9"
 openai-harmony = "0.0.8"
 openmetrics-parser = "0.4.4"

--- a/model_gateway/src/routers/common/openai_bridge/format_registry.rs
+++ b/model_gateway/src/routers/common/openai_bridge/format_registry.rs
@@ -164,15 +164,7 @@ mod tests {
         let mut schema = serde_json::Map::new();
         schema.insert("type".to_string(), json!("object"));
         schema.insert("properties".to_string(), json!({}));
-        Tool {
-            name: name.to_string().into(),
-            title: None,
-            description: Some("test".into()),
-            input_schema: schema.into(),
-            output_schema: None,
-            icons: None,
-            annotations: None,
-        }
+        Tool::new(name.to_string(), "test", schema)
     }
 
     #[test]

--- a/model_gateway/src/routers/common/openai_bridge/tool_descriptors.rs
+++ b/model_gateway/src/routers/common/openai_bridge/tool_descriptors.rs
@@ -350,27 +350,20 @@ mod tests {
 
     use super::*;
 
+    // `Tool` and `ToolAnnotations` are `#[non_exhaustive]` in rmcp 1.7, so build
+    // them via the constructor/setters rather than struct literals.
     fn entry_with_rmcp_annotations(annotations: Option<RmcpToolAnnotations>) -> ToolEntry {
-        let tool = Tool {
-            name: Cow::Owned("widget".to_string()),
-            title: None,
-            description: Some(Cow::Owned("widget description".to_string())),
-            input_schema: Arc::new(serde_json::Map::new()),
-            output_schema: None,
-            annotations,
-            icons: None,
-        };
+        let mut tool = Tool::new(
+            Cow::Owned("widget".to_string()),
+            Cow::Owned("widget description".to_string()),
+            Arc::new(serde_json::Map::new()),
+        );
+        tool.annotations = annotations;
         ToolEntry::from_server_tool("srv", tool)
     }
 
     fn read_only_hint(value: bool) -> RmcpToolAnnotations {
-        RmcpToolAnnotations {
-            title: None,
-            read_only_hint: Some(value),
-            destructive_hint: None,
-            idempotent_hint: None,
-            open_world_hint: None,
-        }
+        RmcpToolAnnotations::new().read_only(value)
     }
 
     #[test]

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -1306,15 +1306,7 @@ mod tests {
         schema.insert("type".to_string(), json!("object"));
         schema.insert("properties".to_string(), json!({}));
 
-        Tool {
-            name: name.to_string().into(),
-            title: None,
-            description: Some("internal".into()),
-            input_schema: schema.into(),
-            output_schema: None,
-            icons: None,
-            annotations: None,
-        }
+        Tool::new(name.to_string(), "internal", schema)
     }
 
     #[test]

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -441,15 +441,7 @@ mod tests {
             }),
         );
 
-        Tool {
-            name: name.to_string().into(),
-            title: None,
-            description: Some("internal".into()),
-            input_schema: schema.into(),
-            output_schema: None,
-            icons: None,
-            annotations: None,
-        }
+        Tool::new(name.to_string(), "internal", schema)
     }
 
     #[tokio::test]

--- a/model_gateway/tests/common/mock_mcp_server.rs
+++ b/model_gateway/tests/common/mock_mcp_server.rs
@@ -261,17 +261,16 @@ impl MockSearchResponseServer {
 #[tool_handler]
 impl ServerHandler for MockSearchServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::V_2024_11_05,
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation::from_build_env(),
-            instructions: Some("Mock server for testing".to_string()),
-        }
+        // `ServerInfo`/`InitializeResult` is `#[non_exhaustive]` in rmcp 1.7;
+        // build via the constructor instead of a struct literal.
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_instructions("Mock server for testing")
     }
 
     async fn initialize(
         &self,
-        _request: InitializeRequestParam,
+        _request: InitializeRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<InitializeResult, McpError> {
         Ok(self.get_info())
@@ -333,17 +332,14 @@ impl MockFailingSearchServer {
 #[tool_handler]
 impl ServerHandler for MockFailingSearchServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::V_2024_11_05,
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation::from_build_env(),
-            instructions: Some("Mock failing server for testing".to_string()),
-        }
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_instructions("Mock failing server for testing")
     }
 
     async fn initialize(
         &self,
-        _request: InitializeRequestParam,
+        _request: InitializeRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<InitializeResult, McpError> {
         Ok(self.get_info())
@@ -353,17 +349,14 @@ impl ServerHandler for MockFailingSearchServer {
 #[tool_handler]
 impl ServerHandler for MockSearchResponseServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::V_2024_11_05,
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation::from_build_env(),
-            instructions: Some("Mock search response server for testing".to_string()),
-        }
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_protocol_version(ProtocolVersion::V_2024_11_05)
+            .with_instructions("Mock search response server for testing")
     }
 
     async fn initialize(
         &self,
-        _request: InitializeRequestParam,
+        _request: InitializeRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<InitializeResult, McpError> {
         Ok(self.get_info())
@@ -477,7 +470,7 @@ mod tests {
     #[tokio::test]
     async fn test_mock_failing_server_startup() {
         use rmcp::{
-            model::CallToolRequestParam, transport::StreamableHttpClientTransport, ServiceExt,
+            model::CallToolRequestParams, transport::StreamableHttpClientTransport, ServiceExt,
         };
 
         let mut server = MockFailingMCPServer::start("marker").await.unwrap();
@@ -488,17 +481,14 @@ mod tests {
         let client = ().serve(transport).await.expect("connect failing mock server");
 
         let err = client
-            .call_tool(CallToolRequestParam {
-                name: "brave_web_search".into(),
-                arguments: Some(
-                    serde_json::json!({
-                        "query": "smoke"
-                    })
-                    .as_object()
-                    .unwrap()
-                    .clone(),
+            .call_tool(
+                CallToolRequestParams::new("brave_web_search").with_arguments(
+                    serde_json::json!({ "query": "smoke" })
+                        .as_object()
+                        .unwrap()
+                        .clone(),
                 ),
-            })
+            )
             .await
             .expect_err("failing mock tool call should error");
         assert!(err.to_string().contains("marker"));


### PR DESCRIPTION
## Bump

- `rmcp` **0.8.3 -> 1.7** in `crates/mcp/Cargo.toml` and `model_gateway/Cargo.toml`
- `crates/mcp` now pins `reqwest` **0.13** directly (rmcp 1.7's `StreamableHttpClient` impl is on reqwest 0.13's `Client`; the rest of the workspace still uses 0.12)

## Breaking changes fixed

rmcp 0.8 -> 1.7 is a major MCP SDK API change. Migrations:

- **Deprecated singular request-param aliases renamed to plural types** (they are `#[deprecated(since = "0.13.0")]` and fail under `-D warnings`):
  - `CallToolRequestParam` -> `CallToolRequestParams`
  - `CreateElicitationRequestParam` -> `CreateElicitationRequestParams`
  - `InitializeRequestParam` -> `InitializeRequestParams`
- **`CreateElicitationRequestParams` is now an enum** (`FormElicitationParams` / `UrlElicitationParams`). The client handler reads `message` via a match instead of a struct field.
- **Many model types became `#[non_exhaustive]`** (`Tool`, `ToolAnnotations`, `Prompt`, `RawResource`, `CallToolRequestParams`, `InitializeResult`/`ServerInfo`). All struct-literal constructions (prod + tests + mock server) switched to constructors/setters (`Tool::new`, `ToolAnnotations::new().read_only(..)`, `Prompt::new`, `RawResource::new`, `CallToolRequestParams::new().with_arguments(..)`, `ServerInfo::new().with_protocol_version(..).with_instructions(..)`). `CreateElicitationResult` gained a `meta` field, so it's built with `CreateElicitationResult::new(action)`.
- **Standalone SSE client transport removed upstream** (`transport-sse-client-reqwest`; HTTP+SSE was superseded by Streamable HTTP). The feature is dropped and `McpTransport::Sse` connections now return a clear error pointing at `protocol: streamable`. The Streamable HTTP and stdio transports are unchanged.
- **rmcp 1.7 requires reqwest 0.13** (TLS feature `rustls-tls` -> `rustls`), handled in `crates/mcp`.

## Verification

All run with `RUSTC_WRAPPER=""` (sccache off), default features:

- `cargo build --workspace` — clean
- `cargo build -p smg-python -p smg-golang` — clean (maturin not used)
- `cargo clippy -p smg-mcp -p smg --all-targets -- -D warnings` — clean
- `cargo test -p smg-mcp` — 160 passed, 0 failed
- `cargo test -p smg` — all suites pass, incl. `mcp_test` integration (23 passed) and the mock-server rmcp client/server round-trip tests over Streamable HTTP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated MCP protocol implementation to support streamable HTTP transport features.

* **Chores**
  * Upgraded core library dependencies to latest versions for improved stability and compatibility.

* **Breaking Changes**
  * Removed SSE client transport support. Applications relying on SSE transport will need to migrate to streamable HTTP transport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->