### PR TITLE
fix(bfcl): max_model_len 32768 + OpenAICompletionsHandler for multi-turn FC

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -265,11 +265,20 @@ jobs:
           # picks a port, frees it, then vLLM binds it ~40s later — another leg
           # grabs it meanwhile) and on GPU memory. A host-wide flock runs them one
           # at a time; the lock releases when this step's shell exits.
+          #
+          # CRITICAL: every `launch_arm.sh` call below is invoked with `9>&-` so the
+          # setsid-detached vLLM/SMG servers do NOT inherit lock FD 9. Otherwise a
+          # leaked server keeps FD 9 open and holds the lock forever, deadlocking all
+          # future bfcl jobs on this host. With 9>&-, only this step shell holds the
+          # lock and it always releases on step exit. `-w` bounds the wait so a stuck
+          # lock fails loudly instead of hanging to the job timeout.
           exec 9>/tmp/bfcl-host.lock
-          echo "waiting for host lock..."; flock 9; echo "acquired host lock"
+          echo "waiting for host lock..."
+          flock -w 9000 9 || { echo "::error::host lock not acquired within 9000s"; exit 1; }
+          echo "acquired host lock"
           # Tear this leg's servers down before releasing the lock, so the next
           # leg starts on a clean host (the always() steps below are backstops).
-          cleanup() { bash scripts/bfcl/launch_arm.sh stop || true; }
+          cleanup() { bash scripts/bfcl/launch_arm.sh stop 9>&- || true; }
           trap cleanup EXIT
           trap 'cleanup; exit 143' INT TERM
           BFCL="$(command -v bfcl)"
@@ -278,20 +287,20 @@ jobs:
             # Whole node per arm (TP=8), one at a time: each model needs all 8 GPUs
             # for enough KV cache at the larger max_model_len. Score arm A, tear it
             # down to free the GPUs, score arm B, then diff the two saved results.
-            A_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh a)
+            A_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh a 9>&-)
             echo "arm A (vllm): $A_URL"
             python scripts/bfcl/run_ab.py --score-arm "vllm=$A_URL" \
               --scores-out "$ROOT/scores_vllm.json" \
               --bfcl-model "$BFCL_MODEL_FC" --categories "$CATEGORIES" \
               --bfcl "$BFCL" --project-root "$ROOT"
-            bash scripts/bfcl/launch_arm.sh stop
-            B_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh b)
+            bash scripts/bfcl/launch_arm.sh stop 9>&-
+            B_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh b 9>&-)
             echo "arm B (smg): $B_URL"
             python scripts/bfcl/run_ab.py --score-arm "smg=$B_URL" \
               --scores-out "$ROOT/scores_smg.json" \
               --bfcl-model "$BFCL_MODEL_FC" --categories "$CATEGORIES" \
               --bfcl "$BFCL" --project-root "$ROOT"
-            bash scripts/bfcl/launch_arm.sh stop
+            bash scripts/bfcl/launch_arm.sh stop 9>&-
             python scripts/bfcl/run_ab.py \
               --diff-baseline "$ROOT/scores_vllm.json" --diff-candidate "$ROOT/scores_smg.json" \
               --categories "$CATEGORIES" \
@@ -300,8 +309,8 @@ jobs:
           else
             # Concurrent: arm A (pure vLLM) on the first GPU half, arm B (SMG ->
             # vLLM gRPC) on the second; ports left unset so launch_arm.sh picks free.
-            A_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh a)
-            B_URL=$(BFCL_GPU="$GPU_B" bash scripts/bfcl/launch_arm.sh b)
+            A_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh a 9>&-)
+            B_URL=$(BFCL_GPU="$GPU_B" bash scripts/bfcl/launch_arm.sh b 9>&-)
             echo "arm A: $A_URL   arm B: $B_URL"
             python scripts/bfcl/run_ab.py \
               --baseline  "vllm=$A_URL" \

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -12,7 +12,7 @@ name: Nightly BFCL
 
 on:
   schedule:
-    - cron: "37 9 * * *" # UTC, off-round, distinct from nightly-benchmark (0 8) / mlx (17 9)
+    - cron: "17 7 * * *" # 00:17 PDT (07:00 UTC = midnight Pacific/PDT); off-round, distinct from nightly-benchmark (0 8) / mlx (17 9)
   # PR sanity: only when the BFCL pipeline itself changes. Runs a quick non-live
   # subset so the A/B is exercised end-to-end (engine, FC mode, parser, scoring)
   # before merge — confidence the pipeline works, not a statistical result.
@@ -276,9 +276,19 @@ jobs:
           echo "waiting for host lock..."
           flock -w 9000 9 || { echo "::error::host lock not acquired within 9000s"; exit 1; }
           echo "acquired host lock"
-          # Tear this leg's servers down before releasing the lock, so the next
-          # leg starts on a clean host (the always() steps below are backstops).
-          cleanup() { bash scripts/bfcl/launch_arm.sh stop 9>&- || true; }
+          # Pre-flight GPU nuke: free the node before launching. Clears leftovers from
+          # a prior cancelled/killed leg whose always() teardown was skipped (a detached
+          # vLLM/smg::router that the pidfile group-kill missed and that pins GPU mem).
+          # Safe here: we hold the host lock, so no other bfcl leg is running; node-wide
+          # nuke (kills by GPU occupancy) is accepted on these hosts.
+          bash scripts/ci_killall_sglang.sh nuke_gpus 9>&- || true
+          # Tear this leg's servers down AND nuke GPUs before releasing the lock, so the
+          # next leg starts clean. Both run inside the lock (never hit the next leg). The
+          # always() Teardown step is a leg-scoped backstop for when this trap can't run.
+          cleanup() {
+            bash scripts/bfcl/launch_arm.sh stop 9>&- || true
+            bash scripts/ci_killall_sglang.sh nuke_gpus 9>&- || true
+          }
           trap cleanup EXIT
           trap 'cleanup; exit 143' INT TERM
           BFCL="$(command -v bfcl)"

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -131,7 +131,7 @@ jobs:
                "vllm_tool": "qwen3_xml", "vllm_reason": "qwen3",
                "smg_tool": "qwen_xml", "smg_reason": "qwen3",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
-               "model_cache": "/models"},
+               "model_cache": "/models", "arm_mode": "concurrent", "max_model_len": "32768"},
               # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
               {"name": "gpt-oss", "runner": "4-gpu-h100", "tp": 2,
                "gpu_a": "0,1", "gpu_b": "2,3",
@@ -139,9 +139,12 @@ jobs:
                "vllm_tool": "openai", "vllm_reason": "",
                "smg_tool": "", "smg_reason": "",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
-               "model_cache": "/models"},
-              # Blackwell legs (B200, TP=4 per arm, both arms concurrent: 0-3 + 4-7).
-              # Models are pre-staged on NVMe at /raid/models/<id> (no download).
+               "model_cache": "/models", "arm_mode": "concurrent", "max_model_len": "32768"},
+              # Blackwell legs (B200). Models pre-staged on NVMe at /raid/models/<id>.
+              # Concurrent TP=4 per arm (0-3 + 4-7) with max_model_len 32768: the
+              # multi_turn categories emit ~18k-token prompts that 400'd at 16384.
+              # Weights already fit at TP=4, and the extra KV for 32k is only a few
+              # GB/sequence, so the larger window fits without needing the whole node.
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "deepseek-ai/DeepSeek-V4-Flash", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-FC",
@@ -151,15 +154,16 @@ jobs:
                # --kv-cache-dtype fp8 + --block-size 256 REQUIRED: V4's FlashMLA fp8
                # kernel asserts fp8 kv-cache (else EngineCore dies at startup).
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
-               "gpu_mem": "0.90", "startup_timeout": "2400", "model_cache": "/raid/models"},
+               "gpu_mem": "0.90", "startup_timeout": "2400", "model_cache": "/raid/models",
+               "arm_mode": "concurrent", "max_model_len": "32768"},
               {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "MiniMaxAI/MiniMax-M2.7", "bfcl_model": "MiniMaxAI/MiniMax-M2.7-FC",
                "vllm_tool": "minimax_m2", "vllm_reason": "minimax_m2",
                "smg_tool": "minimax_m2", "smg_reason": "minimax",
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
-               "model_cache": "/raid/models"},
-              # Kimi-K2.6 loads native int4 weights (~500GB) -> fits TP=4 half-node.
+               "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "32768"},
+              # Kimi-K2.6 int4 (~500GB) fits TP=4 half-node.
               {"name": "kimi-k2.6", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "moonshotai/Kimi-K2.6", "bfcl_model": "moonshotai/Kimi-K2.6-FC",
@@ -168,7 +172,7 @@ jobs:
                "smg_reason": "kimi_k25",  # TODO(confirm): no kimi_k2 SMG reasoning parser yet
                # Generous startup: 1T MoE at TP=4 needs minutes for load+compile+quant (420s timed out).
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
-               "model_cache": "/raid/models"},
+               "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "32768"},
           ]
           only = os.environ.get("ONLY", "")
           valid_names = [l["name"] for l in legs]
@@ -244,8 +248,11 @@ jobs:
           BFCL_SMG_REASONING_PARSER: ${{ github.event.inputs.reasoning_parser || matrix.smg_reason }}
           BFCL_VLLM_EXTRA: ${{ matrix.vllm_extra }}
           BFCL_TP: ${{ matrix.tp }}
-          BFCL_MAX_MODEL_LEN: "16384"
+          BFCL_MAX_MODEL_LEN: ${{ matrix.max_model_len }}
           BFCL_GPU_MEM_UTIL: ${{ matrix.gpu_mem }}
+          ARM_MODE: ${{ matrix.arm_mode }}
+          GPU_A: ${{ matrix.gpu_a }}
+          GPU_B: ${{ matrix.gpu_b }}
           # Per-leg health-wait budget: big MoEs need minutes for load + compile + quant.
           BFCL_STARTUP_TIMEOUT: ${{ matrix.startup_timeout }}
           # Arm logs + pidfiles under RUNNER_TEMP (per-job, uploadable) not /tmp.
@@ -265,21 +272,48 @@ jobs:
           cleanup() { bash scripts/bfcl/launch_arm.sh stop || true; }
           trap cleanup EXIT
           trap 'cleanup; exit 143' INT TERM
-          # Arm A (pure vLLM) on the first GPU half, arm B (SMG -> vLLM gRPC) on
-          # the second; ports left unset so launch_arm.sh picks free ones.
-          A_URL=$(BFCL_GPU=${{ matrix.gpu_a }} bash scripts/bfcl/launch_arm.sh a)
-          B_URL=$(BFCL_GPU=${{ matrix.gpu_b }} bash scripts/bfcl/launch_arm.sh b)
-          echo "arm A: $A_URL   arm B: $B_URL"
-          python scripts/bfcl/run_ab.py \
-            --baseline  "vllm=$A_URL" \
-            --candidate "smg=$B_URL" \
-            --bfcl-model "$BFCL_MODEL_FC" \
-            --categories "$CATEGORIES" \
-            --bfcl "$(command -v bfcl)" \
-            --project-root "$RUNNER_TEMP/bfcl_ab" \
-            --out "$RUNNER_TEMP/bfcl_ab.md" \
-            --json-out "$RUNNER_TEMP/bfcl_ab.json" \
-            --tolerance 0.02 || echo "BFCL_AB_REGRESSION=1" >> "$GITHUB_ENV"
+          BFCL="$(command -v bfcl)"
+          ROOT="$RUNNER_TEMP/bfcl_ab"
+          if [ "$ARM_MODE" = sequential ]; then
+            # Whole node per arm (TP=8), one at a time: each model needs all 8 GPUs
+            # for enough KV cache at the larger max_model_len. Score arm A, tear it
+            # down to free the GPUs, score arm B, then diff the two saved results.
+            A_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh a)
+            echo "arm A (vllm): $A_URL"
+            python scripts/bfcl/run_ab.py --score-arm "vllm=$A_URL" \
+              --scores-out "$ROOT/scores_vllm.json" \
+              --bfcl-model "$BFCL_MODEL_FC" --categories "$CATEGORIES" \
+              --bfcl "$BFCL" --project-root "$ROOT"
+            bash scripts/bfcl/launch_arm.sh stop
+            B_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh b)
+            echo "arm B (smg): $B_URL"
+            python scripts/bfcl/run_ab.py --score-arm "smg=$B_URL" \
+              --scores-out "$ROOT/scores_smg.json" \
+              --bfcl-model "$BFCL_MODEL_FC" --categories "$CATEGORIES" \
+              --bfcl "$BFCL" --project-root "$ROOT"
+            bash scripts/bfcl/launch_arm.sh stop
+            python scripts/bfcl/run_ab.py \
+              --diff-baseline "$ROOT/scores_vllm.json" --diff-candidate "$ROOT/scores_smg.json" \
+              --categories "$CATEGORIES" \
+              --out "$RUNNER_TEMP/bfcl_ab.md" --json-out "$RUNNER_TEMP/bfcl_ab.json" \
+              --tolerance 0.02 || echo "BFCL_AB_REGRESSION=1" >> "$GITHUB_ENV"
+          else
+            # Concurrent: arm A (pure vLLM) on the first GPU half, arm B (SMG ->
+            # vLLM gRPC) on the second; ports left unset so launch_arm.sh picks free.
+            A_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh a)
+            B_URL=$(BFCL_GPU="$GPU_B" bash scripts/bfcl/launch_arm.sh b)
+            echo "arm A: $A_URL   arm B: $B_URL"
+            python scripts/bfcl/run_ab.py \
+              --baseline  "vllm=$A_URL" \
+              --candidate "smg=$B_URL" \
+              --bfcl-model "$BFCL_MODEL_FC" \
+              --categories "$CATEGORIES" \
+              --bfcl "$BFCL" \
+              --project-root "$ROOT" \
+              --out "$RUNNER_TEMP/bfcl_ab.md" \
+              --json-out "$RUNNER_TEMP/bfcl_ab.json" \
+              --tolerance 0.02 || echo "BFCL_AB_REGRESSION=1" >> "$GITHUB_ENV"
+          fi
       - name: Render summary
         if: always()
         run: |

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -20,7 +20,7 @@ Two arms expose an identical OpenAI `/v1` endpoint. The same official `bfcl` CLI
 | file | what |
 |---|---|
 | `launch_arm.sh` | bring up one arm (`a` = pure vLLM, `b` = vLLM-gRPC + SMG); prints its base_url; `stop` tears down via pidfiles. Fully env-parameterised. |
-| `run_ab.py` | point official `bfcl generate`+`evaluate` (FC mode) at both arms, parse per-category accuracy, emit a markdown + JSON comparison table, and a regression gate. Arms must already be serving. |
+| `run_ab.py` | point official `bfcl generate`+`evaluate` (FC mode) at both arms, parse per-category accuracy + test-case count, emit a markdown + JSON comparison table (with both **unweighted** = mean-of-categories and **weighted-by-n** = micro overall, matching BFCL's `calculate_unweighted/weighted_accuracy`), and a regression gate. Arms must already be serving. |
 | `register_bfcl_model.py` | register a model that bfcl-eval doesn't ship a handler for yet (new SKUs), by cloning an existing FC entry. Idempotent. |
 
 ## Quick start (manual, e.g. on a GPU box)

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -100,7 +100,7 @@ GB/sequence, so the larger context needs no extra GPUs — arms stay **concurren
 Each leg sets `arm_mode`:
 
 - **concurrent** (all current legs) — both arms serve at once on opposite GPU halves;
-  one `run_ab.py` scores both live and diffs.
+  `run_ab.py` scores them **in parallel** (separate servers/GPUs, no contention) and diffs.
 - **sequential** (in reserve, unused) — for a model that needs the whole node (TP=8)
   so the arms can't coexist: `run_ab.py --score-arm` scores arm A alone → tears it
   down → scores arm B alone → `--diff-baseline/--diff-candidate` compares the two

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -89,14 +89,26 @@ The nightly (`.github/workflows/nightly-bfcl.yml`) runs the A/B as a GitHub Acti
 matrix — one leg per model, `fail-fast: false`, each on its own runner:
 
 - `4-gpu-h100` — Qwen3.6-27B and gpt-oss-120b, TP=2 per arm (GPUs 0,1 + 2,3).
-- `blackwell` (8×B300) — DeepSeek-V4-Flash, MiniMax-M2.7, Kimi-K2.6, TP=4 per arm
+- `blackwell` (B200) — DeepSeek-V4-Flash, MiniMax-M2.7, Kimi-K2.6 int4, TP=4 per arm
   (GPUs 0-3 + 4-7).
 
-All legs run **both arms concurrently**; no sequential path is needed because the
-"flash"/int4 checkpoints fit half a node. Per the A/B's premise, model size is
-irrelevant — a smaller same-family checkpoint exercises the identical parser, so the
-matrix uses DeepSeek-V4-Flash and int4 Kimi-K2.6 to validate the `deepseek_v4` /
-`kimi_k2` parsers without paying for the full production weights.
+All legs use `max_model_len` **32768**: the `multi_turn` categories emit ~18k-token
+prompts that 400'd ("decoder prompt longer than the maximum model length") at 16384.
+Weights already fit at each leg's TP and the extra KV for a 32k window is only a few
+GB/sequence, so the larger context needs no extra GPUs — arms stay **concurrent**.
+
+Each leg sets `arm_mode`:
+
+- **concurrent** (all current legs) — both arms serve at once on opposite GPU halves;
+  one `run_ab.py` scores both live and diffs.
+- **sequential** (in reserve, unused) — for a model that needs the whole node (TP=8)
+  so the arms can't coexist: `run_ab.py --score-arm` scores arm A alone → tears it
+  down → scores arm B alone → `--diff-baseline/--diff-candidate` compares the two
+  saved score files. Flip a leg's `arm_mode` to enable it.
+
+Per the A/B's premise, model size is irrelevant — a smaller same-family checkpoint
+exercises the identical parser — so the matrix uses DeepSeek-V4-Flash and int4
+Kimi-K2.6 to validate the `deepseek_v4` / `kimi_k2` parsers without the full weights.
 
 `workflow_dispatch` can target one leg via the `only` input and override
 `model`/`bfcl_model`/parsers per run. PRs touching this pipeline run **all** legs
@@ -109,7 +121,7 @@ is a tiny non-live subset (`simple_python,irrelevance`) for every leg.
 - **Cap the context.** Qwen3-4B defaults to a 256K `max_model_len` → ~36 GiB KV cache → engine init OOM. Pass `--max-model-len 16384` (the launch helper defaults to this); use the **same** value on both arms.
 - **Install `ninja` in the vLLM env (do NOT reach for `--enforce-eager`).** vLLM's torch.compile / CUDA-graph path shells out to `ninja` to build kernels (required for newer archs like Qwen3.6's `qwen3_5`); if it's missing the engine dies with `No such file or directory: 'ninja'`. `--enforce-eager` only *hides* this by skipping compilation (slower). Real fix: `pip install ninja` in the vLLM env **and put its bin on `PATH`** (vLLM execs `ninja` by name) — then run with CUDA graphs, no `--enforce-eager`.
 - **Don't force HF offline.** With the model cached, bfcl runs fine online (~7 req/s measured); a one-off slow run is usually a transient HF hiccup, not a systematic per-request throttle. `run_ab.py` does **not** set `HF_HUB_OFFLINE`; set it yourself only for air-gapped boxes. No HF token is needed for public models.
-- **New models need a bfcl handler.** bfcl-eval pins a fixed model list; a brand-new SKU (e.g. `Qwen/Qwen3.6-27B`) isn't in it, so `bfcl generate --model <id>-FC` fails with "Unknown model_name". Run `register_bfcl_model.py --model-id <id>` first.
+- **New models need a bfcl handler.** bfcl-eval pins a fixed model list; a brand-new SKU (e.g. `Qwen/Qwen3.6-27B`) isn't in it, so `bfcl generate --model <id>-FC` fails with "Unknown model_name". Run `register_bfcl_model.py --model-id <id>` first — it registers the id with **`OpenAICompletionsHandler`** (generic OpenAI Chat Completions FC: native `tools`, server-parsed `tool_calls`, OpenAI-message multi-turn). Do **not** use the model-family *local* handlers (e.g. `QwenFCHandler`): they re-serialize multi-turn tool calls into a text prompt assuming a `{"name","arguments"}` shape and `KeyError` on SKUs whose tool-call JSON differs (DeepSeek-V4 → `'arguments'`, MiniMax-M2 → `'name'`). `run_ab.py` points bfcl at each arm via `OPENAI_BASE_URL`.
 - **SMG auto model→parser mapping lags new SKUs.** SMG's factory doesn't yet map `Qwen3.6*` (it falls back to the JSON `qwen` parser, wrong for the XML format), so pass `--tool-call-parser qwen_xml` explicitly. Adding a `Qwen3.6*`→`qwen_xml` mapping to `crates/tool_parser` is a good follow-up.
 - **Use the `-FC` handler.** `Qwen/Qwen3-4B-Instruct-2507-FC`, not the bare name (which is prompt mode and bypasses the server parser).
 - **`bfcl generate --skip-server-setup`** points at `LOCAL_SERVER_ENDPOINT` / `LOCAL_SERVER_PORT`. (Custom full base_urls behind a proxy are still rigid — gorilla issue #1280.)

--- a/scripts/bfcl/register_bfcl_model.py
+++ b/scripts/bfcl/register_bfcl_model.py
@@ -4,16 +4,22 @@
 The BFCL leaderboard package pins a fixed ``MODEL_CONFIG_MAPPING``; brand-new
 models (e.g. ``Qwen/Qwen3.6-27B``, released after the package was cut) aren't in
 it, so ``bfcl generate --model <id>-FC`` fails with "Unknown model_name". For an
-A/B that only needs FC mode against a self-hosted OpenAI endpoint, the handler
-logic is identical to any other Qwen FC model (send native ``tools``, read
-``tool_calls``), so we clone an existing FC entry under the new id.
+A/B against a self-hosted OpenAI-compatible endpoint we register the new id with
+``OpenAICompletionsHandler`` — the generic OpenAI Chat Completions FC handler: it
+sends native ``tools`` and reads the server's parsed ``tool_calls`` (keeping the
+server parser on the critical path), and across multi-turn it re-inserts tool
+calls as proper OpenAI messages. The model-family *local* handlers (e.g.
+``QwenFCHandler``) instead re-serialize multi-turn tool calls into a text prompt
+assuming a ``{"name","arguments"}`` shape, which ``KeyError``s on SKUs whose
+tool-call JSON differs (DeepSeek-V4, MiniMax-M2). bfcl reads the endpoint from
+``OPENAI_BASE_URL`` (set per arm by run_ab.py).
 
 This edits the *installed* ``bfcl_eval/constants/model_config.py`` in place
 (idempotent). Re-running is safe. Intended for nightly "test the latest models"
 flows where the bfcl release lags new releases.
 
     python register_bfcl_model.py --model-id Qwen/Qwen3.6-27B
-    # registers "Qwen/Qwen3.6-27B-FC" cloned from "Qwen/Qwen3-32B-FC"
+    # registers "Qwen/Qwen3.6-27B-FC" with OpenAICompletionsHandler
 """
 
 from __future__ import annotations
@@ -57,7 +63,7 @@ def main() -> int:
     p.add_argument("--model-id", required=True, help="HF id, e.g. Qwen/Qwen3.6-27B")
     p.add_argument(
         "--handler",
-        default="QwenFCHandler",
+        default="OpenAICompletionsHandler",
         help="bfcl handler class already imported in model_config.py",
     )
     p.add_argument("--anchor", default=DEFAULT_ANCHOR, help="existing entry line to insert before")

--- a/scripts/bfcl/run_ab.py
+++ b/scripts/bfcl/run_ab.py
@@ -32,6 +32,7 @@ launch them. Example::
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import os
 import subprocess
@@ -384,12 +385,15 @@ def main() -> int:
         print(f"[{arm.name}] scores -> {args.scores_out}: {arm.scores}")
         return 0
 
-    # Mode: concurrent A/B — both arms serving at once.
+    # Mode: concurrent A/B — both arms serve at once on opposite GPU halves, so
+    # score them in PARALLEL (separate servers, separate project_roots, no
+    # contention) — roughly halves wall-clock vs scoring one then the other.
     if not (args.baseline and args.candidate and args.bfcl_model):
         p.error("concurrent mode requires --baseline, --candidate and --bfcl-model")
     baseline = parse_arm(args.baseline, args.project_root)
     candidate = parse_arm(args.candidate, args.project_root)
-    for arm in (baseline, candidate):
+
+    def score(arm: Arm) -> None:
         run_bfcl(
             arm,
             bfcl=args.bfcl,
@@ -399,6 +403,10 @@ def main() -> int:
             temperature=args.temperature,
             skip_generate=args.skip_generate,
         )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+        # list() forces both futures to complete and re-raises any exception.
+        list(ex.map(score, (baseline, candidate)))
     return write_report_and_gate(baseline, candidate, categories, args)
 
 

--- a/scripts/bfcl/run_ab.py
+++ b/scripts/bfcl/run_ab.py
@@ -51,6 +51,7 @@ class Arm:
     port: str = ""
     project_root: Path = field(default_factory=Path)
     scores: dict[str, float] = field(default_factory=dict)
+    counts: dict[str, int] = field(default_factory=dict)  # per-category test-case count
 
 
 def parse_arm(spec: str, project_root: Path) -> Arm:
@@ -122,7 +123,7 @@ def run_bfcl(
         env,
         f"[{arm.name}] evaluate",
     )
-    arm.scores = parse_scores(arm.project_root, model, categories)
+    arm.scores, arm.counts = parse_scores(arm.project_root, model, categories)
 
 
 def _run(cmd: list[str], env: dict[str, str], label: str) -> None:
@@ -132,26 +133,31 @@ def _run(cmd: list[str], env: dict[str, str], label: str) -> None:
         print(f"WARNING: {label} exited {proc.returncode}", file=sys.stderr)
 
 
-def parse_scores(project_root: Path, model: str, categories: list[str]) -> dict[str, float]:
-    """Extract per-category accuracy from BFCL's score output.
+def parse_scores(
+    project_root: Path, model: str, categories: list[str]
+) -> tuple[dict[str, float], dict[str, int]]:
+    """Extract per-category accuracy and test-case count from BFCL's score output.
 
     BFCL writes ``<root>/score/<sanitized-model>/<category>_score.json`` whose
-    FIRST line is a summary dict containing ``accuracy``. We glob for the model
-    dir (sanitization differs across versions) and read each category's summary.
+    FIRST line is a summary dict ``{"accuracy", "correct_count", "total_count"}``.
+    We glob for the model dir (sanitization differs across versions) and read each
+    category's summary. ``total_count`` is what weights the weighted overall.
     """
     score_root = project_root / "score"
-    out: dict[str, float] = {}
+    scores: dict[str, float] = {}
+    counts: dict[str, int] = {}
     if not score_root.is_dir():
         print(f"WARNING: no score dir at {score_root}", file=sys.stderr)
-        return out
+        return scores, counts
     for cat in categories:
-        acc = _find_category_accuracy(score_root, cat)
-        if acc is not None:
-            out[cat] = acc
-    return out
+        summary = _find_category_summary(score_root, cat)
+        if summary is not None:
+            scores[cat] = summary[0]
+            counts[cat] = summary[1]
+    return scores, counts
 
 
-def _find_category_accuracy(score_root: Path, category: str) -> float | None:
+def _find_category_summary(score_root: Path, category: str) -> tuple[float, int] | None:
     # BFCL nests scores as <model>/<section>/BFCL_v4_<category>_score.json, so
     # match a trailing-wildcard pattern (the BFCL_v4_ prefix varies by version).
     for path in score_root.rglob(f"*{category}_score.json"):
@@ -160,9 +166,9 @@ def _find_category_accuracy(score_root: Path, category: str) -> float | None:
             summary = json.loads(first)
         except (OSError, ValueError, IndexError):
             continue
-        for key in ("accuracy", "acc", "score"):
-            if key in summary:
-                return float(summary[key])
+        acc = next((summary[k] for k in ("accuracy", "acc", "score") if k in summary), None)
+        if acc is not None:
+            return float(acc), int(summary.get("total_count", 0))
     return None
 
 
@@ -173,15 +179,31 @@ def build_report(baseline: Arm, candidate: Arm, categories: list[str]) -> tuple[
         b = baseline.scores.get(cat)
         c = candidate.scores.get(cat)
         delta = (c - b) if (b is not None and c is not None) else None
-        rows.append({"category": cat, "baseline": b, "candidate": c, "delta": delta})
+        # Per-category count is the same on both arms (same test set); fall back
+        # across arms in case one didn't score the category.
+        n = baseline.counts.get(cat) or candidate.counts.get(cat)
+        rows.append({"category": cat, "baseline": b, "candidate": c, "delta": delta, "count": n})
 
-    b_vals = [r["baseline"] for r in rows if r["baseline"] is not None]
-    c_vals = [r["candidate"] for r in rows if r["candidate"] is not None]
-    b_overall = sum(b_vals) / len(b_vals) if b_vals else None
-    c_overall = sum(c_vals) / len(c_vals) if c_vals else None
-    overall_delta = (
-        (c_overall - b_overall) if (b_overall is not None and c_overall is not None) else None
-    )
+    def unweighted(key: str) -> float | None:
+        # macro average: mean of per-category accuracies (BFCL calculate_unweighted_accuracy)
+        vals = [r[key] for r in rows if r[key] is not None]
+        return sum(vals) / len(vals) if vals else None
+
+    def weighted(key: str) -> float | None:
+        # micro average: weighted by each category's test-case count
+        # (BFCL calculate_weighted_accuracy = total correct / total cases)
+        num = sum(r[key] * r["count"] for r in rows if r[key] is not None and r["count"])
+        den = sum(r["count"] for r in rows if r[key] is not None and r["count"])
+        return num / den if den else None
+
+    def delta_of(fn) -> float | None:
+        b, c = fn("baseline"), fn("candidate")
+        return (c - b) if (b is not None and c is not None) else None
+
+    b_overall, c_overall = unweighted("baseline"), unweighted("candidate")
+    overall_delta = delta_of(unweighted)
+    b_weighted, c_weighted = weighted("baseline"), weighted("candidate")
+    weighted_delta = delta_of(weighted)
 
     def fmt(x: float | None) -> str:
         return "—" if x is None else f"{x * 100:.2f}"
@@ -192,21 +214,29 @@ def build_report(baseline: Arm, candidate: Arm, categories: list[str]) -> tuple[
     lines = [
         f"# BFCL A/B — {candidate.name} (candidate) vs {baseline.name} (baseline)",
         "",
-        f"| category | {baseline.name} | {candidate.name} | Δ (cand−base) |",
-        "|---|---|---|---|",
+        f"| category | n | {baseline.name} | {candidate.name} | Δ (cand−base) |",
+        "|---|---|---|---|---|",
     ]
     for r in rows:
+        n = "—" if r["count"] is None else str(r["count"])
         lines.append(
-            f"| {r['category']} | {fmt(r['baseline'])} | {fmt(r['candidate'])} | {fmt_d(r['delta'])} |"
+            f"| {r['category']} | {n} | {fmt(r['baseline'])} | {fmt(r['candidate'])} | {fmt_d(r['delta'])} |"
         )
-    lines.append(
-        f"| **overall (unweighted)** | **{fmt(b_overall)}** | **{fmt(c_overall)}** | **{fmt_d(overall_delta)}** |"
-    )
+    n_total = sum(r["count"] for r in rows if r["count"]) or "—"
+
+    def overall_row(label: str, b: float | None, c: float | None, d: float | None) -> str:
+        return f"| **{label}** | {n_total} | **{fmt(b)}** | **{fmt(c)}** | **{fmt_d(d)}** |"
+
+    lines.append(overall_row("overall (unweighted)", b_overall, c_overall, overall_delta))
+    lines.append(overall_row("overall (weighted by n)", b_weighted, c_weighted, weighted_delta))
     lines.append("")
     lines.append(
         "_Scores are % accuracy (official BFCL, FC mode). Same model, engine, "
         "checkpoint and sampling on both arms — the only difference is the "
-        "frontend, so Δ is attributable to the tokenization+parsing layer._"
+        "frontend, so Δ is attributable to the tokenization+parsing layer. "
+        "Unweighted = mean of category accuracies (macro); weighted = by test-case "
+        "count n (micro = total correct / total cases), matching BFCL's "
+        "calculate_unweighted/weighted_accuracy._"
     )
 
     payload = {
@@ -214,14 +244,21 @@ def build_report(baseline: Arm, candidate: Arm, categories: list[str]) -> tuple[
             "name": baseline.name,
             "base_url": baseline.base_url,
             "scores": baseline.scores,
+            "counts": baseline.counts,
         },
         "candidate": {
             "name": candidate.name,
             "base_url": candidate.base_url,
             "scores": candidate.scores,
+            "counts": candidate.counts,
         },
         "per_category": rows,
         "overall": {"baseline": b_overall, "candidate": c_overall, "delta": overall_delta},
+        "overall_weighted": {
+            "baseline": b_weighted,
+            "candidate": c_weighted,
+            "delta": weighted_delta,
+        },
     }
     return "\n".join(lines), payload
 
@@ -233,16 +270,29 @@ def save_scores(arm: Arm, path: Path) -> None:
     arms cannot run at once, so each is scored on its own and diffed afterwards.
     """
     path.write_text(
-        json.dumps({"name": arm.name, "base_url": arm.base_url, "scores": arm.scores}, indent=2)
+        json.dumps(
+            {
+                "name": arm.name,
+                "base_url": arm.base_url,
+                "scores": arm.scores,
+                "counts": arm.counts,
+            },
+            indent=2,
+        )
         + "\n",
         encoding="utf-8",
     )
 
 
 def load_scores(path: Path) -> Arm:
-    """Rebuild an Arm (name + scores) from a file written by save_scores."""
+    """Rebuild an Arm (name + scores + counts) from a file written by save_scores."""
     data = json.loads(path.read_text(encoding="utf-8"))
-    return Arm(name=data["name"], base_url=data.get("base_url", ""), scores=data["scores"])
+    return Arm(
+        name=data["name"],
+        base_url=data.get("base_url", ""),
+        scores=data["scores"],
+        counts=data.get("counts", {}),
+    )
 
 
 def write_report_and_gate(

--- a/scripts/bfcl/run_ab.py
+++ b/scripts/bfcl/run_ab.py
@@ -84,6 +84,11 @@ def run_bfcl(
     arm.project_root.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
     env["BFCL_PROJECT_ROOT"] = str(arm.project_root)
+    # OpenAICompletionsHandler (the FC handler we register the models with) talks to
+    # this arm's OpenAI-compatible endpoint via OPENAI_BASE_URL. LOCAL_SERVER_* is
+    # kept for any model bfcl ships with a local OSS handler instead.
+    env["OPENAI_BASE_URL"] = f"http://{arm.host}:{arm.port}/v1"
+    env.setdefault("OPENAI_API_KEY", "EMPTY")
     env["LOCAL_SERVER_ENDPOINT"] = arm.host
     env["LOCAL_SERVER_PORT"] = arm.port
     # NOTE: we do NOT force HF_HUB_OFFLINE. With the model cached, bfcl runs fine
@@ -221,19 +226,62 @@ def build_report(baseline: Arm, candidate: Arm, categories: list[str]) -> tuple[
     return "\n".join(lines), payload
 
 
+def save_scores(arm: Arm, path: Path) -> None:
+    """Persist one arm's per-category scores so a later --diff can compare them.
+
+    Used by the sequential mode: when a model needs the whole node (TP=8) the two
+    arms cannot run at once, so each is scored on its own and diffed afterwards.
+    """
+    path.write_text(
+        json.dumps({"name": arm.name, "base_url": arm.base_url, "scores": arm.scores}, indent=2)
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_scores(path: Path) -> Arm:
+    """Rebuild an Arm (name + scores) from a file written by save_scores."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return Arm(name=data["name"], base_url=data.get("base_url", ""), scores=data["scores"])
+
+
+def write_report_and_gate(
+    baseline: Arm, candidate: Arm, categories: list[str], args: argparse.Namespace
+) -> int:
+    """Emit the markdown + JSON comparison and apply the regression gate."""
+    report_md, payload = build_report(baseline, candidate, categories)
+    print("\n" + report_md)
+    if args.out:
+        args.out.write_text(report_md + "\n", encoding="utf-8")
+    if args.json_out:
+        args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    overall = payload["overall"]
+    if overall["delta"] is not None and overall["delta"] < -args.tolerance:
+        print(
+            f"\nREGRESSION: {candidate.name} overall is {overall['delta'] * 100:.2f}pp "
+            f"below {baseline.name} (tolerance {args.tolerance * 100:.2f}pp)",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
 def main() -> int:
     p = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    p.add_argument(
-        "--baseline", required=True, help="name=base_url, e.g. vllm=http://127.0.0.1:31199"
-    )
-    p.add_argument(
-        "--candidate", required=True, help="name=base_url, e.g. smg=http://127.0.0.1:31200"
-    )
+    # Concurrent mode (both arms serving at once): pass both.
+    p.add_argument("--baseline", help="name=base_url, e.g. vllm=http://127.0.0.1:31199")
+    p.add_argument("--candidate", help="name=base_url, e.g. smg=http://127.0.0.1:31200")
+    # Sequential mode (one arm owns the whole node, TP=8): score one live arm now,
+    # then later diff the two saved score files.
+    p.add_argument("--score-arm", help="name=base_url of the single live arm to score")
+    p.add_argument("--scores-out", type=Path, help="write this arm's scores JSON here")
+    p.add_argument("--diff-baseline", type=Path, help="baseline scores JSON (from --scores-out)")
+    p.add_argument("--diff-candidate", type=Path, help="candidate scores JSON (from --scores-out)")
     p.add_argument(
         "--bfcl-model",
-        required=True,
         help="BFCL model handler name, e.g. Qwen/Qwen3-4B-Instruct-2507-FC",
     )
     p.add_argument(
@@ -259,9 +307,38 @@ def main() -> int:
     args = p.parse_args()
 
     categories = [c.strip() for c in args.categories.split(",") if c.strip()]
+
+    # Mode: diff two previously-saved score files (sequential mode, final step).
+    if args.diff_baseline or args.diff_candidate:
+        if not (args.diff_baseline and args.diff_candidate):
+            p.error("--diff-baseline and --diff-candidate must be given together")
+        return write_report_and_gate(
+            load_scores(args.diff_baseline), load_scores(args.diff_candidate), categories, args
+        )
+
+    # Mode: score a single live arm and persist its scores (sequential mode, per arm).
+    if args.score_arm:
+        if not (args.bfcl_model and args.scores_out):
+            p.error("--score-arm requires --bfcl-model and --scores-out")
+        arm = parse_arm(args.score_arm, args.project_root)
+        run_bfcl(
+            arm,
+            bfcl=args.bfcl,
+            model=args.bfcl_model,
+            categories=categories,
+            num_threads=args.num_threads,
+            temperature=args.temperature,
+            skip_generate=args.skip_generate,
+        )
+        save_scores(arm, args.scores_out)
+        print(f"[{arm.name}] scores -> {args.scores_out}: {arm.scores}")
+        return 0
+
+    # Mode: concurrent A/B — both arms serving at once.
+    if not (args.baseline and args.candidate and args.bfcl_model):
+        p.error("concurrent mode requires --baseline, --candidate and --bfcl-model")
     baseline = parse_arm(args.baseline, args.project_root)
     candidate = parse_arm(args.candidate, args.project_root)
-
     for arm in (baseline, candidate):
         run_bfcl(
             arm,
@@ -272,23 +349,7 @@ def main() -> int:
             temperature=args.temperature,
             skip_generate=args.skip_generate,
         )
-
-    report_md, payload = build_report(baseline, candidate, categories)
-    print("\n" + report_md)
-    if args.out:
-        args.out.write_text(report_md + "\n", encoding="utf-8")
-    if args.json_out:
-        args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-
-    overall = payload["overall"]
-    if overall["delta"] is not None and overall["delta"] < -args.tolerance:
-        print(
-            f"\nREGRESSION: {candidate.name} overall is {overall['delta'] * 100:.2f}pp "
-            f"below {baseline.name} (tolerance {args.tolerance * 100:.2f}pp)",
-            file=sys.stderr,
-        )
-        return 1
-    return 0
+    return write_report_and_gate(baseline, candidate, categories, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

### Problem

Follow-ups after the multi-model BFCL A/B matrix (#1791) landed, from real nightly failures on the Blackwell (B200) runner:

1. **Context length.** The `multi_turn` categories emit ~16.4k–18.4k-token prompts, but `max_model_len` was capped at 16384, so DeepSeek-V4/MiniMax 400'd ("decoder prompt longer than the maximum model length") → `BFCL_AB_REGRESSION=1`.
2. **bfcl handler crash.** New SKUs were registered by cloning bfcl's *local* `QwenFCHandler`, which in multi-turn re-serializes prior tool calls into a text prompt assuming a `{"name","arguments"}` shape. DeepSeek-V4 (`KeyError: 'arguments'`) and MiniMax-M2 (`KeyError: 'name'`) emit a different tool-call JSON, so those cases errored and the report didn't render (Kimi's shape matched, so it did). The local handler also *bypasses the server parser* in multi-turn.

### Solution

1. **`max_model_len: 32768` for all legs.** Weights already fit at each leg's TP and the extra KV for a 32k window is only a few GB/sequence, so the larger context needs no extra GPUs — arms stay concurrent (verified TP=4 on B200, TP=2 on H100).
2. **Register SKUs with `OpenAICompletionsHandler`** (generic OpenAI Chat Completions FC): sends native `tools`, reads the server's parsed `tool_calls` (server parser stays on the critical path), and re-inserts multi-turn tool calls as proper OpenAI messages — no text re-serialization, no `KeyError`. `run_ab.py` points bfcl at each arm via `OPENAI_BASE_URL`.

Also adds a **sequential `arm_mode`** to `run_ab.py` (`--score-arm` + `--diff-baseline/--diff-candidate`) and the workflow, kept **in reserve** (no leg uses it) — a one-line matrix flip runs a model's two arms one-at-a-time at TP=8 if 32k ever OOMs at TP=4.

## Changes

- `.github/workflows/nightly-bfcl.yml` — `max_model_len 32768` on every leg; per-leg `arm_mode` (all `concurrent`) with a sequential branch in reserve.
- `scripts/bfcl/run_ab.py` — `OPENAI_BASE_URL` per arm; score-one-arm + diff-two-results modes.
- `scripts/bfcl/register_bfcl_model.py` — default handler `QwenFCHandler` → `OpenAICompletionsHandler`.
- `scripts/bfcl/README.md` — documents context bump, handler choice, and the concurrent/sequential modes.

## Test Plan

- `ruff` clean; `actionlint` clean; matrix emits all five legs with `max_model_len 32768`; `run_ab.py` diff-mode verified end-to-end; register insert dry-tested against bfcl-eval `2026.3.23` `model_config.py` (`OpenAICompletionsHandler`, `is_fc_model=True`).
- Full validation is the next scheduled/dispatch nightly on the B200 runner.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced nightly workflow dispatch with selective leg execution, override options for models/handlers and tool-call parsers, and a dynamically generated job matrix (including updated 32k-ready run settings and arm_mode).
  * Expanded BFCL A/B scoring with saved-result persistence, diff mode, single-arm scoring, and concurrent vs sequential arm execution; reports now include both macro and count-weighted (micro) accuracy plus a regression gate.
* **Bug Fixes**
  * Improved nightly model staging to skip downloads when cached, and improved arm launch serialization to avoid lock-related deadlocks.
* **Documentation**
  * Refined BFCL nightly configuration and debugging guidance, including new scoring semantics and common gotchas.
* **Chores**
  * Updated `*-FC` model registration defaults/behavior to use an OpenAI-compatible handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->