### PR TITLE
fix(e2e): reap orphaned engine subprocesses on worker teardown

### DIFF
--- a/e2e_test/infra/test_worker_teardown.py
+++ b/e2e_test/infra/test_worker_teardown.py
@@ -1,0 +1,73 @@
+"""Regression test for Worker.stop() reaping orphaned children.
+
+sglang forks a GPU-holding scheduler subprocess that shares the worker's
+process group. If the parent crashes first, stop() must still kill the group
+— otherwise the child keeps the GPU pinned and the next launch OOMs.
+POSIX-only (process groups).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+from e2e_test.infra.worker import Worker
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="process groups are POSIX-only")
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def test_stop_reaps_orphaned_child_after_parent_exits() -> None:
+    # Leader (own session) spawns a long-lived child, then exits immediately —
+    # the exact orphan scenario behind the e2e-1gpu-responses OOM.
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import os, subprocess;"
+            "c = subprocess.Popen(['sleep', '300']);"
+            "print(c.pid, flush=True);"
+            "os._exit(0)",
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    assert proc.stdout is not None
+    child_pid = int(proc.stdout.readline())
+    worker = Worker(model_id="test/dummy", engine="sglang", port=0, gpu_ids=[0])
+    worker.process = proc
+    worker._pgid = proc.pid  # start_new_session ⇒ pgid == pid
+
+    try:
+        while proc.poll() is None:
+            time.sleep(0.02)
+        assert _alive(child_pid), "child should outlive the parent (orphan setup)"
+
+        worker.stop()
+
+        deadline = time.perf_counter() + 5
+        while _alive(child_pid) and time.perf_counter() < deadline:
+            time.sleep(0.05)
+        assert not _alive(child_pid), "orphaned child survived stop() — GPU would stay pinned"
+    finally:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except OSError:
+            pass
+
+
+def test_stop_is_safe_when_never_started() -> None:
+    Worker(model_id="test/dummy", engine="sglang", port=0, gpu_ids=[0]).stop()

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -26,9 +26,27 @@ from .constants import (
     vllm_kv_backend,
 )
 from .model_specs import get_model_spec
-from .process_utils import detect_ib_device, get_open_port, wait_for_health
+from .process_utils import detect_ib_device, get_open_port, release_port, wait_for_health
 
 logger = logging.getLogger(__name__)
+
+
+def _process_group_alive(pgid: int) -> bool:
+    """True while any process remains in the group (signal-0 liveness probe)."""
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _killpg(pgid: int, sig: int) -> None:
+    try:
+        os.killpg(pgid, sig)
+    except (ProcessLookupError, OSError):
+        pass
 
 
 @dataclass
@@ -48,6 +66,7 @@ class Worker:
     extra_engine_args: list[str] | None = None
     process: subprocess.Popen | None = field(default=None, repr=False)
     _log_file: IO[Any] | None = field(default=None, repr=False)
+    _pgid: int | None = field(default=None, repr=False)
 
     @property
     def base_url(self) -> str:
@@ -92,6 +111,13 @@ class Worker:
         logger.debug("Command: %s", " ".join(cmd))
 
         self.process = self._spawn_process(cmd, env)
+        # Record the group id while the leader is alive so teardown can reap
+        # orphaned children even if the parent exits first. start_new_session
+        # makes the worker its own group leader (pgid == pid).
+        try:
+            self._pgid = os.getpgid(self.process.pid)
+        except (ProcessLookupError, OSError):
+            self._pgid = self.process.pid
 
         if not wait_ready:
             logger.info(
@@ -120,32 +146,30 @@ class Worker:
         )
 
     def stop(self) -> None:
-        """Terminate worker process and all child processes."""
-        if self.process is None or self.process.poll() is not None:
-            return
+        """Terminate the worker's entire process group.
 
-        pid = self.process.pid
-        logger.info("Stopping worker %s (PID %d)", self.model_id, pid)
+        Engines such as sglang fork a scheduler subprocess that holds the GPU
+        and shares the worker's process group (we launch with
+        ``start_new_session=True``). Killing by the group id reaps that child
+        even when the parent crashed first and orphaned it — leaving it alive
+        would keep the GPU pinned and OOM the next launch.
+        """
+        pgid = self._pgid
+        if pgid is not None and _process_group_alive(pgid):
+            logger.info("Stopping worker %s (PGID %d)", self.model_id, pgid)
+            _killpg(pgid, signal.SIGTERM)
+            deadline = time.perf_counter() + 10
+            while _process_group_alive(pgid) and time.perf_counter() < deadline:
+                time.sleep(0.2)
+            if _process_group_alive(pgid):
+                logger.warning(
+                    "Worker %s (PGID %d) survived SIGTERM; sending SIGKILL", self.model_id, pgid
+                )
+                _killpg(pgid, signal.SIGKILL)
 
-        # Kill entire process group (workers run in their own session)
-        try:
-            pgid = os.getpgid(pid)
-            os.killpg(pgid, signal.SIGTERM)
-        except (ProcessLookupError, OSError):
-            self.process.terminate()
-
-        try:
-            self.process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            try:
-                pgid = os.getpgid(pid)
-                os.killpg(pgid, signal.SIGKILL)
-            except (ProcessLookupError, OSError):
-                self.process.kill()
-            try:
-                self.process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                logger.error("Worker PID %d did not die after SIGKILL", pid)
+        # Reap the parent zombie if it has exited.
+        if self.process is not None:
+            self.process.poll()
 
         # Clean up log file
         if self._log_file is not None:
@@ -156,8 +180,6 @@ class Worker:
             self._log_file = None
 
         # Release reserved ports
-        from .process_utils import release_port
-
         release_port(self.port)
         if self.bootstrap_port is not None:
             release_port(self.bootstrap_port)


### PR DESCRIPTION
## Description

### Problem

The `e2e-1gpu-responses` job intermittently aborts with a CUDA OOM during worker startup: `RuntimeError: Worker <model> (PID ...) died during startup`, then `Engine sglang failed to start workers 3 times — aborting test session`.

Root cause, in this repo's test infra: on a single-GPU runner the suite hot-swaps models, so the pool must tear down one sglang worker before launching the next. sglang forks a separate **scheduler subprocess** that owns the GPU memory and shares the worker's process group. The pre-fix `Worker.stop()` acted only on the tracked parent process and **early-returned if that parent had already exited** — so when a worker's main process went away while its scheduler was still running, the scheduler was never killed. That orphaned process (PID 6791) kept ~69 GiB pinned on the GPU, and every subsequent launch OOM'd against it.

Evidence:
- All five post-failure OOM logs name the same surviving `Process 6791 ... 69.40 GiB`.
- The GitHub runner had to reap orphaned `python3` processes at job cleanup — teardown had left them behind.
- `nvidia-smi` showed the GPU empty before the run, so this is a within-session leak, not cross-job contamination.

What put the worker into the bad state first: it had gone unhealthy (the gateway's `detect_connection_mode` gRPC health checks timed out for ~50s; the worker logged sglang's `Unknown type on tokenizer socket: <HealthCheckOutput>` health-check warning) and its main process then exited while the scheduler lingered. The precise upstream trigger is **not** diagnosed here (pinned `sglang==0.5.12.post1`; cf. related health-check-stall report sgl-project/sglang#22511), and **this fix is independent of it** — the infra must reclaim a dead worker's GPU regardless of why the worker died.

It is **flaky** because the leak only triggers when the worker's parent exits before the pool tears it down; on the normal eviction path the parent is alive and `killpg` already reaps the whole group. The `responses` suite is the most exposed because it swaps two large models on one GPU.

### Solution

Tear down by **process group** rather than only the tracked parent:
- Record the worker's process-group id at launch, while the group leader is alive.
- On `stop()`, signal the whole group (SIGTERM → SIGKILL) by that pgid regardless of whether the parent is still running, so orphaned children are always reaped.

## Changes

- `e2e_test/infra/worker.py`: capture `_pgid` at spawn; rewrite `stop()` to kill the process group by stored pgid (`_process_group_alive` / `_killpg` helpers); hoist `release_port` to a top-level import.
- `e2e_test/infra/test_worker_teardown.py`: POSIX regression test reproducing the parent-exits-first orphan scenario (fails on the pre-fix code), plus a stop-before-start safety check.

## Test Plan

- `pytest e2e_test/infra/test_worker_teardown.py` — `test_stop_reaps_orphaned_child_after_parent_exits` fails on `main` ("orphaned child survived stop()") and passes with this change; `test_stop_is_safe_when_never_started` passes.
- `ruff check` / `ruff format --check`, `mypy --config-file mypy.ini`, and `pre-commit run` on the changed files — all clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changed)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)