### PR TITLE
refactor(proto): hoist ShmHandle/RemoteTensorHandle to common.proto

### DIFF
--- a/crates/grpc_client/proto/common.proto
+++ b/crates/grpc_client/proto/common.proto
@@ -92,3 +92,26 @@ message ProfileResponse {
   bool success = 1;
   string message = 2;
 }
+
+// =====================
+// Multimodal Tensor Transport
+// =====================
+//
+// Out-of-band transport descriptors for large multimodal tensor payloads,
+// shared by every engine's TensorData. The raw tensor bytes live in exactly
+// one transport; the engine's TensorData carries shape and dtype.
+
+message ShmHandle {
+  string name = 1;
+  uint64 offset = 2;
+  uint64 nbytes = 3;
+  // Producer/lifetime owner. Used by implementations to coordinate cleanup.
+  string owner_id = 4;
+}
+
+message RemoteTensorHandle {
+  // Examples: "nixl", "ucx", "object_store".
+  string transport = 1;
+  bytes descriptor = 2;
+  uint64 nbytes = 3;
+}

--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -178,26 +178,11 @@ message TensorData {
     bytes inline = 3;
     // Same-host CPU shared memory path. This is the preferred large-payload
     // transport when SMG and TokenSpeed share /dev/shm.
-    ShmHandle shm = 4;
+    smg.grpc.common.ShmHandle shm = 4;
     // Cross-node or non-shared-memory transport descriptor. NIXL is the
     // expected remote transport for distributed multimodal tensor payloads.
-    RemoteTensorHandle remote = 5;
+    smg.grpc.common.RemoteTensorHandle remote = 5;
   }
-}
-
-message ShmHandle {
-  string name = 1;
-  uint64 offset = 2;
-  uint64 nbytes = 3;
-  // Producer/lifetime owner. Used by implementations to coordinate cleanup.
-  string owner_id = 4;
-}
-
-message RemoteTensorHandle {
-  // Examples: "nixl", "ucx", "object_store".
-  string transport = 1;
-  bytes descriptor = 2;
-  uint64 nbytes = 3;
 }
 
 // Where a multimodal item's tokens sit inside input_ids.

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -1253,7 +1253,7 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
 
     @staticmethod
     def _tensor_payload_bytes_from_shm(
-        shm_handle: tokenspeed_scheduler_pb2.ShmHandle,
+        shm_handle: common_pb2.ShmHandle,
     ) -> bytes:
         name = TokenSpeedSchedulerServicer._validated_shm_name(shm_handle.name)
 

--- a/model_gateway/src/routers/grpc/epd_encode.rs
+++ b/model_gateway/src/routers/grpc/epd_encode.rs
@@ -7,8 +7,8 @@
 use anyhow::{anyhow, Result};
 use rand::RngExt;
 use smg_grpc_client::{
+    common_proto,
     tokenspeed_encoder::{tokenspeed_encoder_proto as tokenspeed_encoder, TokenSpeedEncoderClient},
-    tokenspeed_proto,
 };
 use uuid::Uuid;
 
@@ -128,7 +128,7 @@ impl PreparedEncodeItem {
     }
 }
 
-struct TokenSpeedShmCleanupGuard(Vec<tokenspeed_proto::ShmHandle>);
+struct TokenSpeedShmCleanupGuard(Vec<common_proto::ShmHandle>);
 
 impl Drop for TokenSpeedShmCleanupGuard {
     fn drop(&mut self) {

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -22,6 +22,7 @@ use memmap2::MmapOptions;
 #[cfg(target_os = "linux")]
 use rustix::fs::FallocateFlags;
 use smg_grpc_client::{
+    common_proto::{self as common},
     mlx_engine::AbortOnDropStream as MlxStream,
     mlx_proto::{self as mlx},
     sglang_proto::{self as sglang, generate_complete::MatchedStop as SglangMatchedStop},
@@ -148,7 +149,7 @@ pub struct TokenSpeedTensor {
 #[derive(Debug, Clone)]
 pub enum TokenSpeedTensorStorage {
     Inline(Vec<u8>),
-    Shm(tokenspeed::ShmHandle),
+    Shm(common::ShmHandle),
 }
 
 impl TokenSpeedTensor {
@@ -160,7 +161,7 @@ impl TokenSpeedTensor {
         }
     }
 
-    pub fn shm(handle: tokenspeed::ShmHandle, shape: Vec<u32>, dtype: String) -> Self {
+    pub fn shm(handle: common::ShmHandle, shape: Vec<u32>, dtype: String) -> Self {
         Self {
             storage: TokenSpeedTensorStorage::Shm(handle),
             shape,
@@ -432,7 +433,7 @@ pub fn tokenspeed_mm_shm_min_bytes() -> usize {
 
 static TOKENSPEED_SHM_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-fn write_tokenspeed_shm(data: &[u8]) -> std::io::Result<tokenspeed::ShmHandle> {
+fn write_tokenspeed_shm(data: &[u8]) -> std::io::Result<common::ShmHandle> {
     write_tokenspeed_shm_with(data.len(), |output| {
         output.copy_from_slice(data);
         Ok(())
@@ -527,7 +528,7 @@ fn sweep_orphan_tokenspeed_shm_once() {
 pub fn write_tokenspeed_shm_with(
     nbytes: usize,
     write_fn: impl FnOnce(&mut [u8]) -> std::io::Result<()>,
-) -> std::io::Result<tokenspeed::ShmHandle> {
+) -> std::io::Result<common::ShmHandle> {
     sweep_orphan_tokenspeed_shm_once();
     let name = next_tokenspeed_shm_name();
     let path = tokenspeed_shm_path(&name);
@@ -556,7 +557,7 @@ pub fn write_tokenspeed_shm_with(
         return Err(error);
     }
 
-    Ok(tokenspeed::ShmHandle {
+    Ok(common::ShmHandle {
         name,
         offset: 0,
         nbytes: nbytes as u64,
@@ -584,7 +585,7 @@ fn reserve_tokenspeed_shm_file(file: &std::fs::File, nbytes: usize) -> std::io::
 
 pub fn collect_tokenspeed_multimodal_inputs_shm_handles(
     inputs: &tokenspeed::MultimodalInputs,
-) -> Vec<tokenspeed::ShmHandle> {
+) -> Vec<common::ShmHandle> {
     let mut handles = Vec::new();
     for item in &inputs.items {
         collect_optional_tokenspeed_tensor_shm_handles(item.encoder_input.as_ref(), &mut handles);
@@ -597,7 +598,7 @@ pub fn collect_tokenspeed_multimodal_inputs_shm_handles(
 
 pub fn collect_tokenspeed_generate_request_shm_handles(
     request: &tokenspeed::GenerateRequest,
-) -> Vec<tokenspeed::ShmHandle> {
+) -> Vec<common::ShmHandle> {
     request
         .mm_inputs
         .as_ref()
@@ -605,7 +606,7 @@ pub fn collect_tokenspeed_generate_request_shm_handles(
         .unwrap_or_default()
 }
 
-pub fn cleanup_tokenspeed_shm_handles(handles: &[tokenspeed::ShmHandle]) {
+pub fn cleanup_tokenspeed_shm_handles(handles: &[common::ShmHandle]) {
     for handle in handles {
         let Some(name) = validate_tokenspeed_shm_name_for_cleanup(&handle.name) else {
             tracing::warn!(
@@ -684,7 +685,7 @@ pub(crate) fn cleanup_tokenspeed_items_encoder_shm(
 
 fn collect_optional_tokenspeed_tensor_shm_handles(
     tensor: Option<&tokenspeed::TensorData>,
-    handles: &mut Vec<tokenspeed::ShmHandle>,
+    handles: &mut Vec<common::ShmHandle>,
 ) {
     let Some(tensor) = tensor else {
         return;
@@ -694,7 +695,7 @@ fn collect_optional_tokenspeed_tensor_shm_handles(
 
 fn collect_tokenspeed_tensor_shm_handles(
     tensor: &tokenspeed::TensorData,
-    handles: &mut Vec<tokenspeed::ShmHandle>,
+    handles: &mut Vec<common::ShmHandle>,
 ) {
     if let Some(tokenspeed::tensor_data::Payload::Shm(handle)) = &tensor.payload {
         handles.push(handle.clone());
@@ -1947,7 +1948,7 @@ mod tests {
             items: vec![TokenSpeedMultimodalItem {
                 modality: TokenSpeedModality::Image,
                 encoder_input: TokenSpeedTensor::shm(
-                    tokenspeed::ShmHandle {
+                    common::ShmHandle {
                         name: "smg-test-shm".to_string(),
                         offset: 0,
                         nbytes: 8,


### PR DESCRIPTION
## Description

### Problem

The multimodal tensor transport descriptors `ShmHandle` and `RemoteTensorHandle`
are defined in `tokenspeed_scheduler.proto`, but they are engine-neutral — any
engine's `TensorData` can carry an out-of-band SHM or remote payload. Keeping
them in the TokenSpeed proto forces other engines to redefine equivalent
messages to adopt the same transport.

### Solution

Hoist both messages to `common.proto` (`smg.grpc.common`) so every engine can
reference the same descriptors. This is groundwork for engine-neutral multimodal
tensor transport (vLLM SHM next).

**Wire-compatible.** protobuf does not encode package/message names on the wire,
and the embedded field numbers are unchanged, so a gateway built against the
moved definitions interoperates with workers built against the old ones.

## Changes

- **`common.proto`** — add `ShmHandle` + `RemoteTensorHandle` under a new
  "Multimodal Tensor Transport" section.
- **`tokenspeed_scheduler.proto`** — drop the two definitions; `TensorData.payload`
  now references `smg.grpc.common.ShmHandle` / `RemoteTensorHandle` (the file
  already imports `common.proto`; Rust codegen already externs
  `.smg.grpc.common → crate::common_proto`).
- **Rust** — `proto_wrapper.rs` and `epd_encode.rs` reference
  `common_proto::ShmHandle` instead of `tokenspeed_proto::ShmHandle`.
- **Python** — the TokenSpeed servicer annotates `common_pb2.ShmHandle`
  (`common_pb2` was already imported).

No `smg-grpc-proto` version bump (matches the convention of prior proto changes,
e.g. #1852; version bumps happen in dedicated release commits).

## Test Plan

- `cargo check -p smg --lib --tests` — clean (proto bindings regenerate;
  `common_proto::ShmHandle` resolves)
- `cargo clippy -p smg --lib --tests -- -D warnings` — clean
- `cargo +nightly fmt` — clean (only the touched files)
- `cargo test -p smg --lib` — 1146 pass (one unrelated `middleware::metrics`
  interner test is a known parallel-test flake; passes in isolation)
- **Python proto regen (grpc_tools):** verified `common_pb2.ShmHandle` and
  `RemoteTensorHandle` now exist, `tokenspeed_scheduler_pb2` no longer defines
  them, and `tokenspeed_scheduler_pb2.TensorData.shm` resolves to
  `common_pb2.ShmHandle`.

## Checklist

- [x] Conventional commit + DCO sign-off
- [x] `cargo +nightly fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] Tests pass (proto + multimodal)
- [x] Wire-compatible (no field-number changes)
- [x] Python servicer + regenerated stubs verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in tensor data handling across services, reducing mismatches when using shared-memory or remote tensor transport.
  * Updated cleanup and transport handling so tensor metadata is managed more reliably end to end.
* **Refactor**
  * Consolidated shared tensor handle definitions into a common location and aligned related components to use the same format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->