### PR TITLE
fix(multimodal): gate shm-namespace test to Linux

### DIFF
--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -1881,7 +1881,7 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     fn local_shm_namespace_id_resolves_on_linux() {
         // /proc/.../boot_id and /dev/shm both exist on the Linux CI/runtime
         // image, so the token must resolve to `<boot_id>:<st_dev>`. If it ever


### PR DESCRIPTION
## Summary
The `local_shm_namespace_id_resolves_on_linux` test was gated with `#[cfg(unix)]`, but it reads Linux-only paths (`/proc/sys/kernel/random/boot_id` and `/dev/shm`). On macOS dev hosts (which are also `unix`), the test fails because those paths don't exist.

Re-gated the test to `#[cfg(target_os = "linux")]` so it only runs on Linux where the required paths exist.

## Test plan
- `cargo build -p smg` - clean
- `cargo test -p smg --lib routers::grpc::multimodal` - 19 passed, test correctly skipped on macOS
- `cargo clippy -p smg --all-targets` - clean (only pre-existing warnings)

CI (Linux) behavior unchanged - the test will continue to run and pass on Linux CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restricted a platform-specific test to run only on Linux, improving compatibility across other Unix-like environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->