### PR TITLE
fix(protocols): accept min_tokens=0 in OpenAI requests

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -259,7 +259,7 @@ pub struct ChatCompletionRequest {
     pub min_p: Option<f32>,
 
     /// Minimum number of tokens to generate
-    #[validate(range(min = 1))]
+    #[validate(range(min = 0))]
     pub min_tokens: Option<u32>,
 
     /// Repetition penalty for reducing repetitive text

--- a/crates/protocols/src/completion.rs
+++ b/crates/protocols/src/completion.rs
@@ -96,7 +96,7 @@ pub struct CompletionRequest {
     pub min_p: Option<f32>,
 
     /// Minimum number of tokens to generate
-    #[validate(range(min = 1))]
+    #[validate(range(min = 0))]
     pub min_tokens: Option<u32>,
 
     /// Repetition penalty for reducing repetitive text

--- a/model_gateway/tests/spec/chat_completion.rs
+++ b/model_gateway/tests/spec/chat_completion.rs
@@ -191,6 +191,22 @@ fn test_function_call_function_variant_normalizes() {
     );
 }
 
+#[test]
+fn test_min_tokens_zero_is_valid() {
+    let req = ChatCompletionRequest {
+        model: "test-model".to_string(),
+        messages: vec![ChatMessage::User {
+            content: MessageContent::Text("hello".to_string()),
+            name: None,
+        }],
+        min_tokens: Some(0),
+        max_completion_tokens: Some(1),
+        ..Default::default()
+    };
+
+    assert!(req.validate().is_ok());
+}
+
 // Stream options validation tests
 
 #[test]


### PR DESCRIPTION
## Description

### Problem

OpenAI-compatible Chat Completions/Completions requests currently reject `min_tokens: 0` at protocol validation time because both request types use `#[validate(range(min = 1))]`.

`min_tokens=0` is commonly used as the no-minimum-generation value. vLLM accepts `min_tokens >= 0`, SGLang documents `min_new_tokens: int = 0`, and TensorRT-LLM documents that `min_tokens < 1` has no effect:

- https://docs.vllm.ai/en/stable/api/vllm/sampling_params/#vllm.sampling_params.SamplingParams.min_tokens
- https://docs.sglang.io/docs/basic_usage/sampling_params
- https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html#tensorrt_llm.llmapi.SamplingParams

### Solution

Allow `min_tokens=0` in Chat Completions and legacy Completions protocol validation.

## Changes

- Relax `ChatCompletionRequest.min_tokens` validation from `min=1` to `min=0`.
- Relax `CompletionRequest.min_tokens` validation from `min=1` to `min=0`.
- Add a Chat Completions spec test covering `min_tokens=0`.

## Test Plan

- `cargo +nightly fmt --all --check` - pass
- `cargo test -p smg --test spec_test` - pass (`96 passed; 0 failed; 1 ignored`)
- `cargo clippy --all-targets --all-features -- -D warnings` - pass

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated request validation to accept `0` for sampling-related minimum settings in both chat and completion requests, instead of requiring values to be at least `1`.
* **Tests**
  * Added a unit test to cover the `min_tokens = 0` edge case and confirm such requests validate successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->