### PR TITLE
fix(harmony): revert no-op <|call|> stop filter for gpt-oss (#1845)

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -281,21 +281,12 @@ impl HarmonyBuilder {
 
         let selection_text = self.extract_selection_text(&all_messages);
 
-        // Chat API: the *client* executes tools, so let the model emit ALL tool
-        // calls in one turn (parallel function calling) instead of stopping at
-        // the first <|call|>. Drop <|call|> (HARMONY_CALL_TOKEN) from the stop
-        // set, keeping <|return|>: generation then flows
-        // analysis<|end|> -> call_1<|call|> -> call_2<|call|> -> final<|return|>
-        // (stop), and `HarmonyParserAdapter::parse_messages` collects every tool
-        // call. (The Responses/agentic path keeps <|call|> as a stop because SMG
-        // executes the tools itself in a loop and must yield after each call.)
-        const HARMONY_CALL_TOKEN: u32 = 200012; // <|call|>
+        // Get stop tokens for Harmony assistant actions (<|return|> and <|call|>)
         let stop_token_ids: Vec<u32> = self
             .encoding
             .stop_tokens_for_assistant_actions()
             .into_iter()
             .flat_map(|set| set.into_iter())
-            .filter(|&token_id| token_id != HARMONY_CALL_TOKEN)
             .collect();
 
         Ok(HarmonyBuildOutput {
@@ -1190,43 +1181,6 @@ mod tests {
             !BUILTIN_TOOLS.contains(&"image_generation"),
             "image_generation must not be advertised as a gpt-oss builtin; \
              it is rendered as a function tool instead",
-        );
-    }
-
-    /// Chat API drops the `<|call|>` stop token (so gpt-oss can emit parallel
-    /// tool calls in one turn — the client executes them), while the
-    /// Responses/agentic path keeps it (SMG executes tools in a loop and must
-    /// yield after each call). Regression for BFCL `parallel*` scoring 0.
-    #[test]
-    fn chat_drops_call_stop_token_responses_keeps_it() {
-        use openai_protocol::chat::{ChatCompletionRequest, ChatMessage, MessageContent};
-        const CALL: u32 = 200012; // <|call|>
-        const RETURN: u32 = 200002; // <|return|>
-        let builder = HarmonyBuilder::new();
-
-        let chat = ChatCompletionRequest {
-            messages: vec![ChatMessage::User {
-                content: MessageContent::Text("hi".to_string()),
-                name: None,
-            }],
-            ..Default::default()
-        };
-        let chat_out = builder.build_from_chat(&chat).expect("build_from_chat");
-        assert!(
-            !chat_out.stop_token_ids.contains(&CALL),
-            "Chat must drop <|call|> so parallel tool calls aren't cut off after the first",
-        );
-        assert!(
-            chat_out.stop_token_ids.contains(&RETURN),
-            "Chat must keep <|return|> as a stop token",
-        );
-
-        let resp_out = builder
-            .build_from_responses(&ResponsesRequest::default())
-            .expect("build_from_responses");
-        assert!(
-            resp_out.stop_token_ids.contains(&CALL),
-            "Responses/agentic path must keep <|call|> (SMG executes tools in a loop)",
         );
     }
 


### PR DESCRIPTION
## Description

### Problem

PR #1845 ("feat(harmony): emit parallel tool calls for gpt-oss on the Chat API") was merged by automation, but **its diff is a no-op** and it should not have landed.

It filtered `<|call|>` (200012) out of `build_from_chat`'s stop set to let gpt-oss emit multiple tool calls in one turn. H100 validation (gpt-oss-120b, TP2; SMG → vllm gRPC worker vs `vllm serve`) proves this has **zero effect**:

- `<|call|>` (200012) is part of gpt-oss's `generation_config.json` `eos_token_id`: `[200002, 199999, 200012]`.
- vLLM's `SamplingParams.update_from_generation_config` re-adds those EOS ids to `stop_token_ids` whenever `ignore_eos=False`. So omitting 200012 on the SMG side is silently undone by the engine.
- Isolating test (temp=0.001): a request with `stop_token_ids=[200002]` (200012 omitted — exactly this PR's behavior) **still stops at `stop_reason=200012`**, identical to including it. End-to-end, SMG returns 1 tool call, same as `vllm serve`.

Suppressing the stop genuinely requires `ignore_eos=True` + `stop_token_ids=[<|return|>]`, **and** a sampling temperature ≳ 0.6 — at BFCL's `temperature=0.001` (greedy) the model degenerates into hundreds of repeated `<|call|>` tokens rather than emitting a second call. `vllm serve` shares the same limitation.

Full investigation: https://github.com/lightseekorg/smg/pull/1845#issuecomment-4807471715

### Solution

Revert the dead code and the misleading regression test. A real fix (opt-in `ignore_eos` + `<|return|>` stop + temperature floor for gpt-oss tool calls, default off) can follow once the determinism tradeoff is agreed.

## Changes

- Revert `model_gateway/src/routers/grpc/harmony/builder.rs` changes from #1845 (the `<|call|>` stop-token filter in `build_from_chat` and its regression test).

## Test Plan

- No behavior change vs `vllm serve` for gpt-oss (both stop at the first `<|call|>`), which is the state before #1845.
- Empirically: `vllm /v1/completions` with a harmony prompt at temp=0.001 stops at `stop_reason=200012` whether or not 200012 is in the request `stop_token_ids` (proves the reverted code was a no-op).

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat response handling so tool-call sequences are less likely to stop prematurely.
  * Aligned chat output behavior with the expected assistant action flow for more reliable multi-step interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->