### PR TITLE
fix(bfcl): run the A/B greedy (temperature=0) for reproducibility

### DIFF
--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -20,7 +20,7 @@ Two arms expose an identical OpenAI `/v1` endpoint. The same official `bfcl` CLI
 | file | what |
 |---|---|
 | `launch_arm.sh` | bring up one arm (`a` = pure vLLM, `b` = vLLM-gRPC + SMG); prints its base_url; `stop` tears down via pidfiles. Fully env-parameterised. |
-| `run_ab.py` | point official `bfcl generate`+`evaluate` (FC mode) at both arms, parse per-category accuracy + test-case count, emit a markdown + JSON comparison table (with both **unweighted** = mean-of-categories and **weighted-by-n** = micro overall, matching BFCL's `calculate_unweighted/weighted_accuracy`), and a regression gate. Arms must already be serving. |
+| `run_ab.py` | point official `bfcl generate`+`evaluate` (FC mode) at both arms, parse per-category accuracy + test-case count, emit a markdown + JSON comparison table (with both **unweighted** = mean-of-categories and **weighted-by-n** = micro overall, matching BFCL's `calculate_unweighted/weighted_accuracy`), and a regression gate. Runs **greedy** (`--temperature 0`) so the A/B is reproducible and isolates the frontend — `temperature=0.001` is not deterministic and its sampling noise otherwise dominates the multi_turn delta. Arms must already be serving. |
 | `register_bfcl_model.py` | register a model that bfcl-eval doesn't ship a handler for yet (new SKUs), by cloning an existing FC entry. Idempotent. |
 
 ## Quick start (manual, e.g. on a GPU box)

--- a/scripts/bfcl/run_ab.py
+++ b/scripts/bfcl/run_ab.py
@@ -341,7 +341,11 @@ def main() -> int:
     p.add_argument("--bfcl", default="bfcl", help="path to the bfcl executable")
     p.add_argument("--project-root", default="/tmp/bfcl_ab", type=Path)
     p.add_argument("--num-threads", default=16, type=int)
-    p.add_argument("--temperature", default=0.001, type=float)
+    # Greedy (temperature=0) so the A/B is reproducible and isolates the frontend.
+    # bfcl exposes no --seed, and temperature=0.001 is NOT deterministic — measured
+    # 2 distinct outputs in 4 identical runs (same model/prompt), which compounds
+    # across multi_turn and otherwise dominates the SMG-vs-vLLM delta as pure noise.
+    p.add_argument("--temperature", default=0.0, type=float)
     p.add_argument(
         "--tolerance",
         default=0.02,


### PR DESCRIPTION
## Description

### Problem

The nightly BFCL A/B ran at `temperature=0.001`, which is **not deterministic**. Measured on an H100 (Qwen3-0.6B, identical prompt, 4 runs):

| setting | distinct outputs / 4 |
|---|---|
| `temperature=0.001`, no seed | **2** |
| `temperature=0.001`, fixed seed | 1 |
| greedy (`temperature=0`) | 1 |

Near-greedy sampling still flips tokens, and in `multi_turn` that compounds — a large fraction of cases diverged on the **very first action with an identical prompt**. So the SMG-vs-vLLM `multi_turn` delta was dominated by **sampling noise**, not the frontend it's meant to measure. (bfcl even assumes 0.001 is deterministic and skips retries on that basis — it isn't.)

### Solution

Default the A/B driver to **greedy** (`temperature=0`). bfcl exposes no `--seed`, so greedy is the available lever to remove sampling RNG. With greedy decoding, any remaining per-category delta is attributable to the frontend (chat-template rendering, tokenization, tool/reasoning parsing) — the actual purpose of the A/B.

## Changes

- `scripts/bfcl/run_ab.py` — `--temperature` default `0.001` → `0.0` (still overridable).
- `scripts/bfcl/README.md` — document the greedy default + rationale.

## Test Plan

- `ruff` clean; `run_ab.py --help` parses.
- Validation is the next nightly: `multi_turn` deltas should shrink to the frontend-attributable component (single-turn is already at parity), instead of fluctuating with sampling noise.

## Context

From a deep-dive audit of the qwen/deepseek `multi_turn` regression: SMG's chat-template rendering is byte-identical to HF/vLLM, so the gap was (a) this sampling nondeterminism and (b) tool-call argument serialization (compact vs spaced) — the latter fixed separately.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated A/B testing documentation to clarify that reproducible decoding settings are used to isolate functional differences from noise.

* **Chores**
  * Changed A/B testing default to deterministic mode for consistent, reproducible test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->