### PR TITLE
feat(harmony): emit parallel tool calls for gpt-oss on the Chat API

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -281,12 +281,21 @@ impl HarmonyBuilder {
 
         let selection_text = self.extract_selection_text(&all_messages);
 
-        // Get stop tokens for Harmony assistant actions (<|return|> and <|call|>)
+        // Chat API: the *client* executes tools, so let the model emit ALL tool
+        // calls in one turn (parallel function calling) instead of stopping at
+        // the first <|call|>. Drop <|call|> (HARMONY_CALL_TOKEN) from the stop
+        // set, keeping <|return|>: generation then flows
+        // analysis<|end|> -> call_1<|call|> -> call_2<|call|> -> final<|return|>
+        // (stop), and `HarmonyParserAdapter::parse_messages` collects every tool
+        // call. (The Responses/agentic path keeps <|call|> as a stop because SMG
+        // executes the tools itself in a loop and must yield after each call.)
+        const HARMONY_CALL_TOKEN: u32 = 200012; // <|call|>
         let stop_token_ids: Vec<u32> = self
             .encoding
             .stop_tokens_for_assistant_actions()
             .into_iter()
             .flat_map(|set| set.into_iter())
+            .filter(|&token_id| token_id != HARMONY_CALL_TOKEN)
             .collect();
 
         Ok(HarmonyBuildOutput {
@@ -1181,6 +1190,43 @@ mod tests {
             !BUILTIN_TOOLS.contains(&"image_generation"),
             "image_generation must not be advertised as a gpt-oss builtin; \
              it is rendered as a function tool instead",
+        );
+    }
+
+    /// Chat API drops the `<|call|>` stop token (so gpt-oss can emit parallel
+    /// tool calls in one turn — the client executes them), while the
+    /// Responses/agentic path keeps it (SMG executes tools in a loop and must
+    /// yield after each call). Regression for BFCL `parallel*` scoring 0.
+    #[test]
+    fn chat_drops_call_stop_token_responses_keeps_it() {
+        use openai_protocol::chat::{ChatCompletionRequest, ChatMessage, MessageContent};
+        const CALL: u32 = 200012; // <|call|>
+        const RETURN: u32 = 200002; // <|return|>
+        let builder = HarmonyBuilder::new();
+
+        let chat = ChatCompletionRequest {
+            messages: vec![ChatMessage::User {
+                content: MessageContent::Text("hi".to_string()),
+                name: None,
+            }],
+            ..Default::default()
+        };
+        let chat_out = builder.build_from_chat(&chat).expect("build_from_chat");
+        assert!(
+            !chat_out.stop_token_ids.contains(&CALL),
+            "Chat must drop <|call|> so parallel tool calls aren't cut off after the first",
+        );
+        assert!(
+            chat_out.stop_token_ids.contains(&RETURN),
+            "Chat must keep <|return|> as a stop token",
+        );
+
+        let resp_out = builder
+            .build_from_responses(&ResponsesRequest::default())
+            .expect("build_from_responses");
+        assert!(
+            resp_out.stop_token_ids.contains(&CALL),
+            "Responses/agentic path must keep <|call|> (SMG executes tools in a loop)",
         );
     }
 


### PR DESCRIPTION
## Description

### Problem

gpt-oss-120b scores **0 on every parallel function-calling category** in the BFCL A/B (`parallel`, `parallel_multiple`, `live_parallel`, `live_parallel_multiple`) — on **both** arms (vllm baseline and SMG), e.g. run 28157011801.

Root cause: gpt-oss/harmony renders each tool call as a `commentary to=functions.*` message terminated by `<|call|>`, and `<|call|>` is one of harmony's `stop_tokens_for_assistant_actions` (`[<|call|>, <|return|>]`). The Chat build path forwarded that whole set as stop tokens, so generation stopped at the **first** `<|call|>` and only one tool call was ever returned. A 2-call request ("play Taylor Swift for 20m **and** Maroon 5 for 15m") returned just the first call → "Wrong number of functions" → 0.

The model *does* support parallel — it's purely the stop convention. On the H100, generating with `ignore_eos` so it runs past `<|call|>`:
```
analysis: "We need to call it twice … We'll output calls."
commentary to=functions.spotify_play {"artist":"Taylor Swift","duration":20}<|call|>
commentary to=functions.spotify_play {"artist":"Maroon 5","duration":15}<|call|>
final: ...<|return|>
```

### Solution

For the **Chat API** the *client* executes tools, so we can let the model emit all calls in one turn. Drop `<|call|>` from the Chat stop set (keep `<|return|>`) in `HarmonyBuilder::build_from_chat`. Generation then flows `analysis<|end|> -> call_1<|call|> -> call_2<|call|> -> final<|return|>`(stop), and the existing `HarmonyParserAdapter::parse_messages` already collects every `functions.*` message into the `tool_calls` vec.

The **Responses/agentic path is unchanged** (`build_from_responses` keeps `<|call|>` as a stop) because SMG executes the tools itself in a loop and must yield after each call.

This makes the SMG arm score higher than the pure-vLLM baseline on parallel categories (vLLM still stops at the first `<|call|>`).

## Changes

- `model_gateway/src/routers/grpc/harmony/builder.rs` — `build_from_chat` filters `<|call|>` (200012) out of the stop-token set; `build_from_responses` unchanged.
- Regression test `chat_drops_call_stop_token_responses_keeps_it`: Chat stop tokens exclude `<|call|>` / include `<|return|>`; Responses keep `<|call|>`.

## Test Plan

- `cargo test -p smg --lib chat_drops_call_stop_token` — passes.
- Single-call requests verified to still emit exactly one call (the model emits one call then its final).
- Live validation in progress on the H100 (gpt-oss-120b, SMG → grpc worker): confirming a parallel request now returns multiple `tool_calls`, plus a `multi_turn` regression check. Results to follow in a comment.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted chat completion stop-token handling so assistant actions no longer stop on the call token, while the return token still does.
  * Preserved the existing stop-token behavior for responses-based flows.
* **Tests**
  * Added regression coverage to verify the updated stop-token behavior across both chat completion and responses paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->