### PR TITLE
fix(tool_parser): treat qwen_xml tool-call arg values literally

### DIFF
--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -54,95 +54,26 @@ pub struct QwenXmlParser {
     xml_param_pattern: Regex,
 }
 
-/// Decode HTML entities in a string (equivalent to Python's html.unescape)
+/// Parse a raw parameter value, similar to Python's `_safe_val`.
 ///
-/// Handles common HTML entities like &amp; &lt; &gt; &quot; &#39; and numeric entities
-fn html_unescape(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        if c == '&' {
-            let mut entity = String::new();
-            let mut consumed_semicolon = false;
-            while let Some(&next) = chars.peek() {
-                if next == ';' {
-                    chars.next();
-                    consumed_semicolon = true;
-                    break;
-                }
-                if next.is_alphanumeric() || next == '#' {
-                    // Safe: peek() returned Some, so next() will too
-                    if let Some(ch) = chars.next() {
-                        entity.push(ch);
-                    }
-                } else {
-                    break;
-                }
-            }
-
-            let decoded = match entity.as_str() {
-                "amp" => "&",
-                "lt" => "<",
-                "gt" => ">",
-                "quot" => "\"",
-                "apos" => "'",
-                "nbsp" => "\u{00A0}",
-                s if s.starts_with('#') => {
-                    let num_str = &s[1..];
-                    let code_point = if num_str.starts_with('x') || num_str.starts_with('X') {
-                        u32::from_str_radix(&num_str[1..], 16).ok()
-                    } else {
-                        num_str.parse::<u32>().ok()
-                    };
-                    if let Some(cp) = code_point {
-                        if let Some(ch) = char::from_u32(cp) {
-                            result.push(ch);
-                            continue;
-                        }
-                    }
-                    // Invalid numeric entity, reconstruct original
-                    result.push('&');
-                    result.push_str(&entity);
-                    if consumed_semicolon {
-                        result.push(';');
-                    }
-                    continue;
-                }
-                _ => {
-                    // Unknown entity, reconstruct original
-                    result.push('&');
-                    result.push_str(&entity);
-                    if consumed_semicolon {
-                        result.push(';');
-                    }
-                    continue;
-                }
-            };
-            result.push_str(decoded);
-        } else {
-            result.push(c);
-        }
-    }
-
-    result
-}
-
-/// Parse a raw parameter value, similar to Python's _safe_val
+/// Argument values are treated **literally** — no HTML-entity decoding. The
+/// Qwen3-Coder XML tool format is not HTML-escaped on render (the chat template
+/// emits values via `| tojson | safe` / `| string`), so parsing must not
+/// unescape it. This matches vLLM's `Qwen3CoderToolParser`, Qwen-Agent, and
+/// Qwen's chat template, all of which pass argument values through verbatim.
 ///
-/// 1. Decode HTML entities
-/// 2. Try to parse as JSON (numbers, booleans, null, objects, arrays)
-/// 3. Fall back to string if JSON parsing fails
+/// 1. Try to parse as JSON (numbers, booleans, null, objects, arrays)
+/// 2. Fall back to string if JSON parsing fails
 fn safe_val(raw: &str) -> Value {
-    let unescaped = html_unescape(raw.trim());
+    let trimmed = raw.trim();
 
     // Try JSON parsing first
-    if let Ok(v) = serde_json::from_str::<Value>(&unescaped) {
+    if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
         return v;
     }
 
     // Handle Python-style literals (True, False, None)
-    match unescaped.as_str() {
+    match trimmed {
         "True" => return Value::Bool(true),
         "False" => return Value::Bool(false),
         "None" => return Value::Null,
@@ -150,14 +81,17 @@ fn safe_val(raw: &str) -> Value {
     }
 
     // Fall back to string
-    Value::String(unescaped)
+    Value::String(trimmed.to_string())
 }
 
 /// Coerce an XML parameter value by its declared schema type, falling back to
 /// [`safe_val`] inference when the type is unknown.
+///
+/// Values are treated literally; see [`safe_val`] for why the format is not
+/// HTML-unescaped.
 fn coerce_value(raw: &str, declared_type: Option<&str>) -> Value {
-    let decoded = html_unescape(raw.trim());
-    helpers::coerce_by_schema_type(&decoded, declared_type).unwrap_or_else(|| safe_val(raw))
+    let trimmed = raw.trim();
+    helpers::coerce_by_schema_type(trimmed, declared_type).unwrap_or_else(|| safe_val(raw))
 }
 
 impl QwenXmlParser {
@@ -551,40 +485,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_html_unescape_basic() {
-        assert_eq!(html_unescape("&amp;"), "&");
-        assert_eq!(html_unescape("&lt;"), "<");
-        assert_eq!(html_unescape("&gt;"), ">");
-        assert_eq!(html_unescape("&quot;"), "\"");
-        assert_eq!(html_unescape("&apos;"), "'");
-    }
-
-    #[test]
-    fn test_html_unescape_numeric() {
-        assert_eq!(html_unescape("&#60;"), "<");
-        assert_eq!(html_unescape("&#x3C;"), "<");
-        assert_eq!(html_unescape("&#x3c;"), "<");
-    }
-
-    #[test]
-    fn test_html_unescape_mixed() {
-        assert_eq!(
-            html_unescape("Hello &amp; World &lt;tag&gt;"),
-            "Hello & World <tag>"
-        );
-    }
-
-    #[test]
-    fn test_html_unescape_unknown() {
-        // Unknown entities with semicolon should be preserved as-is
-        assert_eq!(html_unescape("&unknown;"), "&unknown;");
-        // Unterminated entities should NOT have semicolon added
-        assert_eq!(html_unescape("&foo bar"), "&foo bar");
-        assert_eq!(html_unescape("&"), "&");
-        assert_eq!(html_unescape("& "), "& ");
-    }
-
-    #[test]
     fn test_safe_val_json() {
         assert_eq!(safe_val("42"), Value::Number(42.into()));
         assert_eq!(safe_val("1.5"), serde_json::json!(1.5));
@@ -614,13 +514,21 @@ mod tests {
         assert_eq!(safe_val("  spaces  "), Value::String("spaces".to_string()));
     }
 
+    // Values are treated literally: entity-like substrings must NOT be decoded
+    // (parity with vLLM's Qwen3CoderToolParser, which does no html.unescape).
     #[test]
-    fn test_safe_val_html_entities() {
-        assert_eq!(safe_val("&lt;div&gt;"), Value::String("<div>".to_string()));
+    fn test_safe_val_preserves_html_entities() {
+        assert_eq!(
+            safe_val("&lt;div&gt;"),
+            Value::String("&lt;div&gt;".to_string())
+        );
         assert_eq!(
             safe_val("Tom &amp; Jerry"),
-            Value::String("Tom & Jerry".to_string())
+            Value::String("Tom &amp; Jerry".to_string())
         );
+        // Numeric/hex entities are likewise left untouched.
+        assert_eq!(safe_val("it&#39;s"), Value::String("it&#39;s".to_string()));
+        assert_eq!(safe_val("&#x3C;"), Value::String("&#x3C;".to_string()));
     }
 
     fn tool_with_props(props: Value) -> Vec<Tool> {
@@ -689,5 +597,37 @@ mod tests {
             args.contains(r#""count": 5"#),
             "int param must coerce: {args}"
         );
+    }
+
+    // Golden conformance test (regression guard for #1888): a tool argument
+    // whose value contains HTML entities must round-trip UNCHANGED, matching
+    // vLLM's `qwen3coder` parser. Covers both the schema-typed `string` path and
+    // the schema-less inference fallback.
+    #[tokio::test]
+    async fn test_arg_values_with_entities_roundtrip_unchanged() {
+        let literal = "<a>Tom &amp; Jerry</a> &lt;x&gt; it&#39;s";
+
+        // Schema-less inference path (`safe_val`): not valid JSON -> stays a
+        // literal string with entities intact.
+        let text = format!(
+            "<tool_call>\n<function=write_file>\n\
+             <parameter=content>\n{literal}\n</parameter>\n\
+             </function>\n</tool_call>"
+        );
+        let (_, calls) = QwenXmlParser::new().parse_complete(&text).await.unwrap();
+        assert_eq!(calls.len(), 1);
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["content"], Value::String(literal.to_string()));
+
+        // Schema-typed `string` path (`coerce_value`): same literal value.
+        let tools = tool_with_props(serde_json::json!({
+            "content": {"type": "string"},
+        }));
+        let (_, calls) = QwenXmlParser::new()
+            .parse_complete_with_tools(&text, &tools)
+            .await
+            .unwrap();
+        let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["content"], Value::String(literal.to_string()));
     }
 }

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -56,11 +56,14 @@ pub struct QwenXmlParser {
 
 /// Parse a raw parameter value, similar to Python's `_safe_val`.
 ///
-/// Argument values are treated **literally** — no HTML-entity decoding. The
-/// Qwen3-Coder XML tool format is not HTML-escaped on render (the chat template
-/// emits values via `| tojson | safe` / `| string`), so parsing must not
-/// unescape it. This matches vLLM's `Qwen3CoderToolParser`, Qwen-Agent, and
-/// Qwen's chat template, all of which pass argument values through verbatim.
+/// Argument values are treated **literally** — no HTML-entity decoding. This
+/// matches Qwen's own official API (DashScope), verified for both Qwen3-Coder
+/// and Qwen3.5: a tool argument whose value contains `&amp;`, `&lt;`, `&#39;`
+/// is returned with those entities intact. The Qwen XML tool format is not
+/// HTML-escaped on render either (the chat template emits values via
+/// `| tojson | safe` / `| string`), so parsing must not unescape it. vLLM's
+/// `Qwen3CoderToolParser`, SGLang's `qwen3_coder_detector`, and Qwen-Agent all
+/// agree, passing argument values through verbatim.
 ///
 /// 1. Try to parse as JSON (numbers, booleans, null, objects, arrays)
 /// 2. Fall back to string if JSON parsing fails
@@ -515,7 +518,7 @@ mod tests {
     }
 
     // Values are treated literally: entity-like substrings must NOT be decoded
-    // (parity with vLLM's Qwen3CoderToolParser, which does no html.unescape).
+    // (parity with Qwen's official API, which returns them intact).
     #[test]
     fn test_safe_val_preserves_html_entities() {
         assert_eq!(
@@ -601,8 +604,8 @@ mod tests {
 
     // Golden conformance test (regression guard for #1888): a tool argument
     // whose value contains HTML entities must round-trip UNCHANGED, matching
-    // vLLM's `qwen3coder` parser. Covers both the schema-typed `string` path and
-    // the schema-less inference fallback.
+    // Qwen's official API (verified on Qwen3-Coder and Qwen3.5). Covers both the
+    // schema-typed `string` path and the schema-less inference fallback.
     #[tokio::test]
     async fn test_arg_values_with_entities_roundtrip_unchanged() {
         let literal = "<a>Tom &amp; Jerry</a> &lt;x&gt; it&#39;s";

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -610,19 +610,22 @@ mod tests {
     async fn test_arg_values_with_entities_roundtrip_unchanged() {
         let literal = "<a>Tom &amp; Jerry</a> &lt;x&gt; it&#39;s";
 
-        // Schema-less inference path (`safe_val`): not valid JSON -> stays a
-        // literal string with entities intact.
+        // Function name matches `tool_with_props` (`f`) so the schema-typed
+        // branch below actually resolves the `content` param's type.
         let text = format!(
-            "<tool_call>\n<function=write_file>\n\
+            "<tool_call>\n<function=f>\n\
              <parameter=content>\n{literal}\n</parameter>\n\
              </function>\n</tool_call>"
         );
+
+        // Schema-less inference path (`safe_val`): not valid JSON -> stays a
+        // literal string with entities intact.
         let (_, calls) = QwenXmlParser::new().parse_complete(&text).await.unwrap();
         assert_eq!(calls.len(), 1);
         let args: Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["content"], Value::String(literal.to_string()));
 
-        // Schema-typed `string` path (`coerce_value`): same literal value.
+        // Schema-typed `string` path (`coerce_value` -> `coerce_by_schema_type`).
         let tools = tool_with_props(serde_json::json!({
             "content": {"type": "string"},
         }));

--- a/crates/tool_parser/tests/tool_parser_qwen_xml.rs
+++ b/crates/tool_parser/tests/tool_parser_qwen_xml.rs
@@ -855,14 +855,17 @@ async fn test_qwen_xml_empty_parameter_value() {
 }
 
 // ============================================================================
-// HTML Entity and Python Literal Tests
+// Literal Value (HTML-entity parity) and Python Literal Tests
+//
+// Argument values are treated literally — entity-like substrings are NOT
+// decoded, matching vLLM's Qwen3CoderToolParser. Regression guard for #1888.
 // ============================================================================
 
 #[tokio::test]
-async fn test_qwen_xml_html_entity_decoding() {
+async fn test_qwen_xml_preserves_html_entities() {
     let parser = QwenXmlParser::new();
 
-    // Test HTML entities in parameter values
+    // Named HTML entities in parameter values must be preserved verbatim.
     let input = r"<tool_call>
 <function=process>
 <parameter=ampersand>Tom &amp; Jerry</parameter>
@@ -875,16 +878,16 @@ async fn test_qwen_xml_html_entity_decoding() {
     assert_eq!(tools.len(), 1);
 
     let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
-    assert_eq!(args["ampersand"], "Tom & Jerry");
-    assert_eq!(args["comparison"], "5 < 10 && 10 > 5");
-    assert_eq!(args["quotes"], "\"Hello\" & 'World'");
+    assert_eq!(args["ampersand"], "Tom &amp; Jerry");
+    assert_eq!(args["comparison"], "5 &lt; 10 &amp;&amp; 10 &gt; 5");
+    assert_eq!(args["quotes"], "&quot;Hello&quot; &amp; &apos;World&apos;");
 }
 
 #[tokio::test]
-async fn test_qwen_xml_html_numeric_entities() {
+async fn test_qwen_xml_preserves_numeric_entity_text() {
     let parser = QwenXmlParser::new();
 
-    // Test numeric HTML entities
+    // Numeric/hex entity text must be preserved verbatim (not decoded).
     let input = r"<tool_call>
 <function=process>
 <parameter=decimal>&#60;tag&#62;</parameter>
@@ -896,8 +899,8 @@ async fn test_qwen_xml_html_numeric_entities() {
     assert_eq!(tools.len(), 1);
 
     let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
-    assert_eq!(args["decimal"], "<tag>");
-    assert_eq!(args["hex"], "<tag>");
+    assert_eq!(args["decimal"], "&#60;tag&#62;");
+    assert_eq!(args["hex"], "&#x3C;tag&#x3E;");
 }
 
 #[tokio::test]
@@ -934,7 +937,7 @@ async fn test_qwen_xml_python_literals() {
 async fn test_qwen_xml_mixed_html_and_json() {
     let parser = QwenXmlParser::new();
 
-    // Test HTML entities within JSON structures
+    // Entity-like text alongside a JSON-valued parameter.
     let input = r#"<tool_call>
 <function=search>
 <parameter=query>price &lt; 100 &amp;&amp; rating &gt; 4</parameter>
@@ -946,8 +949,11 @@ async fn test_qwen_xml_mixed_html_and_json() {
     assert_eq!(tools.len(), 1);
 
     let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
-    assert_eq!(args["query"], "price < 100 && rating > 4");
-    // JSON with HTML entity inside - the entity gets decoded first, then JSON parsed
+    // Non-JSON value stays a literal string with entities intact.
+    assert_eq!(args["query"], "price &lt; 100 &amp;&amp; rating &gt; 4");
+    // JSON value parses as an object; entities inside its strings are preserved
+    // (JSON has no notion of HTML entities, so they are ordinary characters).
     assert!(args["config"].is_object());
-    assert_eq!(args["config"]["operator"], "&&");
+    assert_eq!(args["config"]["operator"], "&amp;&amp;");
+    assert_eq!(args["config"]["escape"], true);
 }

--- a/crates/tool_parser/tests/tool_parser_qwen_xml.rs
+++ b/crates/tool_parser/tests/tool_parser_qwen_xml.rs
@@ -858,7 +858,8 @@ async fn test_qwen_xml_empty_parameter_value() {
 // Literal Value (HTML-entity parity) and Python Literal Tests
 //
 // Argument values are treated literally — entity-like substrings are NOT
-// decoded, matching vLLM's Qwen3CoderToolParser. Regression guard for #1888.
+// decoded, matching Qwen's official API (verified on Qwen3-Coder and Qwen3.5).
+// Regression guard for #1888.
 // ============================================================================
 
 #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

`qwen_xml`'s value decoder ran `html.unescape` on every tool-call argument value, so any argument containing a literal HTML entity (`&amp;`, `&lt;`, `&#39;`, …) was silently mutated on parse (`&amp;` → `&`).

The Qwen3-Coder XML tool format is **not** HTML-escaped on render — the chat template emits argument values via `| tojson | safe` / `| string`, so the model emits literal characters. vLLM's `Qwen3CoderToolParser`, Qwen-Agent, and Qwen's chat template all pass argument values through verbatim. SMG was the only implementation that unescaped, and it applies no matching escape on its own render side, so its parse was not the inverse of its render.

**Impact:** a coding agent writing an HTML/XML/Markdown snippet had its argument silently corrupted before it reached the tool:

- Model emits (literal): `<parameter=content>\n<a>Tom &amp; Jerry</a>\n</parameter>`
- vLLM delivers to the tool: `<a>Tom &amp; Jerry</a>` ✅
- SMG delivered to the tool: `<a>Tom & Jerry</a>` ❌

Because the assistant tool call is re-serialized into the next turn's prompt, the mutated value also propagated into subsequent turns.

Fixes #1888.

### Solution

Treat argument values literally — drop the `html_unescape` call from both `safe_val` (schema-less inference path) and `coerce_value` (schema-typed path), matching vLLM's `qwen3coder` parser. JSON / schema-type coercion is unchanged.

## Changes

- Remove `html_unescape` from `safe_val` and `coerce_value` in `crates/tool_parser/src/parsers/qwen_xml.rs` (keep trim + JSON / schema-type coercion).
- Delete the now-dead `html_unescape` helper (~70 lines).
- Invert the unit + integration tests that asserted entity decoding so they now assert literal preservation.
- Add golden conformance test `test_arg_values_with_entities_roundtrip_unchanged` covering both the inference and string-schema paths — this class of divergence now fails in CI, not as a benchmark score.

## Test Plan

**Before:** value `<a>Tom &amp; Jerry</a> &lt;x&gt; it&#39;s` parsed to `<a>Tom & Jerry</a> <x> it's` (entities decoded).
**After:** the same value round-trips unchanged.

```bash
cargo test -p tool-parser                                            # all pass, incl. new golden test
cargo +nightly fmt --all -- --check                                  # clean
cargo clippy -p tool-parser --all-targets --all-features -- -D warnings  # clean
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Qwen XML tool parameter values now preserve HTML-entity-like text verbatim (named, numeric, and hex), instead of decoding it to rendered characters.
  * Encoded argument values now round-trip unchanged across both schema-less parsing and schema-typed `string` parsing.
  * Mixed XML text and embedded JSON values now keep non-JSON entity-like substrings unchanged.
* **Tests**
  * Updated and expanded Qwen XML tests to verify literal preservation for named, numeric, and hex entities, including a new round-trip regression case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->