### PR TITLE
feat(parser): route GLM-5.x to existing GLM-4.7/4.5 parsers

### DIFF
--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -191,6 +191,7 @@ impl ParserFactory {
         registry.register_pattern("qwen", "qwen3");
         registry.register_pattern("glm45", "glm45");
         registry.register_pattern("glm47", "glm45"); // glm47 uses same reasoning format as glm45
+        registry.register_pattern("glm-5", "glm45"); // GLM-5.x reuse glm45 reasoning format
         registry.register_pattern("kimi-k2-thinking", "kimi_thinking");
         registry.register_pattern("kimi-k2.5", "kimi_k25");
         registry.register_pattern("kimi", "kimi"); // legacy: Kimi-K2-Instruct with unicode tokens
@@ -305,6 +306,8 @@ mod tests {
         let factory = ParserFactory::new();
         let glm45 = factory.create("glm45-v2");
         assert_eq!(glm45.model_type(), "glm45");
+        // GLM-5.x reuse the glm45 reasoning parser.
+        assert_eq!(factory.create("glm-5.2-fp8").model_type(), "glm45");
     }
 
     #[test]

--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -390,6 +390,7 @@ impl ParserFactory {
         registry.map_model("glm-4.5*", "glm45_moe");
         registry.map_model("glm-4.6*", "glm45_moe");
         registry.map_model("glm-4.7*", "glm47_moe");
+        registry.map_model("glm-5*", "glm47_moe");
         registry.map_model("glm-*", "json");
 
         // Step3 models

--- a/crates/tool_parser/tests/tool_parser_glm47_moe.rs
+++ b/crates/tool_parser/tests/tool_parser_glm47_moe.rs
@@ -2,7 +2,7 @@
 mod common;
 
 use common::create_test_tools;
-use tool_parser::{Glm4MoeParser, ToolParser};
+use tool_parser::{Glm4MoeParser, ParserFactory, ToolParser};
 
 #[tokio::test]
 async fn test_glm47_complete_parsing() {
@@ -98,6 +98,23 @@ fn test_glm47_format_detection() {
     assert!(!parser.has_tool_markers("[TOOL_CALLS]"));
     assert!(!parser.has_tool_markers("<｜tool▁calls▁begin｜>"));
     assert!(!parser.has_tool_markers("plain text"));
+}
+
+#[tokio::test]
+async fn test_glm5_routes_to_glm47_moe() {
+    // GLM-5.x must route to glm47_moe, not the catch-all glm-* -> json mapping.
+    let factory = ParserFactory::new();
+    let input =
+        r"<tool_call>get_weather<arg_key>city</arg_key><arg_value>Beijing</arg_value></tool_call>";
+    for model in ["glm-5", "glm-5.1", "glm-5.2", "glm-5.2-fp8"] {
+        let parser = factory
+            .registry()
+            .create_for_model(model)
+            .unwrap_or_else(|| panic!("no parser for {model}"));
+        let (_, tools) = parser.parse_complete(input).await.unwrap();
+        assert_eq!(tools.len(), 1, "{model} should extract one tool call");
+        assert_eq!(tools[0].function.name, "get_weather", "{model}");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

SMG had no routing for GLM-5/5.1/5.2 model IDs. A model ID like `glm-5.2-fp8` fell through the tool-parser catch-all `glm-*` -> `json` (which cannot parse GLM's `<arg_key>`/`<arg_value>` XML, silently breaking tool calls), and matched no reasoning pattern (falling back to the default parser, so reasoning was not extracted).

### Solution

GLM-5.x reuse existing formats — no new parser code needed. They use the GLM-4.7 tool-call format (`glm47_moe` / `Glm4MoeParser::glm47()`) and the GLM-4.5 `<think>`/`</think>` reasoning format (`glm45`). This mirrors vLLM's published serving command for GLM-5.2: `--tool-call-parser glm47 --reasoning-parser glm45`. GLM-5.2 swapped `enable_thinking` for a `reasoning_effort` field, but the emitted delimiters are unchanged, so the parsers are unaffected.

## Changes

- `tool_parser/src/factory.rs`: map `glm-5*` -> `glm47_moe` (longest-prefix-wins beats the `glm-*` -> `json` catch-all).
- `reasoning_parser/src/factory.rs`: register substring pattern `glm-5` -> `glm45`.
- Tests: integration test asserting `glm-5{,.1,.2,.2-fp8}` route to `glm47_moe` and extract a tool call; one-line assertion in the reasoning factory test.

## Test Plan

- `cargo test -p tool-parser -p reasoning-parser` — all suites pass, including the new `test_glm5_routes_to_glm47_moe`.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy -p tool-parser -p reasoning-parser --all-targets --all-features -- -D warnings` — clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GLM-5 model variants to use the appropriate existing reasoning and tool-parsing behavior.
* **Tests**
  * Added coverage to confirm GLM-5 and GLM-5.x model IDs route to the correct parsers and correctly extract the expected tool call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->