### PR TITLE
fix(grpc/chat): honor reasoning_effort "none"/"minimal" as enable_thinking=false

### DIFF
--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -107,8 +107,9 @@ impl ResponseProcessor {
                 // If the template injected `<think>` in the prefill (thinking toggle
                 // is supported and effectively ON), start in reasoning mode.
                 if utils::should_mark_reasoning_started(
-                    utils::extract_thinking_from_kwargs(
+                    utils::resolve_user_thinking(
                         original_request.chat_template_kwargs.as_ref(),
+                        original_request.reasoning_effort.as_deref(),
                         tokenizer.as_ref(),
                     ),
                     tokenizer.as_ref(),

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -99,8 +99,9 @@ impl PipelineStage for ChatRequestBuildingStage {
 
         let require_reasoning = ctx.tokenizer_arc().is_some_and(|tokenizer| {
             utils::should_mark_reasoning_started(
-                utils::extract_thinking_from_kwargs(
+                utils::resolve_user_thinking(
                     chat_request.chat_template_kwargs.as_ref(),
+                    chat_request.reasoning_effort.as_deref(),
                     tokenizer.as_ref(),
                 ),
                 tokenizer.as_ref(),

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -281,8 +281,9 @@ impl StreamingProcessor {
         // the template injected `<think>` in the prefill — parsers should start
         // in reasoning mode.
         let thinking_override = utils::should_mark_reasoning_started(
-            utils::extract_thinking_from_kwargs(
+            utils::resolve_user_thinking(
                 original_request.chat_template_kwargs.as_ref(),
+                original_request.reasoning_effort.as_deref(),
                 tokenizer.as_ref(),
             ),
             tokenizer.as_ref(),

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -388,6 +388,20 @@ pub fn process_chat_messages(
                 "reasoning_effort".to_string(),
                 Value::String(reasoning_effort.clone()),
             );
+
+            // OpenAI semantics: reasoning_effort "none"/"minimal" means "do not
+            // produce reasoning". Many chat templates gate thinking on a boolean
+            // toggle and treat `reasoning_effort` only as a *level* (so "none"
+            // would otherwise still think). Translate the disable case to the
+            // thinking toggle = false. Templates use different key names
+            // (`enable_thinking` for GLM-4.x/5, Qwen3; `thinking` for
+            // DeepSeek-V3.1, Kimi-K2.5), so set both; the unused one is ignored.
+            // These are defaults only: an explicit chat_template_kwargs value
+            // (applied below) still wins.
+            if matches!(reasoning_effort.as_str(), "none" | "minimal") {
+                combined_template_kwargs.insert("enable_thinking".to_string(), Value::Bool(false));
+                combined_template_kwargs.insert("thinking".to_string(), Value::Bool(false));
+            }
         }
 
         // Add any additional template kwargs from request

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -25,4 +25,6 @@ pub(crate) use parsers::{
 };
 // `pub` (not `pub(crate)`) so the Go bindings can reuse the gateway's reasoning
 // detection instead of duplicating it.
-pub use parsers::{extract_thinking_from_kwargs, should_mark_reasoning_started};
+pub use parsers::{
+    extract_thinking_from_kwargs, resolve_user_thinking, should_mark_reasoning_started,
+};

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -45,6 +45,40 @@ pub fn extract_thinking_from_kwargs(
     .and_then(|v| v.as_bool())
 }
 
+/// Map an OpenAI `reasoning_effort` value to a thinking preference.
+///
+/// OpenAI semantics: `"none"`/`"minimal"` mean "do not produce reasoning", so
+/// they map to thinking OFF (`Some(false)`). Level values (`"low"`/`"medium"`/
+/// `"high"`) don't toggle thinking on their own, so they return `None` (defer to
+/// the template default / explicit thinking kwarg).
+pub(crate) fn thinking_from_reasoning_effort(reasoning_effort: Option<&str>) -> Option<bool> {
+    match reasoning_effort {
+        Some("none") | Some("minimal") => Some(false),
+        _ => None,
+    }
+}
+
+/// Precedence for the effective thinking preference: an explicit template
+/// toggle (already extracted from kwargs) always wins; otherwise fall back to
+/// the OpenAI `reasoning_effort` mapping.
+fn resolve_thinking_pref(explicit: Option<bool>, reasoning_effort: Option<&str>) -> Option<bool> {
+    explicit.or_else(|| thinking_from_reasoning_effort(reasoning_effort))
+}
+
+/// Resolve the user's effective thinking preference, honoring an explicit
+/// template thinking kwarg first (it always wins), then falling back to the
+/// OpenAI `reasoning_effort` mapping.
+pub fn resolve_user_thinking(
+    kwargs: Option<&std::collections::HashMap<String, Value>>,
+    reasoning_effort: Option<&str>,
+    tokenizer: &dyn Tokenizer,
+) -> Option<bool> {
+    resolve_thinking_pref(
+        extract_thinking_from_kwargs(kwargs, tokenizer),
+        reasoning_effort,
+    )
+}
+
 /// Check if a reasoning parser is available for the given model
 pub(crate) fn check_reasoning_parser_availability(
     reasoning_parser_factory: &ReasoningParserFactory,
@@ -155,6 +189,35 @@ pub(crate) fn create_tool_parser(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_thinking_pref_explicit_kwarg_wins() {
+        // An explicit template toggle always wins over the reasoning_effort mapping.
+        assert_eq!(resolve_thinking_pref(Some(true), Some("none")), Some(true));
+        assert_eq!(
+            resolve_thinking_pref(Some(false), Some("high")),
+            Some(false)
+        );
+        // No explicit toggle -> fall back to the reasoning_effort mapping.
+        assert_eq!(resolve_thinking_pref(None, Some("none")), Some(false));
+        assert_eq!(resolve_thinking_pref(None, Some("minimal")), Some(false));
+        assert_eq!(resolve_thinking_pref(None, Some("high")), None);
+        assert_eq!(resolve_thinking_pref(None, None), None);
+    }
+
+    #[test]
+    fn thinking_from_reasoning_effort_maps_disable_values() {
+        // "none"/"minimal" mean do-not-reason -> thinking OFF
+        assert_eq!(thinking_from_reasoning_effort(Some("none")), Some(false));
+        assert_eq!(thinking_from_reasoning_effort(Some("minimal")), Some(false));
+        // level values do not toggle thinking on their own
+        assert_eq!(thinking_from_reasoning_effort(Some("low")), None);
+        assert_eq!(thinking_from_reasoning_effort(Some("medium")), None);
+        assert_eq!(thinking_from_reasoning_effort(Some("high")), None);
+        // unspecified / unknown -> defer
+        assert_eq!(thinking_from_reasoning_effort(None), None);
+        assert_eq!(thinking_from_reasoning_effort(Some("bogus")), None);
+    }
 
     #[test]
     fn create_reasoning_parser_returns_independent_instances() {


### PR DESCRIPTION
Draft — not build-tested in CI yet; opening for discussion.

## Problem
`reasoning_effort` is already forwarded into the chat-template kwargs (`chat_utils.rs`), but for templates that gate reasoning on `enable_thinking` and treat `reasoning_effort` only as a *level* — e.g. GLM-4.x/5, Qwen3 — `reasoning_effort: "none"` does **not** disable thinking. The value falls through to a default level (GLM maps anything != "high" to "max") and the model keeps emitting `reasoning_content`.

Observed on `GLM-5.2-NVFP4` served over smg gRPC:

| request | reasoning_content |
| --- | --- |
| `reasoning_effort: "none"` | still ~450 chars (thinks) |
| `chat_template_kwargs: {"enable_thinking": false}` | empty (no thinking) |

So OpenAI clients cannot turn thinking off via the standard `reasoning_effort` field.

## Fix
When `reasoning_effort` is `"none"` or `"minimal"` (OpenAI "do not reason" semantics), also set `enable_thinking=false` in the template kwargs. Applied as a **default only** — an explicit `chat_template_kwargs.enable_thinking` is applied afterward and still wins, so callers keep full control.

```rust
if matches!(reasoning_effort.as_str(), "none" | "minimal") {
    combined_template_kwargs.insert("enable_thinking".to_string(), Value::Bool(false));
}
```

This makes `reasoning_effort: "none"` behave like `chat_template_kwargs={"enable_thinking": false}` for GLM/Qwen-style templates, while leaving level values ("low"/"medium"/"high") untouched.

## Notes / open questions
- Scope: only the gRPC chat path (`routers/grpc/utils/chat_utils.rs`). Should the HTTP/other backends get the same mapping?
- Should `"low"` also map anywhere, or leave as level-only (current behavior)?
- Happy to add an e2e case alongside `e2e_test/chat_completions/test_enable_thinking.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat requests now interpret `reasoning_effort` consistently: `none`/`minimal` disable “thinking” by default, while `low`/`medium`/`high` no longer force it.
  * “Thinking” detection and reasoning-start marking were updated across request building, response processing, and streaming.
  * Explicit chat template “thinking” settings still take precedence over defaults.
* **Tests**
  * Added unit coverage for `reasoning_effort` mapping and precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->