### PR TITLE
fix(tool_parser): serialize tool-call arguments with vLLM/json.dumps spacing

### DIFF
--- a/crates/tool_parser/src/parsers/deepseek_dsml.rs
+++ b/crates/tool_parser/src/parsers/deepseek_dsml.rs
@@ -232,7 +232,9 @@ impl DeepSeekDsmlParser {
             }
         }
 
-        serde_json::to_string(&Value::Object(params)).unwrap_or_else(|_| "{}".to_string())
+        // Spaced separators (Python json.dumps / vLLM) so multi-turn fed-back
+        // tool_calls render to the same prompt tokens as pure vLLM.
+        helpers::args_to_json_string(&Value::Object(params)).unwrap_or_else(|_| "{}".to_string())
     }
 
     /// Parse a single complete invoke block into a ToolCall

--- a/crates/tool_parser/src/parsers/deepseek_dsml.rs
+++ b/crates/tool_parser/src/parsers/deepseek_dsml.rs
@@ -232,8 +232,6 @@ impl DeepSeekDsmlParser {
             }
         }
 
-        // Spaced separators (Python json.dumps / vLLM) so multi-turn fed-back
-        // tool_calls render to the same prompt tokens as pure vLLM.
         helpers::args_to_json_string(&Value::Object(params)).unwrap_or_else(|_| "{}".to_string())
     }
 

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -394,8 +394,7 @@ pub(crate) fn handle_json_tool_streaming(
     Ok(result)
 }
 
-/// serde_json formatter matching Python `json.dumps` default item/key separators
-/// (`", "` and `": "`).
+/// serde_json formatter with Python `json.dumps` separators (`", "` / `": "`).
 struct SpacedFormatter;
 
 impl serde_json::ser::Formatter for SpacedFormatter {
@@ -431,12 +430,9 @@ impl serde_json::ser::Formatter for SpacedFormatter {
     }
 }
 
-/// Serialize tool-call arguments like Python `json.dumps` — spaced separators
-/// (`", "` / `": "`), no newlines. vLLM serializes `tool_calls[].arguments` with
-/// `json.dumps`, so SMG must match the spacing: otherwise the assistant tool_calls
-/// fed back across a multi-turn conversation render to different prompt tokens than
-/// pure vLLM (the chat template emits `arguments` verbatim), diverging generations.
-/// String escaping is left as serde's UTF-8 default (`ensure_ascii=False`).
+/// Serialize tool-call arguments like Python `json.dumps` (spaced separators), so
+/// they match vLLM — chat templates emit `arguments` verbatim, so compact vs spaced
+/// would diverge the prompt across multi-turn tool calls.
 pub fn args_to_json_string<T: serde::Serialize>(value: &T) -> ParserResult<String> {
     let mut buf = Vec::new();
     let mut ser = serde_json::Serializer::with_formatter(&mut buf, SpacedFormatter);

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -394,6 +394,58 @@ pub(crate) fn handle_json_tool_streaming(
     Ok(result)
 }
 
+/// serde_json formatter matching Python `json.dumps` default item/key separators
+/// (`", "` and `": "`).
+struct SpacedFormatter;
+
+impl serde_json::ser::Formatter for SpacedFormatter {
+    fn begin_array_value<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+        first: bool,
+    ) -> std::io::Result<()> {
+        if first {
+            Ok(())
+        } else {
+            writer.write_all(b", ")
+        }
+    }
+
+    fn begin_object_key<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+        first: bool,
+    ) -> std::io::Result<()> {
+        if first {
+            Ok(())
+        } else {
+            writer.write_all(b", ")
+        }
+    }
+
+    fn begin_object_value<W: ?Sized + std::io::Write>(
+        &mut self,
+        writer: &mut W,
+    ) -> std::io::Result<()> {
+        writer.write_all(b": ")
+    }
+}
+
+/// Serialize tool-call arguments like Python `json.dumps` — spaced separators
+/// (`", "` / `": "`), no newlines. vLLM serializes `tool_calls[].arguments` with
+/// `json.dumps`, so SMG must match the spacing: otherwise the assistant tool_calls
+/// fed back across a multi-turn conversation render to different prompt tokens than
+/// pure vLLM (the chat template emits `arguments` verbatim), diverging generations.
+/// String escaping is left as serde's UTF-8 default (`ensure_ascii=False`).
+pub fn args_to_json_string<T: serde::Serialize>(value: &T) -> ParserResult<String> {
+    let mut buf = Vec::new();
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, SpacedFormatter);
+    value
+        .serialize(&mut ser)
+        .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tool_parser/src/parsers/minimax_m2.rs
+++ b/crates/tool_parser/src/parsers/minimax_m2.rs
@@ -160,7 +160,9 @@ impl MinimaxM2Parser {
             let param_types = helpers::param_types_for_function(tools, func_name);
             let parameters = self.parse_parameters(params_text, &param_types);
 
-            match serde_json::to_string(&parameters) {
+            // Spaced separators (Python json.dumps / vLLM) so multi-turn fed-back
+            // tool_calls render to the same prompt tokens as pure vLLM.
+            match helpers::args_to_json_string(&parameters) {
                 Ok(arguments_str) => calls.push(ToolCall {
                     function: FunctionCall {
                         name: func_name.to_string(),

--- a/crates/tool_parser/src/parsers/minimax_m2.rs
+++ b/crates/tool_parser/src/parsers/minimax_m2.rs
@@ -160,8 +160,6 @@ impl MinimaxM2Parser {
             let param_types = helpers::param_types_for_function(tools, func_name);
             let parameters = self.parse_parameters(params_text, &param_types);
 
-            // Spaced separators (Python json.dumps / vLLM) so multi-turn fed-back
-            // tool_calls render to the same prompt tokens as pure vLLM.
             match helpers::args_to_json_string(&parameters) {
                 Ok(arguments_str) => calls.push(ToolCall {
                     function: FunctionCall {

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -216,8 +216,9 @@ impl QwenXmlParser {
             }
         }
 
-        let arguments = serde_json::to_string(&parameters)
-            .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
+        // Spaced separators (Python json.dumps / vLLM) so multi-turn fed-back
+        // tool_calls render to the same prompt tokens as pure vLLM.
+        let arguments = helpers::args_to_json_string(&parameters)?;
 
         Ok(Some(ToolCall {
             function: FunctionCall {

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -216,8 +216,6 @@ impl QwenXmlParser {
             }
         }
 
-        // Spaced separators (Python json.dumps / vLLM) so multi-turn fed-back
-        // tool_calls render to the same prompt tokens as pure vLLM.
         let arguments = helpers::args_to_json_string(&parameters)?;
 
         Ok(Some(ToolCall {

--- a/crates/tool_parser/tests/tool_parser_minimax_m2.rs
+++ b/crates/tool_parser/tests/tool_parser_minimax_m2.rs
@@ -965,3 +965,24 @@ async fn test_minimax_invalid_json_in_parameters() {
 
     assert_eq!(normal_text, "");
 }
+
+#[tokio::test]
+async fn test_minimax_arguments_use_python_json_spacing() {
+    // Args must serialize with spaced separators (", " / ": "), matching vLLM's
+    // json.dumps — so multi-turn fed-back tool_calls produce identical prompt tokens.
+    let parser = MinimaxM2Parser::new();
+    let input = r#"<minimax:tool_call>
+<invoke name="get_weather">
+<parameter name="city">Tokyo</parameter>
+<parameter name="units">celsius</parameter>
+</invoke>
+</minimax:tool_call>"#;
+    let (_n, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    let a = &tools[0].function.arguments;
+    assert!(
+        a.contains("\": \""),
+        "expected spaced key/value separators, got {a}"
+    );
+    assert!(!a.contains("\":\""), "must not be compact, got {a}");
+}

--- a/crates/tool_parser/tests/tool_parser_minimax_m2.rs
+++ b/crates/tool_parser/tests/tool_parser_minimax_m2.rs
@@ -968,8 +968,7 @@ async fn test_minimax_invalid_json_in_parameters() {
 
 #[tokio::test]
 async fn test_minimax_arguments_use_python_json_spacing() {
-    // Args must serialize with spaced separators (", " / ": "), matching vLLM's
-    // json.dumps — so multi-turn fed-back tool_calls produce identical prompt tokens.
+    // Spaced separators (", " / ": "), matching vLLM's json.dumps.
     let parser = MinimaxM2Parser::new();
     let input = r#"<minimax:tool_call>
 <invoke name="get_weather">


### PR DESCRIPTION
## Description

### Problem

vLLM serializes `tool_calls[].arguments` with Python `json.dumps` — **spaced** separators (`{"folder": "tmp"}`). SMG's XML-derived parsers used `serde_json::to_string` — **compact** (`{"folder":"tmp"}`).

A byte-for-byte parity test (SMG's `ChatTemplateProcessor` vs HF `apply_chat_template` for a Qwen3 multi-turn conversation) matches **except for this spacing**. Because the chat template emits `arguments` **verbatim**, every multi-turn step that feeds back a prior tool call renders to different prompt tokens on the SMG arm than on pure vLLM — diverging generations that compound across turns (one driver of the BFCL `multi_turn` gap; the other, sampling nondeterminism, is addressed by the greedy A/B change).

### Solution

Add `helpers::args_to_json_string` (a serde_json `Formatter` with Python `json.dumps` separators) and use it in the XML-style parsers that **build** args from `<parameter>` tags — `qwen_xml`, `minimax_m2`, `deepseek_dsml`. Type coercion is unchanged; only the output spacing changes. `kimik2` already passes the model's raw arguments string through, so it's untouched. (String escaping stays serde's UTF-8 default = `ensure_ascii=False`.)

## Changes

- `crates/tool_parser/src/parsers/helpers.rs` — `args_to_json_string` + `SpacedFormatter`.
- `qwen_xml.rs`, `minimax_m2.rs`, `deepseek_dsml.rs` — use it for the final argument serialization.
- `tool_parser_minimax_m2.rs` — assert spaced output.

## Test Plan

- `cargo test -p tool-parser` — all pass (existing parser tests compare parsed `Value`, so they're spacing-agnostic; added an explicit spaced-output assertion).
- `cargo +nightly fmt` + `cargo clippy -p tool-parser` clean.
- Behavioral validation: greedy nightly A/B (see the temperature=0 PR) — multi_turn tool steps should now feed back prompts identical to vLLM's.

## Context

From the multi_turn deep-dive: SMG's chat-template rendering is byte-identical to HF/vLLM; the only systematic frontend difference was this argument spacing.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized JSON formatting for tool-call arguments across parsers to use Python-style spacing conventions (spaces after colons and commas) for improved consistency.

* **Tests**
  * Added test coverage to verify correct JSON spacing formatting in tool-call argument serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->