### PR TITLE
ci(benchmarks): bump genai-bench timeout 480s -> 600s

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -363,7 +363,7 @@ jobs:
         env:
           ROUTER_LOCAL_MODEL_PATH: /models
           E2E_LOG_DIR: benchmark-logs
-          GENAI_BENCH_TEST_TIMEOUT: "480"
+          GENAI_BENCH_TEST_TIMEOUT: "600"
         run: |
           mkdir -p benchmark-logs
           bash scripts/ci_killall_sglang.sh "nuke_gpus"


### PR DESCRIPTION
## Description

### Problem

The `benchmarks` job intermittently fails on PRs that don't touch the PD path. The PD perf benchmark `test_pd_perf[pd_http]` exceeds the genai-bench kill ceiling and is SIGKILLed:

```
ERROR genai-bench timed out after 480s
FAILED e2e_test/benchmarks/test_pd_perf.py::TestPDPerf::test_pd_perf[pd_http]
  - Failed: genai-bench failed with exit code -9
```

Observed on PR #1834 (run [28066454683](https://github.com/lightseekorg/smg/actions/runs/28066454683)), whose only change was an unrelated nightly-workflow YAML — and the same branch had passed the `benchmarks` job ~2h earlier. The two regular-perf legs passed in the same run; only PD timed out.

### Solution

Bump the shared `GENAI_BENCH_TEST_TIMEOUT` ceiling from `480` to `600` seconds.

The PD leg starts 2 prefill + 2 decode workers (staggered launches) and occasionally hits a slow start that pushes the genai-bench run past 480s. The benchmark work itself is bounded by `--max-time-per-run`, so this is transient slowness rather than legitimately-needed compute. 600s gives headroom while staying well within the `benchmarks` job's `timeout-minutes: 36` budget (the failing run used ~25 min).

## Changes

- `.github/workflows/pr-test-rust.yml`: `GENAI_BENCH_TEST_TIMEOUT` `"480"` → `"600"` for the `Run benchmarks` step.

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-test-rust.yml'))"` — workflow parses.
- The env var is consumed at `e2e_test/benchmarks/conftest.py:202` as the genai-bench subprocess kill timeout; both `test_pd_perf` and `test_regular_perf` rely on it (neither passes `timeout_sec`), so the new ceiling applies uniformly.
- Full validation runs on the `benchmarks` job (requires the 4-GPU H100 runner).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the timeout duration for benchmark test execution to improve overall test stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->