### PR TITLE
fix(ci): use hermetic Python for PyPI upload (Metadata 2.4)

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -162,10 +162,18 @@ jobs:
           path: dist
           merge-multiple: true
 
+      # Hermetic Python so twine pulls a modern `packaging` (>= 24.2); the
+      # runner's system packaging can't parse Metadata 2.4 (PEP 639
+      # License-Expression/License-File) and rejects the wheels.
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
       - name: Upload to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_ROUTER }}
         run: |
-          pip install twine
+          pip install -U twine
           twine upload dist/* --verbose


### PR DESCRIPTION
## Problem

With the aarch64 fix (#1855) merged, the v1.7.0 publish got further — **all 7 wheels + the sdist built successfully** (incl. the new `manylinux_2_28_aarch64`) — but **`Upload to PyPI` failed** ([run](https://github.com/lightseekorg/smg/actions/runs/28392979362)):

```
ERROR InvalidDistribution: Invalid distribution metadata: unrecognized or
      malformed field 'license-file'; unrecognized or malformed field 'license-expression'
```

## Root cause

The wheels are **valid** — `Metadata-Version: 2.4` with PEP 639 `License-Expression: Apache-2.0` / `License-File: LICENSE` (introduced by #1847's `license = "Apache-2.0"` + `license-files`). The **upload job is stale**: unlike the build/sdist jobs, it has no `actions/setup-python`, so `pip install twine` runs against the runner's **system `packaging` (24.0)**, which predates PEP 639 / Metadata 2.4 parsing (added in `packaging` 24.2) and rejects the wheels client-side.

Verified locally: `twine check` with modern tooling **passes on all 7 wheels + the sdist**, so the artifacts are fine — only the uploader's environment was the problem.

## Fix

Give the upload job a hermetic modern Python (mirroring the build jobs) and `pip install -U twine`, so twine pulls `packaging >= 24.2` and accepts Metadata 2.4.

## Test Plan

- `twine check packages-*/*.whl sdist/*.tar.gz` on the real run artifacts → all `PASSED` (with modern packaging).
- After merge, re-dispatch `Release SMG to PyPI` on `main`; the `Upload to PyPI` step should publish smg v1.7.0 (nothing uploaded yet — no conflict).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the PyPI release process by using a consistent Python version during upload and updating the package uploader to the latest version.
  * This helps make package publishing more reliable and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->