### PR TITLE
fix(grpc): return content:null instead of whitespace when emitting tool calls (OpenAI-compat)

### DIFF
--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -193,11 +193,9 @@ impl ResponseProcessor {
         // Step 5: Build ChatCompletionMessage (proper response message type)
         let chat_message = ChatCompletionMessage {
             role: "assistant".to_string(),
-            content: if processed_text.is_empty() {
-                None
-            } else {
-                Some(processed_text)
-            },
+            // Whitespace-only residual (e.g. "\n\n" between </think> and <tool_call>)
+            // must be None, not Some("\n\n") — see normalize_assistant_content.
+            content: normalize_assistant_content(processed_text),
             tool_calls,
             reasoning_content: reasoning_text,
         };
@@ -687,8 +685,8 @@ impl ResponseProcessor {
             });
         }
 
-        // Text block (if non-empty)
-        if !processed_text.is_empty() {
+        // Text block (only if non-whitespace; a bare "\n\n" residual must not become one).
+        if !processed_text.trim().is_empty() {
             content_blocks.push(messages::ContentBlock::Text {
                 text: processed_text,
                 citations: None,
@@ -873,5 +871,31 @@ impl ResponseProcessor {
             usage: Some(Usage::from_counts(total_prompt, total_completion)),
             system_fingerprint: dispatch.weight_version.clone(),
         })
+    }
+}
+
+/// Residual assistant text → OpenAI `content`. Whitespace-only (the `"\n\n"` left
+/// after reasoning + tool-call extraction) becomes `None`, not `Some("\n\n")`, which
+/// would otherwise diverge multi-turn conversations. Real content is kept verbatim.
+fn normalize_assistant_content(text: String) -> Option<String> {
+    if text.trim().is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+#[cfg(test)]
+mod content_normalization_tests {
+    use super::normalize_assistant_content;
+
+    #[test]
+    fn whitespace_only_is_none_real_text_kept_verbatim() {
+        assert_eq!(normalize_assistant_content("\n\n".to_string()), None);
+        assert_eq!(normalize_assistant_content("  \t".to_string()), None);
+        assert_eq!(
+            normalize_assistant_content("\n\nDone.".to_string()),
+            Some("\n\nDone.".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Description

> **Scope note:** This is a small **OpenAI-compatibility / correctness** fix. It is **not** the fix for the qwen/deepseek `multi_turn` BFCL regression — see "What this does NOT fix" below. Originally filed believing it would close that gap; a deeper audit showed otherwise, so it's re-scoped here on its own merits.

### Problem

In the non-streaming chat path, the assistant `content` field was built with a bare emptiness check:

```rust
content: if processed_text.is_empty() { None } else { Some(processed_text) },
```

`processed_text` is what remains **after** reasoning (`<think>…</think>`) and tool-call extraction. For a typical reasoning-model FC response — `"<think>…</think>\n\n<tool_call>…</tool_call>"` — the residual is `"\n\n"`, which is **not** `.is_empty()`, so SMG returns `content: "\n\n"`.

The standard behavior (verified against the live OpenAI API) is `content: null` when `tool_calls` are present:

```
arguments = '{"location": "Beijing"}'
content    = None
```

So SMG emitting `content: "\n\n"` is a small deviation from the OpenAI contract that other engines follow.

### Solution

Normalize whitespace-only residual text to `None` (real content preserved verbatim) in both response builders — the OpenAI chat path and the Anthropic Messages text-block path.

## What this does NOT fix (audit result)

This does **not** close the Qwen3.6 / DeepSeek-V4 `multi_turn` gap in the nightly BFCL A/B. That gap is driven by **frontend token-parity differences** between the two arms (SMG renders the chat template + tokenizes; pure vLLM does it internally), not by content formatting:

- In **~⅓ of cases the model diverges on turn 0, step 0** — the identical first prompt, before any assistant `content` exists (e.g. vLLM `cd "/temp"` vs SMG `cd "temp"`; vLLM `[cd, ls]` vs SMG `[cd]`). Content normalization cannot affect the first generation.
- The divergent `content` that appears in later turns is **prose** ("I've navigated to the …"), which this PR does **not** strip (only whitespace-only is nulled).

The real follow-up is frontend parity (chat-template rendering, tokenization, tool-arg serialization). Tracked separately; do **not** expect this PR to move nightly multi_turn numbers.

## Changes

- `model_gateway/src/routers/grpc/regular/processor.rs`:
  - Add `normalize_assistant_content()` (`trim().is_empty()` → `None`), used for the OpenAI chat `content`.
  - Gate the Anthropic Messages `Text` block on `!processed_text.trim().is_empty()`.
  - Unit test for whitespace-only vs real-content cases.

## Test Plan

- `cargo test -p smg content_normalization` passes.
- `cargo +nightly fmt` applied; no new clippy findings on the change.
- This is a correctness/standards-alignment change; behavior is covered by the unit test. It is explicitly not expected to change BFCL multi_turn scores.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
