### PR TITLE
fix(tool_parser): coerce XML tool-call args by declared schema type (qwen_xml, glm4_moe)

### DIFF
--- a/crates/tool_parser/src/parsers/glm4_moe.rs
+++ b/crates/tool_parser/src/parsers/glm4_moe.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use openai_protocol::common::Tool;
 use regex::Regex;
@@ -89,37 +91,23 @@ impl Glm4MoeParser {
         Self::new(r"(?s)<tool_call>\s*([^<\s]+)\s*(.*?)</tool_call>")
     }
 
-    /// Parse arguments from key-value pairs
-    fn parse_arguments(&self, args_text: &str) -> serde_json::Map<String, Value> {
+    /// Parse arguments from key-value pairs, coerced by the function's declared
+    /// schema. A `string` parameter keeps a numeric/bool/array-looking value as a
+    /// string (matches vLLM); unknown types fall back to [`infer_value`].
+    fn parse_arguments(
+        &self,
+        args_text: &str,
+        param_types: &HashMap<String, String>,
+    ) -> serde_json::Map<String, Value> {
         let mut arguments = serde_json::Map::new();
 
         for capture in self.arg_extractor.captures_iter(args_text) {
             let key = capture.get(1).map_or("", |m| m.as_str()).trim();
             let value_str = capture.get(2).map_or("", |m| m.as_str()).trim();
 
-            // Try to parse the value as JSON first, fallback to string
-            let value = if let Ok(json_val) = serde_json::from_str::<Value>(value_str) {
-                json_val
-            } else {
-                // Try parsing as Python literal (similar to Python's ast.literal_eval)
-                if value_str == "true" || value_str == "True" {
-                    Value::Bool(true)
-                } else if value_str == "false" || value_str == "False" {
-                    Value::Bool(false)
-                } else if value_str == "null" || value_str == "None" {
-                    Value::Null
-                } else if let Ok(num) = value_str.parse::<i64>() {
-                    Value::Number(num.into())
-                } else if let Ok(num) = value_str.parse::<f64>() {
-                    if let Some(n) = serde_json::Number::from_f64(num) {
-                        Value::Number(n)
-                    } else {
-                        Value::String(value_str.to_string())
-                    }
-                } else {
-                    Value::String(value_str.to_string())
-                }
-            };
+            let value =
+                helpers::coerce_by_schema_type(value_str, param_types.get(key).map(String::as_str))
+                    .unwrap_or_else(|| infer_value(value_str));
 
             arguments.insert(key.to_string(), value);
         }
@@ -128,7 +116,7 @@ impl Glm4MoeParser {
     }
 
     /// Parse a single tool call block
-    fn parse_tool_call(&self, block: &str) -> ParserResult<Option<ToolCall>> {
+    fn parse_tool_call(&self, block: &str, tools: &[Tool]) -> ParserResult<Option<ToolCall>> {
         if let Some(captures) = self.func_detail_extractor.captures(block) {
             // Get function name
             let func_name = captures.get(1).map_or("", |m| m.as_str()).trim();
@@ -136,8 +124,9 @@ impl Glm4MoeParser {
             // Get arguments text
             let args_text = captures.get(2).map_or("", |m| m.as_str());
 
-            // Parse arguments
-            let arguments = self.parse_arguments(args_text);
+            // Parse arguments, coerced by this function's declared schema.
+            let param_types = helpers::param_types_for_function(tools, func_name);
+            let arguments = self.parse_arguments(args_text, &param_types);
 
             let arguments_str = serde_json::to_string(&arguments)
                 .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
@@ -154,12 +143,12 @@ impl Glm4MoeParser {
     }
 
     /// Parse all tool calls from text (shared logic for complete and incremental parsing)
-    fn parse_tool_calls_from_text(&self, text: &str) -> Vec<ToolCall> {
-        let mut tools = Vec::new();
+    fn parse_tool_calls_from_text(&self, text: &str, tools: &[Tool]) -> Vec<ToolCall> {
+        let mut parsed = Vec::new();
 
         for mat in self.tool_call_extractor.find_iter(text) {
-            match self.parse_tool_call(mat.as_str()) {
-                Ok(Some(tool)) => tools.push(tool),
+            match self.parse_tool_call(mat.as_str(), tools) {
+                Ok(Some(tool)) => parsed.push(tool),
                 Ok(None) => continue,
                 Err(e) => {
                     tracing::debug!("Failed to parse tool call: {}", e);
@@ -168,7 +157,59 @@ impl Glm4MoeParser {
             }
         }
 
-        tools
+        parsed
+    }
+}
+
+impl Glm4MoeParser {
+    /// Shared non-streaming parse, schema-aware when `tools` are provided.
+    fn parse_complete_inner(
+        &self,
+        text: &str,
+        tools: &[Tool],
+    ) -> ParserResult<(String, Vec<ToolCall>)> {
+        if !self.has_tool_markers(text) {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        // Find where tool calls begin
+        // Safe: has_tool_markers() already confirmed the marker exists
+        let idx = text
+            .find("<tool_call>")
+            .ok_or_else(|| ParserError::ParsingFailed("tool call marker not found".to_string()))?;
+        let normal_text = text[..idx].to_string();
+
+        let parsed = self.parse_tool_calls_from_text(text, tools);
+
+        // If no tools were successfully parsed despite having markers, return entire text as fallback
+        if parsed.is_empty() {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        Ok((normal_text, parsed))
+    }
+}
+
+/// Infer a JSON value from raw text when the schema type is unknown: JSON
+/// (numbers/bools/null/objects/arrays), then Python-style literals, then string.
+fn infer_value(value_str: &str) -> Value {
+    if let Ok(json_val) = serde_json::from_str::<Value>(value_str) {
+        return json_val;
+    }
+    match value_str {
+        "true" | "True" => Value::Bool(true),
+        "false" | "False" => Value::Bool(false),
+        "null" | "None" => Value::Null,
+        _ => {
+            if let Ok(num) = value_str.parse::<i64>() {
+                Value::Number(num.into())
+            } else if let Ok(num) = value_str.parse::<f64>() {
+                serde_json::Number::from_f64(num)
+                    .map_or_else(|| Value::String(value_str.to_string()), Value::Number)
+            } else {
+                Value::String(value_str.to_string())
+            }
+        }
     }
 }
 
@@ -181,27 +222,15 @@ impl Default for Glm4MoeParser {
 #[async_trait]
 impl ToolParser for Glm4MoeParser {
     async fn parse_complete(&self, text: &str) -> ParserResult<(String, Vec<ToolCall>)> {
-        // Check if text contains GLM-4 MoE format
-        if !self.has_tool_markers(text) {
-            return Ok((text.to_string(), vec![]));
-        }
+        self.parse_complete_inner(text, &[])
+    }
 
-        // Find where tool calls begin
-        // Safe: has_tool_markers() already confirmed the marker exists
-        let idx = text
-            .find("<tool_call>")
-            .ok_or_else(|| ParserError::ParsingFailed("tool call marker not found".to_string()))?;
-        let normal_text = text[..idx].to_string();
-
-        // Parse all tool calls using shared helper
-        let tools = self.parse_tool_calls_from_text(text);
-
-        // If no tools were successfully parsed despite having markers, return entire text as fallback
-        if tools.is_empty() {
-            return Ok((text.to_string(), vec![]));
-        }
-
-        Ok((normal_text, tools))
+    async fn parse_complete_with_tools(
+        &self,
+        text: &str,
+        tools: &[Tool],
+    ) -> ParserResult<(String, Vec<ToolCall>)> {
+        self.parse_complete_inner(text, tools)
     }
 
     async fn parse_incremental(
@@ -250,7 +279,7 @@ impl ToolParser for Glm4MoeParser {
 
             // Parse the complete block using shared helper
             let block_end = end_pos + self.eot_token.len();
-            let parsed_tools = self.parse_tool_calls_from_text(&current_text[..block_end]);
+            let parsed_tools = self.parse_tool_calls_from_text(&current_text[..block_end], tools);
 
             // Extract normal text before tool calls
             let idx = current_text.find(self.bot_token);
@@ -344,5 +373,61 @@ impl ToolParser for Glm4MoeParser {
         self.prev_tool_call_arr.clear();
         self.current_tool_id = -1;
         self.streamed_args_for_tool.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::common::Function;
+
+    use super::*;
+
+    fn tool_with_props(props: Value) -> Vec<Tool> {
+        vec![Tool {
+            tool_type: "function".to_string(),
+            function: Function {
+                name: "f".to_string(),
+                description: None,
+                parameters: serde_json::json!({"type": "object", "properties": props}),
+                strict: None,
+            },
+        }]
+    }
+
+    // String-typed params keep numeric/bool/array-looking values as strings (the
+    // JavaScript-category bug); non-string params still coerce.
+    #[tokio::test]
+    async fn test_schema_aware_coercion_keeps_strings() {
+        let tools = tool_with_props(serde_json::json!({
+            "limit": {"type": "string"},
+            "flag": {"type": "string"},
+            "coords": {"type": "string"},
+            "count": {"type": "integer"},
+        }));
+        let text = "<tool_call>f\n\
+            <arg_key>limit</arg_key>\n<arg_value>4</arg_value>\n\
+            <arg_key>flag</arg_key>\n<arg_value>true</arg_value>\n\
+            <arg_key>coords</arg_key>\n<arg_value>[60,30]</arg_value>\n\
+            <arg_key>count</arg_key>\n<arg_value>5</arg_value>\n\
+            </tool_call>";
+        let (_, calls) = Glm4MoeParser::glm45()
+            .parse_complete_with_tools(text, &tools)
+            .await
+            .unwrap();
+        assert_eq!(calls.len(), 1);
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["limit"], Value::String("4".to_string()));
+        assert_eq!(args["flag"], Value::String("true".to_string()));
+        assert_eq!(args["coords"], Value::String("[60,30]".to_string()));
+        assert_eq!(args["count"], Value::Number(5.into()));
+    }
+
+    // Without a schema (no tools), behavior is unchanged: blind inference.
+    #[tokio::test]
+    async fn test_no_schema_infers_type() {
+        let text = "<tool_call>f\n<arg_key>count</arg_key>\n<arg_value>5</arg_value>\n</tool_call>";
+        let (_, calls) = Glm4MoeParser::glm45().parse_complete(text).await.unwrap();
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["count"], Value::Number(5.into()));
     }
 }

--- a/crates/tool_parser/src/parsers/glm4_moe.rs
+++ b/crates/tool_parser/src/parsers/glm4_moe.rs
@@ -91,9 +91,8 @@ impl Glm4MoeParser {
         Self::new(r"(?s)<tool_call>\s*([^<\s]+)\s*(.*?)</tool_call>")
     }
 
-    /// Parse arguments from key-value pairs, coerced by the function's declared
-    /// schema. A `string` parameter keeps a numeric/bool/array-looking value as a
-    /// string (matches vLLM); unknown types fall back to [`infer_value`].
+    /// Parse arguments, coercing each value by its declared schema type and
+    /// falling back to [`infer_value`] when the type is unknown.
     fn parse_arguments(
         &self,
         args_text: &str,
@@ -124,7 +123,6 @@ impl Glm4MoeParser {
             // Get arguments text
             let args_text = captures.get(2).map_or("", |m| m.as_str());
 
-            // Parse arguments, coerced by this function's declared schema.
             let param_types = helpers::param_types_for_function(tools, func_name);
             let arguments = self.parse_arguments(args_text, &param_types);
 
@@ -394,8 +392,7 @@ mod tests {
         }]
     }
 
-    // String-typed params keep numeric/bool/array-looking values as strings (the
-    // JavaScript-category bug); non-string params still coerce.
+    // String-typed params stay strings even when they look numeric/bool/array.
     #[tokio::test]
     async fn test_schema_aware_coercion_keeps_strings() {
         let tools = tool_with_props(serde_json::json!({
@@ -419,35 +416,6 @@ mod tests {
         assert_eq!(args["limit"], Value::String("4".to_string()));
         assert_eq!(args["flag"], Value::String("true".to_string()));
         assert_eq!(args["coords"], Value::String("[60,30]".to_string()));
-        assert_eq!(args["count"], Value::Number(5.into()));
-    }
-
-    // Without a schema (no tools), behavior is unchanged: blind inference.
-    #[tokio::test]
-    async fn test_no_schema_infers_type() {
-        let text = "<tool_call>f\n<arg_key>count</arg_key>\n<arg_value>5</arg_value>\n</tool_call>";
-        let (_, calls) = Glm4MoeParser::glm45().parse_complete(text).await.unwrap();
-        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["count"], Value::Number(5.into()));
-    }
-
-    // The incremental path forwards tools, so it coerces by schema too.
-    #[tokio::test]
-    async fn test_streaming_schema_aware_coercion() {
-        let tools = tool_with_props(serde_json::json!({
-            "limit": {"type": "string"},
-            "count": {"type": "integer"},
-        }));
-        let text = "<tool_call>f\n\
-            <arg_key>limit</arg_key>\n<arg_value>4</arg_value>\n\
-            <arg_key>count</arg_key>\n<arg_value>5</arg_value>\n\
-            </tool_call>";
-        let result = Glm4MoeParser::glm45()
-            .parse_incremental(text, &tools)
-            .await
-            .unwrap();
-        let args: Value = serde_json::from_str(&result.calls[0].parameters).unwrap();
-        assert_eq!(args["limit"], Value::String("4".to_string()));
         assert_eq!(args["count"], Value::Number(5.into()));
     }
 }

--- a/crates/tool_parser/src/parsers/glm4_moe.rs
+++ b/crates/tool_parser/src/parsers/glm4_moe.rs
@@ -430,4 +430,24 @@ mod tests {
         let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["count"], Value::Number(5.into()));
     }
+
+    // The incremental path forwards tools, so it coerces by schema too.
+    #[tokio::test]
+    async fn test_streaming_schema_aware_coercion() {
+        let tools = tool_with_props(serde_json::json!({
+            "limit": {"type": "string"},
+            "count": {"type": "integer"},
+        }));
+        let text = "<tool_call>f\n\
+            <arg_key>limit</arg_key>\n<arg_value>4</arg_value>\n\
+            <arg_key>count</arg_key>\n<arg_value>5</arg_value>\n\
+            </tool_call>";
+        let result = Glm4MoeParser::glm45()
+            .parse_incremental(text, &tools)
+            .await
+            .unwrap();
+        let args: Value = serde_json::from_str(&result.calls[0].parameters).unwrap();
+        assert_eq!(args["limit"], Value::String("4".to_string()));
+        assert_eq!(args["count"], Value::Number(5.into()));
+    }
 }

--- a/crates/tool_parser/src/parsers/glm4_moe.rs
+++ b/crates/tool_parser/src/parsers/glm4_moe.rs
@@ -418,4 +418,24 @@ mod tests {
         assert_eq!(args["coords"], Value::String("[60,30]".to_string()));
         assert_eq!(args["count"], Value::Number(5.into()));
     }
+
+    // The streaming path threads `tools` separately, so cover it too.
+    #[tokio::test]
+    async fn test_streaming_schema_aware_coercion() {
+        let tools = tool_with_props(serde_json::json!({
+            "limit": {"type": "string"},
+            "count": {"type": "integer"},
+        }));
+        let text = "<tool_call>f\n\
+            <arg_key>limit</arg_key>\n<arg_value>4</arg_value>\n\
+            <arg_key>count</arg_key>\n<arg_value>5</arg_value>\n\
+            </tool_call>";
+        let result = Glm4MoeParser::glm45()
+            .parse_incremental(text, &tools)
+            .await
+            .unwrap();
+        let args: Value = serde_json::from_str(&result.calls[0].parameters).unwrap();
+        assert_eq!(args["limit"], Value::String("4".to_string()));
+        assert_eq!(args["count"], Value::Number(5.into()));
+    }
 }

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -657,7 +657,7 @@ mod tests {
             Some(json!([60, 30]))
         );
 
-        // unknown type / unparseable -> None (caller falls back to inference)
+        // unknown type / value that fails to parse -> None (caller infers)
         assert_eq!(coerce_by_schema_type("4", None), None);
         assert_eq!(coerce_by_schema_type("abc", Some("integer")), None);
     }

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -9,12 +9,9 @@ use crate::{
     types::{StreamingParseResult, ToolCallItem},
 };
 
-/// Resolve a property schema to a single representative JSON-schema type,
-/// looking through the common nullable/union spellings so an optional `string`
-/// is still treated as `string`:
-/// - scalar: `{"type": "string"}`
-/// - nullable array: `{"type": ["string", "null"]}` (first non-`null`)
-/// - union: `{"anyOf"|"oneOf": [{"type": "string"}, {"type": "null"}]}`
+/// Representative JSON-schema type for a property, resolving the common nullable/
+/// union spellings (`["string","null"]`, `anyOf`/`oneOf`) to their non-`null`
+/// type so an optional string still resolves to `string`.
 fn schema_type(schema: &Value) -> Option<&str> {
     if let Some(t) = schema.get("type").and_then(Value::as_str) {
         return Some(t);
@@ -57,10 +54,9 @@ pub fn param_types_for_function(tools: &[Tool], func_name: &str) -> HashMap<Stri
 }
 
 /// Coerce a raw value by its declared JSON-schema type. For `string`, a JSON
-/// string literal (`"4"`) is unwrapped to its content while bare text (`4`,
-/// `true`, `[60,30]`) is kept as the string itself; numeric/boolean/structured
-/// types are parsed. `None` (unknown type or parse failure) means the caller
-/// should fall back to its own inference.
+/// string literal (`"4"`) is unwrapped while bare text (`4`, `true`) is kept
+/// verbatim; other types are parsed. `None` (unknown type or parse failure)
+/// means the caller should infer.
 pub fn coerce_by_schema_type(text: &str, declared_type: Option<&str>) -> Option<Value> {
     match declared_type? {
         "string" => Some(Value::String(
@@ -653,23 +649,17 @@ mod tests {
     #[test]
     fn test_coerce_by_schema_type() {
         use serde_json::json;
-        // string: bare numeric/bool/array-looking text stays a string...
+        // string: bare text stays a string; a JSON string literal is unwrapped.
         assert_eq!(coerce_by_schema_type("4", Some("string")), Some(json!("4")));
-        assert_eq!(
-            coerce_by_schema_type("true", Some("string")),
-            Some(json!("true"))
-        );
         assert_eq!(
             coerce_by_schema_type("[60,30]", Some("string")),
             Some(json!("[60,30]"))
         );
-        // ...but a JSON string literal is unwrapped to its content.
         assert_eq!(
             coerce_by_schema_type("\"4\"", Some("string")),
             Some(json!("4"))
         );
 
-        // typed values are parsed
         assert_eq!(coerce_by_schema_type("4", Some("integer")), Some(json!(4)));
         assert_eq!(
             coerce_by_schema_type("true", Some("boolean")),

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -33,12 +33,16 @@ pub fn param_types_for_function(tools: &[Tool], func_name: &str) -> HashMap<Stri
     types
 }
 
-/// Coerce a raw value by its declared JSON-schema type. `string` is kept verbatim;
-/// numeric/boolean/structured types are parsed. `None` (unknown type or parse
-/// failure) means the caller should fall back to its own inference.
+/// Coerce a raw value by its declared JSON-schema type. For `string`, a JSON
+/// string literal (`"4"`) is unwrapped to its content while bare text (`4`,
+/// `true`, `[60,30]`) is kept as the string itself; numeric/boolean/structured
+/// types are parsed. `None` (unknown type or parse failure) means the caller
+/// should fall back to its own inference.
 pub fn coerce_by_schema_type(text: &str, declared_type: Option<&str>) -> Option<Value> {
     match declared_type? {
-        "string" => Some(Value::String(text.to_string())),
+        "string" => Some(Value::String(
+            serde_json::from_str::<String>(text).unwrap_or_else(|_| text.to_string()),
+        )),
         "integer" => text
             .trim()
             .parse::<i64>()
@@ -621,5 +625,40 @@ mod tests {
             normalized.get("arguments").unwrap(),
             &serde_json::json!({"key": "value"})
         );
+    }
+
+    #[test]
+    fn test_coerce_by_schema_type() {
+        use serde_json::json;
+        // string: bare numeric/bool/array-looking text stays a string...
+        assert_eq!(coerce_by_schema_type("4", Some("string")), Some(json!("4")));
+        assert_eq!(
+            coerce_by_schema_type("true", Some("string")),
+            Some(json!("true"))
+        );
+        assert_eq!(
+            coerce_by_schema_type("[60,30]", Some("string")),
+            Some(json!("[60,30]"))
+        );
+        // ...but a JSON string literal is unwrapped to its content.
+        assert_eq!(
+            coerce_by_schema_type("\"4\"", Some("string")),
+            Some(json!("4"))
+        );
+
+        // typed values are parsed
+        assert_eq!(coerce_by_schema_type("4", Some("integer")), Some(json!(4)));
+        assert_eq!(
+            coerce_by_schema_type("true", Some("boolean")),
+            Some(json!(true))
+        );
+        assert_eq!(
+            coerce_by_schema_type("[60,30]", Some("array")),
+            Some(json!([60, 30]))
+        );
+
+        // unknown type / unparseable -> None (caller falls back to inference)
+        assert_eq!(coerce_by_schema_type("4", None), None);
+        assert_eq!(coerce_by_schema_type("abc", Some("integer")), None);
     }
 }

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -9,10 +9,33 @@ use crate::{
     types::{StreamingParseResult, ToolCallItem},
 };
 
+/// Resolve a property schema to a single representative JSON-schema type,
+/// looking through the common nullable/union spellings so an optional `string`
+/// is still treated as `string`:
+/// - scalar: `{"type": "string"}`
+/// - nullable array: `{"type": ["string", "null"]}` (first non-`null`)
+/// - union: `{"anyOf"|"oneOf": [{"type": "string"}, {"type": "null"}]}`
+fn schema_type(schema: &Value) -> Option<&str> {
+    if let Some(t) = schema.get("type").and_then(Value::as_str) {
+        return Some(t);
+    }
+    if let Some(arr) = schema.get("type").and_then(Value::as_array) {
+        return arr.iter().filter_map(Value::as_str).find(|t| *t != "null");
+    }
+    ["anyOf", "oneOf"].iter().find_map(|key| {
+        schema
+            .get(key)
+            .and_then(Value::as_array)?
+            .iter()
+            .filter_map(schema_type)
+            .find(|t| *t != "null")
+    })
+}
+
 /// `param_name -> declared JSON-schema type` for the named function (empty if the
 /// function or its `properties` are absent). Lets XML-style parsers coerce by the
 /// declared type instead of guessing from text (e.g. keep a numeric-looking
-/// `string` as a string).
+/// `string` as a string). Nullable/union schemas resolve to their non-`null` type.
 pub fn param_types_for_function(tools: &[Tool], func_name: &str) -> HashMap<String, String> {
     let mut types = HashMap::new();
     let Some(tool) = tools.iter().find(|t| t.function.name == func_name) else {
@@ -25,7 +48,7 @@ pub fn param_types_for_function(tools: &[Tool], func_name: &str) -> HashMap<Stri
         .and_then(Value::as_object)
     {
         for (key, schema) in props {
-            if let Some(ty) = schema.get("type").and_then(Value::as_str) {
+            if let Some(ty) = schema_type(schema) {
                 types.insert(key.clone(), ty.to_string());
             }
         }
@@ -660,5 +683,33 @@ mod tests {
         // unknown type / value that fails to parse -> None (caller infers)
         assert_eq!(coerce_by_schema_type("4", None), None);
         assert_eq!(coerce_by_schema_type("abc", Some("integer")), None);
+    }
+
+    #[test]
+    fn test_param_types_nullable_and_union() {
+        use openai_protocol::common::Function;
+        let tools = vec![Tool {
+            tool_type: "function".to_string(),
+            function: Function {
+                name: "f".to_string(),
+                description: None,
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "string"},
+                        "b": {"type": ["string", "null"]},
+                        "c": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                        "d": {"type": ["null", "integer"]},
+                    }
+                }),
+                strict: None,
+            },
+        }];
+        let types = param_types_for_function(&tools, "f");
+        // Optional/nullable strings still resolve to "string" (not dropped).
+        assert_eq!(types.get("a").map(String::as_str), Some("string"));
+        assert_eq!(types.get("b").map(String::as_str), Some("string"));
+        assert_eq!(types.get("c").map(String::as_str), Some("string"));
+        assert_eq!(types.get("d").map(String::as_str), Some("integer"));
     }
 }

--- a/crates/tool_parser/src/parsers/helpers.rs
+++ b/crates/tool_parser/src/parsers/helpers.rs
@@ -9,30 +9,11 @@ use crate::{
     types::{StreamingParseResult, ToolCallItem},
 };
 
-/// Representative JSON-schema type for a property, resolving the common nullable/
-/// union spellings (`["string","null"]`, `anyOf`/`oneOf`) to their non-`null`
-/// type so an optional string still resolves to `string`.
-fn schema_type(schema: &Value) -> Option<&str> {
-    if let Some(t) = schema.get("type").and_then(Value::as_str) {
-        return Some(t);
-    }
-    if let Some(arr) = schema.get("type").and_then(Value::as_array) {
-        return arr.iter().filter_map(Value::as_str).find(|t| *t != "null");
-    }
-    ["anyOf", "oneOf"].iter().find_map(|key| {
-        schema
-            .get(key)
-            .and_then(Value::as_array)?
-            .iter()
-            .filter_map(schema_type)
-            .find(|t| *t != "null")
-    })
-}
-
 /// `param_name -> declared JSON-schema type` for the named function (empty if the
 /// function or its `properties` are absent). Lets XML-style parsers coerce by the
 /// declared type instead of guessing from text (e.g. keep a numeric-looking
-/// `string` as a string). Nullable/union schemas resolve to their non-`null` type.
+/// `string` as a string). Only scalar `type` is read; unions/nullable schemas
+/// have no single type, so they fall back to the caller's inference.
 pub fn param_types_for_function(tools: &[Tool], func_name: &str) -> HashMap<String, String> {
     let mut types = HashMap::new();
     let Some(tool) = tools.iter().find(|t| t.function.name == func_name) else {
@@ -45,7 +26,7 @@ pub fn param_types_for_function(tools: &[Tool], func_name: &str) -> HashMap<Stri
         .and_then(Value::as_object)
     {
         for (key, schema) in props {
-            if let Some(ty) = schema_type(schema) {
+            if let Some(ty) = schema.get("type").and_then(Value::as_str) {
                 types.insert(key.clone(), ty.to_string());
             }
         }
@@ -67,12 +48,11 @@ pub fn coerce_by_schema_type(text: &str, declared_type: Option<&str>) -> Option<
             .parse::<i64>()
             .ok()
             .map(|n| Value::Number(n.into())),
-        "number" => text
-            .trim()
-            .parse::<f64>()
+        // Parse as JSON so large integers keep their precision (a plain f64 parse
+        // would round e.g. 9007199254740993).
+        "number" => serde_json::from_str::<Value>(text.trim())
             .ok()
-            .and_then(serde_json::Number::from_f64)
-            .map(Value::Number),
+            .filter(Value::is_number),
         "boolean" => match text.trim() {
             "true" | "True" => Some(Value::Bool(true)),
             "false" | "False" => Some(Value::Bool(false)),
@@ -649,8 +629,13 @@ mod tests {
     #[test]
     fn test_coerce_by_schema_type() {
         use serde_json::json;
-        // string: bare text stays a string; a JSON string literal is unwrapped.
+        // string: numeric/bool/array-looking text stays a string; a JSON string
+        // literal is unwrapped.
         assert_eq!(coerce_by_schema_type("4", Some("string")), Some(json!("4")));
+        assert_eq!(
+            coerce_by_schema_type("true", Some("string")),
+            Some(json!("true"))
+        );
         assert_eq!(
             coerce_by_schema_type("[60,30]", Some("string")),
             Some(json!("[60,30]"))
@@ -669,37 +654,14 @@ mod tests {
             coerce_by_schema_type("[60,30]", Some("array")),
             Some(json!([60, 30]))
         );
+        // number keeps integer precision (no f64 rounding).
+        assert_eq!(
+            coerce_by_schema_type("9007199254740993", Some("number")),
+            Some(json!(9007199254740993i64))
+        );
 
         // unknown type / value that fails to parse -> None (caller infers)
         assert_eq!(coerce_by_schema_type("4", None), None);
         assert_eq!(coerce_by_schema_type("abc", Some("integer")), None);
-    }
-
-    #[test]
-    fn test_param_types_nullable_and_union() {
-        use openai_protocol::common::Function;
-        let tools = vec![Tool {
-            tool_type: "function".to_string(),
-            function: Function {
-                name: "f".to_string(),
-                description: None,
-                parameters: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "a": {"type": "string"},
-                        "b": {"type": ["string", "null"]},
-                        "c": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                        "d": {"type": ["null", "integer"]},
-                    }
-                }),
-                strict: None,
-            },
-        }];
-        let types = param_types_for_function(&tools, "f");
-        // Optional/nullable strings still resolve to "string" (not dropped).
-        assert_eq!(types.get("a").map(String::as_str), Some("string"));
-        assert_eq!(types.get("b").map(String::as_str), Some("string"));
-        assert_eq!(types.get("c").map(String::as_str), Some("string"));
-        assert_eq!(types.get("d").map(String::as_str), Some("integer"));
     }
 }

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -153,11 +153,8 @@ fn safe_val(raw: &str) -> Value {
     Value::String(unescaped)
 }
 
-/// Coerce a raw XML parameter value by its declared JSON-schema type: a declared
-/// `string` is kept verbatim (decoded), typed values are parsed, and an unknown
-/// type falls back to [`safe_val`]'s inference. Mirrors `minimax_m2`/vLLM so a
-/// numeric- or bool-looking value for a `string` parameter stays a string
-/// instead of being coerced to a number/bool/array/object.
+/// Coerce an XML parameter value by its declared schema type, falling back to
+/// [`safe_val`] inference when the type is unknown.
 fn coerce_value(raw: &str, declared_type: Option<&str>) -> Value {
     let decoded = html_unescape(raw.trim());
     helpers::coerce_by_schema_type(&decoded, declared_type).unwrap_or_else(|| safe_val(raw))
@@ -215,8 +212,6 @@ impl QwenXmlParser {
             return Ok(None);
         }
 
-        // Coerce by the function's declared schema so e.g. a `string` parameter
-        // whose value looks numeric/bool/array stays a string (matches vLLM).
         let param_types = helpers::param_types_for_function(tools, &function_name);
         let mut parameters = serde_json::Map::new();
 
@@ -244,8 +239,6 @@ impl QwenXmlParser {
     /// Returns tool call items to emit (similar to Python's _parse_and_stream_parameters)
     fn parse_and_stream_parameters(&mut self, tools: &[Tool]) -> Vec<ToolCallItem> {
         let mut calls: Vec<ToolCallItem> = vec![];
-
-        // Coerce by the current function's declared schema (see parse_xml_format).
         let param_types = helpers::param_types_for_function(tools, &self.current_function_name);
 
         // Find all complete parameter patterns in buffer
@@ -642,8 +635,7 @@ mod tests {
         }]
     }
 
-    // String-typed params keep numeric/bool/array/object-looking values as
-    // strings (the JavaScript-category bug); non-string params still coerce.
+    // String-typed params stay strings even when they look numeric/bool/array/object.
     #[tokio::test]
     async fn test_schema_aware_coercion_keeps_strings() {
         let tools = tool_with_props(serde_json::json!({
@@ -671,42 +663,5 @@ mod tests {
         assert_eq!(args["coords"], Value::String("[60,30]".to_string()));
         assert_eq!(args["cfg"], Value::String("{\"a\": 1}".to_string()));
         assert_eq!(args["count"], Value::Number(5.into()));
-    }
-
-    // Without a schema (no tools), behavior is unchanged: blind inference.
-    #[tokio::test]
-    async fn test_no_schema_infers_type() {
-        let text =
-            "<tool_call>\n<function=f>\n<parameter=count>5</parameter>\n</function>\n</tool_call>";
-        let (_, calls) = QwenXmlParser::new().parse_complete(text).await.unwrap();
-        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
-        assert_eq!(args["count"], Value::Number(5.into()));
-    }
-
-    // The streaming path coerces by schema too: concatenated parameter fragments
-    // keep a string-typed value quoted while a non-string one is parsed.
-    #[tokio::test]
-    async fn test_streaming_schema_aware_coercion() {
-        let tools = tool_with_props(serde_json::json!({
-            "limit": {"type": "string"},
-            "count": {"type": "integer"},
-        }));
-        let text = "<tool_call>\n<function=f>\n\
-            <parameter=limit>4</parameter>\n\
-            <parameter=count>5</parameter>\n\
-            </function>\n</tool_call>";
-        let result = QwenXmlParser::new()
-            .parse_incremental(text, &tools)
-            .await
-            .unwrap();
-        let args: String = result.calls.iter().map(|c| c.parameters.as_str()).collect();
-        assert!(
-            args.contains(r#""limit": "4""#),
-            "string param must stay string: {args}"
-        );
-        assert!(
-            args.contains(r#""count": 5"#),
-            "int param must coerce: {args}"
-        );
     }
 }

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -682,4 +682,31 @@ mod tests {
         let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["count"], Value::Number(5.into()));
     }
+
+    // The streaming path coerces by schema too: concatenated parameter fragments
+    // keep a string-typed value quoted while a non-string one is parsed.
+    #[tokio::test]
+    async fn test_streaming_schema_aware_coercion() {
+        let tools = tool_with_props(serde_json::json!({
+            "limit": {"type": "string"},
+            "count": {"type": "integer"},
+        }));
+        let text = "<tool_call>\n<function=f>\n\
+            <parameter=limit>4</parameter>\n\
+            <parameter=count>5</parameter>\n\
+            </function>\n</tool_call>";
+        let result = QwenXmlParser::new()
+            .parse_incremental(text, &tools)
+            .await
+            .unwrap();
+        let args: String = result.calls.iter().map(|c| c.parameters.as_str()).collect();
+        assert!(
+            args.contains(r#""limit": "4""#),
+            "string param must stay string: {args}"
+        );
+        assert!(
+            args.contains(r#""count": 5"#),
+            "int param must coerce: {args}"
+        );
+    }
 }

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -664,4 +664,30 @@ mod tests {
         assert_eq!(args["cfg"], Value::String("{\"a\": 1}".to_string()));
         assert_eq!(args["count"], Value::Number(5.into()));
     }
+
+    // The streaming path threads `tools` separately, so cover it too.
+    #[tokio::test]
+    async fn test_streaming_schema_aware_coercion() {
+        let tools = tool_with_props(serde_json::json!({
+            "limit": {"type": "string"},
+            "count": {"type": "integer"},
+        }));
+        let text = "<tool_call>\n<function=f>\n\
+            <parameter=limit>4</parameter>\n\
+            <parameter=count>5</parameter>\n\
+            </function>\n</tool_call>";
+        let result = QwenXmlParser::new()
+            .parse_incremental(text, &tools)
+            .await
+            .unwrap();
+        let args: String = result.calls.iter().map(|c| c.parameters.as_str()).collect();
+        assert!(
+            args.contains(r#""limit": "4""#),
+            "string param must stay string: {args}"
+        );
+        assert!(
+            args.contains(r#""count": 5"#),
+            "int param must coerce: {args}"
+        );
+    }
 }

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -153,6 +153,16 @@ fn safe_val(raw: &str) -> Value {
     Value::String(unescaped)
 }
 
+/// Coerce a raw XML parameter value by its declared JSON-schema type: a declared
+/// `string` is kept verbatim (decoded), typed values are parsed, and an unknown
+/// type falls back to [`safe_val`]'s inference. Mirrors `minimax_m2`/vLLM so a
+/// numeric- or bool-looking value for a `string` parameter stays a string
+/// instead of being coerced to a number/bool/array/object.
+fn coerce_value(raw: &str, declared_type: Option<&str>) -> Value {
+    let decoded = html_unescape(raw.trim());
+    helpers::coerce_by_schema_type(&decoded, declared_type).unwrap_or_else(|| safe_val(raw))
+}
+
 impl QwenXmlParser {
     /// Create a new Qwen XML parser
     #[expect(
@@ -188,7 +198,7 @@ impl QwenXmlParser {
     }
 
     /// Parse XML format tool call: <function=name><parameter=key>value</parameter></function>
-    fn parse_xml_format(&self, content: &str) -> ParserResult<Option<ToolCall>> {
+    fn parse_xml_format(&self, content: &str, tools: &[Tool]) -> ParserResult<Option<ToolCall>> {
         let function_captures = self
             .xml_function_pattern
             .captures(content)
@@ -205,13 +215,16 @@ impl QwenXmlParser {
             return Ok(None);
         }
 
+        // Coerce by the function's declared schema so e.g. a `string` parameter
+        // whose value looks numeric/bool/array stays a string (matches vLLM).
+        let param_types = helpers::param_types_for_function(tools, &function_name);
         let mut parameters = serde_json::Map::new();
 
         for cap in self.xml_param_pattern.captures_iter(content) {
             if let (Some(key_match), Some(value_match)) = (cap.get(1), cap.get(2)) {
                 let key = key_match.as_str().trim().to_string();
                 let value = value_match.as_str();
-                let json_value = safe_val(value);
+                let json_value = coerce_value(value, param_types.get(&key).map(String::as_str));
                 parameters.insert(key, json_value);
             }
         }
@@ -229,8 +242,11 @@ impl QwenXmlParser {
 
     /// Parse and stream complete parameters from buffer
     /// Returns tool call items to emit (similar to Python's _parse_and_stream_parameters)
-    fn parse_and_stream_parameters(&mut self) -> Vec<ToolCallItem> {
+    fn parse_and_stream_parameters(&mut self, tools: &[Tool]) -> Vec<ToolCallItem> {
         let mut calls: Vec<ToolCallItem> = vec![];
+
+        // Coerce by the current function's declared schema (see parse_xml_format).
+        let param_types = helpers::param_types_for_function(tools, &self.current_function_name);
 
         // Find all complete parameter patterns in buffer
         let mut new_params = serde_json::Map::new();
@@ -238,7 +254,7 @@ impl QwenXmlParser {
             if let (Some(key_match), Some(value_match)) = (cap.get(1), cap.get(2)) {
                 let key = key_match.as_str().trim().to_string();
                 let value = value_match.as_str();
-                let json_value = safe_val(value);
+                let json_value = coerce_value(value, param_types.get(&key).map(String::as_str));
                 new_params.insert(key, json_value);
             }
         }
@@ -305,6 +321,49 @@ impl QwenXmlParser {
         calls
     }
 
+    /// Shared non-streaming parse, schema-aware when `tools` are provided.
+    fn parse_complete_inner(
+        &self,
+        text: &str,
+        tools: &[Tool],
+    ) -> ParserResult<(String, Vec<ToolCall>)> {
+        // Check if text contains Qwen XML format
+        if !self.has_tool_markers(text) {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        // Find where the first tool call begins
+        // Safe: has_tool_markers() already confirmed the marker exists
+        let idx = text
+            .find(self.tool_call_start_token)
+            .ok_or_else(|| ParserError::ParsingFailed("tool call marker not found".to_string()))?;
+        let normal_text = text[..idx].to_string();
+
+        // Extract tool calls
+        let mut parsed = Vec::new();
+        for captures in self.extractor.captures_iter(text) {
+            if let Some(content_str) = captures.get(1) {
+                let content = content_str.as_str().trim();
+
+                match self.parse_xml_format(content, tools) {
+                    Ok(Some(tool)) => parsed.push(tool),
+                    Ok(None) => continue,
+                    Err(e) => {
+                        tracing::warn!("Failed to parse XML tool call: {:?}", e);
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // If no tools were successfully parsed despite having markers, return entire text
+        if parsed.is_empty() {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        Ok((normal_text, parsed))
+    }
+
     /// Reset streaming state for next tool call
     fn reset_streaming_state(&mut self) {
         self.in_tool_call = false;
@@ -323,41 +382,15 @@ impl Default for QwenXmlParser {
 #[async_trait]
 impl ToolParser for QwenXmlParser {
     async fn parse_complete(&self, text: &str) -> ParserResult<(String, Vec<ToolCall>)> {
-        // Check if text contains Qwen XML format
-        if !self.has_tool_markers(text) {
-            return Ok((text.to_string(), vec![]));
-        }
+        self.parse_complete_inner(text, &[])
+    }
 
-        // Find where the first tool call begins
-        // Safe: has_tool_markers() already confirmed the marker exists
-        let idx = text
-            .find(self.tool_call_start_token)
-            .ok_or_else(|| ParserError::ParsingFailed("tool call marker not found".to_string()))?;
-        let normal_text = text[..idx].to_string();
-
-        // Extract tool calls
-        let mut tools = Vec::new();
-        for captures in self.extractor.captures_iter(text) {
-            if let Some(content_str) = captures.get(1) {
-                let content = content_str.as_str().trim();
-
-                match self.parse_xml_format(content) {
-                    Ok(Some(tool)) => tools.push(tool),
-                    Ok(None) => continue,
-                    Err(e) => {
-                        tracing::warn!("Failed to parse XML tool call: {:?}", e);
-                        continue;
-                    }
-                }
-            }
-        }
-
-        // If no tools were successfully parsed despite having markers, return entire text
-        if tools.is_empty() {
-            return Ok((text.to_string(), vec![]));
-        }
-
-        Ok((normal_text, tools))
+    async fn parse_complete_with_tools(
+        &self,
+        text: &str,
+        tools: &[Tool],
+    ) -> ParserResult<(String, Vec<ToolCall>)> {
+        self.parse_complete_inner(text, tools)
     }
 
     async fn parse_incremental(
@@ -459,7 +492,7 @@ impl ToolParser for QwenXmlParser {
 
             // Parse parameters (only complete ones)
             if self.current_tool_name_sent {
-                let param_calls = self.parse_and_stream_parameters();
+                let param_calls = self.parse_and_stream_parameters(tools);
                 calls.extend(param_calls);
 
                 // Check if tool call is complete
@@ -520,6 +553,8 @@ impl ToolParser for QwenXmlParser {
 
 #[cfg(test)]
 mod tests {
+    use openai_protocol::common::Function;
+
     use super::*;
 
     #[test]
@@ -593,5 +628,58 @@ mod tests {
             safe_val("Tom &amp; Jerry"),
             Value::String("Tom & Jerry".to_string())
         );
+    }
+
+    fn tool_with_props(props: Value) -> Vec<Tool> {
+        vec![Tool {
+            tool_type: "function".to_string(),
+            function: Function {
+                name: "f".to_string(),
+                description: None,
+                parameters: serde_json::json!({"type": "object", "properties": props}),
+                strict: None,
+            },
+        }]
+    }
+
+    // String-typed params keep numeric/bool/array/object-looking values as
+    // strings (the JavaScript-category bug); non-string params still coerce.
+    #[tokio::test]
+    async fn test_schema_aware_coercion_keeps_strings() {
+        let tools = tool_with_props(serde_json::json!({
+            "limit": {"type": "string"},
+            "flag": {"type": "string"},
+            "coords": {"type": "string"},
+            "cfg": {"type": "string"},
+            "count": {"type": "integer"},
+        }));
+        let text = "<tool_call>\n<function=f>\n\
+            <parameter=limit>4</parameter>\n\
+            <parameter=flag>true</parameter>\n\
+            <parameter=coords>[60,30]</parameter>\n\
+            <parameter=cfg>{\"a\": 1}</parameter>\n\
+            <parameter=count>5</parameter>\n\
+            </function>\n</tool_call>";
+        let (_, calls) = QwenXmlParser::new()
+            .parse_complete_with_tools(text, &tools)
+            .await
+            .unwrap();
+        assert_eq!(calls.len(), 1);
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["limit"], Value::String("4".to_string()));
+        assert_eq!(args["flag"], Value::String("true".to_string()));
+        assert_eq!(args["coords"], Value::String("[60,30]".to_string()));
+        assert_eq!(args["cfg"], Value::String("{\"a\": 1}".to_string()));
+        assert_eq!(args["count"], Value::Number(5.into()));
+    }
+
+    // Without a schema (no tools), behavior is unchanged: blind inference.
+    #[tokio::test]
+    async fn test_no_schema_infers_type() {
+        let text =
+            "<tool_call>\n<function=f>\n<parameter=count>5</parameter>\n</function>\n</tool_call>";
+        let (_, calls) = QwenXmlParser::new().parse_complete(text).await.unwrap();
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["count"], Value::Number(5.into()));
     }
 }


### PR DESCRIPTION
## Description

### Problem

**JavaScript collapse — root cause found, fixable (the clearest issue)**

SMG's `qwen_xml` and `glm4_moe` tool parsers blindly type-coerce XML parameter values, ignoring the schema:

| case | schema type | model emits | vLLM keeps | SMG coerces to | result |
|---|---|---|---|---|---|
| `isComplete` | String | `true` | `"true"` ✓ | `true` (bool) | ❌ Expected String, got bool |
| `limit` | String | `4` | `"4"` ✓ | `4` (int) | ❌ got int |
| `coordinates` | String | `[60,30]` | `"[60,30]"` ✓ | `[60,30]` (list) | ❌ got list |
| `chart` | String | `{...}` | `"{...}"` ✓ | `{...}` (dict) | ❌ got dict |

`qwen_xml::safe_val` and `glm4_moe` do `serde_json::from_str(value)` and keep the parsed type. JS schemas declare many params as String, so coercion produces the wrong type → BFCL rejects. vLLM keeps them as strings (schema-correct).

The fix already exists in-repo: `minimax_m2` uses `helpers::param_types_for_function` + `helpers::coerce_by_schema_type` (schema-aware) — which is why minimax is only −6 vs qwen −32 / glm −40. The gateway already passes `tools` to the parser (`parse_complete_with_tools`); `qwen_xml` just doesn't override it (ignores tools), and `glm4_moe` parses blindly. Fix: make both use schema-aware coercion like `minimax_m2`. This should also recover much of qwen/glm's `live_multiple` (−8.5) and `multi_turn` loss (same String-param coercion across categories).

Observed on the nightly BFCL A/B (`simple_javascript`, SMG vs vLLM): **qwen3.6 −32, glm-5.2 −40, deepseek-v4 −10, minimax −6** (minimax already schema-aware).

### Solution

`qwen_xml` and `glm4_moe` now coerce each XML argument by its declared JSON-schema type via `helpers::param_types_for_function` + `helpers::coerce_by_schema_type`:

- a `string` parameter keeps a numeric/bool/array/object-looking value **as a string**,
- typed params (`integer`/`number`/`boolean`/`object`/`array`) are parsed,
- unknown params (not in the schema) fall back to the previous blind inference, so behavior is unchanged when no schema is available.

Both parsers now thread `tools` through the complete (`parse_complete_with_tools`) and streaming (`parse_incremental`) paths; `parse_complete` (no tools) preserves the old inference. Mirrors the existing `minimax_m2` implementation.

## Changes

- `crates/tool_parser/src/parsers/qwen_xml.rs` — `parse_complete_with_tools` override + schema-aware `coerce_value` (keeps `safe_val` as the no-schema fallback); thread tools through streaming.
- `crates/tool_parser/src/parsers/glm4_moe.rs` — schema-aware coercion in `parse_arguments` (extracted blind inference into `infer_value` as the fallback); `parse_complete_with_tools` override; thread tools through.
- Unit tests in both parsers: String-typed params with numeric/bool/array/object values stay strings; non-string params still coerce; no-schema path unchanged.

## Test Plan

`cargo test -p tool-parser` (lib + integration, incl. existing qwen/glm suites) all pass; new coercion tests added. `cargo +nightly fmt` and `cargo clippy -p tool-parser --all-targets --all-features -- -D warnings` clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (tool_parser crate)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made tool-call argument parsing schema-aware in both complete and streaming modes (when tool definitions are provided) so declared types guide value coercion.
  * Added “complete parsing with tools” methods to apply schema-based coercion when tools are available.
* **Bug Fixes**
  * Improved consistency between streamed and non-streamed argument interpretation.
  * Enhanced `string` coercion to unwrap JSON string literals (e.g., `"\"4\""` → `4` as a string) while preserving prior behavior without schema.
* **Tests**
  * Expanded coverage for schema-aware coercion, including nullable/union schemas and streaming consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->