### PR TITLE
ci(bfcl): set max_model_len=auto and capture both arms' transcripts

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -124,6 +124,8 @@ jobs:
           fi
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json, os
+          # max_model_len "auto": largest window that fits in GPU memory (capped at
+          # native max). A fixed 32768 400'd on multi_turn_long_context (>32k prompts).
           legs = [
               # H100 legs (TP=2 per arm, both arms concurrent: GPUs 0,1 + 2,3).
               {"name": "qwen3.6", "runner": "4-gpu-h100", "tp": 2,
@@ -132,7 +134,7 @@ jobs:
                "vllm_tool": "qwen3_xml", "vllm_reason": "qwen3",
                "smg_tool": "qwen_xml", "smg_reason": "qwen3",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
-               "model_cache": "/models", "arm_mode": "concurrent", "max_model_len": "32768"},
+               "model_cache": "/models", "arm_mode": "concurrent", "max_model_len": "auto"},
               # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
               {"name": "gpt-oss", "runner": "4-gpu-h100", "tp": 2,
                "gpu_a": "0,1", "gpu_b": "2,3",
@@ -140,12 +142,9 @@ jobs:
                "vllm_tool": "openai", "vllm_reason": "",
                "smg_tool": "", "smg_reason": "",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
-               "model_cache": "/models", "arm_mode": "concurrent", "max_model_len": "32768"},
+               "model_cache": "/models", "arm_mode": "concurrent", "max_model_len": "auto"},
               # Blackwell legs (B200). Models pre-staged on NVMe at /raid/models/<id>.
-              # Concurrent TP=4 per arm (0-3 + 4-7) with max_model_len 32768: the
-              # multi_turn categories emit ~18k-token prompts that 400'd at 16384.
-              # Weights already fit at TP=4, and the extra KV for 32k is only a few
-              # GB/sequence, so the larger window fits without needing the whole node.
+              # Concurrent TP=4 per arm (0-3 + 4-7).
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "deepseek-ai/DeepSeek-V4-Flash", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-FC",
@@ -156,14 +155,14 @@ jobs:
                # kernel asserts fp8 kv-cache (else EngineCore dies at startup).
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
                "gpu_mem": "0.90", "startup_timeout": "2400", "model_cache": "/raid/models",
-               "arm_mode": "concurrent", "max_model_len": "32768"},
+               "arm_mode": "concurrent", "max_model_len": "auto"},
               {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "MiniMaxAI/MiniMax-M2.7", "bfcl_model": "MiniMaxAI/MiniMax-M2.7-FC",
                "vllm_tool": "minimax_m2", "vllm_reason": "minimax_m2",
                "smg_tool": "minimax_m2", "smg_reason": "minimax",
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
-               "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "32768"},
+               "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "auto"},
               # Kimi-K2.6 int4 (~500GB) fits TP=4 half-node.
               {"name": "kimi-k2.6", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
@@ -173,7 +172,7 @@ jobs:
                "smg_reason": "kimi_k25",  # TODO(confirm): no kimi_k2 SMG reasoning parser yet
                # Generous startup: 1T MoE at TP=4 needs minutes for load+compile+quant (420s timed out).
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
-               "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "32768"},
+               "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "auto"},
               # GLM-5.2-FP8 (~744GB) needs the whole 8-GPU node, so it runs SEQUENTIAL
               # (arm A then arm B; gpu_b unused) unlike the concurrent half-node legs.
               # vLLM recipe: TP=8, glm47/glm45, --kv-cache-dtype fp8_e4m3. SMG passes
@@ -185,7 +184,7 @@ jobs:
                "smg_tool": "glm47_moe", "smg_reason": "glm45",
                # FP8 load + DeepGEMM warmup on the largest leg: generous startup ceiling.
                "vllm_extra": "--trust-remote-code --kv-cache-dtype fp8_e4m3", "gpu_mem": "0.90", "startup_timeout": "3000",
-               "model_cache": "/raid/models", "arm_mode": "sequential", "max_model_len": "32768"},
+               "model_cache": "/raid/models", "arm_mode": "sequential", "max_model_len": "auto"},
           ]
           only = os.environ.get("ONLY", "")
           valid_names = [l["name"] for l in legs]

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -366,9 +366,12 @@ jobs:
           ROOT="$RUNNER_TEMP/bfcl_ab"
           OUT="$RUNNER_TEMP/bfcl_transcripts.tgz"
           if [ -d "$ROOT" ]; then
-            tar -czf "$OUT" -C "$ROOT" . 2>/dev/null || true
-            echo "transcript tarball: $(du -h "$OUT" 2>/dev/null | cut -f1)"
-            echo "contents (head):"; tar tzf "$OUT" 2>/dev/null | head -40 || echo "(empty)"
+            if tar -czf "$OUT" -C "$ROOT" .; then
+              echo "transcript tarball: $(du -h "$OUT" | cut -f1)"
+              echo "contents (head):"; tar tzf "$OUT" | head -40 || true
+            else
+              echo "::warning::failed to create $OUT"
+            fi
           else
             echo "no $ROOT"
           fi

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -354,17 +354,36 @@ jobs:
             echo "## BFCL A/B — ${{ matrix.name }} (${{ matrix.model }})"
             cat "$RUNNER_TEMP/bfcl_ab.md"
           } >> "$GITHUB_STEP_SUMMARY" || echo "no report produced for ${{ matrix.name }}" >> "$GITHUB_STEP_SUMMARY"
-      - name: Upload results (summary + per-case scores)
+      - name: Collect BFCL transcripts (both arms)
+        if: always()
+        # Tar the whole A/B root — both arms' raw per-turn model outputs (result)
+        # and per-case verdicts (score). gzip'd JSON is small (a few MB for a
+        # multi_turn-only run, tens of MB for the full suite), and tarring the
+        # entire tree is more robust than the upload-artifact glob that silently
+        # matched nothing. Lets us diff arm-A (vLLM) vs arm-B (SMG) turn by turn.
+        run: |
+          set -uo pipefail
+          ROOT="$RUNNER_TEMP/bfcl_ab"
+          OUT="$RUNNER_TEMP/bfcl_transcripts.tgz"
+          if [ -d "$ROOT" ]; then
+            tar -czf "$OUT" -C "$ROOT" . 2>/dev/null || true
+            echo "transcript tarball: $(du -h "$OUT" 2>/dev/null | cut -f1)"
+            echo "contents (head):"; tar tzf "$OUT" 2>/dev/null | head -40 || echo "(empty)"
+          else
+            echo "no $ROOT"
+          fi
+      - name: Upload results (summary + per-case scores + transcripts)
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: bfcl-ab-${{ matrix.name }}-${{ github.run_id }}
           # Summary + per-category score files (which list each failed case for
-          # both arms). Raw generate dumps (bfcl_ab/<arm>/result/**) excluded as bulky.
+          # both arms) + a tarball of both arms' raw per-turn transcripts.
           path: |
             ${{ runner.temp }}/bfcl_ab.md
             ${{ runner.temp }}/bfcl_ab.json
             ${{ runner.temp }}/bfcl_ab/*/score/**
+            ${{ runner.temp }}/bfcl_transcripts.tgz
           if-no-files-found: warn
           retention-days: 30
       - name: Upload arm logs (failure only)


### PR DESCRIPTION
## Description

### Problem

Two issues with the nightly BFCL A/B:

1. **Fixed `max_model_len: 32768`** — the `multi_turn_long_context` category emits >32k-token prompts, which 400'd; even 16384 was too small earlier. A hard cap silently truncates/rejects the longest cases on both arms.
2. **No way to see *why* an arm fails** — the artifact only carried the summary + (a glob that, in practice, matched nothing). When DeepSeek-V4 `multi_turn` collapsed on the SMG arm (−22…−30 pts vs vLLM) while single-turn stayed at parity, there were no per-turn transcripts to diff, so the divergence couldn't be localized.

### Solution

1. Set `max_model_len: auto` for every leg — vLLM picks the largest window that fits in GPU memory (capped at the model's native max), so long-context prompts fit without a hand-tuned constant.
2. Capture both arms' raw per-turn transcripts: a step tars the whole A/B root (each arm's `result/` raw model outputs + `score/` per-case verdicts) and uploads it. gzip'd JSON is small (a few MB for a multi_turn-only run, tens of MB for the full suite), and tarring the tree is robust where the previous `*/score/**` upload glob silently matched nothing. This lets us diff arm-A (vLLM) vs arm-B (SMG) turn by turn to localize multi_turn divergences.

## Changes

- `max_model_len` `32768` → `auto` on all legs (qwen3.6, gpt-oss, deepseek-v4, minimax-m2.7, kimi-k2.6, glm-5.2).
- New "Collect BFCL transcripts" step + transcript tarball added to the results artifact.

## Test Plan

- YAML validated; dispatched `deepseek-v4` / `multi_turn_base` on this branch — the transcript tarball uploads and `auto` boots without the prior 32k 400s.
- CodeRabbit review addressed: tar step no longer masks failures (emits `::warning::`, stays non-fatal); SHA-pinning suggestion declined as out-of-scope (the repo pins all ~50 action refs by version tag — a blanket pin should be a separate repo-wide change).

<details>
<summary>Checklist</summary>

- [x] YAML valid
- [x] CodeRabbit comments resolved
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>