### PR TITLE
fix(ci): build aarch64 wheels on manylinux_2_28

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -21,7 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        target: [x86_64, aarch64]
+        # aarch64 is added via the `include` entries below so the linux build can
+        # pin a newer manylinux image; the base manylinux2014 toolchain is too old
+        # to compile aws-lc-sys for aarch64 (no stdatomic.h / no armv8.4 -march).
+        target: [x86_64]
         manylinux: [auto]
         include:
           - os: ubuntu
@@ -40,6 +43,9 @@ jobs:
           - os: ubuntu
             platform: linux
             target: aarch64
+            # manylinux2014's aarch64 cross-gcc is too old for aws-lc-sys 0.41;
+            # 2_28 (AlmaLinux 8) has stdatomic.h + armv8.4 support.
+            manylinux: "2_28"
           # musllinux
           - os: ubuntu
             platform: linux


### PR DESCRIPTION
## Problem

The **v1.7.0** "Release SMG to PyPI" run failed on `build on linux (aarch64 - auto)`, and because one matrix build failed, **`Upload to PyPI` was skipped** — so no `smg` wheels were published for v1.7.0. ([failed run](https://github.com/lightseekorg/smg/actions/runs/28384706149))

## Root cause

The aarch64 wheel is cross-compiled in the `manylinux: auto` (**manylinux2014 / CentOS 7**) container, whose aarch64 cross-gcc (~GCC 4.8) is too old to build **`aws-lc-sys 0.41.0`**:

```
.../aws-lc-sys-0.41.0/aws-lc/crypto/asn1/../internal.h:488:23:
   fatal error: stdatomic.h: No such file or directory
.../neon_sha3_check.c: error: unknown value 'armv8.4-a+sha3' for -march
```

`aws-lc-sys` isn't a direct dependency — it's pulled transitively (`aws-lc-sys` ← `aws-lc-rs` ← `rustls 0.23`, whose default provider is aws-lc-rs; carriers are reqwest's `rustls` feature and kube's default `rustls-tls`). It entered the graph during the post-v1.6.0 dependency-bump wave, and since `Cargo.lock` is gitignored, CI resolves the new combination fresh. The **musllinux aarch64** build already passes because Alpine ships a modern GCC.

## Fix

Pin the **linux aarch64** wheel to **`manylinux_2_28`** (AlmaLinux 8, modern GCC with `<stdatomic.h>` and armv8.4 `-march`). `x86_64` stays on `manylinux2014` for broader glibc compatibility; macOS-aarch64 and musllinux-aarch64 are unchanged. aarch64 is moved out of the base `target` list so the old `aarch64 × auto` (manylinux2014) job no longer exists.

This is the minimal unblock and doesn't touch the dependency graph. (Purging `aws-lc-rs` to honor the pure-Rust/ring stack is a reasonable separate follow-up.)

## Test Plan

- CI is authoritative for the aarch64 cross-compile (can't be validated locally).
- Verify the matrix produces `linux aarch64 - 2_28` (not `- auto`), the aarch64 build's `aws-lc-sys` step compiles, and `Upload to PyPI` runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PyPI release workflow to streamline build targets.
  * Adjusted Linux build packaging settings for improved compatibility on one architecture.
  * No changes to application features or end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->