### PR TITLE
ci: alternate BFCL (Mon/Wed/Fri) and tau2 (Tue/Thu/Sat) nightlies

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -12,7 +12,7 @@ name: Nightly BFCL
 
 on:
   schedule:
-    - cron: "17 7 * * 1,3,5" # Mon/Wed/Fri 07:17 UTC = 00:17 PDT (alternates nights with nightly-tau2; both are ~7h and share the Blackwell host)
+    - cron: "17 7 * * 1,3,5" # Mon/Wed/Fri 07:17 UTC = 00:17 PDT — alternates nights with nightly-tau2 so the two ~7h runs don't queue back-to-back on the shared Blackwell runner
   # PR sanity: only when the BFCL pipeline itself changes. Runs a quick non-live
   # subset so the A/B is exercised end-to-end (engine, FC mode, parser, scoring)
   # before merge — confidence the pipeline works, not a statistical result.

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -12,7 +12,7 @@ name: Nightly BFCL
 
 on:
   schedule:
-    - cron: "17 7 * * *" # 07:17 UTC = 00:17 PDT
+    - cron: "17 7 * * 1,3,5" # Mon/Wed/Fri 07:17 UTC = 00:17 PDT (alternates nights with nightly-tau2; both are ~7h and share the Blackwell host)
   # PR sanity: only when the BFCL pipeline itself changes. Runs a quick non-live
   # subset so the A/B is exercised end-to-end (engine, FC mode, parser, scoring)
   # before merge — confidence the pipeline works, not a statistical result.

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -19,7 +19,7 @@ name: Nightly tau2
 
 on:
   schedule:
-    - cron: "23 10 * * 2,4,6" # Tue/Thu/Sat 10:23 UTC = 03:23 PDT (alternates nights with nightly-bfcl; both are ~7h and share the Blackwell host)
+    - cron: "17 7 * * 2,4,6" # Tue/Thu/Sat 07:17 UTC = 00:17 PDT (alternates nights with nightly-bfcl; both are ~7h and share the Blackwell host)
   # PR sanity: only when the tau2 pipeline itself changes. Runs the H100 legs on a
   # quick single-domain, single-trial, small-task subset so the A/B is exercised
   # end-to-end (engine, tool/reasoning parsing, scoring) before merge.

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -19,7 +19,7 @@ name: Nightly tau2
 
 on:
   schedule:
-    - cron: "23 10 * * *" # 10:23 UTC = 03:23 PDT
+    - cron: "23 10 * * 2,4,6" # Tue/Thu/Sat 10:23 UTC = 03:23 PDT (alternates nights with nightly-bfcl; both are ~7h and share the Blackwell host)
   # PR sanity: only when the tau2 pipeline itself changes. Runs the H100 legs on a
   # quick single-domain, single-trial, small-task subset so the A/B is exercised
   # end-to-end (engine, tool/reasoning parsing, scoring) before merge.

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -19,14 +19,15 @@ name: Nightly tau2
 
 on:
   schedule:
-    - cron: "17 7 * * 2,4,6" # Tue/Thu/Sat 07:17 UTC = 00:17 PDT (alternates nights with nightly-bfcl; both are ~7h and share the Blackwell host)
-  # PR sanity: only when the tau2 pipeline itself changes. Runs the H100 legs on a
-  # quick single-domain, single-trial, small-task subset so the A/B is exercised
-  # end-to-end (engine, tool/reasoning parsing, scoring) before merge.
-  pull_request:
-    paths:
-      - "scripts/tau2/**"
-      - ".github/workflows/nightly-tau2.yml"
+    - cron: "17 7 * * 2,4,6" # Tue/Thu/Sat 07:17 UTC = 00:17 PDT — alternates nights with nightly-bfcl so the two ~7h runs don't queue back-to-back on the shared Blackwell runner
+  # PR sanity (disabled, like nightly-bfcl): when the tau2 pipeline itself changes
+  # this would run ALL legs on a tiny retail / 1-trial / few-task subset — but the
+  # 6-leg run (incl. the ~7h Blackwell legs) is too heavy for every pipeline PR.
+  # Re-enable temporarily to smoke a pipeline change, or use workflow_dispatch.
+  # pull_request:
+  #   paths:
+  #     - "scripts/tau2/**"
+  #     - ".github/workflows/nightly-tau2.yml"
   workflow_dispatch:
     inputs:
       only:


### PR DESCRIPTION
## Description

### Problem

Both nightlies run **daily** and each takes **~7h** (dominated by the shared Blackwell legs). They run on the **same self-hosted Blackwell runner**, so running both the same night doesn't collide on GPUs — GitHub **queues** them — but that serializes into a ~14h back-to-back run that can overrun into the next day and back up the runner queue.

Separately, the tau2 pipeline's `pull_request` trigger runs the **full 6-leg matrix** (incl. the ~7h Blackwell legs) on every PR that touches it — far too heavy now that the matrix is validated.

### Solution

- **Alternate nights** so each has the runner to itself: **bfcl** Mon/Wed/Fri, **tau2** Tue/Thu/Sat, both at **07:17 UTC (00:17 PDT)**. Sunday is idle as slack for a run that overruns.
- **Disable tau2's `pull_request` trigger** (comment it out, matching `nightly-bfcl`). Use the schedule or `workflow_dispatch` (`only=<leg>`) going forward; re-enable temporarily to smoke a pipeline change.

## Changes

- `.github/workflows/nightly-bfcl.yml`: cron `* * *` → `* * 1,3,5` (Mon/Wed/Fri).
- `.github/workflows/nightly-tau2.yml`: cron `23 10 * * *` → `17 7 * * 2,4,6` (Tue/Thu/Sat, 07:17 UTC = 00:17 PDT); `pull_request` trigger commented out.

## Test Plan

- `yaml.safe_load` parses both; each workflow's `on:` = `schedule` + `workflow_dispatch` only.
- Schedule check (current UTC = Thu): next scheduled run is **tau2 today (Thu) 07:17 UTC = 00:17 PDT**; bfcl's next is **Fri 07:17 UTC**.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` — N/A (no Rust)
- [ ] `cargo clippy` — N/A (no Rust)
- [x] YAML validated; both `on:` triggers confirmed
- [x] (Optional) Documentation updated (cron comments note the alternation + PDT + queue rationale)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
