### PR TITLE
docs: add project governance documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for everything
-* @slin1237 @CatherineSue
+* @slin1237 @CatherineSue @key4ng
 
 # Benchmarks
 /model_gateway/benches @slin1237

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ document is the front door. The detailed guides live under
 
 - **Code of Conduct**: [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) — applies to
   every interaction in this repo and in community spaces.
+- **Governance**: For how the project is governed — roles, decision making, and how maintainers are added — see [GOVERNANCE.md](GOVERNANCE.md).
 - **How to contribute code**: [`docs/contributing/index.md`](./docs/contributing/index.md)
 - **Development environment**: [`docs/contributing/development.md`](./docs/contributing/development.md)
 - **Code style**: [`docs/contributing/code-style.md`](./docs/contributing/code-style.md)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -24,6 +24,7 @@ owners (`*`) in CODEOWNERS. Current core maintainers:
 
 - Simo Lin ([@slin1237](https://github.com/slin1237))
 - Chang Su ([@CatherineSue](https://github.com/CatherineSue))
+- Keyang Ru ([@key4ng](https://github.com/key4ng))
 
 ## Decision Making
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,74 @@
+# SMG Project Governance
+
+This document describes how the Shepherd Model Gateway (SMG) project is
+governed. It follows the spirit of the Linux Foundation's
+[Minimum Viable Governance](https://github.com/github/MVG) framework.
+
+## Roles
+
+**Contributors** — Anyone who files issues, participates in discussions, or
+submits pull requests. No special status is required; see
+[CONTRIBUTING.md](CONTRIBUTING.md) for how to get started.
+
+**Code Owners** — Contributors with sustained, high-quality contributions to
+a specific area of the codebase (e.g., a workspace crate, bindings, CI).
+Code owners review and approve changes in their areas. The authoritative
+list of who owns what is
+[`.github/CODEOWNERS`](.github/CODEOWNERS) — this is also the right place
+to look when you need to find a reviewer or contact for a given part of
+the code.
+
+**Core Maintainers** — Responsible for the overall direction, architecture,
+releases, and health of the project. Core maintainers are the default
+owners (`*`) in CODEOWNERS. Current core maintainers:
+
+- Simo Lin ([@slin1237](https://github.com/slin1237))
+- Chang Su ([@CatherineSue](https://github.com/CatherineSue))
+
+## Decision Making
+
+Day-to-day technical decisions are made through **lazy consensus** on pull
+requests and issues. A pull request may merge when it has approval from
+the relevant code owners (enforced via CODEOWNERS) and passing CI.
+
+Significant changes — new architecture, breaking API changes, new workspace
+crates, release planning, deprecations — are proposed as a GitHub issue or
+design discussion and decided by consensus among the core maintainers.
+
+If consensus cannot be reached in a reasonable time, the final decision
+rests with the core maintainers. Disagreements are expected to be resolved
+through discussion in the open, on GitHub.
+
+## Becoming a Maintainer
+
+The typical path is contributor → code owner → core maintainer:
+
+1. A contributor with a track record of quality contributions and reviews
+   in an area may be nominated by an existing maintainer to become a code
+   owner for that area.
+2. Code owners who demonstrate sustained ownership across the project may
+   be nominated as core maintainers.
+
+In both cases, additions require agreement from the core maintainers and
+are made concrete via a pull request updating CODEOWNERS.
+
+## Stepping Down and Removal
+
+Maintainers and code owners may step down at any time by opening a pull
+request removing themselves from CODEOWNERS. Maintainers who are inactive
+for an extended period (roughly 6+ months), or who violate the
+[Code of Conduct](CODE_OF_CONDUCT.md), may be removed by consensus of the
+remaining core maintainers.
+
+## Communication
+
+Project communication happens in the open on GitHub — issues, pull
+requests, and discussions in
+[lightseekorg/smg](https://github.com/lightseekorg/smg). Security issues
+should be reported privately to the core maintainers (see contact
+information above).
+
+## Changes to Governance
+
+Changes to this document are proposed via pull request and require
+approval from the core maintainers.


### PR DESCRIPTION
## Description

### Problem

The project had no formal, written description of how it is governed — who
holds which role, how decisions are made, or how someone becomes (or stops
being) a maintainer. Newcomers had no single place to learn the project's
governance model, and code ownership was implicit.

### Solution

Adds formal governance documentation covering roles (contributor → code
owner → core maintainer), decision making, the maintainer lifecycle, and
code ownership, with `.github/CODEOWNERS` as the source of truth for who
owns what.

Modeled on the Linux Foundation's Minimum Viable Governance framework.

## Changes

- Add `GOVERNANCE.md` at the repository root describing roles, decision
  making, the path to becoming a maintainer, stepping down / removal,
  communication, and how governance itself is changed.
- Link to `GOVERNANCE.md` from `CONTRIBUTING.md`, next to the existing
  Code of Conduct reference.

## Test Plan

Docs-only change; no code paths are affected.

- Verified the three relative links in `GOVERNANCE.md` resolve on this
  branch: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `.github/CODEOWNERS`.
- Ran `pre-commit` on the changed files (trailing-whitespace,
  end-of-file-fixer, codespell, DCO sign-off, no-AI-attribution, branch
  naming) — all passed.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes <!-- n/a: docs-only -->
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes <!-- n/a: docs-only -->
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new governance guide covering contributor roles, decision-making, maintainer responsibilities, and approval of governance changes.
  * Updated contributor guidance to direct readers to the new governance information.
* **Chores**
  * Updated default code ownership rules to include an additional code owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->