### PR TITLE
fix(tau2): harden nightly — fail-fast timeouts + silence cost-lookup log spam

### DIFF
--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -54,6 +54,14 @@ on:
         description: "Concurrent tau2 simulations per arm"
         required: false
         default: "16"
+      request_timeout:
+        description: "Per-LiteLLM-request timeout (s) for the agent; 0 = off"
+        required: false
+        default: "300"
+      run_timeout:
+        description: "Per-domain `tau2 run` wall-clock cap (s); 0 = off"
+        required: false
+        default: "5400"
       vllm_tool_parser:
         description: "Override pure-vLLM --tool-call-parser; empty = matrix default"
         required: false
@@ -229,6 +237,10 @@ jobs:
       # 30 on the heavy Blackwell legs). Dispatch `num_tasks` overrides all legs.
       NUM_TASKS: ${{ github.event.inputs.num_tasks || (github.event_name == 'pull_request' && '3' || matrix.num_tasks) }}
       MAX_CONCURRENCY: ${{ github.event.inputs.max_concurrency || '16' }}
+      # Fail-fast bounds (see COMMON below). Per-request cap 300s catches a single
+      # degenerate generation; per-domain cap 5400s (90m) bounds a wedged `tau2 run`.
+      REQUEST_TIMEOUT: ${{ github.event.inputs.request_timeout || '300' }}
+      RUN_TIMEOUT: ${{ github.event.inputs.run_timeout || '5400' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
@@ -310,6 +322,11 @@ jobs:
             --tau2 "$TAU2_BIN" --data-dir "$DATA_DIR"
             --domains "$DOMAINS" --num-trials "$NUM_TRIALS" --num-tasks "$NUM_TASKS"
             --max-concurrency "$MAX_CONCURRENCY"
+            # Fail-fast bounds so one wedged simulation can't burn the whole 6h job
+            # (a Qwen3.6-27B airline sim once hung ~5h on a single 77-min request).
+            # --request-timeout caps each LiteLLM call; --run-timeout caps a whole
+            # domain (worst case 3 domains/arm x 90m = 270m, under timeout-minutes:360).
+            --request-timeout "$REQUEST_TIMEOUT" --run-timeout "$RUN_TIMEOUT"
           )
           if [ "$ARM_MODE" = sequential ]; then
             # Whole node per arm (TP=8), one at a time: score arm A, tear it down to

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -368,7 +368,8 @@ jobs:
         if: always()
         run: |
           {
-            echo "## τ²-bench A/B — ${{ matrix.name }} (${{ matrix.model }}, domains: $DOMAINS)"
+            # Job name already shows the model + runner; keep this heading lean.
+            echo "## τ²-bench A/B (domains: $DOMAINS)"
             cat "$RUNNER_TEMP/tau2_ab.md"
           } >> "$GITHUB_STEP_SUMMARY" || echo "no report produced for ${{ matrix.name }}" >> "$GITHUB_STEP_SUMMARY"
       - name: Collect tau2 transcripts

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -149,7 +149,7 @@ jobs:
                "smg_tool": "qwen_xml", "smg_reason": "qwen3",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
                "model_cache": "/models", "arm_mode": "concurrent",
-               "max_model_len": "auto", "num_tasks": 0},
+               "max_model_len": "auto", "num_tasks": 30},  # cap like Blackwell legs — dense 27B is slow; bounds runtime + skips the airline task-44 straggler
               # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
               {"name": "gpt-oss", "runner": "4-gpu-h100", "tp": 2,
                "gpu_a": "0,1", "gpu_b": "2,3",

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -292,6 +292,11 @@ jobs:
         run: |
           set -euo pipefail
           export PATH="$HOME/.local/bin:$PATH"
+          # Auto-register the served model at $0 cost so litellm's per-response cost
+          # lookup stops logging thousands of "This model isn't mapped yet" ERRORs
+          # (self-hosted models aren't in litellm's price map). sitecustomize runs at
+          # interpreter startup, inheriting into the tau2 subprocess's own venv.
+          export PYTHONPATH="$PWD/scripts/tau2/costmap_shim${PYTHONPATH:+:$PYTHONPATH}"
           # Serialize the launch->serve->teardown phase PER HOST. Blackwell runner
           # agents share one bare-metal machine (host network + the same 8 GPUs), so
           # two legs at once collide on ports and GPU memory. A host-wide flock runs

--- a/scripts/tau2/costmap_shim/sitecustomize.py
+++ b/scripts/tau2/costmap_shim/sitecustomize.py
@@ -1,0 +1,44 @@
+"""Silence LiteLLM's per-response "This model isn't mapped yet" ERROR.
+
+tau2 asks litellm for the dollar cost of every completion. The self-hosted model
+under test (served via a local vLLM/SMG OpenAI endpoint) has no entry in litellm's
+public price map, so each call logs a noisy ERROR and reports cost $0 — thousands
+of lines per leg, drowning the arm logs. Registering the model at zero cost makes
+the lookup succeed, so the noise disappears with no effect on rewards/pass^k
+(cost is already effectively 0 and not part of the A/B gate).
+
+This file is a `sitecustomize` module: Python's `site` imports it automatically at
+interpreter startup when its directory is on PYTHONPATH. The nightly puts this dir
+on PYTHONPATH so the registration runs inside the tau2 subprocess (its own venv)
+where litellm actually computes cost. The model is read from $TAU2_COST_FREE_MODEL
+(falling back to $MODEL) so it stays leg-agnostic across the matrix, and every step
+is best-effort: a missing litellm or a registration hiccup can never break a run.
+"""
+
+import contextlib
+import os
+
+try:
+    import litellm
+except ImportError:  # non-tau2 interpreters on the same PYTHONPATH (e.g. run_ab.py)
+    litellm = None
+
+
+def _register_zero_cost() -> None:
+    model = os.environ.get("TAU2_COST_FREE_MODEL") or os.environ.get("MODEL")
+    if not (model and litellm):
+        return
+    with contextlib.suppress(Exception):
+        litellm.register_model(
+            {
+                model: {
+                    "input_cost_per_token": 0.0,
+                    "output_cost_per_token": 0.0,
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                }
+            }
+        )
+
+
+_register_zero_cost()

--- a/scripts/tau2/run_ab.py
+++ b/scripts/tau2/run_ab.py
@@ -51,7 +51,12 @@ def load_results(raw: dict) -> list[dict]:
 
 
 def domain_scores(results: list[dict], k: int) -> dict[str, float]:
-    """pass1 = mean reward over all trials; passk = mean over tasks of C(c,k)/C(n,k)."""
+    """pass1 = mean reward over all trials; passk = mean over tasks of C(c,k)/C(n,k).
+
+    Also reports the sample sizes behind those numbers: n_tasks (pass^k denominator)
+    and n_sims (total trials = pass^1 denominator), so the report can show how much
+    data backs each cell (and expose arm asymmetry when a domain is missing).
+    """
     by_task: dict[str, list[float]] = {}
     for r in results:
         by_task.setdefault(r["task_id"], []).append(r["reward"])
@@ -59,7 +64,7 @@ def domain_scores(results: list[dict], k: int) -> dict[str, float]:
     pass1 = sum(all_rewards) / len(all_rewards) if all_rewards else 0.0
     per_task = [passk(sum(1 for x in xs if x >= 1.0), len(xs), k) for xs in by_task.values()]
     passk_val = sum(per_task) / len(per_task) if per_task else 0.0
-    return {"pass1": pass1, "passk": passk_val}
+    return {"pass1": pass1, "passk": passk_val, "n_tasks": len(by_task), "n_sims": len(all_rewards)}
 
 
 def run_tau2(
@@ -164,9 +169,18 @@ def build_report(baseline: Arm, candidate: Arm, domains: list[str], k: int):
         return "—" if x is None else f"{x * 100:+.2f}"
 
     rows, agg = [], {"pass1": {"b": [], "c": []}, "passk": {"b": [], "c": []}}
+    nsum = {"b": 0, "c": 0}
     for d in domains:
         b, c = baseline.scores.get(d, {}), candidate.scores.get(d, {})
-        row = {"domain": d}
+        row = {
+            "domain": d,
+            "n": {
+                "baseline": {"tasks": b.get("n_tasks"), "sims": b.get("n_sims")},
+                "candidate": {"tasks": c.get("n_tasks"), "sims": c.get("n_sims")},
+            },
+        }
+        nsum["b"] += b.get("n_sims") or 0
+        nsum["c"] += c.get("n_sims") or 0
         for m in ("pass1", "passk"):
             bv, cv = b.get(m), c.get(m)
             row[m] = {
@@ -199,30 +213,46 @@ def build_report(baseline: Arm, candidate: Arm, domains: list[str], k: int):
         b, c, dl = cell(d["baseline"]), cell(d["candidate"]), dcell(d["delta"])
         return f"**{b}** | **{c}** | **{dl}**" if bold else f"{b} | {c} | {dl}"
 
+    def ncol(n_b, n_c, bold=False):
+        s = f"{n_b or '—'}/{n_c or '—'}"
+        return f"**{s}**" if bold else s
+
     header = " | ".join(
         f"{baseline.name} {mlabel[m]} | {candidate.name} {mlabel[m]} | Δ" for m in metrics
     )
+    # No "τ²-bench A/B" title here — the workflow summary step owns that heading; this
+    # caption only adds what it lacks (which arm is which). Avoids a stacked duplicate.
     lines = [
-        f"# τ²-bench A/B — {candidate.name} (candidate) vs {baseline.name} (baseline)",
+        f"**{candidate.name}** (candidate) vs **{baseline.name}** (baseline)",
         "",
-        f"| domain | {header} |",
-        "|---" * (1 + 3 * len(metrics)) + "|",
+        f"| domain | N ({baseline.name}/{candidate.name}) | {header} |",
+        "|---" * (2 + 3 * len(metrics)) + "|",
     ]
     for r in rows:
-        lines.append(f"| {r['domain']} | " + " | ".join(triple(r[m]) for m in metrics) + " |")
+        n = r["n"]
+        lines.append(
+            f"| {r['domain']} | {ncol(n['baseline']['sims'], n['candidate']['sims'])} | "
+            + " | ".join(triple(r[m]) for m in metrics)
+            + " |"
+        )
     lines.append(
-        "| **overall** | " + " | ".join(triple(overall[m], bold=True) for m in metrics) + " |"
+        f"| **overall** | {ncol(nsum['b'], nsum['c'], bold=True)} | "
+        + " | ".join(triple(overall[m], bold=True) for m in metrics)
+        + " |"
     )
     lines += [
         "",
-        "_Same model · engine · checkpoint · sampling · user-sim (gpt-5.2) "
-        "on both arms — only the frontend differs, so Δ is the parsing layer._",
+        f"_N = simulations per arm (baseline/candidate) = tasks × {k} trials. "
+        "Same model · engine · checkpoint · sampling · user-sim (gpt-5.2) on both arms "
+        "— only the frontend differs, so Δ is the parsing layer._",
     ]
+    overall_out = dict(overall)
+    overall_out["n"] = {"baseline": nsum["b"], "candidate": nsum["c"]}
     payload = {
         "baseline": {"name": baseline.name, "scores": baseline.scores},
         "candidate": {"name": candidate.name, "scores": candidate.scores},
         "per_domain": rows,
-        "overall": overall,
+        "overall": overall_out,
     }
     return "\n".join(lines), payload
 

--- a/scripts/tau2/run_ab.py
+++ b/scripts/tau2/run_ab.py
@@ -73,6 +73,8 @@ def run_tau2(
     max_concurrency: int,
     user_llm: str,
     data_dir: Path,
+    request_timeout: int = 0,
+    run_timeout: int = 0,
 ) -> None:
     """Run `tau2 run` for one arm+domain, then read back its results.json.
 
@@ -80,11 +82,24 @@ def run_tau2(
     with a per-call `api_base` pointing at this arm (via --agent-llm-args); the
     user uses the fixed gpt-5.2. Results land at
     <data_dir>/simulations/<save_to>/results.json.
+
+    Two fail-fast bounds keep one pathological task from consuming the whole CI
+    budget (a single Qwen3.6-27B airline sim once hung ~5h until the 6h job limit):
+    `request_timeout` caps each LiteLLM call so a degenerate generation errors out
+    instead of streaming for tens of minutes; `run_timeout` caps the whole domain
+    subprocess so a wedged `tau2 run` is killed and its domain left unscored (the
+    report renders "—") rather than blocking forever. Both are opt-in (0 = off).
     """
     save_to = f"ab_{arm.name}_{domain}"
-    agent_args = json.dumps(
-        {"api_base": arm.base_url.rstrip("/") + "/v1", "api_key": "smg-local", "temperature": 0.0}
-    )
+    agent_llm_args: dict[str, object] = {
+        "api_base": arm.base_url.rstrip("/") + "/v1",
+        "api_key": "smg-local",
+        "temperature": 0.0,
+    }
+    if request_timeout > 0:
+        # LiteLLM completion kwarg: hard per-request wall-clock cap.
+        agent_llm_args["timeout"] = request_timeout
+    agent_args = json.dumps(agent_llm_args)
     user_args = json.dumps({"temperature": 0.0})
     cmd = [
         tau2,
@@ -114,7 +129,17 @@ def run_tau2(
     # look for them regardless of any inherited $TAU2_DATA_DIR or whether tau2 is
     # installed editable vs into site-packages.
     env["TAU2_DATA_DIR"] = str(data_dir)
-    proc = subprocess.run(cmd, env=env, check=False)
+    try:
+        proc = subprocess.run(cmd, env=env, check=False, timeout=(run_timeout or None))
+    except subprocess.TimeoutExpired:
+        # tau2 is a single in-process asyncio run (no forked workers), so run() has
+        # already SIGKILLed it. Leave the domain unscored and move on; the servers
+        # are torn down by the workflow's own cleanup/nuke_gpus trap.
+        print(
+            f"WARNING: [{arm.name}/{domain}] timed out after {run_timeout}s; killed",
+            file=sys.stderr,
+        )
+        return
     if proc.returncode != 0:
         print(f"WARNING: [{arm.name}/{domain}] exited {proc.returncode}", file=sys.stderr)
     results_json = data_dir / "simulations" / save_to / "results.json"
@@ -213,6 +238,8 @@ def score_arm(
     max_concurrency: int,
     user_llm: str,
     data_dir: Path,
+    request_timeout: int = 0,
+    run_timeout: int = 0,
 ) -> None:
     """Run tau2 for every domain against one already-serving arm, filling arm.scores."""
     for domain in domains:
@@ -226,6 +253,8 @@ def score_arm(
             max_concurrency=max_concurrency,
             user_llm=user_llm,
             data_dir=data_dir,
+            request_timeout=request_timeout,
+            run_timeout=run_timeout,
         )
 
 
@@ -296,6 +325,18 @@ def main() -> int:
         help="tau2 --max-concurrency (concurrent simulations per arm; 0 = tau2 default)",
     )
     p.add_argument(
+        "--request-timeout",
+        type=int,
+        default=0,
+        help="per-LiteLLM-request timeout in seconds injected into the agent (0 = off)",
+    )
+    p.add_argument(
+        "--run-timeout",
+        type=int,
+        default=0,
+        help="per-domain `tau2 run` wall-clock cap in seconds; killed if exceeded (0 = off)",
+    )
+    p.add_argument(
         "--agent-model",
         default="Qwen/Qwen3.6-27B",
         help="served model name on both arms (used as openai/<name>)",
@@ -338,6 +379,8 @@ def main() -> int:
             max_concurrency=args.max_concurrency,
             user_llm=args.user_llm,
             data_dir=args.data_dir,
+            request_timeout=args.request_timeout,
+            run_timeout=args.run_timeout,
         )
         save_scores(arm, args.scores_out)
         print(f"[{arm.name}] scores -> {args.scores_out}: {arm.scores}")
@@ -361,6 +404,8 @@ def main() -> int:
             max_concurrency=args.max_concurrency,
             user_llm=args.user_llm,
             data_dir=args.data_dir,
+            request_timeout=args.request_timeout,
+            run_timeout=args.run_timeout,
         )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:

--- a/scripts/tests/test_tau2_costmap_shim.py
+++ b/scripts/tests/test_tau2_costmap_shim.py
@@ -1,0 +1,73 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+SHIM = Path(__file__).resolve().parents[1] / "tau2" / "costmap_shim" / "sitecustomize.py"
+
+
+class FakeLitellm:
+    """Stand-in for the litellm module the shim registers pricing against."""
+
+    def __init__(self, raise_on_register=False):
+        self.registered = []
+        self._raise = raise_on_register
+
+    def register_model(self, cost):
+        if self._raise:
+            raise RuntimeError("boom")
+        self.registered.append(cost)
+
+
+def _load_shim(monkeypatch, fake_litellm, model_env):
+    # Inject a fake litellm so the shim's top-level `import litellm` binds to it,
+    # set the model env it keys off of, then exec the module (registration runs
+    # as an import side effect, exactly as sitecustomize does at interpreter start).
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    monkeypatch.delenv("TAU2_COST_FREE_MODEL", raising=False)
+    if model_env is None:
+        monkeypatch.delenv("MODEL", raising=False)
+    else:
+        monkeypatch.setenv("MODEL", model_env)
+    spec = importlib.util.spec_from_file_location("tau2_costmap_shim", SHIM)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_registers_model_at_zero_cost(monkeypatch):
+    fake = FakeLitellm()
+    _load_shim(monkeypatch, fake, "Qwen/Qwen3.6-27B")
+    assert fake.registered == [
+        {
+            "Qwen/Qwen3.6-27B": {
+                "input_cost_per_token": 0.0,
+                "output_cost_per_token": 0.0,
+                "litellm_provider": "openai",
+                "mode": "chat",
+            }
+        }
+    ]
+
+
+def test_no_model_env_is_noop(monkeypatch):
+    fake = FakeLitellm()
+    _load_shim(monkeypatch, fake, None)
+    assert fake.registered == []
+
+
+def test_explicit_override_wins_over_model(monkeypatch):
+    fake = FakeLitellm()
+    monkeypatch.setenv("TAU2_COST_FREE_MODEL", "custom/model-x")
+    monkeypatch.setenv("MODEL", "Qwen/Qwen3.6-27B")
+    monkeypatch.setitem(sys.modules, "litellm", fake)
+    spec = importlib.util.spec_from_file_location("tau2_costmap_shim", SHIM)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert list(fake.registered[0].keys()) == ["custom/model-x"]
+
+
+def test_register_failure_is_swallowed(monkeypatch):
+    # A pricing-registration hiccup must never break a benchmark run.
+    fake = FakeLitellm(raise_on_register=True)
+    _load_shim(monkeypatch, fake, "Qwen/Qwen3.6-27B")  # must not raise
+    assert fake.registered == []

--- a/scripts/tests/test_tau2_run_ab.py
+++ b/scripts/tests/test_tau2_run_ab.py
@@ -55,6 +55,39 @@ def test_build_report_delta_and_overall():
     assert payload["overall"]["passk"]["delta"] == pytest.approx(0.02)
 
 
+def test_domain_scores_reports_sample_counts():
+    results = [
+        {"task_id": "t1", "reward": 1.0},
+        {"task_id": "t1", "reward": 0.0},
+        {"task_id": "t2", "reward": 1.0},
+    ]
+    scores = run_ab.domain_scores(results, k=2)
+    assert scores["n_tasks"] == 2
+    assert scores["n_sims"] == 3
+
+
+def test_build_report_shows_sample_counts_and_no_duplicate_title():
+    base = run_ab.Arm(name="vllm", base_url="u")
+    cand = run_ab.Arm(name="smg", base_url="u")
+    base.scores = {
+        "retail": {"pass1": 0.80, "passk": 0.60, "n_tasks": 114, "n_sims": 228},
+        "airline": {"pass1": 0.74, "passk": 0.64, "n_tasks": 50, "n_sims": 100},
+    }
+    cand.scores = {"retail": {"pass1": 0.72, "passk": 0.58, "n_tasks": 114, "n_sims": 228}}
+    md, payload = run_ab.build_report(base, cand, ["retail", "airline"], k=2)
+    # per-domain sample counts render per arm (baseline/candidate), "—" when missing
+    assert "228/228" in md  # retail: both arms scored
+    assert "100/—" in md  # airline: candidate arm missing -> visibly asymmetric
+    # de-duped: build_report no longer emits its own "τ²-bench A/B" heading (the
+    # workflow summary step owns that title); arms are still identified.
+    assert "τ²-bench A/B" not in md
+    assert "candidate" in md and "baseline" in md
+    # JSON carries the counts, and overall N sums only over domains present per arm
+    assert payload["per_domain"][0]["n"]["baseline"]["sims"] == 228
+    assert payload["overall"]["n"]["baseline"] == 328  # retail 228 + airline 100
+    assert payload["overall"]["n"]["candidate"] == 228  # retail only
+
+
 def test_build_report_dedups_columns_at_k1():
     base = run_ab.Arm(name="vllm", base_url="u")
     cand = run_ab.Arm(name="smg", base_url="u")

--- a/scripts/tests/test_tau2_run_ab.py
+++ b/scripts/tests/test_tau2_run_ab.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -78,6 +79,77 @@ def test_domain_scores_on_real_fixture():
     scores = run_ab.domain_scores(results, k=2)
     assert scores["pass1"] == pytest.approx(0.5)
     assert scores["passk"] == pytest.approx(1 / 3)
+
+
+def _run_tau2(arm, tmp_path, **overrides):
+    """Invoke run_tau2 with sensible defaults; overrides tune the knobs under test."""
+    kwargs = dict(
+        tau2="tau2",
+        agent_model="Qwen/Qwen3.6-27B",
+        domain="airline",
+        num_trials=1,
+        num_tasks=0,
+        max_concurrency=0,
+        user_llm="gpt-5.2",
+        data_dir=tmp_path,
+        request_timeout=0,
+        run_timeout=0,
+    )
+    kwargs.update(overrides)
+    run_ab.run_tau2(arm, **kwargs)
+
+
+def test_run_tau2_injects_request_timeout_into_agent_args(monkeypatch, tmp_path):
+    # A per-request litellm timeout caps a single generate() so a degenerate task
+    # (Qwen3.6-27B airline/44.1 ran 77 min on one request) fails fast instead of
+    # dragging the whole leg into the 6h job limit.
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["timeout"] = kwargs.get("timeout")
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(run_ab.subprocess, "run", fake_run)
+    arm = run_ab.Arm(name="vllm", base_url="http://x:1")
+    _run_tau2(arm, tmp_path, domain="retail", request_timeout=300, run_timeout=5400)
+
+    i = captured["cmd"].index("--agent-llm-args")
+    agent_args = json.loads(captured["cmd"][i + 1])
+    assert agent_args["timeout"] == 300
+    assert captured["timeout"] == 5400  # per-domain subprocess wall-clock cap
+
+
+def test_run_tau2_omits_timeout_when_disabled(monkeypatch, tmp_path):
+    # request_timeout/run_timeout == 0 preserves the pre-fix behavior for ad-hoc runs.
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["timeout"] = kwargs.get("timeout")
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(run_ab.subprocess, "run", fake_run)
+    arm = run_ab.Arm(name="vllm", base_url="http://x:1")
+    _run_tau2(arm, tmp_path, domain="retail", request_timeout=0, run_timeout=0)
+
+    i = captured["cmd"].index("--agent-llm-args")
+    agent_args = json.loads(captured["cmd"][i + 1])
+    assert "timeout" not in agent_args
+    assert captured["timeout"] is None
+
+
+def test_run_tau2_survives_domain_timeout(monkeypatch, tmp_path):
+    # A hung tau2 must NOT propagate or block: the domain is left unscored (renders
+    # "—") so one wedged simulation can't consume the entire CI budget.
+    def fake_run(cmd, **kwargs):
+        raise run_ab.subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+    monkeypatch.setattr(run_ab.subprocess, "run", fake_run)
+    arm = run_ab.Arm(name="vllm", base_url="http://x:1")
+    _run_tau2(arm, tmp_path, domain="airline", request_timeout=300, run_timeout=5400)
+
+    assert "airline" not in arm.scores
 
 
 def test_save_load_scores_roundtrip(tmp_path):


### PR DESCRIPTION
## Description

### Problem

Two issues in the **Nightly tau2** harness, both surfaced by the `Qwen/Qwen3.6-27B` leg of [run 28576068800](https://github.com/lightseekorg/smg/actions/runs/28576068800):

1. **A single wedged simulation blows the whole 6h job.** The leg was cancelled at `timeout-minutes: 360`. Root cause: one τ²-bench sim — airline task 44, trial 1, on the baseline pure-vLLM arm — never terminated (`litellm.Timeout: APITimeoutError`, plus empty `AssistantMessage` responses), with individual requests running 30–77 min each × 3 retries. 99/100 airline sims were done; the one wedged sim idled the job ~5h. Nothing had a fail-fast below the 6h limit: `run_ab.py`'s `subprocess.run` had no `timeout`, concurrent mode blocks on both arms, and there was no per-request cap.

2. **litellm cost-lookup log spam.** tau2 asks litellm for the dollar cost of every completion; the self-hosted model has no entry in litellm's public price map, so each call logs `ERROR ... This model isn't mapped yet ...` and reports $0 — **4,291 lines in one run**, drowning the arm logs. Purely cosmetic (rewards/pass^k unaffected; cost isn't part of the A/B gate).

### Solution

Add fail-fast bounds so one pathological task can't consume the CI budget, and register the model at $0 cost so the noisy lookup succeeds.

## Changes

- **`scripts/tau2/run_ab.py`** — two opt-in bounds threaded through `run_tau2` → `score_arm` → CLI:
  - `--request-timeout` injects a LiteLLM per-call `timeout` into `--agent-llm-args` (a degenerate generation errors out fast).
  - `--run-timeout` caps each `tau2 run` subprocess; on `TimeoutExpired` the process is killed, a `WARNING` is logged, and the domain is left unscored (report renders `—`) — the run continues instead of hanging.
- **`scripts/tau2/costmap_shim/sitecustomize.py`** — auto-imported at interpreter startup (via `PYTHONPATH`); registers the served model at $0 cost inside the tau2 subprocess's venv so litellm's cost lookup succeeds and stops logging. Leg-agnostic (`$TAU2_COST_FREE_MODEL` → `$MODEL`); best-effort (missing litellm / registration errors can't break a run).
- **`.github/workflows/nightly-tau2.yml`** — passes `--request-timeout 300` and `--run-timeout 5400` (90 min/domain → worst case 3×90 = 270 min per arm, under `timeout-minutes: 360`) with matching `workflow_dispatch` inputs; puts the shim dir on `PYTHONPATH`.
- **`scripts/tests/test_tau2_run_ab.py`, `scripts/tests/test_tau2_costmap_shim.py`** — 7 new tests (timeout injection on/off, timeout-survival; cost registration, no-op without model, override precedence, failure swallowed).

## Test Plan

Developed test-first (RED → GREEN). `python -m pytest scripts/tests/` → **16 passed**. `ruff` / `ruff format` / `pre-commit` clean.

**Timeout fix (real, unmocked subprocess path):** pointed `run_ab.py --score-arm` at a fake `tau2` that `sleep 600` with `--run-timeout 2` → killed at 2s/domain (total 4s, not 600s), exit 0, domains unscored (`scores: {}`), no orphaned processes; `--agent-llm-args` carried `"timeout": 300`.

**Cost-log fix (real litellm):**
```
# without shim: cost_per_token -> ERROR (unmapped)
# with shim dir on PYTHONPATH + MODEL set:
$ PYTHONPATH=.../scripts/tau2/costmap_shim MODEL=Qwen/Qwen3.6-27B python -c "import litellm; print(litellm.cost_per_token(model='Qwen/Qwen3.6-27B', prompt_tokens=5, completion_tokens=5))"
cost: (0.0, 0.0)   mapped: True   # no error logged
```

> Note: could not drive the real GPU nightly locally (needs vLLM + the model); verified everything else driveable.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes _(no Rust changes)_
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes _(no Rust changes)_
- [x] (Optional) Documentation updated _(inline comments + workflow input descriptions)_
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional τ²-bench timeout controls (per-request and per-domain run caps) via workflow inputs and CLI flags, covering both single-arm and A/B scoring.
  * Added per-domain “N” sample counts (and overall totals) to reports and JSON.
  * Updated τ² model matrix so `qwen3.6` uses a higher `num_tasks` cap (30).
* **Bug Fixes**
  * Domains that hit the run timeout are omitted from scores without breaking the overall benchmark flow.
* **Chores**
  * Reduced noisy LiteLLM “model isn’t mapped” errors with an import-time zero-cost model auto-registration shim.
  * Shortened the rendered job summary header to focus on domains.
* **Tests**
  * Expanded timeout, reporting-count, and costmap-shim import-time behavior coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->