### PR TITLE
fix(tokenizer): render object-form tool-call arguments in DeepSeek V3.2/V4 encoders

### DIFF
--- a/crates/tokenizer/src/encoders/deepseek_v32.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v32.rs
@@ -173,14 +173,20 @@ fn tool_calls_from_openai_format(tool_calls: &[Value]) -> Vec<Value> {
 /// Mirrors `encode_arguments_to_dsml`. `tool_call["arguments"]` is a JSON
 /// *string* in OpenAI schema; the Python code does `json.loads(...)` and
 /// iterates over the resulting dict.
+///
+/// It may also arrive as an already-parsed object: `model_gateway`'s
+/// `process_tool_call_arguments` converts the string into a dict before the
+/// chat template runs. Reading only `as_str()` silently dropped object-form
+/// args, which erased every historical tool call's parameters in multi-turn
+/// prompts.
 fn encode_arguments_to_dsml(tool_call: &Value) -> Result<String, DsEncodingError> {
-    let arguments_str = tool_call
-        .get("arguments")
-        .and_then(|v| v.as_str())
-        .unwrap_or("{}");
-
-    let arguments: Value =
-        serde_json::from_str(arguments_str).map_err(DsEncodingError::InvalidToolArgumentsJson)?;
+    let arguments: Value = match tool_call.get("arguments") {
+        Some(Value::String(s)) => {
+            serde_json::from_str(s).map_err(DsEncodingError::InvalidToolArgumentsJson)?
+        }
+        Some(v) if v.is_object() => v.clone(),
+        _ => Value::Object(serde_json::Map::new()),
+    };
 
     let obj = match arguments.as_object() {
         Some(obj) => obj,
@@ -615,6 +621,40 @@ mod tests {
         )));
         assert!(out.contains(&format!("</{DSML_TOKEN}function_calls>")));
         assert!(out.ends_with(EOS_TOKEN));
+    }
+
+    #[test]
+    fn object_form_tool_call_arguments_render_params() {
+        // `model_gateway`'s `process_tool_call_arguments` converts the OpenAI
+        // arguments *string* into a dict before the chat template runs, so the
+        // encoder receives object-form arguments. It must render them, not drop
+        // them — dropping erased every historical tool call's parameters in
+        // multi-turn prompts and made the model loop (re-calling tools forever).
+        let msgs = [
+            user("call my tool"),
+            json!({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "search",
+                            "arguments": { "query": "deepseek", "limit": 5 }
+                        }
+                    }
+                ]
+            }),
+        ];
+
+        let out = encode_messages(&msgs, ThinkingMode::Chat, &EncodeParams::default()).unwrap();
+
+        assert!(out.contains(&format!(
+            "<{DSML_TOKEN}parameter name=\"query\" string=\"true\">deepseek</{DSML_TOKEN}parameter>"
+        )));
+        assert!(out.contains(&format!(
+            "<{DSML_TOKEN}parameter name=\"limit\" string=\"false\">5</{DSML_TOKEN}parameter>"
+        )));
     }
 
     #[test]

--- a/crates/tokenizer/src/encoders/deepseek_v4.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v4.rs
@@ -164,14 +164,19 @@ fn tool_calls_from_openai_format(tool_calls: &[Value]) -> Vec<Value> {
 
 /// V4 differs from V3.2: when `arguments` fails to JSON-parse, the upstream
 /// wraps the raw string in `{"arguments": <raw>}` instead of erroring.
+///
+/// `arguments` may arrive as a JSON *string* (raw OpenAI tool_calls) or as an
+/// already-parsed object — `model_gateway`'s `process_tool_call_arguments`
+/// converts the string into a dict before the chat template runs. Reading only
+/// `as_str()` silently dropped object-form args, which erased every historical
+/// tool call's parameters in multi-turn prompts.
 fn encode_arguments_to_dsml(tool_call: &Value) -> String {
-    let arguments_str = tool_call
-        .get("arguments")
-        .and_then(|v| v.as_str())
-        .unwrap_or("{}");
-    let arguments: Value = match serde_json::from_str(arguments_str) {
-        Ok(v) => v,
-        Err(_) => json!({ "arguments": arguments_str }),
+    let arguments: Value = match tool_call.get("arguments") {
+        Some(Value::String(s)) => {
+            serde_json::from_str(s).unwrap_or_else(|_| json!({ "arguments": s }))
+        }
+        Some(v) if v.is_object() => v.clone(),
+        _ => json!({}),
     };
     let obj = match arguments.as_object() {
         Some(obj) => obj,
@@ -784,6 +789,37 @@ mod tests {
         )));
         assert!(out.contains(&format!("</{DSML_TOKEN}{TOOL_CALLS_BLOCK_NAME}>")));
         assert!(out.ends_with(EOS_TOKEN));
+    }
+    #[test]
+    fn object_form_tool_call_arguments_render_params() {
+        // `model_gateway`'s `process_tool_call_arguments` converts the OpenAI
+        // arguments *string* into a dict before the chat template runs, so the
+        // encoder receives object-form arguments. It must render them, not drop
+        // them — dropping erased every historical tool call's parameters in
+        // multi-turn prompts and made the model loop (re-calling tools forever).
+        let msgs = [
+            user("call my tool"),
+            json!({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "search",
+                            "arguments": { "query": "deepseek", "limit": 5 }
+                        }
+                    }
+                ]
+            }),
+        ];
+        let out = encode_messages(&msgs, ThinkingMode::Chat, &EncodeParams::default()).unwrap();
+        assert!(out.contains(&format!(
+            "<{DSML_TOKEN}parameter name=\"query\" string=\"true\">deepseek</{DSML_TOKEN}parameter>"
+        )));
+        assert!(out.contains(&format!(
+            "<{DSML_TOKEN}parameter name=\"limit\" string=\"false\">5</{DSML_TOKEN}parameter>"
+        )));
     }
     #[test]
     fn unknown_role_errors() {


### PR DESCRIPTION
## Description

### Problem

DeepSeek-V4 (and V3.2) **`multi_turn` collapses by ~30pp** vs pure vLLM on the BFCL A/B (SMG arm), even after the json.dumps-spacing fixes. Root cause is a type mismatch between two layers:

1. `model_gateway`'s `routers/grpc/utils/chat_utils.rs::process_tool_call_arguments` parses each assistant `tool_calls[].function.arguments` from a **JSON string into a dict/Object** before the chat template runs (HF Transformers convention — Jinja templates expect dicts).
2. The DeepSeek V3.2/V4 **native** encoders' `encode_arguments_to_dsml` read `arguments` via **`.as_str()`** and fell back to `"{}"` for a non-string — so every **object-form** argument was silently **dropped**.

In multi-turn prompts this erased the parameters of every *historical* tool call. A prior `ls(a=true)` rendered as `<｜DSML｜invoke name="ls"></｜DSML｜invoke>` (no parameter) instead of carrying `a=true`. The model could no longer tell it had already acted, re-issued the same tool call repeatedly, exhausted the per-turn step budget, and the case `force_terminated`.

How it was isolated (H100, DeepSeek-V4-Flash, TP4):
- A/A control (serve vs serve) = **+0.5** → the gap is systematic, not non-determinism.
- A/B (serve vs SMG) = **−32.5** → real.
- Dominant failure = `multi_turn:force_terminated` (51/74 SMG-only failures): the model loops re-calling the same tool.
- Feeding **serve** the *correct* rendering (args present) → it **stops**; feeding serve **SMG's actual** rendering (args dropped) → it **loops** too → it's the prompt the encoder produces, not the engine.
- Decoded SMG's prompt: historical `ls(a=true)` → `<｜DSML｜invoke name="ls">\n\n</｜DSML｜invoke>` (empty).
- Local repro: encoder with **string** args renders the params; with **dict** args drops them. `process_tool_call_arguments` always converts string→dict, so the live path always dropped.

### Solution

Make `encode_arguments_to_dsml` (both `deepseek_v4.rs` and `deepseek_v32.rs`) accept `arguments` as **either a JSON string or an already-parsed object**:

```rust
let arguments: Value = match tool_call.get("arguments") {
    Some(Value::String(s)) => serde_json::from_str(s).unwrap_or_else(|_| json!({ "arguments": s })),
    Some(v) if v.is_object() => v.clone(),
    _ => json!({}),
};
```

## Changes

- `crates/tokenizer/src/encoders/deepseek_v4.rs` — accept string **or** object `arguments`.
- `crates/tokenizer/src/encoders/deepseek_v32.rs` — same fix.
- Regression test in both (`object_form_tool_call_arguments_render_params`): object-form arguments must render `<parameter …>` entries.

## Test Plan

- `cargo test -p llm-tokenizer deepseek` — all encoder tests pass, including the two new regression tests.
- Verified locally: with the fix, an object-form `ls(a=true)` history renders `<｜DSML｜parameter name="a" string="false">true</｜DSML｜parameter>` (previously dropped).
- Recommended follow-up: rebuild the SMG arm with this fix and re-run the DeepSeek-V4 BFCL `multi_turn` A/B (expect the −30pp gap to close to ~0, matching `vllm serve`).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call argument handling so parameter values are preserved whether they arrive as JSON strings or already-parsed objects.
  * Added safer fallback handling for unexpected argument formats, preventing dropped or missing parameters.

* **Tests**
  * Added coverage for object-form tool-call arguments to confirm they render correctly in output, including proper handling of string and non-string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->