### PR TITLE
feat(multimodal): vLLM SHM tensor transport

### DIFF
--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -95,11 +95,22 @@ message TokenizedInput {
   repeated uint32 input_ids = 2;  // Actual token IDs to process
 }
 
-// A typed tensor: raw little-endian bytes + shape + dtype.
+// A typed tensor descriptor. The raw bytes live in exactly one payload
+// transport; shape and dtype describe how the receiver interprets them.
 message TensorData {
-  bytes data = 1;              // Raw little-endian bytes (f32/i64/u32)
   repeated uint32 shape = 2;   // Dimension sizes
   string dtype = 3;            // "float32", "int64", "uint32"
+
+  oneof payload {
+    // Current path: raw little-endian bytes carried in the gRPC message
+    // (field 1, formerly `bytes data`, kept for wire compatibility).
+    bytes inline = 1;
+    // Same-host CPU shared memory path; preferred for large payloads when
+    // SMG and the vLLM worker share /dev/shm.
+    smg.grpc.common.ShmHandle shm = 4;
+    // Cross-node or non-shared-memory transport (e.g. NIXL). Not implemented.
+    smg.grpc.common.RemoteTensorHandle remote = 5;
+  }
 }
 
 message PlaceholderRange {
@@ -339,6 +350,11 @@ message GetServerInfoResponse {
   string kv_engine_id = 8;  // kv_transfer_config.engine_id, "" if not configured
 
   int32 data_parallel_size = 9;  // parallel_config.data_parallel_size (1 when DP is off)
+
+  // This worker's /dev/shm tmpfs identity (<boot_id>:<st_dev>), advertised so
+  // the router can verify a shared /dev/shm before using the SHM tensor
+  // transport under `auto`. Empty when it can't be determined.
+  string shm_namespace_id = 10;
 }
 
 // =====================

--- a/grpc_servicer/smg_grpc_servicer/mm_shm.py
+++ b/grpc_servicer/smg_grpc_servicer/mm_shm.py
@@ -8,6 +8,7 @@ oneof shape (``inline`` | ``shm`` | ``remote``) via ``common.proto``.
 """
 
 import os
+import stat
 
 # Unlink each /dev/shm segment right after the worker reads it (default on) so
 # same-host SHM tensors don't accumulate. Disable with
@@ -39,7 +40,12 @@ def tensor_payload_bytes_from_shm(shm_handle) -> bytes:
     path = os.path.join("/dev/shm", name)
     fd = None
     try:
-        fd = os.open(path, os.O_RDONLY)
+        # O_NOFOLLOW: never follow a symlink at the final path component, so a
+        # crafted name that resolves to a pre-existing symlink in /dev/shm can't
+        # redirect the read. Then require a regular file (fail closed otherwise).
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise ValueError(f"TensorData.shm is not a regular file: {shm_handle.name!r}")
         raw = os.pread(fd, int(shm_handle.nbytes), int(shm_handle.offset))
     finally:
         if fd is not None:
@@ -66,6 +72,9 @@ def validated_shm_name(name: str) -> str:
     return name
 
 
+_shm_namespace_id_cache: str | None = None
+
+
 def shm_namespace_id() -> str:
     """Identity of this process's ``/dev/shm`` tmpfs: ``<boot_id>:<st_dev>``.
 
@@ -75,12 +84,17 @@ def shm_namespace_id() -> str:
     separate containers sharing it via ``--ipc``/bind-mount, where mount
     namespaces differ but the underlying superblock (``st_dev``) is the same. The
     router compares this token to its own to decide the SHM tensor transport.
-    Empty string if it can't be determined.
+    Empty string if it can't be determined. Cached: both components are static
+    for the process lifetime, and this is read on every GetServerInfo.
     """
+    global _shm_namespace_id_cache
+    if _shm_namespace_id_cache is not None:
+        return _shm_namespace_id_cache
     try:
         with open("/proc/sys/kernel/random/boot_id", encoding="ascii") as f:
             boot_id = f.read().strip()
         shm_dev = os.stat("/dev/shm").st_dev
-        return f"{boot_id}:{shm_dev}"
+        _shm_namespace_id_cache = f"{boot_id}:{shm_dev}"
     except OSError:
-        return ""
+        _shm_namespace_id_cache = ""
+    return _shm_namespace_id_cache

--- a/grpc_servicer/smg_grpc_servicer/mm_shm.py
+++ b/grpc_servicer/smg_grpc_servicer/mm_shm.py
@@ -1,0 +1,86 @@
+"""Shared multimodal SHM tensor-transport helpers (engine-neutral).
+
+Reads a ``TensorData`` payload that carries its raw little-endian bytes either
+inline in the gRPC message or via a same-host ``/dev/shm`` handle, and reports
+this process's ``/dev/shm`` namespace identity. Used by the vLLM and TokenSpeed
+gRPC servicers; their ``TensorData``/``ShmHandle`` messages share the ``payload``
+oneof shape (``inline`` | ``shm`` | ``remote``) via ``common.proto``.
+"""
+
+import os
+
+# Unlink each /dev/shm segment right after the worker reads it (default on) so
+# same-host SHM tensors don't accumulate. Disable with
+# TOKENSPEED_UNLINK_MM_SHM_AFTER_READ=0 (e.g. for debugging).
+UNLINK_MM_SHM_AFTER_READ = os.getenv("TOKENSPEED_UNLINK_MM_SHM_AFTER_READ", "1").lower() not in (
+    "0",
+    "false",
+    "no",
+)
+
+
+def tensor_payload_bytes(tensor_data) -> bytes:
+    """Raw bytes of a ``TensorData``, from whichever payload transport it carries."""
+    payload = tensor_data.WhichOneof("payload")
+    if payload == "inline":
+        return bytes(tensor_data.inline)
+    if payload == "shm":
+        return tensor_payload_bytes_from_shm(tensor_data.shm)
+    if payload == "remote":
+        raise ValueError("TensorData.remote payload is not implemented yet")
+    raise ValueError("TensorData payload is required")
+
+
+def tensor_payload_bytes_from_shm(shm_handle) -> bytes:
+    """Read ``nbytes`` from ``/dev/shm/<name>`` at ``offset`` (unlinking after read
+    when enabled)."""
+    name = validated_shm_name(shm_handle.name)
+
+    path = os.path.join("/dev/shm", name)
+    fd = None
+    try:
+        fd = os.open(path, os.O_RDONLY)
+        raw = os.pread(fd, int(shm_handle.nbytes), int(shm_handle.offset))
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if fd is not None and UNLINK_MM_SHM_AFTER_READ:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+    if len(raw) != int(shm_handle.nbytes):
+        raise ValueError(
+            f"TensorData.shm byte length mismatch for name={shm_handle.name!r}: "
+            f"expected {int(shm_handle.nbytes)}, got {len(raw)}"
+        )
+    return raw
+
+
+def validated_shm_name(name: str) -> str:
+    """Reject path-traversal / absolute / empty SHM names before opening."""
+    name = name.lstrip("/")
+    if not name or "/" in name or name in (".", "..") or "\x00" in name:
+        raise ValueError(f"Invalid TensorData.shm name: {name!r}")
+    return name
+
+
+def shm_namespace_id() -> str:
+    """Identity of this process's ``/dev/shm`` tmpfs: ``<boot_id>:<st_dev>``.
+
+    ``boot_id`` (``/proc/sys/kernel/random/boot_id``) is not namespaced, so it
+    pins the host; ``st_dev`` is the tmpfs superblock device backing
+    ``/dev/shm``. Two processes share ``/dev/shm`` iff both match -- including
+    separate containers sharing it via ``--ipc``/bind-mount, where mount
+    namespaces differ but the underlying superblock (``st_dev``) is the same. The
+    router compares this token to its own to decide the SHM tensor transport.
+    Empty string if it can't be determined.
+    """
+    try:
+        with open("/proc/sys/kernel/random/boot_id", encoding="ascii") as f:
+            boot_id = f.read().strip()
+        shm_dev = os.stat("/dev/shm").st_dev
+        return f"{boot_id}:{shm_dev}"
+    except OSError:
+        return ""

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -21,6 +21,7 @@ import zmq
 import zmq.asyncio
 from smg_grpc_proto import vllm_engine_pb2, vllm_engine_pb2_grpc
 from smg_grpc_proto.generated import common_pb2
+from smg_grpc_servicer import mm_shm
 from transformers import BatchFeature
 from vllm import PoolingParams, SamplingParams, TokensPrompt
 from vllm.distributed.kv_events import KVEventBatch
@@ -78,7 +79,8 @@ def _tensor_from_proto(td: vllm_engine_pb2.TensorData) -> torch.Tensor:
     torch_dtype = _PROTO_DTYPE_MAP.get(td.dtype)
     if torch_dtype is None:
         raise ValueError(f"Unsupported proto tensor dtype: {td.dtype!r}")
-    return torch.frombuffer(bytearray(td.data), dtype=torch_dtype).reshape(*td.shape)
+    payload = mm_shm.tensor_payload_bytes(td)
+    return torch.frombuffer(bytearray(payload), dtype=torch_dtype).reshape(*td.shape)
 
 
 try:
@@ -487,6 +489,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             kv_role=kv_role,
             kv_engine_id=kv_engine_id,
             data_parallel_size=parallel.data_parallel_size,
+            shm_namespace_id=mm_shm.shm_namespace_id(),
         )
 
     async def GetLoads(

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -21,7 +21,6 @@ import zmq
 import zmq.asyncio
 from smg_grpc_proto import vllm_engine_pb2, vllm_engine_pb2_grpc
 from smg_grpc_proto.generated import common_pb2
-from smg_grpc_servicer import mm_shm
 from transformers import BatchFeature
 from vllm import PoolingParams, SamplingParams, TokensPrompt
 from vllm.distributed.kv_events import KVEventBatch
@@ -38,6 +37,7 @@ from vllm.multimodal.inputs import (
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind, StructuredOutputsParams
 
+from smg_grpc_servicer import mm_shm
 from smg_grpc_servicer.tokenizer_bundle import CHUNK_SIZE, build_tokenizer_zip
 from smg_grpc_servicer.vllm.kv_events import (
     endpoint_for_rank,

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -15,8 +15,8 @@ use smg_grpc_client::{
 use crate::routers::grpc::{
     proto_wrapper::{
         cleanup_mm_shm_handles, collect_tokenspeed_generate_request_shm_handles,
-        collect_vllm_generate_request_shm_handles, finish_tokenspeed_request, ProtoEmbedComplete,
-        ProtoEmbedRequest, ProtoGenerateRequest, ProtoStream,
+        collect_vllm_generate_request_shm_handles, finish_tokenspeed_request, finish_vllm_request,
+        ProtoEmbedComplete, ProtoEmbedRequest, ProtoGenerateRequest, ProtoStream,
     },
     MultimodalData,
 };
@@ -495,15 +495,16 @@ impl GrpcClient {
                     MultimodalData::Vllm(data) => data.into_proto(),
                     _ => unreachable!("caller guarantees matching variant"),
                 });
-                let req = client.build_generate_request_from_chat(
-                    request_id,
-                    body,
-                    processed_text,
-                    token_ids,
-                    vllm_mm,
-                    options.tool_constraints,
-                )?;
-                Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
+                finish_vllm_request(vllm_mm, |mm| {
+                    client.build_generate_request_from_chat(
+                        request_id,
+                        body,
+                        processed_text,
+                        token_ids,
+                        mm,
+                        options.tool_constraints,
+                    )
+                })
             }
             Self::Trtllm(client) => {
                 let trtllm_mm = options.multimodal_inputs.map(|mm| match mm {
@@ -586,15 +587,16 @@ impl GrpcClient {
                     MultimodalData::Vllm(data) => data.into_proto(),
                     _ => unreachable!("caller guarantees matching variant"),
                 });
-                let req = client.build_generate_request_from_messages(
-                    request_id,
-                    body,
-                    processed_text,
-                    token_ids,
-                    vllm_mm,
-                    options.tool_constraints,
-                )?;
-                Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
+                finish_vllm_request(vllm_mm, |mm| {
+                    client.build_generate_request_from_messages(
+                        request_id,
+                        body,
+                        processed_text,
+                        token_ids,
+                        mm,
+                        options.tool_constraints,
+                    )
+                })
             }
             Self::Trtllm(client) => {
                 let trtllm_mm = options.multimodal_inputs.map(|mm| match mm {

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -14,9 +14,9 @@ use smg_grpc_client::{
 
 use crate::routers::grpc::{
     proto_wrapper::{
-        cleanup_tokenspeed_shm_handles, collect_tokenspeed_generate_request_shm_handles,
-        finish_tokenspeed_request, ProtoEmbedComplete, ProtoEmbedRequest, ProtoGenerateRequest,
-        ProtoStream,
+        cleanup_mm_shm_handles, collect_tokenspeed_generate_request_shm_handles,
+        collect_vllm_generate_request_shm_handles, finish_tokenspeed_request, ProtoEmbedComplete,
+        ProtoEmbedRequest, ProtoGenerateRequest, ProtoStream,
     },
     MultimodalData,
 };
@@ -397,8 +397,14 @@ impl GrpcClient {
                 Ok(ProtoStream::Sglang(stream))
             }
             (Self::Vllm(client), ProtoGenerateRequest::Vllm(boxed_req)) => {
-                let stream = client.generate(*boxed_req).await?;
-                Ok(ProtoStream::Vllm(stream))
+                let shm_handles = collect_vllm_generate_request_shm_handles(&boxed_req);
+                match client.generate(*boxed_req).await {
+                    Ok(stream) => Ok(ProtoStream::Vllm(stream)),
+                    Err(error) => {
+                        cleanup_mm_shm_handles(&shm_handles);
+                        Err(error)
+                    }
+                }
             }
             (Self::Trtllm(client), ProtoGenerateRequest::Trtllm(boxed_req)) => {
                 let stream = client.generate(*boxed_req).await?;
@@ -413,7 +419,7 @@ impl GrpcClient {
                 match client.generate(*boxed_req).await {
                     Ok(stream) => Ok(ProtoStream::TokenSpeed(stream)),
                     Err(error) => {
-                        cleanup_tokenspeed_shm_handles(&shm_handles);
+                        cleanup_mm_shm_handles(&shm_handles);
                         Err(error)
                     }
                 }

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -657,6 +657,11 @@ impl RequestExecutionStage {
         // Decode reuses proto_request as-is; same request_id as the prefill leg is
         // load-bearing for NIXL P/D correlation on vLLM < 0.13
         let mut decode_request = proto_request;
+        // Decode doesn't run the vision encoder (it receives KV via the P/D
+        // transfer), so drop the multimodal inputs — mirrors the parallel PD
+        // path. Load-bearing for SHM: prefill already read and unlinked the
+        // /dev/shm segments, so a reused ShmHandle here would be unreadable.
+        decode_request.clear_mm_pixel_values();
         if let Some(rank) = workers.decode_worker().and_then(|w| w.dp_rank()) {
             decode_request.set_data_parallel_rank(rank as i32);
         }

--- a/model_gateway/src/routers/grpc/epd_encode.rs
+++ b/model_gateway/src/routers/grpc/epd_encode.rs
@@ -17,7 +17,7 @@ use super::{
     context::{ClientSelection, WorkerSelection},
     multimodal::{assemble_tokenspeed, MultimodalIntermediate, PrecomputedMultimodalIntermediate},
     proto_wrapper::{
-        cleanup_tokenspeed_items_encoder_shm, cleanup_tokenspeed_shm_handles,
+        cleanup_mm_shm_handles, cleanup_tokenspeed_items_encoder_shm,
         collect_tokenspeed_multimodal_inputs_shm_handles, EncodeItemBootstrapInfo,
         TokenSpeedMultimodalData, TokenSpeedMultimodalItem,
     },
@@ -136,7 +136,7 @@ struct TokenSpeedShmCleanupGuard(Vec<common_proto::ShmHandle>);
 
 impl Drop for TokenSpeedShmCleanupGuard {
     fn drop(&mut self) {
-        cleanup_tokenspeed_shm_handles(&self.0);
+        cleanup_mm_shm_handles(&self.0);
     }
 }
 

--- a/model_gateway/src/routers/grpc/multimodal/assemble.rs
+++ b/model_gateway/src/routers/grpc/multimodal/assemble.rs
@@ -72,7 +72,7 @@ async fn assemble_multimodal_data_impl(
             }
             GrpcClient::Vllm(_) => {
                 ensure_image_only(&precomputed, "vLLM")?;
-                Ok(MultimodalData::Vllm(assemble_vllm(precomputed)))
+                Ok(MultimodalData::Vllm(assemble_vllm(precomputed, workers)))
             }
             GrpcClient::Trtllm(_) => {
                 ensure_image_only(&precomputed, "TRT-LLM")?;
@@ -168,7 +168,10 @@ fn assemble_sglang(intermediate: PrecomputedMultimodalIntermediate) -> SglangMul
     }
 }
 
-fn assemble_vllm(intermediate: PrecomputedMultimodalIntermediate) -> VllmMultimodalData {
+fn assemble_vllm(
+    intermediate: PrecomputedMultimodalIntermediate,
+    workers: Option<&WorkerSelection>,
+) -> VllmMultimodalData {
     let (pixel_values, pixel_values_shape) = serialize_encoder_input(&intermediate.preprocessed);
     let model_specific_tensors = serialize_model_specific(intermediate.preprocessed.model_specific);
     let mm_hashes = intermediate.images.iter().map(|f| f.hash.clone()).collect();
@@ -190,6 +193,8 @@ fn assemble_vllm(intermediate: PrecomputedMultimodalIntermediate) -> VllmMultimo
         batched_keys,
         flat_keys,
         keep_on_cpu_keys: intermediate.keep_on_cpu_keys,
+        shm_enabled: resolve_mm_shm_enabled(workers, false),
+        shm_min_bytes: resolve_mm_shm_min_bytes(workers),
     }
 }
 

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -93,6 +93,12 @@ pub struct VllmMultimodalData {
     pub flat_keys: HashMap<String, String>,
     /// Tensor keys that should remain on CPU (`keep_on_cpu=True` in vLLM).
     pub keep_on_cpu_keys: Vec<String>,
+    /// Resolved per-request SHM transport decision + size threshold (bytes),
+    /// computed upstream (transport mode / worker locality / config). `into_proto`
+    /// uses these to place each tensor inline or in /dev/shm without re-reading
+    /// config or the environment.
+    pub shm_enabled: bool,
+    pub shm_min_bytes: usize,
 }
 
 /// TRT-LLM multimodal data: raw image bytes only.
@@ -228,6 +234,8 @@ impl SglangMultimodalData {
 impl VllmMultimodalData {
     /// Convert to vLLM proto MultimodalInputs.
     pub fn into_proto(self) -> vllm::MultimodalInputs {
+        let shm_enabled = self.shm_enabled;
+        let shm_min_bytes = self.shm_min_bytes;
         let model_specific_tensors = self
             .model_specific_tensors
             .into_iter()
@@ -235,9 +243,9 @@ impl VllmMultimodalData {
                 (
                     k,
                     vllm::TensorData {
-                        data: v.data,
                         shape: v.shape,
                         dtype: v.dtype,
+                        payload: Some(vllm_tensor_payload(v.data, shm_enabled, shm_min_bytes)),
                     },
                 )
             })
@@ -251,9 +259,13 @@ impl VllmMultimodalData {
 
         vllm::MultimodalInputs {
             pixel_values: Some(vllm::TensorData {
-                data: self.pixel_values,
                 shape: self.pixel_values_shape,
                 dtype: "float32".to_string(),
+                payload: Some(vllm_tensor_payload(
+                    self.pixel_values,
+                    shm_enabled,
+                    shm_min_bytes,
+                )),
             }),
             model_specific_tensors,
             im_token_id: self.im_token_id,
@@ -369,32 +381,35 @@ fn tensor_bytes_to_tokenspeed(
     }
 }
 
-fn tokenspeed_tensor_payload(
+/// Engine-neutral inline-vs-SHM decision for a multimodal tensor payload. The
+/// raw bytes go inline unless SHM is enabled and the payload is at least
+/// `min_bytes`; an SHM-write failure falls back to inline. `engine` labels the
+/// metrics/logs. Each backend maps the result onto its own `TensorData` oneof.
+enum MmTensorPayload {
+    Inline(Vec<u8>),
+    Shm(common::ShmHandle),
+}
+
+fn resolve_mm_tensor_payload(
     data: Vec<u8>,
     shm_enabled: bool,
     min_bytes: usize,
-) -> tokenspeed::tensor_data::Payload {
+    engine: &'static str,
+) -> MmTensorPayload {
     use crate::observability::metrics::Metrics;
     let log_timing = log_tokenspeed_mm_timing_enabled();
     let nbytes = data.len();
-    if !shm_enabled {
-        if log_timing {
-            tracing::info!(nbytes, "smg_mm_timing tokenspeed_tensor_payload_inline");
-        }
-        Metrics::record_mm_tensor("tokenspeed", "inline", nbytes);
-        return tokenspeed::tensor_data::Payload::Inline(data);
-    }
-
-    if nbytes < min_bytes {
+    if !shm_enabled || nbytes < min_bytes {
         if log_timing {
             tracing::info!(
+                engine,
                 nbytes,
                 min_bytes,
-                "smg_mm_timing tokenspeed_tensor_payload_inline_below_threshold"
+                "smg_mm_timing mm_tensor_payload_inline"
             );
         }
-        Metrics::record_mm_tensor("tokenspeed", "inline", nbytes);
-        return tokenspeed::tensor_data::Payload::Inline(data);
+        Metrics::record_mm_tensor(engine, "inline", nbytes);
+        return MmTensorPayload::Inline(data);
     }
 
     let started = Instant::now();
@@ -402,24 +417,48 @@ fn tokenspeed_tensor_payload(
         Ok(handle) => {
             if log_timing {
                 tracing::info!(
+                    engine,
                     nbytes,
                     elapsed_ms = started.elapsed().as_secs_f64() * 1000.0,
-                    "smg_mm_timing tokenspeed_shm_write"
+                    "smg_mm_timing mm_shm_write"
                 );
             }
-            Metrics::record_mm_tensor("tokenspeed", "shm", nbytes);
-            tokenspeed::tensor_data::Payload::Shm(handle)
+            Metrics::record_mm_tensor(engine, "shm", nbytes);
+            MmTensorPayload::Shm(handle)
         }
         Err(error) => {
             tracing::warn!(
                 ?error,
+                engine,
                 nbytes,
-                "Failed to create TokenSpeed SHM tensor payload; falling back to inline"
+                "Failed to write multimodal SHM tensor; falling back to inline"
             );
-            Metrics::record_mm_shm_write_failure("tokenspeed");
-            Metrics::record_mm_tensor("tokenspeed", "inline", nbytes);
-            tokenspeed::tensor_data::Payload::Inline(data)
+            Metrics::record_mm_shm_write_failure(engine);
+            Metrics::record_mm_tensor(engine, "inline", nbytes);
+            MmTensorPayload::Inline(data)
         }
+    }
+}
+
+fn tokenspeed_tensor_payload(
+    data: Vec<u8>,
+    shm_enabled: bool,
+    min_bytes: usize,
+) -> tokenspeed::tensor_data::Payload {
+    match resolve_mm_tensor_payload(data, shm_enabled, min_bytes, "tokenspeed") {
+        MmTensorPayload::Inline(data) => tokenspeed::tensor_data::Payload::Inline(data),
+        MmTensorPayload::Shm(handle) => tokenspeed::tensor_data::Payload::Shm(handle),
+    }
+}
+
+fn vllm_tensor_payload(
+    data: Vec<u8>,
+    shm_enabled: bool,
+    min_bytes: usize,
+) -> vllm::tensor_data::Payload {
+    match resolve_mm_tensor_payload(data, shm_enabled, min_bytes, "vllm") {
+        MmTensorPayload::Inline(data) => vllm::tensor_data::Payload::Inline(data),
+        MmTensorPayload::Shm(handle) => vllm::tensor_data::Payload::Shm(handle),
     }
 }
 
@@ -604,7 +643,7 @@ pub fn collect_tokenspeed_generate_request_shm_handles(
         .unwrap_or_default()
 }
 
-pub fn cleanup_tokenspeed_shm_handles(handles: &[common::ShmHandle]) {
+pub fn cleanup_mm_shm_handles(handles: &[common::ShmHandle]) {
     for handle in handles {
         let Some(name) = validate_tokenspeed_shm_name_for_cleanup(&handle.name) else {
             tracing::warn!(
@@ -646,7 +685,7 @@ pub(crate) fn finish_tokenspeed_request(
     match build(tokenspeed_mm) {
         Ok(req) => Ok(ProtoGenerateRequest::TokenSpeed(Box::new(req))),
         Err(error) => {
-            cleanup_tokenspeed_shm_handles(&shm_handles);
+            cleanup_mm_shm_handles(&shm_handles);
             Err(error)
         }
     }
@@ -677,7 +716,7 @@ pub(crate) fn cleanup_tokenspeed_items_encoder_shm(
         push(tensor);
     }
     if !handles.is_empty() {
-        cleanup_tokenspeed_shm_handles(&handles);
+        cleanup_mm_shm_handles(&handles);
     }
 }
 
@@ -696,6 +735,45 @@ fn collect_tokenspeed_tensor_shm_handles(
     handles: &mut Vec<common::ShmHandle>,
 ) {
     if let Some(tokenspeed::tensor_data::Payload::Shm(handle)) = &tensor.payload {
+        handles.push(handle.clone());
+    }
+}
+
+pub fn collect_vllm_multimodal_inputs_shm_handles(
+    inputs: &vllm::MultimodalInputs,
+) -> Vec<common::ShmHandle> {
+    let mut handles = Vec::new();
+    collect_optional_vllm_tensor_shm_handles(inputs.pixel_values.as_ref(), &mut handles);
+    for tensor in inputs.model_specific_tensors.values() {
+        collect_vllm_tensor_shm_handles(tensor, &mut handles);
+    }
+    handles
+}
+
+pub fn collect_vllm_generate_request_shm_handles(
+    request: &vllm::GenerateRequest,
+) -> Vec<common::ShmHandle> {
+    request
+        .mm_inputs
+        .as_ref()
+        .map(collect_vllm_multimodal_inputs_shm_handles)
+        .unwrap_or_default()
+}
+
+fn collect_optional_vllm_tensor_shm_handles(
+    tensor: Option<&vllm::TensorData>,
+    handles: &mut Vec<common::ShmHandle>,
+) {
+    if let Some(tensor) = tensor {
+        collect_vllm_tensor_shm_handles(tensor, handles);
+    }
+}
+
+fn collect_vllm_tensor_shm_handles(
+    tensor: &vllm::TensorData,
+    handles: &mut Vec<common::ShmHandle>,
+) {
+    if let Some(vllm::tensor_data::Payload::Shm(handle)) = &tensor.payload {
         handles.push(handle.clone());
     }
 }
@@ -1990,7 +2068,7 @@ mod tests {
         })
         .unwrap();
         let payload = std::fs::read(tokenspeed_shm_path(&handle.name));
-        cleanup_tokenspeed_shm_handles(std::slice::from_ref(&handle));
+        cleanup_mm_shm_handles(std::slice::from_ref(&handle));
 
         assert_eq!(payload.unwrap(), expected);
         assert!(!tokenspeed_shm_path(&handle.name).exists());

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -463,9 +463,12 @@ fn vllm_tensor_payload(
 }
 
 fn log_tokenspeed_mm_timing_enabled() -> bool {
-    std::env::var("SMG_LOG_MM_TIMING")
-        .map(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
-        .unwrap_or(false)
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("SMG_LOG_MM_TIMING")
+            .map(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false)
+    })
 }
 
 static TOKENSPEED_SHM_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -684,6 +687,27 @@ pub(crate) fn finish_tokenspeed_request(
         .unwrap_or_default();
     match build(tokenspeed_mm) {
         Ok(req) => Ok(ProtoGenerateRequest::TokenSpeed(Box::new(req))),
+        Err(error) => {
+            cleanup_mm_shm_handles(&shm_handles);
+            Err(error)
+        }
+    }
+}
+
+/// Build a vLLM generate request, cleaning up any `/dev/shm` segments backing
+/// `vllm_mm` if the build fails. `into_proto` may write SHM files before the
+/// request is fully assembled (sampling/tool validation), so a build error must
+/// unlink them or the worker — which never receives the request — leaks them.
+pub(crate) fn finish_vllm_request(
+    vllm_mm: Option<vllm::MultimodalInputs>,
+    build: impl FnOnce(Option<vllm::MultimodalInputs>) -> Result<vllm::GenerateRequest, String>,
+) -> Result<ProtoGenerateRequest, String> {
+    let shm_handles = vllm_mm
+        .as_ref()
+        .map(collect_vllm_multimodal_inputs_shm_handles)
+        .unwrap_or_default();
+    match build(vllm_mm) {
+        Ok(req) => Ok(ProtoGenerateRequest::Vllm(Box::new(req))),
         Err(error) => {
             cleanup_mm_shm_handles(&shm_handles);
             Err(error)


### PR DESCRIPTION
## Description

### Problem

The `/dev/shm` tensor transport (added for TokenSpeed) and the engine-neutral
`ShmHandle` (hoisted to `common.proto`) + configurable transport layer are all
in place, but vLLM still only accepts multimodal tensors **inline** in the gRPC
message. Large image tensors to a co-located vLLM worker pay a full gRPC copy.

### Solution

Bring the same-host SHM transport to vLLM, reusing the common `ShmHandle` and
the `--multimodal-tensor-transport` config. Default is `inline`, so existing
deployments are unaffected.

## Changes

**Proto** (`vllm_engine.proto`, already imports `common.proto`):
- `TensorData`: `bytes data = 1` → `oneof payload { bytes inline = 1;
  smg.grpc.common.ShmHandle shm = 4; smg.grpc.common.RemoteTensorHandle
  remote = 5; }`. **Field 1 stays `inline` for wire compatibility.**
- `GetServerInfoResponse`: `+ shm_namespace_id = 10` (so the router can verify a
  shared `/dev/shm` under `auto`).

**Gateway (Rust)**:
- Extracted an engine-neutral `resolve_mm_tensor_payload` (the inline-vs-SHM
  decision + metrics); both `tokenspeed_tensor_payload` and the new
  `vllm_tensor_payload` map its result onto their own oneof.
- `VllmMultimodalData` carries resolved `shm_enabled`/`shm_min_bytes`;
  `assemble_vllm` resolves them (transport config → worker override); `into_proto`
  emits the oneof payload.
- `collect_vllm_*_shm_handles` + the vLLM client cleans up SHM on send failure
  (mirrors TokenSpeed). Renamed the engine-neutral `cleanup_tokenspeed_shm_handles`
  → `cleanup_mm_shm_handles`.

**Servicer (Python)**:
- New shared `mm_shm` module (reads a `TensorData` payload inline-or-SHM,
  validates SHM names, unlinks after read, computes the `/dev/shm` namespace id).
- The vLLM servicer reads tensors through `mm_shm` (the `oneof` renames `.data`
  → `.inline`, so this is required) and advertises `shm_namespace_id`.

## Test Plan

- `cargo clippy -p smg --all-targets -- -D warnings` — clean
- `cargo test -p smg --lib` — 1147 pass (one unrelated `middleware::metrics`
  interner test is a known parallel-test flake; passes in isolation)
- `cargo +nightly fmt` — clean
- **Python proto regen (grpc_tools)** — verified `vllm_engine_pb2.TensorData`
  exposes the `inline|shm|remote` oneof (`shm` → `common_pb2.ShmHandle`) and
  `GetServerInfoResponse.shm_namespace_id` exists
- `python -m py_compile` on `mm_shm.py` + the vLLM servicer — OK

e2e for the SHM path (co-located worker, assert SHM is taken) is deferred to the
multimodal coverage PR.

## Follow-ups

- Migrate the TokenSpeed servicer onto the shared `mm_shm` module (mechanical
  dedup; kept out of this PR to avoid churning the critical servicer).
- vLLM **video** (`is_video` → `pixel_values_videos`) — PR #3b.

## Checklist

- [x] Conventional commit + DCO sign-off
- [x] `cargo +nightly fmt` + `clippy -- -D warnings` clean
- [x] Tests pass (Rust) + Python proto regen / py_compile verified
- [x] Wire-compatible proto (`inline` keeps field 1)
- [x] SHM cleanup on failure (no `/dev/shm` leak)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared-memory transport for vLLM multimodal tensor payloads, with automatic fallback to inline when SHM is unavailable or below size thresholds.
  * Extended server information with a shared-memory namespace identifier to improve compatibility checks between workers and clients.
* **Bug Fixes**
  * Improved multimodal shared-memory cleanup across both success and error paths to reduce leaked segments.
  * Hardened shared-memory payload reading with stricter validation and safer file access.
  * Fixed vLLM sequential decode reuse to avoid carrying over vision inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->