### PR TITLE
fix(external): route unlisted models to wildcard external workers (#1871)

### DIFF
--- a/e2e_test/router/test_worker_api.py
+++ b/e2e_test/router/test_worker_api.py
@@ -476,6 +476,75 @@ class TestIGWMixedWorkerClassification:
 @pytest.mark.engine("sglang")
 @pytest.mark.gpu(1)
 @pytest.mark.e2e
+class TestWorkerUrlsMixedExternal:
+    """Regression for discussion #1871: mixed local + OpenAI via ``--worker-urls``.
+
+    Starting the gateway with ``--worker-urls <local-sglang> https://api.openai.com``
+    registers the OpenAI URL as an external worker; a ``gpt-*`` request routes to it
+    and the caller's ``Authorization`` (BYOK) is forwarded upstream. External workers
+    stay open-ended/wildcard for routing, so models newer than a provider's
+    ``/v1/models`` still forward. Exercises the CLI startup path (not ``POST /workers``).
+
+    Requires OPENAI_API_KEY (used as the caller's bearer token).
+    """
+
+    def test_worker_urls_openai_routes_with_byok(self):
+        openai_key = os.environ.get("OPENAI_API_KEY")
+        if not openai_key:
+            pytest.skip("OPENAI_API_KEY not set")
+
+        engine = os.environ.get("E2E_ENGINE", "sglang")
+        model = "meta-llama/Llama-3.1-8B-Instruct"
+        http_workers = start_workers(model, engine, mode=ConnectionMode.HTTP, count=1)
+
+        try:
+            # Regular mode == the reported `--worker-urls` path (CLI startup, no
+            # POST /workers).
+            gateway = Gateway()
+            try:
+                gateway.start(
+                    worker_urls=[http_workers[0].base_url, "https://api.openai.com"],
+                    model_path=model,
+                    policy="cache_aware",
+                )
+
+                # The OpenAI URL is classified as an external worker.
+                raw = httpx.get(f"{gateway.base_url}/workers", timeout=10).json()
+                openai_worker = next(
+                    (w for w in raw.get("workers", []) if "api.openai.com" in w.get("url", "")),
+                    None,
+                )
+                assert openai_worker is not None, f"OpenAI worker not registered: {raw}"
+                assert openai_worker.get("runtime_type") == "external", (
+                    f"OpenAI worker should be external, got {openai_worker.get('runtime_type')}"
+                )
+
+                # A gpt-* request routes to the OpenAI worker; the caller's bearer
+                # (BYOK) is forwarded upstream. Only the OpenAI worker matches gpt-*,
+                # so routing is unambiguous alongside the local worker.
+                resp = httpx.post(
+                    f"{gateway.base_url}/v1/chat/completions",
+                    headers={"Authorization": f"Bearer {openai_key}"},
+                    json={
+                        "model": "gpt-4o-mini",
+                        "messages": [{"role": "user", "content": "ping"}],
+                        "max_tokens": 1,
+                    },
+                    timeout=30,
+                )
+                assert resp.status_code == 200, (
+                    "gpt request should route to the external OpenAI worker and "
+                    f"forward the caller's key, got {resp.status_code}: {resp.text}"
+                )
+            finally:
+                gateway.shutdown()
+        finally:
+            stop_workers(http_workers)
+
+
+@pytest.mark.engine("sglang")
+@pytest.mark.gpu(1)
+@pytest.mark.e2e
 class TestWorkerAPIRestSemantics:
     """Tests for proper REST semantics on worker management endpoints.
 

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -169,13 +169,33 @@ impl Router {
         } else {
             Some(model_id)
         };
-        let workers = self.worker_registry.get_workers_filtered(
+        let mut workers = self.worker_registry.get_workers_filtered(
             model_filter,
             Some(WorkerType::Regular),
             Some(ConnectionMode::Http),
             None,  // any runtime type
             false, // get all workers, we'll filter by is_available() next
         );
+
+        // Wildcard workers (external providers registered via `--worker-urls`)
+        // accept any model but aren't in the per-model index, so the lookup
+        // above misses them. When no worker explicitly serves this model, fall
+        // back to workers that support it (wildcards), so e.g. `gpt-*` routes to
+        // an external OpenAI worker alongside local models. Explicit matches
+        // win — a local model never falls through to a wildcard. (#1871)
+        if workers.is_empty() {
+            if let Some(model) = model_filter {
+                let mut fallback = self.worker_registry.get_workers_filtered(
+                    None,
+                    Some(WorkerType::Regular),
+                    Some(ConnectionMode::Http),
+                    None,
+                    false,
+                );
+                fallback.retain(|w| w.supports_model(model));
+                workers = fallback;
+            }
+        }
 
         let available: Vec<Arc<dyn Worker>> = workers
             .iter()
@@ -1423,7 +1443,7 @@ impl RouterTrait for Router {
 
 #[cfg(test)]
 mod tests {
-    use openai_protocol::worker::HealthCheckConfig;
+    use openai_protocol::{model_card::ModelCard, worker::HealthCheckConfig};
 
     use super::*;
     use crate::{config::types::PolicyConfig, worker::BasicWorkerBuilder};
@@ -1502,5 +1522,53 @@ mod tests {
 
         let worker = router.worker_registry.get_by_url(&url).unwrap();
         assert!(worker.is_healthy());
+    }
+
+    /// #1871: with a local worker plus a wildcard external worker (an external
+    /// provider registered via `--worker-urls`), an unlisted model (e.g. `gpt-*`)
+    /// must fall back to the wildcard worker — it isn't in the per-model index —
+    /// while a locally-served model still routes to the local worker.
+    #[test]
+    fn select_worker_for_model_falls_back_to_wildcard() {
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        // Local worker serving one explicit model (indexed under that model).
+        worker_registry.register_or_replace(Arc::new(
+            BasicWorkerBuilder::new("http://local:8080")
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Http)
+                .health_config(no_health_check())
+                .models(vec![ModelCard::new("meta-llama/Llama-3.1-8B-Instruct")])
+                .build(),
+        ));
+        // Wildcard external worker (no models → accepts any model).
+        worker_registry.register_or_replace(Arc::new(
+            BasicWorkerBuilder::new("http://api.openai.com")
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Http)
+                .runtime_type(crate::worker::RuntimeType::External)
+                .health_config(no_health_check())
+                .build(),
+        ));
+        let router = Router {
+            worker_registry,
+            policy_registry: Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin)),
+            client: Client::new(),
+            retry_config: RetryConfig::default(),
+            realtime_registry: Arc::new(RealtimeRegistry::new()),
+            webrtc_bind_addr: None,
+            webrtc_stun_server: None,
+        };
+
+        // Unlisted model → wildcard external worker.
+        let picked = router
+            .select_worker_for_model("gpt-4o-mini", None, None)
+            .expect("gpt-4o-mini should fall back to the wildcard worker");
+        assert_eq!(picked.url(), "http://api.openai.com");
+
+        // Locally-served model → local worker (explicit match wins).
+        let picked = router
+            .select_worker_for_model("meta-llama/Llama-3.1-8B-Instruct", None, None)
+            .expect("local model should route to the local worker");
+        assert_eq!(picked.url(), "http://local:8080");
     }
 }


### PR DESCRIPTION
## Description

### Problem

Starting SMG with `--worker-urls http://<local-sglang> https://api.openai.com` and only `OPENAI_API_KEY` in the environment, a `gpt-*` request returned `404 model_not_found: "No worker available for model 'gpt-4o-mini'"` — even though the OpenAI URL registered correctly as an external worker (discussion #1871).

### Root cause

An external provider with no key registers as a **wildcard** worker: empty model list → accepts any model, caller's `Authorization` forwarded upstream (BYOK). But the regular HTTP router's `select_worker_for_model` resolves candidates through the registry's **per-model index** (`get_by_model`), which only contains each worker's *explicitly-listed* models. A wildcard worker has no models to index, so `gpt-4o-mini` matched nothing and selection failed before routing.

### Fix

`select_worker_for_model`: when no worker explicitly serves the requested model, fall back to `supports_model`-matching (wildcard) workers. **Explicit matches still win**, so a locally-served model never routes to a wildcard external worker.

That's the whole change — one function.

## Test Plan

**Unit** — `select_worker_for_model_falls_back_to_wildcard`: with a local worker + a wildcard external worker, `gpt-4o-mini` routes to the wildcard; the local model routes to the local worker. (Fails without the fix with the exact #1871 error.)

```
cargo test -p smg --lib -- routers::http::router::tests::select_worker_for_model_falls_back_to_wildcard
```

**e2e** — `TestWorkerUrlsMixedExternal::test_worker_urls_openai_routes_with_byok` (gated on `OPENAI_API_KEY`, `@gpu(1)` `@engine(sglang)`): starts the gateway on `--worker-urls <local-sglang> https://api.openai.com`, asserts the OpenAI URL registers as `external`, and a `gpt-4o-mini` chat carrying the caller's `Authorization: Bearer` (BYOK) returns 200. This reproduced the #1871 failure before the fix.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy -- -D warnings` clean on the changed crate
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
