### PR TITLE
fix(multimodal): expose EPD routing in Python CLI

### DIFF
--- a/bindings/python/src/smg/launch_router.py
+++ b/bindings/python/src/smg/launch_router.py
@@ -98,6 +98,13 @@ Examples:
     --decode http://decode1:8001 --decode http://decode2:8001 \\
     --prefill-policy cache_aware --decode-policy power_of_two
 
+  # EPD disaggregated mode
+  python -m smg.launch_router --epd-disaggregation \\
+    --encode http://encode1:8000 9000 \\
+    --prefill http://prefill1:8000 9001 \\
+    --decode http://decode1:8001 \\
+    --encode-policy consistent_hashing
+
     """,
         formatter_class=CustomHelpFormatter,
     )

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -248,20 +248,32 @@ class Router:
     def from_args(args: RouterArgs) -> Router:
         """Create a router from a RouterArgs instance."""
 
-        args_dict = vars(args)
+        args_dict = vars(args).copy()
         # Convert RouterArgs to _Router parameters
         args_dict["worker_urls"] = (
             []
-            if args_dict["service_discovery"] or args_dict["pd_disaggregation"]
+            if (
+                args_dict["service_discovery"]
+                or args_dict["pd_disaggregation"]
+                or args_dict["epd_disaggregation"]
+            )
             else args_dict["worker_urls"]
         )
         args_dict["policy"] = policy_from_str(args_dict["policy"])
+        args_dict["encode_urls"] = (
+            args_dict["encode_urls"] if args_dict["epd_disaggregation"] else None
+        )
         args_dict["prefill_urls"] = (
-            args_dict["prefill_urls"] if args_dict["pd_disaggregation"] else None
+            args_dict["prefill_urls"]
+            if args_dict["pd_disaggregation"] or args_dict["epd_disaggregation"]
+            else None
         )
         args_dict["decode_urls"] = (
-            args_dict["decode_urls"] if args_dict["pd_disaggregation"] else None
+            args_dict["decode_urls"]
+            if args_dict["pd_disaggregation"] or args_dict["epd_disaggregation"]
+            else None
         )
+        args_dict["encode_policy"] = policy_from_str(args_dict["encode_policy"])
         args_dict["prefill_policy"] = policy_from_str(args_dict["prefill_policy"])
         args_dict["decode_policy"] = policy_from_str(args_dict["decode_policy"])
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -23,6 +23,7 @@ COMMON_POLICY_CHOICES = [
 ]
 
 PREFILL_POLICY_CHOICES = [*COMMON_POLICY_CHOICES, "bucket"]
+ENCODE_POLICY_CHOICES = ["random", "round_robin", "consistent_hashing"]
 
 
 @dataclasses.dataclass
@@ -36,8 +37,12 @@ class RouterArgs:
     # None = dedicated probe listener off (routes stay on the main port).
     health_check_port: int | None = None
 
-    # PD-specific configuration
+    # PD/EPD-specific configuration
     pd_disaggregation: bool = False  # Enable PD disaggregated mode
+    epd_disaggregation: bool = False  # Enable Encode-Prefill-Decode disaggregated mode
+    encode_urls: list[tuple] = dataclasses.field(
+        default_factory=list
+    )  # List of (url, bootstrap_port)
     prefill_urls: list[tuple] = dataclasses.field(
         default_factory=list
     )  # List of (url, bootstrap_port)
@@ -45,6 +50,7 @@ class RouterArgs:
 
     # Routing policy
     policy: str = "cache_aware"
+    encode_policy: str | None = None  # Specific policy for encode nodes in EPD mode
     prefill_policy: str | None = None  # Specific policy for prefill nodes in PD mode
     decode_policy: str | None = None  # Specific policy for decode nodes in PD mode
     worker_startup_timeout_secs: int = 1800
@@ -78,7 +84,8 @@ class RouterArgs:
     selector: dict[str, str] = dataclasses.field(default_factory=dict)
     service_discovery_port: int = 80
     service_discovery_namespace: str | None = None
-    # PD service discovery configuration
+    # PD/EPD service discovery configuration
+    encode_selector: dict[str, str] = dataclasses.field(default_factory=dict)
     prefill_selector: dict[str, str] = dataclasses.field(default_factory=dict)
     decode_selector: dict[str, str] = dataclasses.field(default_factory=dict)
     router_selector: dict[str, str] = dataclasses.field(default_factory=dict)
@@ -216,7 +223,7 @@ class RouterArgs:
             "Routing Policy", "Load balancing and routing configuration"
         )
         pd_group = parser.add_argument_group(
-            "PD Disaggregation", "Prefill-Decode disaggregated mode settings"
+            "PD/EPD Disaggregation", "Encode-Prefill-Decode and Prefill-Decode settings"
         )
         k8s_group = parser.add_argument_group(
             "Service Discovery (Kubernetes)", "Kubernetes-based worker discovery"
@@ -330,6 +337,16 @@ class RouterArgs:
             help=(
                 "Load balancing policy to use. In PD mode, this is used for both prefill and decode"
                 " unless overridden"
+            ),
+        )
+        routing_group.add_argument(
+            f"--{prefix}encode-policy",
+            type=str,
+            default=None,
+            choices=ENCODE_POLICY_CHOICES,
+            help=(
+                "Specific policy for encode nodes in EPD mode."
+                " If not specified, uses consistent_hashing"
             ),
         )
         routing_group.add_argument(
@@ -490,11 +507,24 @@ class RouterArgs:
             help="Enable IGW (Inference-Gateway) mode for multi-model support",
         )
 
-        # PD-specific arguments
+        # PD/EPD-specific arguments
         pd_group.add_argument(
             f"--{prefix}pd-disaggregation",
             action="store_true",
             help="Enable PD (Prefill-Decode) disaggregated mode",
+        )
+        pd_group.add_argument(
+            f"--{prefix}epd-disaggregation",
+            action="store_true",
+            help="Enable EPD (Encode-Prefill-Decode) disaggregated mode",
+        )
+        pd_group.add_argument(
+            f"--{prefix}encode",
+            nargs="+",
+            action="append",
+            help="Encode server URL and optional bootstrap port. Can be specified multiple times. "
+            "Format: --encode URL [BOOTSTRAP_PORT]. "
+            "BOOTSTRAP_PORT can be a port number, 'none', or omitted (defaults to none).",
         )
         pd_group.add_argument(
             f"--{prefix}prefill",
@@ -583,6 +613,16 @@ class RouterArgs:
             help=(
                 "Kubernetes namespace to watch for pods. If not provided, watches all namespaces"
                 " (requires cluster-wide permissions)"
+            ),
+        )
+        k8s_group.add_argument(
+            f"--{prefix}encode-selector",
+            type=str,
+            nargs="+",
+            default={},
+            help=(
+                "Label selector for encode server pods in EPD mode"
+                " (format: key1=value1 key2=value2)"
             ),
         )
         k8s_group.add_argument(
@@ -1240,7 +1280,10 @@ class RouterArgs:
         if f"{prefix}tls_key_path" in cli_args_dict:
             args_dict["server_key_path"] = cli_args_dict[f"{prefix}tls_key_path"]
 
-        # parse special arguments and remove "--prefill" and "--decode" from cli_args_dict
+        # parse special arguments and remove "--encode", "--prefill", and "--decode" from cli_args_dict
+        args_dict["encode_urls"] = cls._parse_encode_urls(
+            cli_args_dict.get(f"{prefix}encode", None)
+        )
         args_dict["prefill_urls"] = cls._parse_prefill_urls(
             cli_args_dict.get(f"{prefix}prefill", None)
         )
@@ -1248,6 +1291,9 @@ class RouterArgs:
             cli_args_dict.get(f"{prefix}decode", None)
         )
         args_dict["selector"] = cls._parse_selector(cli_args_dict.get(f"{prefix}selector", None))
+        args_dict["encode_selector"] = cls._parse_selector(
+            cli_args_dict.get(f"{prefix}encode_selector", None)
+        )
         args_dict["prefill_selector"] = cls._parse_selector(
             cli_args_dict.get(f"{prefix}prefill_selector", None)
         )
@@ -1278,6 +1324,10 @@ class RouterArgs:
 
     def _validate_router_args(self):
         # Validate configuration based on mode
+        if self.epd_disaggregation:
+            if self.encode_policy:
+                logger.info(f"Using --encode-policy '{self.encode_policy}' for encode nodes.")
+
         if self.pd_disaggregation:
             # Warn about policy usage in PD mode
             if self.prefill_policy and self.decode_policy and self.policy:
@@ -1349,6 +1399,18 @@ class RouterArgs:
             prefill_urls.append((url, bootstrap_port))
 
         return prefill_urls
+
+    @staticmethod
+    def _parse_encode_urls(encode_list):
+        """Parse encode URLs from --encode arguments.
+
+        Format: --encode URL [BOOTSTRAP_PORT]
+        Example:
+            --encode http://encode1:8080 9000  # With bootstrap port
+            --encode http://encode2:8080 none  # Explicitly no bootstrap port
+            --encode http://encode3:8080       # Defaults to no bootstrap port
+        """
+        return RouterArgs._parse_prefill_urls(encode_list)
 
     @staticmethod
     def _parse_decode_urls(decode_list):

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -116,6 +116,17 @@ class TestRouterArgs:
         with pytest.raises(ValueError, match="Invalid bootstrap port"):
             RouterArgs._parse_prefill_urls([["http://prefill1:8000", "invalid"]])
 
+    def test_parse_encode_urls_valid(self):
+        """Test parsing valid encode URL arguments."""
+        result = RouterArgs._parse_encode_urls([["http://encode1:8000", "9000"]])
+        assert result == [("http://encode1:8000", 9000)]
+
+        result = RouterArgs._parse_encode_urls([["http://encode1:8000", "none"]])
+        assert result == [("http://encode1:8000", None)]
+
+        result = RouterArgs._parse_encode_urls([["http://encode1:8000"]])
+        assert result == [("http://encode1:8000", None)]
+
     def test_parse_decode_urls_valid(self):
         """Test parsing valid decode URL arguments."""
         # Test single decode URL
@@ -526,6 +537,42 @@ class TestParseRouterArgs:
         ]
         assert router_args.decode_urls == ["http://decode1:8001", "http://decode2:8001"]
         assert router_args.prefill_policy == "power_of_two"
+        assert router_args.decode_policy == "round_robin"
+
+    def test_parse_epd_args(self):
+        """Test parsing EPD disaggregated mode arguments."""
+        args = [
+            "--epd-disaggregation",
+            "--encode",
+            "http://encode1:8000",
+            "9000",
+            "--encode",
+            "http://encode2:8000",
+            "none",
+            "--prefill",
+            "http://prefill1:8000",
+            "9001",
+            "--decode",
+            "http://decode1:8001",
+            "--encode-policy",
+            "consistent_hashing",
+            "--prefill-policy",
+            "cache_aware",
+            "--decode-policy",
+            "round_robin",
+        ]
+
+        router_args = parse_router_args(args)
+
+        assert router_args.epd_disaggregation is True
+        assert router_args.encode_urls == [
+            ("http://encode1:8000", 9000),
+            ("http://encode2:8000", None),
+        ]
+        assert router_args.prefill_urls == [("http://prefill1:8000", 9001)]
+        assert router_args.decode_urls == ["http://decode1:8001"]
+        assert router_args.encode_policy == "consistent_hashing"
+        assert router_args.prefill_policy == "cache_aware"
         assert router_args.decode_policy == "round_robin"
 
     def test_parse_pd_args_with_new_policies(self):

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/encoder_servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/encoder_servicer.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 def _lazy_encode_request():
-    from tokenspeed.runtime.disaggregation.embedding.encode_worker import EncodeRequest
+    from tokenspeed.runtime.pd.epd.encode_worker import EncodeRequest
 
     return EncodeRequest
 


### PR DESCRIPTION
## Summary

Expose EPD routing through the Python SMG CLI wrapper.

This adds Python CLI/router wrapper support for:

- `--epd-disaggregation`
- `--encode`
- `--encode-policy`
- `--encode-selector`

The parsed EPD fields are passed through to the Rust `Router` binding that was added in #1852. The TokenSpeed encoder servicer import is also updated from the old `runtime.disaggregation` path to the new `runtime.pd.epd` path.

## Testing

- `python3 -m py_compile bindings/python/src/smg/launch_router.py bindings/python/src/smg/router_args.py bindings/python/src/smg/router.py bindings/python/tests/test_arg_parser.py grpc_servicer/smg_grpc_servicer/tokenspeed/encoder_servicer.py`
- `python3 -m ruff check bindings/python/src/smg/launch_router.py bindings/python/src/smg/router_args.py bindings/python/src/smg/router.py bindings/python/tests/test_arg_parser.py grpc_servicer/smg_grpc_servicer/tokenspeed/encoder_servicer.py`
- `python3 -m ruff format --check bindings/python/src/smg/launch_router.py bindings/python/src/smg/router_args.py bindings/python/src/smg/router.py bindings/python/tests/test_arg_parser.py grpc_servicer/smg_grpc_servicer/tokenspeed/encoder_servicer.py`
- Verified `python3 -m smg launch --epd-disaggregation ...` with a stubbed Rust router binding
- `pre-commit run --all-files` passed all non-clippy hooks; clippy could not complete in this environment because the system `opencv4.pc` dependency is not installed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for EPD disaggregated mode in the router CLI, including encode, prefill, and decode configuration options.
  * Introduced encode-node policy selection and service discovery support for encode endpoints.

* **Bug Fixes**
  * Improved routing parameter handling so disaggregated modes correctly clear or populate worker, encode, prefill, and decode URLs.

* **Tests**
  * Expanded argument-parsing coverage for EPD mode, including multiple encode endpoints and bootstrap port handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->