### PR TITLE
refactor(grpc/chat): unify thinking resolution by layer

### DIFF
--- a/bindings/golang/src/utils.rs
+++ b/bindings/golang/src/utils.rs
@@ -2,7 +2,7 @@
 
 use llm_tokenizer::traits::Tokenizer;
 use openai_protocol::chat::ChatCompletionRequest;
-use smg::routers::grpc::utils::{extract_thinking_from_kwargs, should_mark_reasoning_started};
+use smg::routers::grpc::utils::{resolve_user_thinking, should_mark_reasoning_started};
 use uuid::Uuid;
 
 /// Helper function to generate tool call ID (matches router implementation)
@@ -32,7 +32,11 @@ pub(crate) fn chat_requires_reasoning(
     tokenizer: &dyn Tokenizer,
 ) -> bool {
     should_mark_reasoning_started(
-        extract_thinking_from_kwargs(request.chat_template_kwargs.as_ref(), tokenizer),
+        resolve_user_thinking(
+            request.chat_template_kwargs.as_ref(),
+            request.reasoning_effort.as_deref(),
+            tokenizer,
+        ),
         tokenizer,
     )
 }

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -320,6 +320,25 @@ pub struct ChatCompletionRequest {
     pub other: Map<String, Value>,
 }
 
+/// Map an OpenAI `reasoning_effort` to a thinking on/off preference.
+///
+/// This is the protocol-level interpretation of "does the caller want
+/// reasoning?" — independent of any model/template. `reasoning_effort` is a
+/// *level* (`"low"`/`"medium"`/`"high"`) plus the vendor-extension `"none"`.
+///
+/// Both `"none"` and `"minimal"` map to thinking OFF (`Some(false)`).
+/// `"minimal"` is treated as an off-signal deliberately: templates that expose
+/// only a boolean thinking toggle (GLM/Qwen3) cannot do "a little" reasoning,
+/// so the lowest OpenAI level is the closest available "do not reason".
+/// Level values return `None` — no opinion, defer to the template default or an
+/// explicit thinking kwarg.
+pub fn thinking_from_reasoning_effort(reasoning_effort: Option<&str>) -> Option<bool> {
+    match reasoning_effort {
+        Some("none") | Some("minimal") => Some(false),
+        _ => None,
+    }
+}
+
 // ============================================================================
 // Validation Functions
 // ============================================================================
@@ -749,4 +768,23 @@ pub struct ChatStreamChoice {
     pub finish_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matched_stop: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::thinking_from_reasoning_effort;
+
+    #[test]
+    fn thinking_from_reasoning_effort_maps_disable_values() {
+        // "none"/"minimal" mean do-not-reason -> thinking OFF.
+        assert_eq!(thinking_from_reasoning_effort(Some("none")), Some(false));
+        assert_eq!(thinking_from_reasoning_effort(Some("minimal")), Some(false));
+        // Level values do not toggle thinking on their own.
+        assert_eq!(thinking_from_reasoning_effort(Some("low")), None);
+        assert_eq!(thinking_from_reasoning_effort(Some("medium")), None);
+        assert_eq!(thinking_from_reasoning_effort(Some("high")), None);
+        // Unspecified / unknown -> defer.
+        assert_eq!(thinking_from_reasoning_effort(None), None);
+        assert_eq!(thinking_from_reasoning_effort(Some("bogus")), None);
+    }
 }

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -48,6 +48,16 @@ pub enum ThinkingKeyName {
     Thinking,
 }
 
+impl ThinkingKeyName {
+    /// The template kwarg name this toggle uses.
+    pub fn as_kwarg(self) -> &'static str {
+        match self {
+            ThinkingKeyName::EnableThinking => "enable_thinking",
+            ThinkingKeyName::Thinking => "thinking",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ThinkingToggle {
     /// Template has no thinking toggle. The model either always reasons
@@ -466,6 +476,11 @@ pub struct ChatTemplateParams<'a> {
     /// Special tokens to inject into the template context.
     /// Many templates reference `{{ bos_token }}`, `{{ eos_token }}`, etc.
     pub special_tokens: Option<&'a crate::traits::SpecialTokens>,
+    /// Resolved thinking preference. When `Some`, `apply` sets the template's
+    /// own thinking-toggle key (`enable_thinking`/`thinking`, per detection) to
+    /// this value as a default. An explicit `template_kwargs` entry for that
+    /// key still wins.
+    pub thinking: Option<bool>,
 }
 
 /// JSON separator pair passed through HuggingFace's `tojson` filter.
@@ -1064,6 +1079,23 @@ impl ChatTemplateState {
                  https://huggingface.co/docs/transformers/main/en/chat_templating",
             )
         })?;
+
+        // Apply the resolved thinking preference under the template's own toggle
+        // key (`enable_thinking` vs `thinking`, per detection). Injected as a
+        // default: an explicit `template_kwargs` entry for that key still wins.
+        if let (Some(thinking), Some(key)) = (params.thinking, self.thinking_key_name) {
+            let mut kwargs = params.template_kwargs.cloned().unwrap_or_default();
+            kwargs
+                .entry(key.as_kwarg().to_string())
+                .or_insert(serde_json::Value::Bool(thinking));
+            let params = ChatTemplateParams {
+                template_kwargs: Some(&kwargs),
+                thinking: None,
+                ..params
+            };
+            return render_chat_template(env, messages, params);
+        }
+
         render_chat_template(env, messages, params)
     }
 
@@ -1189,5 +1221,44 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, "<s>hello");
+    }
+
+    #[test]
+    fn thinking_param_sets_template_key_and_explicit_wins() {
+        use std::collections::HashMap;
+
+        // Template echoes the enable_thinking value so we can observe what was set.
+        let state = ChatTemplateState::new(Some("{{ enable_thinking }}".to_string())).unwrap();
+        assert_eq!(
+            state.thinking_key_name(),
+            Some(ThinkingKeyName::EnableThinking)
+        );
+
+        // thinking = Some(false) injects enable_thinking=false under the model's key.
+        let out = state
+            .apply(
+                &[],
+                ChatTemplateParams {
+                    thinking: Some(false),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(out, "false");
+
+        // An explicit template_kwargs entry overrides the injected default.
+        let mut kwargs: HashMap<String, serde_json::Value> = HashMap::new();
+        kwargs.insert("enable_thinking".to_string(), serde_json::Value::Bool(true));
+        let out = state
+            .apply(
+                &[],
+                ChatTemplateParams {
+                    thinking: Some(false),
+                    template_kwargs: Some(&kwargs),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(out, "true");
     }
 }

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -1081,19 +1081,24 @@ impl ChatTemplateState {
         })?;
 
         // Apply the resolved thinking preference under the template's own toggle
-        // key (`enable_thinking` vs `thinking`, per detection). Injected as a
-        // default: an explicit `template_kwargs` entry for that key still wins.
+        // key (`enable_thinking` vs `thinking`, per detection). Skip entirely
+        // (no clone) when the caller already set that key explicitly — the
+        // explicit value wins.
         if let (Some(thinking), Some(key)) = (params.thinking, self.thinking_key_name) {
-            let mut kwargs = params.template_kwargs.cloned().unwrap_or_default();
-            kwargs
-                .entry(key.as_kwarg().to_string())
-                .or_insert(serde_json::Value::Bool(thinking));
-            let params = ChatTemplateParams {
-                template_kwargs: Some(&kwargs),
-                thinking: None,
-                ..params
-            };
-            return render_chat_template(env, messages, params);
+            let kwarg_key = key.as_kwarg();
+            if params
+                .template_kwargs
+                .is_none_or(|k| !k.contains_key(kwarg_key))
+            {
+                let mut kwargs = params.template_kwargs.cloned().unwrap_or_default();
+                kwargs.insert(kwarg_key.to_string(), serde_json::Value::Bool(thinking));
+                let params = ChatTemplateParams {
+                    template_kwargs: Some(&kwargs),
+                    thinking: None,
+                    ..params
+                };
+                return render_chat_template(env, messages, params);
+            }
         }
 
         render_chat_template(env, messages, params)

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -486,14 +486,18 @@ fn detect_renderer_from_config(dir: &std::path::Path) -> Renderer {
 // ---------------------------------------------------------------------------
 // DeepSeek V3.2 / V4 dispatch shims
 // ---------------------------------------------------------------------------
-/// Derive the V3.2 / V4 thinking mode from `template_kwargs`. Only the
-/// `thinking` key is honored, matching sglang's DeepSeek serving path and
-/// the `ThinkingKeyName::Thinking` contract reported by this tokenizer.
+/// Derive the V3.2 / V4 thinking mode. These native encoders bypass
+/// `ChatTemplateState::apply`, so this is where the resolved thinking preference
+/// is consumed. An explicit `template_kwargs["thinking"]` wins; otherwise fall
+/// back to `params.thinking` (resolved from `reasoning_effort` / Anthropic
+/// `ThinkingConfig`) — same precedence as the Jinja path. Default off, matching
+/// the `ThinkingKeyName::Thinking` / `DefaultOff` contract reported here.
 fn derive_thinking_mode(params: &ChatTemplateParams) -> deepseek_v32::ThinkingMode {
     let enabled = params
         .template_kwargs
         .and_then(|k| k.get("thinking"))
         .and_then(serde_json::Value::as_bool)
+        .or(params.thinking)
         .unwrap_or(false);
     if enabled {
         deepseek_v32::ThinkingMode::Thinking
@@ -577,4 +581,65 @@ fn apply_deepseek_v4(
     };
     deepseek_v4::encode_messages(msgs, thinking_mode, &encode_params)
         .map_err(|e| Error::msg(format!("DeepSeek V4 encode failed: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::derive_thinking_mode;
+    use crate::{chat_template::ChatTemplateParams, encoders::deepseek_v32::ThinkingMode};
+
+    fn thinking_kwargs(value: bool) -> HashMap<String, serde_json::Value> {
+        HashMap::from([("thinking".to_string(), serde_json::Value::Bool(value))])
+    }
+
+    // Regression: DeepSeek V3.2/V4 bypass ChatTemplateState::apply, so the
+    // resolved `params.thinking` (from reasoning_effort / Anthropic ThinkingConfig)
+    // must be honored here — with an explicit `template_kwargs["thinking"]` still
+    // winning. Same precedence as the Jinja path.
+    #[test]
+    fn derive_thinking_mode_honors_params_thinking_and_explicit_override() {
+        // No signal at all -> Chat (default off).
+        assert!(matches!(
+            derive_thinking_mode(&ChatTemplateParams::default()),
+            ThinkingMode::Chat
+        ));
+
+        // params.thinking is the fallback when there is no explicit kwarg.
+        assert!(matches!(
+            derive_thinking_mode(&ChatTemplateParams {
+                thinking: Some(true),
+                ..Default::default()
+            }),
+            ThinkingMode::Thinking
+        ));
+        assert!(matches!(
+            derive_thinking_mode(&ChatTemplateParams {
+                thinking: Some(false),
+                ..Default::default()
+            }),
+            ThinkingMode::Chat
+        ));
+
+        // An explicit template_kwargs["thinking"] wins over params.thinking.
+        let on = thinking_kwargs(true);
+        assert!(matches!(
+            derive_thinking_mode(&ChatTemplateParams {
+                thinking: Some(false),
+                template_kwargs: Some(&on),
+                ..Default::default()
+            }),
+            ThinkingMode::Thinking
+        ));
+        let off = thinking_kwargs(false);
+        assert!(matches!(
+            derive_thinking_mode(&ChatTemplateParams {
+                thinking: Some(true),
+                template_kwargs: Some(&off),
+                ..Default::default()
+            }),
+            ThinkingMode::Chat
+        ));
+    }
 }

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -382,26 +382,15 @@ pub fn process_chat_messages(
         let kwargs_capacity = 1 + request.chat_template_kwargs.as_ref().map_or(0, |k| k.len());
         let mut combined_template_kwargs = HashMap::with_capacity(kwargs_capacity);
 
-        // Add reasoning_effort if present (like Python does)
+        // Add reasoning_effort if present (like Python does): some templates read
+        // it as a *level*. The thinking on/off projection is applied separately
+        // via `ChatTemplateParams.thinking` below, so the tokenizer sets the
+        // model's own toggle key.
         if let Some(reasoning_effort) = &request.reasoning_effort {
             combined_template_kwargs.insert(
                 "reasoning_effort".to_string(),
                 Value::String(reasoning_effort.clone()),
             );
-
-            // OpenAI semantics: reasoning_effort "none"/"minimal" means "do not
-            // produce reasoning". Many chat templates gate thinking on a boolean
-            // toggle and treat `reasoning_effort` only as a *level* (so "none"
-            // would otherwise still think). Translate the disable case to the
-            // thinking toggle = false. Templates use different key names
-            // (`enable_thinking` for GLM-4.x/5, Qwen3; `thinking` for
-            // DeepSeek-V3.1, Kimi-K2.5), so set both; the unused one is ignored.
-            // These are defaults only: an explicit chat_template_kwargs value
-            // (applied below) still wins.
-            if matches!(reasoning_effort.as_str(), "none" | "minimal") {
-                combined_template_kwargs.insert("enable_thinking".to_string(), Value::Bool(false));
-                combined_template_kwargs.insert("thinking".to_string(), Value::Bool(false));
-            }
         }
 
         // Add any additional template kwargs from request
@@ -421,6 +410,12 @@ pub fn process_chat_messages(
             add_generation_prompt: true,
             tools: tools_json.as_deref(),
             template_kwargs: final_template_kwargs,
+            // Project OpenAI `reasoning_effort` (none/minimal) onto the model's
+            // thinking toggle; the tokenizer applies it under the correct key.
+            // An explicit chat_template_kwargs toggle still wins (in apply).
+            thinking: openai_protocol::chat::thinking_from_reasoning_effort(
+                request.reasoning_effort.as_deref(),
+            ),
             ..Default::default()
         };
 

--- a/model_gateway/src/routers/grpc/utils/message_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/message_utils.rs
@@ -5,8 +5,6 @@
 //! instead of `ChatCompletionRequest` / `ChatMessage`.
 #![allow(dead_code)] // wired in follow-up PR (pipeline factory)
 
-use std::collections::HashMap;
-
 use llm_tokenizer::{
     chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
     traits::Tokenizer,
@@ -74,35 +72,21 @@ pub fn process_messages(
         .transpose()
         .map_err(|e| format!("Failed to serialize tools: {e}"))?;
 
-    // Step 5: Build template kwargs from ThinkingConfig
-    let mut combined_template_kwargs = HashMap::new();
-
-    // Pass both `enable_thinking` (Qwen3) and `thinking` (Kimi-K2.5) since
-    // different model templates use different kwarg names for the same concept.
-    // Adaptive mode is treated as "thinking on"; the model decides whether to actually emit it.
-    match &request.thinking {
-        Some(ThinkingConfig::Enabled { .. } | ThinkingConfig::Adaptive { .. }) => {
-            combined_template_kwargs.insert("enable_thinking".to_string(), json!(true));
-            combined_template_kwargs.insert("thinking".to_string(), json!(true));
-        }
-        Some(ThinkingConfig::Disabled) => {
-            combined_template_kwargs.insert("enable_thinking".to_string(), json!(false));
-            combined_template_kwargs.insert("thinking".to_string(), json!(false));
-        }
-        None => {} // Let template use its default behavior
-    }
-
-    let final_template_kwargs = if combined_template_kwargs.is_empty() {
-        None
-    } else {
-        Some(&combined_template_kwargs)
+    // Step 5: Project the Anthropic ThinkingConfig onto a thinking on/off
+    // preference. Adaptive is treated as "thinking on"; the model decides
+    // whether to actually emit it. The tokenizer applies this under the model's
+    // own toggle key (`enable_thinking`/`thinking`) in `apply`.
+    let thinking = match &request.thinking {
+        Some(ThinkingConfig::Enabled { .. } | ThinkingConfig::Adaptive { .. }) => Some(true),
+        Some(ThinkingConfig::Disabled) => Some(false),
+        None => None, // Let template use its default behavior
     };
 
     // Step 6: Apply chat template
     let params = ChatTemplateParams {
         add_generation_prompt: true,
         tools: tools_json.as_deref(),
-        template_kwargs: final_template_kwargs,
+        thinking,
         ..Default::default()
     };
 

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -25,6 +25,4 @@ pub(crate) use parsers::{
 };
 // `pub` (not `pub(crate)`) so the Go bindings can reuse the gateway's reasoning
 // detection instead of duplicating it.
-pub use parsers::{
-    extract_thinking_from_kwargs, resolve_user_thinking, should_mark_reasoning_started,
-};
+pub use parsers::{resolve_user_thinking, should_mark_reasoning_started};

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -4,6 +4,7 @@ use llm_tokenizer::{
     chat_template::{ThinkingKeyName, ThinkingToggle},
     traits::Tokenizer,
 };
+use openai_protocol::chat::thinking_from_reasoning_effort;
 use reasoning_parser::{ParserFactory as ReasoningParserFactory, ReasoningParser};
 use serde_json::Value;
 use tool_parser::{
@@ -32,7 +33,7 @@ pub fn should_mark_reasoning_started(
 /// Only checks the key that the template actually uses (e.g. `enable_thinking`
 /// for Qwen3, `thinking` for Kimi-K2.5). This prevents mismatches where the
 /// user passes the wrong key name and the template ignores it.
-pub fn extract_thinking_from_kwargs(
+pub(crate) fn extract_thinking_from_kwargs(
     kwargs: Option<&std::collections::HashMap<String, Value>>,
     tokenizer: &dyn Tokenizer,
 ) -> Option<bool> {
@@ -45,22 +46,10 @@ pub fn extract_thinking_from_kwargs(
     .and_then(|v| v.as_bool())
 }
 
-/// Map an OpenAI `reasoning_effort` value to a thinking preference.
-///
-/// OpenAI semantics: `"none"`/`"minimal"` mean "do not produce reasoning", so
-/// they map to thinking OFF (`Some(false)`). Level values (`"low"`/`"medium"`/
-/// `"high"`) don't toggle thinking on their own, so they return `None` (defer to
-/// the template default / explicit thinking kwarg).
-pub(crate) fn thinking_from_reasoning_effort(reasoning_effort: Option<&str>) -> Option<bool> {
-    match reasoning_effort {
-        Some("none") | Some("minimal") => Some(false),
-        _ => None,
-    }
-}
-
 /// Precedence for the effective thinking preference: an explicit template
 /// toggle (already extracted from kwargs) always wins; otherwise fall back to
-/// the OpenAI `reasoning_effort` mapping.
+/// the protocol-level OpenAI `reasoning_effort` mapping
+/// ([`thinking_from_reasoning_effort`]).
 fn resolve_thinking_pref(explicit: Option<bool>, reasoning_effort: Option<&str>) -> Option<bool> {
     explicit.or_else(|| thinking_from_reasoning_effort(reasoning_effort))
 }
@@ -203,20 +192,6 @@ mod tests {
         assert_eq!(resolve_thinking_pref(None, Some("minimal")), Some(false));
         assert_eq!(resolve_thinking_pref(None, Some("high")), None);
         assert_eq!(resolve_thinking_pref(None, None), None);
-    }
-
-    #[test]
-    fn thinking_from_reasoning_effort_maps_disable_values() {
-        // "none"/"minimal" mean do-not-reason -> thinking OFF
-        assert_eq!(thinking_from_reasoning_effort(Some("none")), Some(false));
-        assert_eq!(thinking_from_reasoning_effort(Some("minimal")), Some(false));
-        // level values do not toggle thinking on their own
-        assert_eq!(thinking_from_reasoning_effort(Some("low")), None);
-        assert_eq!(thinking_from_reasoning_effort(Some("medium")), None);
-        assert_eq!(thinking_from_reasoning_effort(Some("high")), None);
-        // unspecified / unknown -> defer
-        assert_eq!(thinking_from_reasoning_effort(None), None);
-        assert_eq!(thinking_from_reasoning_effort(Some("bogus")), None);
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

Follow-up to #1876. That fix made `reasoning_effort: "none"/"minimal"` disable thinking, but resolved it **entirely in the gateway** with a blind dual-key write (`enable_thinking` *and* `thinking`), duplicated in `message_utils.rs` (Anthropic `ThinkingConfig`). Two smells surfaced in review of #1876:

1. The **write** path guessed both key names, while the **read** path (`extract_thinking_from_kwargs`) precisely used the template's *one* key — the PR contradicted its own principle.
2. The `none/minimal` rule lived in two places (`chat_utils` and `parsers`) that could drift and desync template-render vs. parser start-state.

It also left the Go binding ignoring `reasoning_effort` entirely.

### Solution

Give thinking-resolution **one owner per concern**, keyed off tokenizer metadata that already exists (`thinking_key_name` / `thinking_toggle`):

- **Interpret** (OpenAI `reasoning_effort` / Anthropic `ThinkingConfig` → `Option<bool>`) at the protocol layer.
- **Apply** (set the model's own toggle key) inside the tokenizer.
- The gateway just composes the two.

## Changes

- **`openai-protocol`** — `thinking_from_reasoning_effort()`: model-agnostic interpretation (`none`/`minimal` → off); the `minimal` decision is documented inline (closest "off" for boolean-toggle models).
- **`llm-tokenizer`** — `ChatTemplateParams.thinking: Option<bool>` + `ThinkingKeyName::as_kwarg()`. `ChatTemplateState::apply` injects the template's **own** toggle key (single correct key, not both) as a default that an explicit `template_kwargs` entry overrides. DeepSeek V3.2/V4 native encoders bypass `apply`, so `derive_thinking_mode` consumes the same preference (explicit kwarg still wins).
- **gateway** — `chat_utils.rs` and `message_utils.rs` drop the dual-key writes and pass the resolved `thinking`; `parsers.rs` delegates the mapping to the protocol fn; `extract_thinking_from_kwargs` demoted to `pub(crate)`.
- **`smg-golang`** — migrated to `resolve_user_thinking` so the Go path honors `reasoning_effort`.

## Test Plan

Behavior is unchanged for target models (GLM/Qwen3, DeepSeek V3.1/V3.2/V4, Kimi). Precedence preserved everywhere: explicit `chat_template_kwargs` toggle > `reasoning_effort`/`ThinkingConfig` mapping > template default.

- `cargo test -p openai-protocol` (145) and `cargo test -p llm-tokenizer --lib` (145) pass — including new tests for the mapping, the `apply` injection + explicit-override, and the DeepSeek `derive_thinking_mode` fallback.
- Gateway `grpc::utils` unit tests pass (21).
- `cargo +nightly fmt` clean; `clippy -D warnings` clean (locally on default features — `--all-features` needs the OpenCV system dep and runs on CI).
- End-to-end covered by existing `e2e_test/chat_completions/test_enable_thinking.py`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (CI; default-features locally)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced “thinking”/reasoning preference handling in chat rendering, including mapping `reasoning_effort` (e.g., `none`, `minimal`) and projecting it into template rendering.
* **Bug Fixes**
  * Fixed inconsistent interpretation of reasoning settings by ensuring clear precedence between explicit template overrides and request-level values.
  * Improved fallback behavior when `reasoning_effort` is missing or unrecognized, and aligned provider behavior with the unified “thinking” preference.
* **Tests**
  * Added/updated unit tests for `reasoning_effort` mapping, precedence rules, and tokenizer override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->