### PR TITLE
fix(k8s): qualify agentic service image references

### DIFF
--- a/scripts/k8s-runner-resources/agentic-services.yaml
+++ b/scripts/k8s-runner-resources/agentic-services.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: oracle-db
-          image: gvenzl/oracle-free:23-slim-faststart
+          image: docker.io/gvenzl/oracle-free:23-slim-faststart
           ports:
             - containerPort: 1521
           env:
@@ -34,6 +34,13 @@ spec:
             limits:
               cpu: "2"
               memory: 4Gi
+          startupProbe:
+            exec:
+              command: ["healthcheck.sh"]
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+            successThreshold: 1
           readinessProbe:
             exec:
               command: ["healthcheck.sh"]
@@ -82,7 +89,7 @@ spec:
     spec:
       containers:
         - name: brave-search-mcp
-          image: mcp/brave-search:latest
+          image: docker.io/mcp/brave-search:latest
           ports:
             - containerPort: 8080
           env:

--- a/scripts/k8s-runner-resources/agentic-services.yaml
+++ b/scripts/k8s-runner-resources/agentic-services.yaml
@@ -44,14 +44,12 @@ spec:
           readinessProbe:
             exec:
               command: ["healthcheck.sh"]
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 10
           livenessProbe:
             exec:
               command: ["healthcheck.sh"]
-            initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
## Description

### Problem

Following a node patch, replacement pods ran on a node image without `/etc/containers/registries.conf`. Without registry search configuration, CRI-O could not resolve unqualified container image names. Oracle database initialization can also exceed the original liveness-probe window.

### Solution

Use explicit Docker Hub registry paths for the shared agentic-service images and add a startup probe that protects Oracle during initialization.

## Changes

- Qualify the Oracle image as `docker.io/gvenzl/oracle-free:23-slim-faststart`.
- Qualify the Brave Search image as `docker.io/mcp/brave-search:latest`.
- Add an Oracle startup probe before liveness checks begin.

## Test Plan

- [x] YAML pre-commit validation passes.
- [x] Kubernetes client-side dry run decodes all four resources.
- [x] `git diff --check` passes.
- [ ] Full pre-commit suite: the local clippy hook is blocked by unavailable OpenCV build prerequisites (`pkg-config`).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by switching to fully qualified container image references.
  * Added a startup health check for the Oracle database service to help ensure it’s ready before taking traffic.
  * Updated Oracle service health probe timing settings for more consistent readiness/liveness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->