### PR TITLE
fix(pd): route chat using full message history

### DIFF
--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -11,8 +11,8 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use memchr::memmem;
 use openai_protocol::{
-    chat::{ChatCompletionRequest, ChatMessage, MessageContent},
-    common::{InputIds, StringOrArray},
+    chat::ChatCompletionRequest,
+    common::{GenerationRequest, InputIds, StringOrArray},
     completion::CompletionRequest,
     generate::GenerateRequest,
     rerank::RerankRequest,
@@ -1442,18 +1442,7 @@ impl RouterTrait for PDRouter {
         let return_logprob = body.logprobs;
 
         let request_text = if self.policies_need_request_text() {
-            body.messages.first().and_then(|msg| match msg {
-                ChatMessage::User { content, .. } => match content {
-                    MessageContent::Text(text) => Some(text.clone()),
-                    MessageContent::Parts(_) => None,
-                },
-                ChatMessage::Developer { content, .. } => match content {
-                    MessageContent::Text(text) => Some(text.clone()),
-                    MessageContent::Parts(_) => None,
-                },
-                ChatMessage::System { content, .. } => Some(content.to_simple_string()),
-                _ => None,
-            })
+            Some(body.extract_text_for_routing())
         } else {
             None
         };


### PR DESCRIPTION
## Description
Closes #1928
### Problem

The HTTP PD router only inspected the first chat message when building routing text. For multi-turn conversations, later messages did not participate in cache-aware or prefix-based worker selection. Multipart text in the first message could also produce no routing text.

### Solution

Use `ChatCompletionRequest::extract_text_for_routing()`, matching the regular HTTP router and including text from the complete message history.

## Changes

- Replace first-message-only extraction in the HTTP PD chat route.
- Remove the now-unused `ChatMessage` and `MessageContent` imports.

## Test Plan

1. Send two multi-turn chat requests with the same first message but different later messages through HTTP PD routing.
2. Confirm the routing text differs and includes the complete message history.
3. Send a request containing multipart text and confirm its text participates in routing.
4. Run `cargo test -p smg --lib routers::http::pd_router::tests` (8 passed, 0 failed).
5. Run `cargo +nightly fmt --all -- --check` (passed).

`cargo clippy --workspace --all-targets -- -D warnings` is currently blocked on macOS by two pre-existing unused imports in `model_gateway/src/routers/grpc/multimodal/assemble.rs`. The all-features variant additionally requires local OpenCV/pkg-config.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (blocked by the environment/pre-existing warnings described above)
- [ ] (Optional) Documentation updated (not required; no user-facing API change)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined chat request text extraction for HTTP routing.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->