### PR TITLE
ci(bfcl): add GLM-5.2-FP8 nightly leg (TP=8 sequential, whole node)

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -174,14 +174,10 @@ jobs:
                # Generous startup: 1T MoE at TP=4 needs minutes for load+compile+quant (420s timed out).
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
                "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "32768"},
-              # GLM-5.2-FP8 (~744GB FP8 weights) does NOT fit a TP=4 half-node — it needs
-              # the whole 8-GPU node, so unlike the concurrent legs above it runs SEQUENTIAL:
-              # arm A on all 8 GPUs, torn down, then arm B on all 8 (gpu_b unused). vLLM's
-              # GLM-5.2 recipe serves it with TP=8 + glm47/glm45 parsers; SMG's tool parser
-              # is glm47_moe. --kv-cache-dtype fp8_e4m3 per the B200 recipe (DeepSeek-style
-              # sparse-attention fp8 path). MTP speculative decoding is omitted — perf-only,
-              # and the A/B isolates parsing. Served name is the org-prefixed HF id, which
-              # SMG auto-detect won't match, so smg_tool is passed explicitly.
+              # GLM-5.2-FP8 (~744GB) needs the whole 8-GPU node, so it runs SEQUENTIAL
+              # (arm A then arm B; gpu_b unused) unlike the concurrent half-node legs.
+              # vLLM recipe: TP=8, glm47/glm45, --kv-cache-dtype fp8_e4m3. SMG passes
+              # glm47_moe explicitly (org-prefixed served name won't auto-detect).
               {"name": "glm-5.2", "runner": "blackwell", "tp": 8,
                "gpu_a": "0,1,2,3,4,5,6,7", "gpu_b": "",  # sequential: arm B reuses GPU_A (whole node)
                "model": "zai-org/GLM-5.2-FP8", "bfcl_model": "zai-org/GLM-5.2-FP8-FC",

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -184,7 +184,7 @@ jobs:
                "vllm_tool": "glm47", "vllm_reason": "glm45",
                "smg_tool": "glm47_moe", "smg_reason": "glm45",
                # FP8 load + DeepGEMM warmup on the largest leg: generous startup ceiling.
-               "vllm_extra": "--kv-cache-dtype fp8_e4m3", "gpu_mem": "0.90", "startup_timeout": "3000",
+               "vllm_extra": "--trust-remote-code --kv-cache-dtype fp8_e4m3", "gpu_mem": "0.90", "startup_timeout": "3000",
                "model_cache": "/raid/models", "arm_mode": "sequential", "max_model_len": "32768"},
           ]
           only = os.environ.get("ONLY", "")

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
     inputs:
       only:
-        description: "Run only this matrix leg (qwen3.6|gpt-oss|deepseek-v4|minimax-m2.7|kimi-k2.6); empty = all"
+        description: "Run only this matrix leg (qwen3.6|gpt-oss|deepseek-v4|minimax-m2.7|kimi-k2.6|glm-5.2); empty = all"
         required: false
         default: ""
       model:
@@ -64,8 +64,9 @@ env:
 
 jobs:
   # Build the smg wheel once (mirrors nightly-benchmark.yml build-wheel + cache).
+  # CPU-only work (Rust/maturin compile) — no GPU needed, so don't occupy a GPU runner.
   build-wheel:
-    runs-on: k8s-runner-gpu
+    runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:
@@ -173,6 +174,22 @@ jobs:
                # Generous startup: 1T MoE at TP=4 needs minutes for load+compile+quant (420s timed out).
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
                "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "32768"},
+              # GLM-5.2-FP8 (~744GB FP8 weights) does NOT fit a TP=4 half-node — it needs
+              # the whole 8-GPU node, so unlike the concurrent legs above it runs SEQUENTIAL:
+              # arm A on all 8 GPUs, torn down, then arm B on all 8 (gpu_b unused). vLLM's
+              # GLM-5.2 recipe serves it with TP=8 + glm47/glm45 parsers; SMG's tool parser
+              # is glm47_moe. --kv-cache-dtype fp8_e4m3 per the B200 recipe (DeepSeek-style
+              # sparse-attention fp8 path). MTP speculative decoding is omitted — perf-only,
+              # and the A/B isolates parsing. Served name is the org-prefixed HF id, which
+              # SMG auto-detect won't match, so smg_tool is passed explicitly.
+              {"name": "glm-5.2", "runner": "blackwell", "tp": 8,
+               "gpu_a": "0,1,2,3,4,5,6,7", "gpu_b": "",  # sequential: arm B reuses GPU_A (whole node)
+               "model": "zai-org/GLM-5.2-FP8", "bfcl_model": "zai-org/GLM-5.2-FP8-FC",
+               "vllm_tool": "glm47", "vllm_reason": "glm45",
+               "smg_tool": "glm47_moe", "smg_reason": "glm45",
+               # FP8 load + DeepGEMM warmup on the largest leg: generous startup ceiling.
+               "vllm_extra": "--kv-cache-dtype fp8_e4m3", "gpu_mem": "0.90", "startup_timeout": "3000",
+               "model_cache": "/raid/models", "arm_mode": "sequential", "max_model_len": "32768"},
           ]
           only = os.environ.get("ONLY", "")
           valid_names = [l["name"] for l in legs]
@@ -195,8 +212,10 @@ jobs:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
     # Generous: the nightly set adds multi_turn (state simulation), much slower
-    # than the single-turn AST/live categories.
-    timeout-minutes: 240
+    # than the single-turn AST/live categories. The sequential glm-5.2 leg needs
+    # the most headroom — two whole-node arms (startup + scoring) run serially,
+    # not concurrently like the half-node legs. Ceiling only; fast legs finish early.
+    timeout-minutes: 360
     permissions:
       contents: read
     env:


### PR DESCRIPTION
## Description

### Problem

The nightly BFCL A/B (SMG parsing frontend vs. pure vLLM) had no GLM-5 family leg. GLM-5.2 ships an `<arg_key>`/`<arg_value>` tool-call format and `<think>` reasoning, so it's a useful parser-correctness check — but its FP8 checkpoint is far larger than the existing Blackwell legs and cannot be slotted in as-is.

### Solution

Add a `glm-5.2` leg to the nightly BFCL matrix.

**Why it can't reuse the concurrent half-node pattern:** GLM-5.2-FP8 is ~744 GB of weights (753B-param MoE). A B200 has ~180–192 GB, so 4× B200 (720–768 GB) cannot even hold the weights with working room — it does **not** fit a TP=4 half-node. vLLM's official recipe requires **8× B200 / TP=8**. The existing Blackwell legs (DeepSeek-V4-Flash, MiniMax-M2.7, Kimi-K2.6-int4) all fit TP=4 and run two arms concurrently on GPUs 0-3 + 4-7; GLM-5.2 needs the whole node per arm.

So this is the first leg to use the workflow's existing `sequential` arm_mode: arm A (pure vLLM) on all 8 GPUs → score → tear down → arm B (SMG→vLLM gRPC) on all 8 → score → diff. The `run_ab.py` sequential path (`--score-arm` / `--diff-baseline` / `--diff-candidate`) was already implemented; no script changes needed.

Parsers follow vLLM's GLM-5.2 recipe — `glm47` / `glm45` for the vLLM arm, `glm47_moe` / `glm45` for SMG (passed explicitly because the org-prefixed served name `zai-org/GLM-5.2-FP8` won't match SMG's `glm-5*` auto-detect). `--kv-cache-dtype fp8_e4m3` per the B200 recipe; MTP speculative decoding omitted (perf-only; the A/B isolates parsing).

## Changes

- Add `glm-5.2` leg (TP=8, `arm_mode: sequential`, whole 8-GPU node, `glm47`/`glm47_moe` + `glm45`, `--kv-cache-dtype fp8_e4m3`, `startup_timeout: 3000`) and list it in the `only` dispatch input.
- Bump job `timeout-minutes` 240 → 360 (sequential runs two whole-node arms serially, ~2× the concurrent legs). Ceiling only; fast legs finish early.
- Move `build-wheel` to `k8s-runner-cpu` (CPU-only maturin compile — no GPU needed).

## Test Plan

- `python -c "import yaml; yaml.safe_load(...)"` — workflow parses.
- Executed the embedded matrix-builder Python: produces all 6 legs incl. `glm-5.2` with TP=8 / `sequential` / correct parsers / whole-node `gpu_a`; `only=glm-5.2` selects exactly that leg.
- `actionlint` — clean apart from the pre-existing custom self-hosted runner-label warnings.
- Verified `run_ab.py` already implements the sequential `--score-arm` / `--diff-baseline` / `--diff-candidate` flags the leg invokes.

Full validation runs on the nightly schedule / `workflow_dispatch` (requires the Blackwell runner + staged weights).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the nightly workflow dispatch input description to recognize an additional supported matrix leg name.
  * Switched the wheel build job to a CPU-based runner to improve build resource alignment.
  * Extended the BFCL test matrix with a new `glm-5.2` sequential leg and related runtime configuration.
  * Increased the `bfcl-ab` job timeout from 240 to 360 minutes to support longer-running scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->