### PR TITLE
fix(router): route unlisted models to wildcard external workers under IGW (#1871)

### DIFF
--- a/e2e_test/infra/gateway.py
+++ b/e2e_test/infra/gateway.py
@@ -102,7 +102,9 @@ class Gateway:
             raise RuntimeError("Gateway already started")
 
         is_pd_mode = prefill_workers is not None or decode_workers is not None
-        is_regular_mode = worker_urls is not None
+        # `--worker-urls` may be combined with `--enable-igw` (mixed self-hosted +
+        # external registered at startup), so IGW takes precedence over regular.
+        is_regular_mode = worker_urls is not None and not igw_mode
         is_igw_mode = igw_mode
         is_cloud_mode = cloud_backend is not None
 
@@ -125,12 +127,20 @@ class Gateway:
         if is_igw_mode:
             self.pd_mode = False
             self.igw_mode = True
+            mode_args = ["--enable-igw"]
+            num_workers = None
+            if worker_urls:
+                # IGW started with `--worker-urls` (self-hosted + external
+                # providers registered at startup, same as the CLI path).
+                mode_args += ["--worker-urls", *worker_urls]
+                num_workers = len(worker_urls)
             self._launch(
-                mode_args=["--enable-igw"],
+                mode_args=mode_args,
                 timeout=timeout,
                 show_output=show_output,
                 extra_args=extra_args,
-                log_msg="IGW gateway (no workers)",
+                num_workers=num_workers,
+                log_msg=f"IGW gateway ({num_workers or 0} worker(s))",
             )
         elif is_pd_mode:
             self.pd_mode = True

--- a/e2e_test/router/test_worker_api.py
+++ b/e2e_test/router/test_worker_api.py
@@ -654,3 +654,75 @@ class TestWorkerAPIRestSemantics:
                 gateway.shutdown()
         finally:
             stop_workers(http_workers)
+
+
+@pytest.mark.engine("sglang")
+@pytest.mark.gpu(1)
+@pytest.mark.e2e
+class TestIGWWorkerUrlsMixedExternal:
+    """Regression for discussion #1871: mixed self-hosted + external under IGW.
+
+    Starting the gateway with ``--enable-igw --worker-urls <local-sglang>
+    https://api.openai.com`` (no key) registers OpenAI as a wildcard external
+    worker. A ``gpt-*`` request is dispatched to the OpenAI proxy router and the
+    caller's ``Authorization`` (BYOK) is forwarded upstream, while the local model
+    stays on the self-hosted worker.
+
+    Requires OPENAI_API_KEY (used as the caller's bearer token).
+    """
+
+    def test_igw_worker_urls_routes_gpt_to_openai(self):
+        openai_key = os.environ.get("OPENAI_API_KEY")
+        if not openai_key:
+            pytest.skip("OPENAI_API_KEY not set")
+
+        engine = os.environ.get("E2E_ENGINE", "sglang")
+        model = "meta-llama/Llama-3.1-8B-Instruct"
+        http_workers = start_workers(model, engine, mode=ConnectionMode.HTTP, count=1)
+
+        try:
+            gateway = Gateway()
+            try:
+                # The local sglang worker can be slow/flaky to register under CI
+                # load, so give registration the same startup budget the other IGW
+                # mixed-worker test uses. The external worker registers instantly.
+                gateway.start(
+                    igw_mode=True,
+                    worker_urls=[http_workers[0].base_url, "https://api.openai.com"],
+                    policy="cache_aware",
+                    timeout=300,
+                    extra_args=["--worker-startup-timeout-secs", "300"],
+                )
+
+                # The OpenAI URL is classified as an external worker.
+                raw = httpx.get(f"{gateway.base_url}/workers", timeout=10).json()
+                openai_worker = next(
+                    (w for w in raw.get("workers", []) if "api.openai.com" in w.get("url", "")),
+                    None,
+                )
+                assert openai_worker is not None, f"OpenAI worker not registered: {raw}"
+                assert openai_worker.get("runtime_type") == "external", (
+                    f"OpenAI worker should be external, got {openai_worker.get('runtime_type')}"
+                )
+
+                # A gpt-* request dispatches to the OpenAI proxy router; the caller's
+                # bearer (BYOK) is forwarded upstream. The local worker only serves
+                # its own model, so routing is unambiguous.
+                resp = httpx.post(
+                    f"{gateway.base_url}/v1/chat/completions",
+                    headers={"Authorization": f"Bearer {openai_key}"},
+                    json={
+                        "model": "gpt-4o-mini",
+                        "messages": [{"role": "user", "content": "ping"}],
+                        "max_tokens": 1,
+                    },
+                    timeout=30,
+                )
+                assert resp.status_code == 200, (
+                    "gpt request should route to the external OpenAI worker and "
+                    f"forward the caller's key, got {resp.status_code}: {resp.text}"
+                )
+            finally:
+                gateway.shutdown()
+        finally:
+            stop_workers(http_workers)

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -323,7 +323,25 @@ impl RouterManager {
         }
 
         let workers = if let Some(model) = model_id {
-            self.worker_registry.get_by_model(model).to_vec()
+            let indexed = self.worker_registry.get_by_model(model).to_vec();
+            if indexed.is_empty() {
+                // Wildcard external workers (e.g. `--worker-urls https://api.openai.com`
+                // with no key) accept any model but aren't in the per-model index, so
+                // `get_by_model` misses them. Fall back to external workers that support
+                // the model, so the request dispatches to the provider proxy router
+                // instead of the default local router. Indexed (explicit) workers win,
+                // so a local model never falls through to a wildcard. (#1871)
+                self.worker_registry
+                    .get_all()
+                    .into_iter()
+                    .filter(|w| {
+                        matches!(w.metadata().spec.runtime_type, RuntimeType::External)
+                            && w.supports_model(model)
+                    })
+                    .collect()
+            } else {
+                indexed
+            }
         } else {
             self.worker_registry.get_all()
         };
@@ -962,6 +980,59 @@ mod tests {
         fn router_type(&self) -> &'static str {
             "epd"
         }
+    }
+
+    // #1871: in IGW mode, an unlisted model served only by a keyless wildcard
+    // external worker (e.g. `--worker-urls https://api.openai.com`) must dispatch
+    // to the OpenAI proxy router, while a locally-served model stays on the local
+    // router (never leaking to the wildcard).
+    #[test]
+    fn igw_dispatches_wildcard_external_model_to_provider_router() {
+        let registry = Arc::new(WorkerRegistry::new());
+        // Local worker serving one explicit model (indexed under that model).
+        registry.register_or_replace(Arc::new(
+            BasicWorkerBuilder::new("http://local:8080")
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Http)
+                .models(vec![ModelCard::new("local-model")])
+                .build(),
+        ));
+        // Keyless wildcard external worker (accepts any model, not indexed).
+        registry.register_or_replace(Arc::new(
+            BasicWorkerBuilder::new("https://api.openai.com")
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Http)
+                .runtime_type(RuntimeType::External)
+                .build(),
+        ));
+
+        let mut manager = RouterManager::new(Arc::clone(&registry), reqwest::Client::new());
+        manager.enable_igw = true;
+        let manager = Arc::new(manager);
+
+        // Distinct instances so we can assert which one was selected by identity.
+        let regular: Arc<dyn RouterTrait> = Arc::new(StubRouter);
+        let openai: Arc<dyn RouterTrait> = Arc::new(StubRouter);
+        manager.register_router(router_ids::HTTP_REGULAR, regular.clone());
+        manager.register_router(router_ids::HTTP_OPENAI, openai.clone());
+
+        // Unlisted model (only the wildcard external serves it) → OpenAI router.
+        let picked = manager
+            .select_router_for_request(Some("gpt-4o-mini"))
+            .expect("a router should be selected for gpt-4o-mini");
+        assert!(
+            Arc::ptr_eq(&picked, &openai),
+            "gpt-4o-mini should dispatch to the OpenAI router"
+        );
+
+        // Locally-served model → local (regular) router; never the wildcard.
+        let picked = manager
+            .select_router_for_request(Some("local-model"))
+            .expect("a router should be selected for the local model");
+        assert!(
+            Arc::ptr_eq(&picked, &regular),
+            "local model should stay on the regular router"
+        );
     }
 
     fn test_manager(enable_igw: bool) -> Arc<RouterManager> {


### PR DESCRIPTION
## Description

### Problem

In IGW mode, starting with `--enable-igw --worker-urls <local-sglang> https://api.openai.com` (no key) registers OpenAI as a wildcard external worker, but a `gpt-*` request returned `404 model_not_found` — it was never dispatched to the OpenAI proxy router (discussion #1871).

Root cause: `select_router_for_request` resolves a request's candidate workers via the registry's per-model index (`get_by_model`), which only contains each worker's *explicitly-listed* models. A wildcard external worker has none, so for an unlisted model the lookup is empty → dispatch falls back to the default (local) router instead of the external→provider-router branch in `select_router_for_workers`.

### Solution

When the per-model index is empty, fall back to external workers that support the model, so the request dispatches to the OpenAI/Anthropic/Gemini proxy router — which forwards the caller's bearer (BYOK) and strips SGLang-only fields. Indexed (explicit) workers still win, so a locally-served model never routes to a wildcard.

First of a few focused PRs from discussion #1871. Follow-ups: warn + auto-enable IGW when `--worker-urls` includes an external provider; stop `--backend openai` from classifying self-hosted workers as external.

## Changes

- `model_gateway/.../routers/router_manager.rs`: wildcard-external fallback in `select_router_for_request`, plus a unit test asserting dispatch by router identity (`Arc::ptr_eq`).
- `e2e_test/infra/gateway.py`: allow `--enable-igw` together with `--worker-urls`.
- `e2e_test/router/test_worker_api.py`: gated e2e for the mixed `--enable-igw --worker-urls` path.

## Test Plan

**Unit:**

```
cargo test -p smg --lib -- routers::router_manager::tests::igw_dispatches_wildcard_external_model_to_provider_router
```

- `gpt-4o-mini` (served only by the wildcard external worker) → OpenAI router; a locally-served model → regular router (never the wildcard).

**e2e** — `TestIGWWorkerUrlsMixedExternal` (gated on `OPENAI_API_KEY`, `@gpu(1)` `@engine(sglang)`): starts `--enable-igw --worker-urls <local-sglang> https://api.openai.com`, asserts the OpenAI URL registers as `external`, and a `gpt-4o-mini` chat carrying the caller's `Authorization: Bearer` (BYOK) returns 200.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy -- -D warnings` clean on the changed crate
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IGW startup when worker URLs are provided: IGW takes precedence, the gateway waits for the expected number of workers, and startup logs reflect the worker count.
  * Updated IGW model dispatch to correctly route models from unindexed “wildcard” external workers, while preserving locally indexed routing.

* **Tests**
  * Added an end-to-end regression test for IGW setups mixing a local HTTP worker with an external OpenAI worker URL.
  * Added a unit test ensuring wildcard external models route to the provider (OpenAI) path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->