### PR TITLE
fix(ci): unbreak sglang/e2e (protobuf gencode) and MLX (transformers 5.13) jobs

### DIFF
--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -1,14 +1,7 @@
-# Cap grpcio-tools at the 1.81.x line so the protoc it bundles emits protobuf-6
-# gencode. grpcio-tools 1.82.x ships a protobuf-7 protoc, which stamps the
-# generated *_pb2.py with gencode 7.x. The engine runtimes (and the protobuf-6
-# floor that scripts/ci_install_e2e_deps.sh pins grpcio-health-checking /
-# grpcio-reflection to) still load a protobuf 6.x runtime, and
-# `_runtime_version.ValidateProtobufRuntimeVersion` refuses to load gencode that
-# is newer than the runtime:
-#   "Detected incompatible Protobuf Gencode/Runtime versions ... gencode 7.x
-#    runtime 6.x. Runtime version cannot be older than the linked gencode version."
-# The 1.81.x line caps protobuf<7 and emits 6.x gencode, which loads on both a
-# 6.x and a 7.x runtime. Drop the cap once the whole stack moves to protobuf 7.
+# Cap grpcio-tools at 1.81.x so the bundled protoc emits protobuf-6 gencode.
+# 1.82.x emits protobuf-7 gencode, which the protobuf 6.x runtime (pinned via
+# grpcio-health-checking/reflection in ci_install_e2e_deps.sh) refuses to load.
+# Drop the cap once the whole stack moves to protobuf 7.
 [build-system]
 requires = ["setuptools>=77.0", "grpcio-tools>=1.81.1,<1.82"]
 build-backend = "setuptools.build_meta"

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -1,5 +1,16 @@
+# Cap grpcio-tools at the 1.81.x line so the protoc it bundles emits protobuf-6
+# gencode. grpcio-tools 1.82.x ships a protobuf-7 protoc, which stamps the
+# generated *_pb2.py with gencode 7.x. The engine runtimes (and the protobuf-6
+# floor that scripts/ci_install_e2e_deps.sh pins grpcio-health-checking /
+# grpcio-reflection to) still load a protobuf 6.x runtime, and
+# `_runtime_version.ValidateProtobufRuntimeVersion` refuses to load gencode that
+# is newer than the runtime:
+#   "Detected incompatible Protobuf Gencode/Runtime versions ... gencode 7.x
+#    runtime 6.x. Runtime version cannot be older than the linked gencode version."
+# The 1.81.x line caps protobuf<7 and emits 6.x gencode, which loads on both a
+# 6.x and a 7.x runtime. Drop the cap once the whole stack moves to protobuf 7.
 [build-system]
-requires = ["setuptools>=77.0", "grpcio-tools>=1.81.1"]
+requires = ["setuptools>=77.0", "grpcio-tools>=1.81.1,<1.82"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -37,7 +37,9 @@ sglang = ["sglang>=0.5.13"]
 # smg-grpc-proto>=0.4.7 is the first release that ships mlx_engine_pb2;
 # without this floor, installing [mlx] against an older proto build would
 # crash at import time when smg_grpc_servicer.mlx.server runs.
-mlx = ["smg-grpc-proto>=0.4.7", "mlx>=0.22.0", "mlx-lm>=0.22.0"]
+# transformers<5.13: 5.13.0 regressed AutoTokenizer.register on string keys,
+# which mlx-lm's NewlineTokenizer registration hits at import.
+mlx = ["smg-grpc-proto>=0.4.7", "mlx>=0.22.0", "mlx-lm>=0.22.0", "transformers<5.13"]
 # TokenSpeed itself is installed from source (no PyPI release); these are the
 # extra runtime deps the KV-event bridge needs on top of a TokenSpeed install.
 tokenspeed = ["pyzmq>=25.0.0", "msgspec>=0.18.0"]


### PR DESCRIPTION
## Description

Two independent CI-breaking dependency-drift failures, both from newly-released
upstream packages resolving into unbounded ranges. Both surface only at import
time (builds/resolves succeed), so they slipped past `grpc-proto-build-check`.

### Problem 1 — protobuf gencode newer than runtime (sglang / e2e jobs)

The sglang gRPC server crashes importing `smg_grpc_proto.sglang_scheduler_pb2`:

```
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf
Gencode/Runtime versions when loading sglang_scheduler.proto: gencode 7.35.0
runtime 6.33.6. Runtime version cannot be older than the linked gencode version.
```

`crates/grpc_client/python/setup.py` regenerates the `*_pb2.py` stubs at install
time via `grpc_tools.protoc`; the protobuf version stamped in is whatever the PEP
517 build isolation resolves. `[build-system].requires` had `grpcio-tools>=1.81.1`
with **no upper bound**, so it picked the freshly-released **grpcio-tools 1.82.0**
(protobuf-7 protoc) → gencode `7.35.0`. But the runtime stays on protobuf 6.x —
`scripts/ci_install_e2e_deps.sh` pins `grpcio-health-checking`/`grpcio-reflection`
to `1.81.*` (protobuf&lt;7), dragging `protobuf` down to `6.33.6`. gencode > runtime → crash.

### Problem 2 — transformers 5.13.0 breaks mlx-lm (MLX job)

Importing `mlx_lm` crashes at module load:

```
File ".../mlx_lm/tokenizer_utils.py", line 505, in <module>
    AutoTokenizer.register("NewlineTokenizer", fast_tokenizer_class=NewlineTokenizer)
  ...
  File ".../transformers/models/auto/auto_factory.py", line 680, in register
    if key.__module__.startswith("transformers."):
AttributeError: 'str' object has no attribute '__module__'
```

**transformers 5.13.0** (released 2026-07-03) changed `_LazyAutoMapping.register`
to assume the key is a class (`key.__module__`), but `mlx-lm 0.31.3` registers its
custom tokenizer with a **string** key. The `[mlx]` extra pulls `transformers` via
`mlx-lm` with no upper bound, so this broke the MLX e2e job on every PR since
5.13.0 shipped (last green run on `main` was 2026-07-02, on transformers 5.12.x).

## Changes

- `crates/grpc_client/python/pyproject.toml`: cap `grpcio-tools>=1.81.1,<1.82` in
  `[build-system].requires` so stubs are generated with protobuf-6 gencode
  (`6.33.x`), which loads on both a 6.x and a 7.x runtime.
- `grpc_servicer/pyproject.toml`: cap `transformers<5.13` in the `[mlx]` extra
  (5.12.x is the last line the MLX job passed on).

Both are documented inline with a "drop once the stack moves forward" note.

## Test Plan

- **Problem 1** — before: `grpcio-tools 1.82.0` → gencode `7.35.0`, runtime `6.33.6`
  → `VersionError` at import. After: build isolation resolves `grpcio-tools==1.81.1`
  (`protobuf<7.0.0,>=6.33.5`) → gencode `6.33.x` ≤ runtime. Verified the bound via
  PyPI metadata.
- **Problem 2** — before: `transformers 5.13.0` + `mlx-lm 0.31.3` → `AttributeError`
  importing `mlx_lm`. After: `<5.13` resolves to `5.12.x`, matching the last green
  MLX run. transformers 5.13.0 release date (2026-07-03) lines up exactly with the
  first MLX failure.
- Full validation is the sglang and MLX e2e jobs in CI on this PR.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes (no Rust changes)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [x] (Optional) Documentation updated (inline comments)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Python gRPC build tooling to cap `grpcio-tools` within a compatible version range, reducing issues from mismatches between generated protobuf code and the installed protobuf runtime.
  * Refined the optional `mlx` extras by adding a `transformers<5.13` constraint to avoid a known `transformers` regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->