### PR TITLE
fix(ci): kimi-k2.6 SMG reasoning parser (kimi_k25 → kimi_thinking)

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -169,7 +169,7 @@ jobs:
                "model": "moonshotai/Kimi-K2.6", "bfcl_model": "moonshotai/Kimi-K2.6-FC",
                "vllm_tool": "kimi_k2", "vllm_reason": "kimi_k2",
                "smg_tool": "kimik2",
-               "smg_reason": "kimi_k25",  # TODO(confirm): no kimi_k2 SMG reasoning parser yet
+               "smg_reason": "kimi_thinking",  # K2.6 template prefills <think> (always-in-reasoning); kimi_k25 (always_in_reasoning=false) mis-splits reasoning -> SMG scored 0
                # Generous startup: 1T MoE at TP=4 needs minutes for load+compile+quant (420s timed out).
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
                "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "auto"},

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -172,7 +172,7 @@ jobs:
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "moonshotai/Kimi-K2.6",
                "vllm_tool": "kimi_k2", "vllm_reason": "kimi_k2",
-               "smg_tool": "kimik2", "smg_reason": "kimi_k25",
+               "smg_tool": "kimik2", "smg_reason": "kimi_thinking",  # K2.6 template prefills <think> (always-in-reasoning); kimi_k25 is always_in_reasoning=false -> mis-splits reasoning
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
                "model_cache": "/raid/models", "arm_mode": "concurrent",
                "max_model_len": "auto", "num_tasks": 30},


### PR DESCRIPTION
## Description
### Problem
In the nightly A/B, **kimi-k2.6 SMG scored 0 vs vLLM 100**. Not a tool-parse bug — SMG emits well-formed tool calls (correct name + args). The SMG agent systematically **over-confirms and never fires the mutating tool** before the user-sim stops → DB unchanged → reward 0 (all tasks).

### Solution
Root cause confirmed on the B200 by inspecting Kimi-K2.6's native `chat_template.jinja`: it **prefills `<think>` at the generation prompt** (every assistant turn starts *inside* a `<think>…</think>` reasoning block). That's an **always-in-reasoning** model. The matrix ran SMG with `--reasoning-parser kimi_k25` (`always_in_reasoning: false` — expects the model to emit `<think>` itself, which never happens), so SMG mis-splits reasoning vs content and the agent degrades. vLLM's `kimi_k2` parser handles the prefill, hence 100.

Fix: kimi-k2.6 `smg_reason` `kimi_k25` → **`kimi_thinking`** (`always_in_reasoning: true`, same `<think>`/`</think>`), in both the tau2 and bfcl matrices.

## Test Plan
- Confirmed the template prefill + delimiter (`<think>`) on the B200 via `apply_chat_template`.
- Validate live: `workflow_dispatch only=kimi-k2.6` (after merge) — expect SMG pass^k to recover toward parity with vLLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly evaluation setup for one model configuration, helping avoid incorrect parsing and scoring behavior during automated runs.
  * Updated the reasoning/tool parsing behavior used in that workflow leg for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->