### PR TITLE
fix(ci): pin nvidia-cutlass-dsl 4.5.2 for TokenSpeed (uv + build subprocess pip)

### DIFF
--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -22,7 +22,13 @@ fi
 # a scheduled bump-and-CI routine) rather than floating against ``main`` —
 # upstream has renamed APIs before and the gRPC servicer broke until we
 # caught up.
-TOKENSPEED_REF="${TOKENSPEED_REF:-5e145afae8e5651cd66234e68c988c31aac6639f}"
+#
+# Bumped from 5e145af (2026-05-25): that ref left ``nvidia-cutlass-dsl``
+# unpinned in the kernel requirements, so the 4.6.0 release (2026-07-02,
+# which dropped ``cute.core.ThrMma``) floated in and broke ``import
+# tokenspeed`` via flash-attn's cute backend → quack. This ref pins
+# ``nvidia-cutlass-dsl==4.5.2``.
+TOKENSPEED_REF="${TOKENSPEED_REF:-f6235c26f1c9333abf75dc0cb5402b1cd1aa10f1}"
 TOKENSPEED_REPO="${TOKENSPEED_REPO:-https://github.com/lightseekorg/tokenspeed.git}"
 TOKENSPEED_DIR="${TOKENSPEED_DIR:-/tmp/tokenspeed-src}"
 

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -18,11 +18,6 @@ if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
 fi
 
-# Keep imports hermetic to the venv. A cutlass build outside the venv (user
-# site-packages / node image) can shadow the pinned one and reintroduce the
-# ``cute.core.ThrMma`` failure even when the venv has the right version.
-export PYTHONNOUSERSITE=1
-
 # Pinned SHA from lightseekorg/tokenspeed main. Bump explicitly (ideally via
 # a scheduled bump-and-CI routine) rather than floating against ``main`` —
 # upstream has renamed APIs before and the gRPC servicer broke until we
@@ -102,28 +97,21 @@ export FLASHINFER_CUDA_ARCH_LIST="${FLASHINFER_CUDA_ARCH_LIST:-9.0a 10.0a}"
 
 # The kernel requirements leave ``nvidia-cutlass-dsl`` unpinned, and 4.6.0
 # dropped ``cute.core.ThrMma`` — which quack (pulled via flash-attn's cute
-# backend) uses, breaking ``import tokenspeed``. Constrain every resolve
-# below to the last compatible release.
+# backend) uses, breaking ``import tokenspeed``. Pin to the last compatible
+# release. Both UV_CONSTRAINT and PIP_CONSTRAINT are needed: the kernel's
+# setup.py shells out to ``pip install -r requirements/cuda.txt`` during the
+# native build (see _install_backend_build_requirements), and that subprocess
+# pip does not see UV_CONSTRAINT — without PIP_CONSTRAINT it pulls 4.6.0
+# alongside the pinned 4.5.2 and wins on sys.path.
 TOKENSPEED_CONSTRAINTS="$(mktemp)"
 echo "nvidia-cutlass-dsl==4.5.2" > "$TOKENSPEED_CONSTRAINTS"
 export UV_CONSTRAINT="$TOKENSPEED_CONSTRAINTS"
+export PIP_CONSTRAINT="$TOKENSPEED_CONSTRAINTS"
 
 # Preseed build-time tooling: ``./python`` and ``tokenspeed-kernel`` use
 # ``setuptools.build_meta`` without declaring ``setuptools`` in
 # ``build-system.requires``, and we install with ``--no-build-isolation``.
 uv pip install setuptools wheel pybind11
-
-# Self-hosted runners reuse ``.venv`` across jobs. An earlier unpinned run can
-# leave nvidia-cutlass-dsl 4.6.0 (``dsl_packages/`` layout) installed alongside
-# the pinned 4.5.2 (``python_packages/``); 4.6.0's ``.pth`` wins on sys.path and
-# it dropped ``cute.core.ThrMma``, so ``import tokenspeed`` fails even with the
-# pin. Purge any pre-existing cutlass-dsl so the constrained install below
-# leaves only 4.5.2.
-uv pip uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base \
-    nvidia-cutlass-dsl-libs-core nvidia-cutlass-dsl-libs-cu12 \
-    nvidia-cutlass-dsl-libs-cu13 2>/dev/null || true
-CUTLASS_SITE="$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
-rm -rf "${CUTLASS_SITE:?}"/nvidia_cutlass_dsl* "${CUTLASS_SITE:?}"/*cutlass*.pth
 
 uv pip install -e tokenspeed-kernel/python/ --no-build-isolation
 uv pip install -e tokenspeed-scheduler/

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -21,9 +21,8 @@ fi
 # Pinned SHA from lightseekorg/tokenspeed main. Bump explicitly (ideally via
 # a scheduled bump-and-CI routine) rather than floating against ``main`` —
 # upstream has renamed APIs before and the gRPC servicer broke until we
-# caught up. This ref pins nvidia-cutlass-dsl==4.5.2; older refs left it
-# unpinned and the 4.6.0 release broke the build.
-TOKENSPEED_REF="${TOKENSPEED_REF:-f6235c26f1c9333abf75dc0cb5402b1cd1aa10f1}"
+# caught up.
+TOKENSPEED_REF="${TOKENSPEED_REF:-5e145afae8e5651cd66234e68c988c31aac6639f}"
 TOKENSPEED_REPO="${TOKENSPEED_REPO:-https://github.com/lightseekorg/tokenspeed.git}"
 TOKENSPEED_DIR="${TOKENSPEED_DIR:-/tmp/tokenspeed-src}"
 
@@ -95,6 +94,14 @@ sudo apt-get install -y --no-install-recommends libssl-dev libopenmpi-dev cmake
 # ── TokenSpeed packages ────────────────────────────────────────────────────
 export MAX_JOBS="${MAX_JOBS:-16}"
 export FLASHINFER_CUDA_ARCH_LIST="${FLASHINFER_CUDA_ARCH_LIST:-9.0a 10.0a}"
+
+# The kernel requirements leave ``nvidia-cutlass-dsl`` unpinned, and 4.6.0
+# dropped ``cute.core.ThrMma`` — which quack (pulled via flash-attn's cute
+# backend) uses, breaking ``import tokenspeed``. Constrain every resolve
+# below to the last compatible release.
+TOKENSPEED_CONSTRAINTS="$(mktemp)"
+echo "nvidia-cutlass-dsl==4.5.2" > "$TOKENSPEED_CONSTRAINTS"
+export UV_CONSTRAINT="$TOKENSPEED_CONSTRAINTS"
 
 # Preseed build-time tooling: ``./python`` and ``tokenspeed-kernel`` use
 # ``setuptools.build_meta`` without declaring ``setuptools`` in

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -21,13 +21,8 @@ fi
 # Pinned SHA from lightseekorg/tokenspeed main. Bump explicitly (ideally via
 # a scheduled bump-and-CI routine) rather than floating against ``main`` —
 # upstream has renamed APIs before and the gRPC servicer broke until we
-# caught up.
-#
-# Bumped from 5e145af (2026-05-25): that ref left ``nvidia-cutlass-dsl``
-# unpinned in the kernel requirements, so the 4.6.0 release (2026-07-02,
-# which dropped ``cute.core.ThrMma``) floated in and broke ``import
-# tokenspeed`` via flash-attn's cute backend → quack. This ref pins
-# ``nvidia-cutlass-dsl==4.5.2``.
+# caught up. This ref pins nvidia-cutlass-dsl==4.5.2; older refs left it
+# unpinned and the 4.6.0 release broke the build.
 TOKENSPEED_REF="${TOKENSPEED_REF:-f6235c26f1c9333abf75dc0cb5402b1cd1aa10f1}"
 TOKENSPEED_REPO="${TOKENSPEED_REPO:-https://github.com/lightseekorg/tokenspeed.git}"
 TOKENSPEED_DIR="${TOKENSPEED_DIR:-/tmp/tokenspeed-src}"

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -113,6 +113,18 @@ export UV_CONSTRAINT="$TOKENSPEED_CONSTRAINTS"
 # ``build-system.requires``, and we install with ``--no-build-isolation``.
 uv pip install setuptools wheel pybind11
 
+# Self-hosted runners reuse ``.venv`` across jobs. An earlier unpinned run can
+# leave nvidia-cutlass-dsl 4.6.0 (``dsl_packages/`` layout) installed alongside
+# the pinned 4.5.2 (``python_packages/``); 4.6.0's ``.pth`` wins on sys.path and
+# it dropped ``cute.core.ThrMma``, so ``import tokenspeed`` fails even with the
+# pin. Purge any pre-existing cutlass-dsl so the constrained install below
+# leaves only 4.5.2.
+uv pip uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base \
+    nvidia-cutlass-dsl-libs-core nvidia-cutlass-dsl-libs-cu12 \
+    nvidia-cutlass-dsl-libs-cu13 2>/dev/null || true
+CUTLASS_SITE="$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+rm -rf "${CUTLASS_SITE:?}"/nvidia_cutlass_dsl* "${CUTLASS_SITE:?}"/*cutlass*.pth
+
 uv pip install -e tokenspeed-kernel/python/ --no-build-isolation
 uv pip install -e tokenspeed-scheduler/
 uv pip install -e "./python" --no-build-isolation

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -18,6 +18,11 @@ if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
 fi
 
+# Keep imports hermetic to the venv. A cutlass build outside the venv (user
+# site-packages / node image) can shadow the pinned one and reintroduce the
+# ``cute.core.ThrMma`` failure even when the venv has the right version.
+export PYTHONNOUSERSITE=1
+
 # Pinned SHA from lightseekorg/tokenspeed main. Bump explicitly (ideally via
 # a scheduled bump-and-CI routine) rather than floating against ``main`` —
 # upstream has renamed APIs before and the gRPC servicer broke until we
@@ -139,6 +144,22 @@ echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."
 uv pip uninstall tokenspeed-smg-grpc-proto tokenspeed-smg-grpc-servicer
 uv pip install -e crates/grpc_client/python/
 uv pip install -e grpc_servicer/
+
+# ── cutlass provenance (diagnostic) ─────────────────────────────────────────
+# quack 0.5.0 uses the deprecated ``cute.core.ThrMma`` shim (present in 4.5.2,
+# removed in 4.6.0). Identical pip installs have imported different cutlass
+# builds across runners, so surface exactly what loads and from where.
+echo "=== cutlass provenance ==="
+uv pip show nvidia-cutlass-dsl 2>/dev/null | grep -iE "^(Name|Version|Location):" || true
+python3 -c "
+import sys, cutlass, cutlass.cute.core as core
+print('import cutlass  ->', cutlass.__file__)
+print('cutlass version ->', getattr(cutlass, '__version__', '?'))
+print('cute.core file  ->', core.__file__)
+print('cute.core ThrMma->', hasattr(core, 'ThrMma'))
+print('sys.path:')
+[print('   ', p) for p in sys.path]
+" || true
 
 # ── Verification ──────────────────────────────────────────────────────────
 echo "=== TokenSpeed verification ==="


### PR DESCRIPTION
## Description

### Problem

The `e2e-1gpu-chat (tokenspeed)` leg started failing on `main` on 2026-07-02, in the **Setup TokenSpeed backend** step, with:

```
AttributeError: module 'cutlass.cute.core' has no attribute 'ThrMma'
```

`import tokenspeed` triggers `flash_attn.cute` → `quack` → `quack/layout_utils.py`, which references `cute.core.ThrMma`.

Root cause is third-party dependency drift, and it has two layers:

1. **`nvidia-cutlass-dsl==4.6.0`** was published to PyPI at 2026-07-02 03:23 UTC and **removed the deprecated `cute.core.ThrMma` shim** (present in 4.5.2). `quack-kernels==0.5.0` still uses it and declares `nvidia-cutlass-dsl>=4.5.2` (no upper bound), so it happily resolves to 4.6.0.
2. **Two install channels pull cutlass-dsl, and only one honored the pin.** Pinning via `UV_CONSTRAINT` fixed the `uv` editable install (→ 4.5.2 in `python_packages/`), but `tokenspeed-kernel`'s `setup.py` also shells out to a subprocess `pip install -r requirements/cuda.txt` during the native build (`_install_backend_build_requirements`). `cuda.txt` leaves `nvidia-cutlass-dsl` unpinned, and that subprocess **`pip` does not see `UV_CONSTRAINT`** — so it installed 4.6.0 into `dsl_packages/` alongside the pinned 4.5.2. 4.6.0's `.pth` wins on `sys.path`, so the broken version loaded.

This is why the leg was green on 2026-07-01 (4.6.0 didn't exist yet) and why a version pin alone didn't fix it.

- First failing run: https://github.com/lightseekorg/smg/actions/runs/28567772523
- Passing run (this PR): https://github.com/lightseekorg/smg/actions/runs/28619732904

### Solution

Pin `nvidia-cutlass-dsl==4.5.2` (the last release with `cute.core.ThrMma`, and the version upstream tokenspeed `main` itself pins) via **both** `UV_CONSTRAINT` **and** `PIP_CONSTRAINT`, pointing at one constraints file — so every resolve honors it, including the kernel build's subprocess `pip`.

Notes:
- Not fixed by bumping the TokenSpeed ref: upstream `main` pins 4.5.2, but it is 200+ commits ahead and its newer kernel fails to compile against the CI CUDA 13 toolchain (`'__cudaLaunch' was not declared`). Pinning on the current known-good ref avoids that.
- Not fixed by a fresh venv: the subprocess `pip` would still install 4.6.0 unpinned regardless of venv state.
- A cutlass-provenance diagnostic is printed before verification (cutlass path / version / `ThrMma` presence) to make any future drift obvious in the logs.

## Changes

- `scripts/ci_install_tokenspeed.sh`: set `UV_CONSTRAINT` + `PIP_CONSTRAINT` to a constraints file pinning `nvidia-cutlass-dsl==4.5.2`; add a cutlass-provenance diagnostic before the verification step.

## Test Plan

`e2e-1gpu-chat (tokenspeed)` now passes. The provenance diagnostic in the passing run confirms the fix:

```
cutlass version -> 4.5.2
import cutlass  -> .../nvidia_cutlass_dsl/python_packages/cutlass/__init__.py
cute.core ThrMma-> True
```

(only 4.5.2 present; 4.6.0 no longer installed; `cute.core.ThrMma` resolves).

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>