### PR TITLE
chore: bump versions for v1.7.0 release

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+SGLang |
   ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.12.post1' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.12.post1') }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.6.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.6.0'
+        default: 'v1.7.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.6.0-sglang-v0.5.12.post1)'
+        description: 'Override image tag (e.g. v1.7.0-sglang-v0.5.12.post1)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.6.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+TRTLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18') }} |
   engine=${{ inputs.trtllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.6.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.6.0'
+        default: 'v1.7.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.6.0-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.7.0-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.6.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
       source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+vLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.22.1') }} |
   engine=${{ inputs.vllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.6.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.6.0'
+        default: 'v1.7.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.6.0-vllm-v0.22.1)'
+        description: 'Override image tag (e.g. v1.7.0-vllm-v0.22.1)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.6.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.8.1", path = "crates/protocols" }
-reasoning-parser = { version = "1.3.1", path = "crates/reasoning_parser" }
-tool-parser = { version = "1.3.1", path = "crates/tool_parser" }
+openai-protocol = { version = "1.9.0", path = "crates/protocols" }
+reasoning-parser = { version = "1.4.0", path = "crates/reasoning_parser" }
+tool-parser = { version = "1.4.0", path = "crates/tool_parser" }
 wfaas = { version = "1.0.5", path = "crates/workflow" }
-llm-tokenizer = { version = "1.4.1", path = "crates/tokenizer" }
-smg-auth = { version = "1.2.1", path = "crates/auth" }
-smg-mcp = { version = "2.3.1", path = "crates/mcp" }
-kv-index = { version = "1.3.1", path = "crates/kv_index" }
-smg-data-connector = { version = "2.3.1", path = "crates/data_connector", package = "data-connector" }
-llm-multimodal = { version = "1.7.0", path = "crates/multimodal" }
-smg-wasm = { version = "1.1.2", path = "crates/wasm", package = "smg-wasm" }
-smg-mesh = { version = "1.4.1", path = "crates/mesh", package = "smg-mesh" }
-smg-grpc-client = { version = "1.7.0", path = "crates/grpc_client" }
+llm-tokenizer = { version = "1.4.2", path = "crates/tokenizer" }
+smg-auth = { version = "1.2.2", path = "crates/auth" }
+smg-mcp = { version = "2.3.2", path = "crates/mcp" }
+kv-index = { version = "1.3.2", path = "crates/kv_index" }
+smg-data-connector = { version = "2.3.2", path = "crates/data_connector", package = "data-connector" }
+llm-multimodal = { version = "1.7.1", path = "crates/multimodal" }
+smg-wasm = { version = "1.1.3", path = "crates/wasm", package = "smg-wasm" }
+smg-mesh = { version = "1.4.2", path = "crates/mesh", package = "smg-mesh" }
+smg-grpc-client = { version = "1.8.0", path = "crates/grpc_client" }
 
 # Shared dependencies
 anyhow = "1.0"

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.6.0"
+version = "1.7.0"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/clients/openapi-gen/Cargo.toml
+++ b/clients/openapi-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openapi-gen"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Generate OpenAPI 3.1 spec from openai-protocol types"
 publish = false

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Rust HTTP client for SMG (Shepherd Model Gateway)"
 license = "Apache-2.0"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-auth"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 description = "Authentication and authorization for control plane APIs"
 license = "Apache-2.0"

--- a/crates/data_connector/Cargo.toml
+++ b/crates/data_connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-connector"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 description = "Storage backends for conversations and responses"
 license = "Apache-2.0"

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-grpc-client"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 description = "gRPC clients for vLLM, TensorRT-LLM, MLX, TokenSpeed, and SGLang backends"
 license = "Apache-2.0"

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.11"
+version = "0.4.12"
 description = "SMG gRPC proto definitions for vLLM, TRT-LLM, MLX, TokenSpeed, and SGLang"
 requires-python = ">=3.10"
 dependencies = [

--- a/crates/kv_index/Cargo.toml
+++ b/crates/kv_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kv-index"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 description = "Radix tree implementations for prefix matching and cache-aware routing"
 license = "Apache-2.0"

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mcp"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 description = "Model Context Protocol (MCP) client implementation"
 license = "Apache-2.0"

--- a/crates/mesh/Cargo.toml
+++ b/crates/mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mesh"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 description = "Mesh gossip protocol and distributed state synchronization for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-multimodal"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.8.1"
+version = "1.9.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/crates/reasoning_parser/Cargo.toml
+++ b/crates/reasoning_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasoning-parser"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"

--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-tokenizer"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 description = "LLM tokenizer library with caching and chat template support"
 license = "Apache-2.0"

--- a/crates/tool_parser/Cargo.toml
+++ b/crates/tool_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool-parser"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 description = "Tool/function call parser for LLM model outputs"
 license = "Apache-2.0"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-wasm"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 description = "WebAssembly runtime and module management for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/deploy/helm/smg/Chart.yaml
+++ b/deploy/helm/smg/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: smg
 description: "Shepherd Model Gateway - high-performance inference router for LLM deployments"
 type: application
-version: 1.6.0
-appVersion: "1.6.0"
+version: 1.7.0
+appVersion: "1.7.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/lightseekorg/smg
 sources:

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-servicer"
-version = "0.5.6"
+version = "0.6.0"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, MLX, TokenSpeed, SGLang)"
 requires-python = ">=3.10"
 dependencies = [

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description

Version bumps for the **SMG v1.7.0** release, generated by `make check-versions` against tag `v1.6.0`. This is a **version-bump-only** release — no engine base-image changes (the `release-{sglang,vllm,trtllm}-docker.yml` diffs are limited to the SMG version refs `v1.6.0 → v1.7.0`, not engine image updates).

## Changes

**Workspace versions** (per `check-versions` proposed fixes, all applied):
- `smg` 1.6.0 → **1.7.0**; synced: `smg-python`, `smg-golang`, python `pyproject.toml`, helm chart, and the SMG refs in `release-{sglang,vllm,trtllm}-docker.yml`
- Minor bumps: `openai-protocol` 1.9.0, `reasoning-parser` 1.4.0, `tool-parser` 1.4.0, `smg-grpc-client` 1.8.0, `smg-grpc-servicer` 0.6.0
- Patch bumps: `llm-tokenizer` 1.4.2, `smg-auth` 1.2.2, `smg-mcp` 2.3.2, `kv-index` 1.3.2, `data-connector` 2.3.2, `llm-multimodal` 1.7.1, `smg-wasm` 1.1.3, `smg-mesh` 1.4.2, `smg-grpc-proto` 0.4.12, `smg-client` 0.1.1, `openapi-gen` 0.1.2

`wfaas` was unchanged this release — no bump needed.

## Test Plan

- `make check-versions` re-run after applying: **"All versions consistent."** (15 crates + 2 Python packages reconciled, 0 issues)
- No engine base-image changes this release; the `release-*-docker.yml` diffs are limited to the `v1.6.0 → v1.7.0` SMG version refs.
- `Cargo.lock` is gitignored in this repo (same as prior release PRs #1792 / #1665); workspace lock refresh happens at build time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version **1.7.0** across the core product, packages, and language bindings.
  * Updated Docker image release defaults to use the newer base/version reference.
  * Bumped the Helm chart and app version to **1.7.0** for deployment consistency.
* **Bug Fixes**
  * Improved release packaging consistency across Rust, Python, Go, and client artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->