### PR TITLE
chore(ci): disable BFCL PR trigger, make nightly benchmark weekly

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -2,7 +2,7 @@ name: Nightly Benchmark
 
 on:
   schedule:
-    - cron: '0 8 * * *'
+    - cron: '0 7 * * 0' # Sundays 00:00 PDT (07:00 UTC = midnight Pacific/PDT)
   workflow_dispatch:
     inputs:
       models:

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -12,7 +12,7 @@ name: Nightly BFCL
 
 on:
   schedule:
-    - cron: "17 7 * * *" # 00:17 PDT (07:00 UTC = midnight Pacific/PDT)
+    - cron: "17 7 * * *" # 07:17 UTC = 00:17 PDT
   # PR sanity: only when the BFCL pipeline itself changes. Runs a quick non-live
   # subset so the A/B is exercised end-to-end (engine, FC mode, parser, scoring)
   # before merge — confidence the pipeline works, not a statistical result.

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -12,14 +12,14 @@ name: Nightly BFCL
 
 on:
   schedule:
-    - cron: "17 7 * * *" # 00:17 PDT (07:00 UTC = midnight Pacific/PDT); off-round, distinct from nightly-benchmark (0 8) / mlx (17 9)
+    - cron: "17 7 * * *" # 00:17 PDT (07:00 UTC = midnight Pacific/PDT)
   # PR sanity: only when the BFCL pipeline itself changes. Runs a quick non-live
   # subset so the A/B is exercised end-to-end (engine, FC mode, parser, scoring)
   # before merge — confidence the pipeline works, not a statistical result.
-  pull_request:
-    paths:
-      - "scripts/bfcl/**"
-      - ".github/workflows/nightly-bfcl.yml"
+  # pull_request:
+  #   paths:
+  #     - "scripts/bfcl/**"
+  #     - ".github/workflows/nightly-bfcl.yml"
   workflow_dispatch:
     inputs:
       only:


### PR DESCRIPTION
## Description

### Problem

The Nightly BFCL workflow runs on every PR that touches the BFCL pipeline, and the Nightly Benchmark runs daily — more often than needed.

### Solution

Disable the BFCL PR trigger and reduce the benchmark to a weekly cadence.

## Changes

- `nightly-bfcl.yml`: comment out the `pull_request` trigger (kept inline for easy re-enable) so BFCL no longer runs on PRs. PR-conditional logic (`cancel-in-progress`, `CATEGORIES`) is left intact so it works if the trigger is restored.
- `nightly-benchmark.yml`: change schedule from daily (`0 8 * * *`) to Sundays at midnight PDT (`0 7 * * 0`).

## Test Plan

No runtime behavior change — CI schedule/trigger config only. YAML validated by GitHub Actions on push.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the nightly benchmark workflow schedule to run weekly on Sundays at 07:00 UTC (instead of daily at 08:00 UTC).
  * Adjusted the BFCL workflow triggers by disabling the automated pull request path-based subset run; scheduled and manual triggers remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->