### PR TITLE
fix(e2e): pin trtllm Open MPI to loopback to fix flaky 1-GPU startup

### DIFF
--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -397,12 +397,21 @@ class Worker:
                 self.nixl_port = get_open_port()
                 env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(self.nixl_port)
 
-        # TRT-LLM multi-GPU needs NCCL tuning for CI compatibility
-        if self.engine == "trtllm" and len(self.gpu_ids) > 1:
-            env["NCCL_DEBUG"] = "WARN"
-            env["NCCL_IB_DISABLE"] = "1"
-            env["NCCL_SHM_DISABLE"] = "1"
-            env["TLLM_DISABLE_ALLREDUCE_AUTOTUNE"] = "1"
+        if self.engine == "trtllm":
+            # TRT-LLM bootstraps workers over Open MPI even at TP=1. On CI pods the
+            # MPI OOB/BTL can pick the routable pod interface and flakily fail to
+            # TCP-connect to a peer ("connect() to <pod-ip>:1025 failed"), so the
+            # engine never starts and the health check times out. All ranks are
+            # co-located on one node, so pin MPI to loopback. setdefault keeps any
+            # explicit override. Applies at TP=1 too (where the flake was seen).
+            env.setdefault("OMPI_MCA_oob_tcp_if_include", "lo")
+            env.setdefault("OMPI_MCA_btl_tcp_if_include", "lo")
+            # Multi-GPU additionally needs NCCL tuning for CI compatibility.
+            if len(self.gpu_ids) > 1:
+                env["NCCL_DEBUG"] = "WARN"
+                env["NCCL_IB_DISABLE"] = "1"
+                env["NCCL_SHM_DISABLE"] = "1"
+                env["TLLM_DISABLE_ALLREDUCE_AUTOTUNE"] = "1"
 
         return env
 


### PR DESCRIPTION
## Description

### Problem

The `e2e-1gpu-chat (trtllm)` CI leg flakes: the TensorRT-LLM worker never becomes healthy and the test session aborts after 3 retries:

```
TimeoutError: gRPC worker Qwen/Qwen3-30B-A3B on port 39649 did not become healthy within 300s
! Engine trtllm failed to start workers 3 times — aborting test session !
```

The worker log shows the real cause:

```
WARNING: Open MPI failed to TCP connect to a peer MPI process.
  Message: connect() to 10.227.32.254:1025 failed
```

TRT-LLM bootstraps its workers over Open MPI **even at TP=1**. On CI pods, MPI's OOB/BTL picks the routable pod interface (`10.227.x`) and intermittently fails to TCP-connect to a peer, so the engine never starts → health check times out. Retries don't help because the interface selection is deterministic per run. The harness only set network env for `gpu_ids > 1`, so the 1-GPU trtllm leg had no protection.

### Solution

Pin Open MPI to **loopback** for all trtllm workers (all ranks are co-located on a single node), via `OMPI_MCA_oob_tcp_if_include=lo` and `OMPI_MCA_btl_tcp_if_include=lo`. `setdefault` so an explicit override still wins. The existing multi-GPU NCCL tuning is preserved.

## Changes

- `e2e_test/infra/worker.py` — `_build_env`: apply loopback MPI pinning for `engine == "trtllm"` (including TP=1), keep NCCL tuning under `gpu_ids > 1`.

## Test Plan

- `ruff check` / `ruff format --check` pass.
- Validation is CI: the `e2e-1gpu-chat (trtllm)` leg should start the worker reliably and stop timing out.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced TRT-LLM test infrastructure configuration to improve multi-GPU worker handling and network interface setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->