### PR TITLE
ci(docker): add TokenSpeed engine image release workflow

### DIFF
--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       engine:
-        description: 'Engine name: vllm, sglang, trtllm, tgl'
+        description: 'Engine name: vllm, sglang, trtllm, tgl, tokenspeed'
         required: true
         type: string
       backend:
@@ -102,8 +102,8 @@ jobs:
           SOURCE_BUILD_REPO: ${{ inputs.source_build_repo }}
         run: |
           case "${ENGINE}" in
-            vllm|sglang|trtllm|tgl) ;;
-            *) echo "ERROR: Unknown engine '${ENGINE}'. Must be one of: vllm, sglang, trtllm, tgl." >&2; exit 1 ;;
+            vllm|sglang|trtllm|tgl|tokenspeed) ;;
+            *) echo "ERROR: Unknown engine '${ENGINE}'. Must be one of: vllm, sglang, trtllm, tgl, tokenspeed." >&2; exit 1 ;;
           esac
           if [ "${ENGINE}" = "trtllm" ] && [ -z "${BASE_IMAGE_REF}" ] && [ -z "${SOURCE_BUILD_REPO}" ]; then
             echo "ERROR: For trtllm, either base_image_ref or source_build_repo must be set." >&2

--- a/.github/workflows/nightly-engine-docker.yml
+++ b/.github/workflows/nightly-engine-docker.yml
@@ -51,6 +51,9 @@ jobs:
           - engine: trtllm
             base_image_ref: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18
             engine_ver: 1.3.0rc18
+          - engine: tokenspeed
+            base_image_ref: lightseekorg/tokenspeed:tml
+            engine_ver: tml
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: ${{ matrix.engine }}

--- a/.github/workflows/release-tokenspeed-docker.yml
+++ b/.github/workflows/release-tokenspeed-docker.yml
@@ -1,0 +1,74 @@
+name: Release SMG+TokenSpeed Docker Image
+
+run-name: >-
+  SMG+TokenSpeed |
+  ${{ github.event_name == 'push' && 'base=lightseekorg/tokenspeed:tml' || format('base={0}', inputs.base_image_ref || 'lightseekorg/tokenspeed:tml') }} |
+  engine=${{ inputs.tokenspeed_commit || 'latest' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }} |
+  ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
+  by @${{ github.actor }}
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - bindings/python/pyproject.toml
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker/engine.Dockerfile'
+      - '.github/workflows/_build-engine-image.yml'
+      - '.github/workflows/release-*-docker.yml'
+      - 'scripts/installation/**'
+  workflow_dispatch:
+    inputs:
+      base_image_ref:
+        description: 'Base image (e.g. lightseekorg/tokenspeed:tml). Engine is baked in; leave engine repo empty.'
+        default: 'lightseekorg/tokenspeed:tml'
+        required: true
+        type: string
+      tokenspeed_repo:
+        description: 'TokenSpeed repo URL (empty = use engine from base image)'
+        required: false
+        type: string
+      tokenspeed_commit:
+        description: 'TokenSpeed commit/ref ("latest" for HEAD)'
+        required: false
+        default: 'latest'
+        type: string
+      smg_repo:
+        description: 'SMG repo URL'
+        required: false
+        default: 'https://github.com/lightseekorg/smg'
+        type: string
+      smg_commit:
+        description: 'SMG commit/ref ("latest" for HEAD)'
+        required: false
+        default: 'v1.7.0'
+        type: string
+      tag:
+        description: 'Override image tag (e.g. v1.7.0-tokenspeed-tml)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        base_image: ${{ github.event_name == 'push' && fromJSON('["lightseekorg/tokenspeed:tml"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'lightseekorg/tokenspeed:tml')) }}
+    uses: ./.github/workflows/_build-engine-image.yml
+    with:
+      engine: tokenspeed
+      base_image_ref: ${{ matrix.base_image }}
+      engine_repo: ${{ inputs.tokenspeed_repo }}
+      engine_commit: ${{ inputs.tokenspeed_commit || 'latest' }}
+      smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }}
+      tag: ${{ inputs.tag }}
+      dry_run: ${{ github.event_name == 'pull_request' }}
+    secrets: inherit

--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -2,7 +2,7 @@
 #
 # Build args:
 #   BASE_IMAGE_REF  - full image:tag to start FROM
-#   ENGINE          - engine name: vllm | sglang | trtllm | tgl
+#   ENGINE          - engine name: vllm | sglang | trtllm | tgl | tokenspeed
 #   BACKEND         - SMG_DEFAULT_BACKEND value (defaults to ENGINE; tgl overrides to sglang)
 #   ENGINE_REPO     - if set, engine source is cloned and install-<ENGINE>.sh runs
 #   ENGINE_COMMIT   - commit/ref for ENGINE_REPO ("latest" = HEAD)
@@ -66,10 +66,21 @@ RUN if [ "${ENGINE}" = "trtllm" ]; then \
       pip install --no-cache-dir --ignore-installed pyyaml; \
     fi
 
+# TokenSpeed base images bake in `tokenspeed-smg-grpc-proto` /
+# `tokenspeed-smg-grpc-servicer`, which install the same `smg_grpc_proto` /
+# `smg_grpc_servicer` import paths that install-smg.sh reinstalls from source.
+# Left in place they can shadow the source installs and serve stale proto
+# descriptors ("Method not found!"). Drop them first so SMG's own gRPC modules
+# win; the install-smg.sh source installs below replace them. Scoped to
+# tokenspeed so the other engine bases keep their exact pip behavior.
+RUN if [ "${ENGINE}" = "tokenspeed" ]; then \
+      pip uninstall -y tokenspeed-smg-grpc-proto tokenspeed-smg-grpc-servicer || true; \
+    fi
+
 RUN bash /tmp/scripts/install-smg.sh /opt/smg-src
 
 RUN case "${ENGINE}" in \
-      vllm|sglang|trtllm|tgl) ;; \
+      vllm|sglang|trtllm|tgl|tokenspeed) ;; \
       *) echo "ERROR: Unknown ENGINE '${ENGINE}'" >&2; exit 1 ;; \
     esac \
     && if [ -n "${ENGINE_REPO}" ]; then \

--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -66,14 +66,21 @@ RUN if [ "${ENGINE}" = "trtllm" ]; then \
       pip install --no-cache-dir --ignore-installed pyyaml; \
     fi
 
-# TokenSpeed base images bake in `tokenspeed-smg-grpc-proto` /
-# `tokenspeed-smg-grpc-servicer`, which install the same `smg_grpc_proto` /
-# `smg_grpc_servicer` import paths that install-smg.sh reinstalls from source.
-# Left in place they can shadow the source installs and serve stale proto
-# descriptors ("Method not found!"). Drop them first so SMG's own gRPC modules
-# win; the install-smg.sh source installs below replace them. Scoped to
-# tokenspeed so the other engine bases keep their exact pip behavior.
+# TokenSpeed prep. The base is a debian-system-Python image, so it needs the
+# same debian-shadow treatment as the NGC trtllm base plus a gRPC cleanup:
+#  1. pip/pyyaml are debian-owned with no pip RECORD file, so install-smg.sh's
+#     `pip install --upgrade pip` (and the smg wheel's pyyaml dep) fail with
+#     "Cannot uninstall … RECORD file not found". Shadow them with pip-managed
+#     copies (--ignore-installed leaves the distro files alone) so the smg
+#     install can upgrade them normally.
+#  2. The base bakes in `tokenspeed-smg-grpc-proto` / `tokenspeed-smg-grpc-servicer`,
+#     which claim the same `smg_grpc_proto` / `smg_grpc_servicer` import paths
+#     that install-smg.sh reinstalls from source. Left in place they can shadow
+#     the source installs and serve stale proto descriptors ("Method not
+#     found!"). Drop them first so SMG's own gRPC modules win.
+# Scoped to tokenspeed so the other engine bases keep their exact pip behavior.
 RUN if [ "${ENGINE}" = "tokenspeed" ]; then \
+      pip install --no-cache-dir --ignore-installed pip pyyaml; \
       pip uninstall -y tokenspeed-smg-grpc-proto tokenspeed-smg-grpc-servicer || true; \
     fi
 

--- a/scripts/installation/install-tokenspeed.sh
+++ b/scripts/installation/install-tokenspeed.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Install tokenspeed from source.
+# Usage: install-tokenspeed.sh [path-to-tokenspeed-src]
+# Default path: /tmp/tokenspeed-src
+#
+# Only used when the engine image is built with ENGINE_REPO set (build the
+# engine from source into a runner base). The published lightseekorg/tokenspeed
+# images already bake the engine in, so the default release path does not run
+# this script.
+
+TS_SRC="${1:-/tmp/tokenspeed-src}"
+cd "${TS_SRC}/python"
+pip install --no-deps --force-reinstall --editable .


### PR DESCRIPTION
## Description

### Problem

SMG publishes co-located gateway+engine Docker images for vLLM, SGLang, and TensorRT-LLM (`release-{vllm,sglang,trtllm}-docker.yml`), but there is no equivalent release for **TokenSpeed**, even though TokenSpeed is a first-class supported backend (`RuntimeType::TokenSpeed`, `tokenspeed_*` gRPC clients, README/docs).

### Solution

TokenSpeed (`lightseekorg/tokenspeed`) publishes a **self-contained** engine image (its docs point at `lightseekorg/tokenspeed:tml`; the nightly workflow also pushes `nightly-<sha>`), built `FROM lightseekorg/tokenspeed-runner:*` with the kernel + scheduler + engine baked in. Because the engine is prebuilt, this uses the **thin-wrapper base-image path** (like `release-sglang-docker.yml`) rather than the trtllm source-build path.

One TokenSpeed-specific quirk: its images bake in `tokenspeed-smg-grpc-proto` / `tokenspeed-smg-grpc-servicer`, which claim the same `smg_grpc_proto` / `smg_grpc_servicer` import paths that `install-smg.sh` reinstalls from source. Left in place they can shadow the source installs and serve stale proto descriptors, so the Dockerfile uninstalls them first (scoped to `tokenspeed`, mirroring the existing trtllm `pyyaml` special-case; the same guard exists in `scripts/ci_install_tokenspeed.sh`).

## Changes

- **`.github/workflows/release-tokenspeed-docker.yml`** (new) — thin wrapper over `_build-engine-image.yml`: `engine: tokenspeed`, default base `lightseekorg/tokenspeed:tml`, single-version, PR dry-run, `workflow_dispatch` overrides.
- **`.github/workflows/_build-engine-image.yml`** — add `tokenspeed` to the engine validate allowlist + error message + input doc.
- **`docker/engine.Dockerfile`** — add `tokenspeed` to the `case` allowlist + header doc; drop `tokenspeed-smg-grpc-{proto,servicer}` before `install-smg.sh`.
- **`scripts/installation/install-tokenspeed.sh`** (new) — editable install for the optional `tokenspeed_repo` source path (parity with the other engines).
- **`.github/workflows/nightly-engine-docker.yml`** — add `tokenspeed` (base `:tml`) to the nightly matrix → floating `nightly-tokenspeed` tag.

**Out of scope (follow-up):** `smg serve --backend tokenspeed` is not yet wired into `bindings/python/src/smg/serve.py` (`BACKEND_CHOICES` is `sglang/vllm/trtllm`). The image works in router mode (`smg launch` → tokenspeed gRPC workers); `SMG_DEFAULT_BACKEND=tokenspeed` is set for consistency with the runtime label.

## Test Plan

Local static validation:
- `pre-commit run --files <changed files>` → all hooks pass (Rust/Python hooks correctly skipped — no such files changed).
- YAML parses for all four touched workflows; `install-tokenspeed.sh` passes `shellcheck` + `sh -n`.

Reproducible CI validation (post-merge / on this PR):
- This PR touches `docker/engine.Dockerfile`, `_build-engine-image.yml`, `release-*-docker.yml`, and `scripts/installation/**`, so the `pull_request` trigger runs the new workflow in **dry-run** (build-only, no push) — before this PR there was no tokenspeed build; after, the SMG+TokenSpeed image builds against `lightseekorg/tokenspeed:tml`.
- Manual `workflow_dispatch` on **Release SMG+TokenSpeed Docker Image** pushes `ghcr.io/lightseekorg/smg:<smg_ver>-tokenspeed-tml`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (N/A — no Rust changed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (N/A — no Rust changed)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TokenSpeed (`tokenspeed`) as a supported engine option for engine image builds.
  * Added nightly Docker builds for the TokenSpeed engine.
  * Added a dedicated workflow to build and release combined SMG + TokenSpeed Docker images.
  * Added local-source installation support for TokenSpeed.
* **Bug Fixes**
  * Prevented TokenSpeed’s bundled gRPC components from overriding SMG’s source-installed modules during image builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->