### PR TITLE
feat(auth): add per-tenant API keys for serving-path authentication

### DIFF
--- a/docs/reference/api/openai.md
+++ b/docs/reference/api/openai.md
@@ -44,6 +44,26 @@ smg --worker-urls http://worker:8000 \
   --tenant-api-key team-blue:blue-secret
 ```
 
+Callers authenticate the same way as with `--api-key` — a `Bearer` token in the
+`Authorization` header — just using their own tenant's key instead of the shared one:
+
+```bash
+curl http://localhost:30000/v1/chat/completions \
+  -H "Authorization: Bearer red-secret" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+This request is attributed to `team-red`, distinct from a request authenticated with
+`blue-secret`. A key that doesn't match any configured `--api-key` or `--tenant-api-key`
+value is rejected with `401 Unauthorized`. Tenant keys authenticate serving endpoints
+only — `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, etc. They do not grant
+access to admin/management routes (`/workers`, `/flush_cache`, and similar); that surface
+requires either the shared `--api-key` or control-plane authentication.
+
 ---
 
 ## Endpoints

--- a/docs/reference/api/openai.md
+++ b/docs/reference/api/openai.md
@@ -33,6 +33,17 @@ Enable authentication with `--api-key`:
 smg --worker-urls http://worker:8000 --api-key "your-api-key"
 ```
 
+For real multi-tenant separation (e.g. per-tenant rate limiting), configure one key per
+tenant instead with `--tenant-api-key tenant_id:key` (repeatable). Each key resolves to
+its own tenant identity; `--api-key` remains available as a single shared fallback key
+whose callers all share one identity.
+
+```bash
+smg --worker-urls http://worker:8000 \
+  --tenant-api-key team-red:red-secret \
+  --tenant-api-key team-blue:blue-secret
+```
+
 ---
 
 ## Endpoints

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -49,7 +49,6 @@ parking_lot.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 rand.workspace = true
-subtle.workspace = true
 thiserror.workspace = true
 tonic.workspace = true
 tonic-prost.workspace = true

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -6,8 +6,8 @@ use smg_mcp::McpConfig;
 use super::{
     CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
     HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, PostgresConfig, RedisConfig,
-    RetryConfig, RouterConfig, RoutingKeyOverrideConfig, RoutingMode, TokenizerCacheConfig,
-    TraceConfig,
+    RetryConfig, RouterConfig, RoutingKeyOverrideConfig, RoutingMode, TenantApiKeyEntry,
+    TokenizerCacheConfig, TraceConfig,
 };
 use crate::worker::ConnectionMode;
 
@@ -279,6 +279,11 @@ impl RouterConfigBuilder {
 
     pub fn api_key<S: Into<String>>(mut self, key: S) -> Self {
         self.config.api_key = Some(key.into());
+        self
+    }
+
+    pub fn tenant_api_keys(mut self, keys: Vec<TenantApiKeyEntry>) -> Self {
+        self.config.tenant_api_keys = keys;
         self
     }
 

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -58,6 +58,10 @@ pub struct RouterConfig {
     #[serde(default)]
     pub dp_minimum_tokens_scheduler: bool,
     pub api_key: Option<String>,
+    /// Per-tenant API keys for serving-path auth, layered on top of
+    /// `api_key` rather than replacing it.
+    #[serde(default)]
+    pub tenant_api_keys: Vec<TenantApiKeyEntry>,
     pub discovery: Option<DiscoveryConfig>,
     pub metrics: Option<MetricsConfig>,
     pub trace_config: Option<TraceConfig>,
@@ -157,6 +161,14 @@ pub struct RouterConfig {
 pub struct TenantResolutionConfig {
     pub trust_tenant_header: bool,
     pub tenant_header_name: String,
+}
+
+/// A single tenant-scoped API key for serving-path authentication.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TenantApiKeyEntry {
+    /// Resolves to tenant key `auth:<tenant_id>`, e.g. `team-red`.
+    pub tenant_id: String,
+    pub key: String,
 }
 
 impl Default for TenantResolutionConfig {
@@ -759,6 +771,7 @@ impl Default for RouterConfig {
             dp_aware: false,
             dp_minimum_tokens_scheduler: false,
             api_key: None,
+            tenant_api_keys: Vec::new(),
             discovery: None,
             metrics: None,
             trace_config: None,

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -164,11 +164,20 @@ pub struct TenantResolutionConfig {
 }
 
 /// A single tenant-scoped API key for serving-path authentication.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TenantApiKeyEntry {
     /// Resolves to tenant key `auth:<tenant_id>`, e.g. `team-red`.
     pub tenant_id: String,
     pub key: String,
+}
+
+impl std::fmt::Debug for TenantApiKeyEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TenantApiKeyEntry")
+            .field("tenant_id", &self.tenant_id)
+            .field("key", &"<redacted>")
+            .finish()
+    }
 }
 
 impl Default for TenantResolutionConfig {

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -133,9 +133,23 @@ impl ConfigValidator {
         }
 
         for entry in &config.tenant_api_keys {
-            if entry.tenant_id.trim().is_empty() {
+            let trimmed_tenant_id = entry.tenant_id.trim();
+            if trimmed_tenant_id.is_empty() {
                 return Err(ConfigError::ValidationFailed {
                     reason: "tenant_api_keys entries must have a non-empty tenant_id".to_string(),
+                });
+            }
+            // The CLI parser already trims tenant_id, but config-file/binding
+            // entries bypass it — reject padding here instead of silently
+            // normalizing, since `auth:<tenant_id>` embeds it verbatim and a
+            // padded id would resolve to a different, likely-unintended
+            // tenant identity than the canonical one.
+            if trimmed_tenant_id != entry.tenant_id {
+                return Err(ConfigError::ValidationFailed {
+                    reason: format!(
+                        "tenant_api_keys tenant_id '{}' must not have surrounding whitespace",
+                        entry.tenant_id
+                    ),
                 });
             }
             if entry.key.trim().is_empty() {
@@ -1108,6 +1122,23 @@ mod tests {
         }];
 
         assert!(ConfigValidator::validate(&config).is_err());
+    }
+
+    /// A padded-but-otherwise-valid tenant_id (e.g. supplied via a config
+    /// file or binding, bypassing the CLI parser's own trim) must be
+    /// rejected rather than silently resolving to a different `auth:` key
+    /// than the canonical, unpadded tenant_id.
+    #[test]
+    fn test_validate_padded_tenant_id_rejected() {
+        let mut config = regular_mode_config();
+        config.tenant_api_keys = vec![TenantApiKeyEntry {
+            tenant_id: " team-a ".to_string(),
+            key: "some-secret".to_string(),
+        }];
+
+        let err = ConfigValidator::validate(&config).unwrap_err();
+        assert!(matches!(err, ConfigError::ValidationFailed { .. }));
+        assert!(err.to_string().contains("whitespace"));
     }
 
     #[test]

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -152,10 +152,24 @@ impl ConfigValidator {
                     ),
                 });
             }
-            if entry.key.trim().is_empty() {
+            let trimmed_key = entry.key.trim();
+            if trimmed_key.is_empty() {
                 return Err(ConfigError::ValidationFailed {
                     reason: format!(
                         "tenant_api_keys entry for tenant_id '{}' must have a non-empty key",
+                        entry.tenant_id
+                    ),
+                });
+            }
+            // Same asymmetry as tenant_id: the CLI trims the key, but
+            // config-file/binding entries don't go through it. A padded key
+            // would hash differently than the operator likely intended,
+            // silently defeating the duplicate-value check above for that
+            // entry.
+            if trimmed_key != entry.key {
+                return Err(ConfigError::ValidationFailed {
+                    reason: format!(
+                        "tenant_api_keys entry for tenant_id '{}' key must not have surrounding whitespace",
                         entry.tenant_id
                     ),
                 });
@@ -1139,6 +1153,29 @@ mod tests {
         let err = ConfigValidator::validate(&config).unwrap_err();
         assert!(matches!(err, ConfigError::ValidationFailed { .. }));
         assert!(err.to_string().contains("whitespace"));
+    }
+
+    /// Same asymmetry as the padded-tenant_id case, but for `key`: the CLI
+    /// trims it, config-file/binding entries don't, so an untrimmed key
+    /// would hash differently than intended and silently evade the
+    /// duplicate-value check.
+    #[test]
+    fn test_validate_padded_key_rejected() {
+        let mut config = regular_mode_config();
+        config.tenant_api_keys = vec![TenantApiKeyEntry {
+            tenant_id: "team-a".to_string(),
+            key: " some-secret ".to_string(),
+        }];
+
+        let err = ConfigValidator::validate(&config).unwrap_err();
+        assert!(matches!(err, ConfigError::ValidationFailed { .. }));
+        let message = err.to_string();
+        assert!(message.contains("team-a"));
+        assert!(message.contains("whitespace"));
+        assert!(
+            !message.contains("some-secret"),
+            "error must not leak the credential value: {message}"
+        );
     }
 
     #[test]

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -1,4 +1,5 @@
 use axum::http::HeaderName;
+use sha2::{Digest, Sha256};
 
 use super::*;
 
@@ -27,6 +28,7 @@ impl ConfigValidator {
         Self::validate_server_settings(config)?;
         Self::validate_storage_context_headers(config)?;
         Self::validate_tenant_resolution(config)?;
+        Self::validate_tenant_api_keys(config)?;
         if let Some(discovery) = &config.discovery {
             Self::validate_discovery(discovery, &config.mode)?;
         }
@@ -108,6 +110,52 @@ impl ConfigValidator {
                 "tenant_resolution.tenant_header_name must be a valid HTTP header name: {e}"
             ),
         })?;
+
+        Ok(())
+    }
+
+    /// Validates `tenant_api_keys`: non-empty `tenant_id`/`key`, and no two
+    /// credentials (including the shared `api_key`) sharing a secret value —
+    /// duplicates would silently attribute one tenant's traffic to another.
+    /// Runs regardless of construction path, since `TenantApiKeyEntry` is a
+    /// public deserializable struct. Compares hashes only; errors never
+    /// include a raw key value.
+    fn validate_tenant_api_keys(config: &RouterConfig) -> ConfigResult<()> {
+        fn hash(key: &str) -> [u8; 32] {
+            Sha256::digest(key.as_bytes()).into()
+        }
+
+        let mut seen: std::collections::HashMap<[u8; 32], String> =
+            std::collections::HashMap::new();
+
+        if let Some(api_key) = &config.api_key {
+            seen.insert(hash(api_key), "the shared api_key".to_string());
+        }
+
+        for entry in &config.tenant_api_keys {
+            if entry.tenant_id.trim().is_empty() {
+                return Err(ConfigError::ValidationFailed {
+                    reason: "tenant_api_keys entries must have a non-empty tenant_id".to_string(),
+                });
+            }
+            if entry.key.trim().is_empty() {
+                return Err(ConfigError::ValidationFailed {
+                    reason: format!(
+                        "tenant_api_keys entry for tenant_id '{}' must have a non-empty key",
+                        entry.tenant_id
+                    ),
+                });
+            }
+
+            let label = format!("tenant_id '{}'", entry.tenant_id);
+            if let Some(existing) = seen.insert(hash(&entry.key), label.clone()) {
+                return Err(ConfigError::ValidationFailed {
+                    reason: format!(
+                        "duplicate API key value: {label} uses the same credential as {existing}. Each credential must be unique, or requests authenticate as whichever entry is checked last."
+                    ),
+                });
+            }
+        }
 
         Ok(())
     }
@@ -965,6 +1013,129 @@ mod tests {
         );
 
         assert!(ConfigValidator::validate(&config).is_ok());
+    }
+
+    fn regular_mode_config() -> RouterConfig {
+        RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        )
+    }
+
+    #[test]
+    fn test_validate_distinct_tenant_api_keys_accepted() {
+        let mut config = regular_mode_config();
+        config.tenant_api_keys = vec![
+            TenantApiKeyEntry {
+                tenant_id: "team-a".to_string(),
+                key: "secret-a".to_string(),
+            },
+            TenantApiKeyEntry {
+                tenant_id: "team-b".to_string(),
+                key: "secret-b".to_string(),
+            },
+        ];
+
+        assert!(ConfigValidator::validate(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_duplicate_tenant_api_keys_rejected() {
+        let mut config = regular_mode_config();
+        config.tenant_api_keys = vec![
+            TenantApiKeyEntry {
+                tenant_id: "team-a".to_string(),
+                key: "shared-secret".to_string(),
+            },
+            TenantApiKeyEntry {
+                tenant_id: "team-b".to_string(),
+                key: "shared-secret".to_string(),
+            },
+        ];
+
+        let err = ConfigValidator::validate(&config).unwrap_err();
+        assert!(matches!(err, ConfigError::ValidationFailed { .. }));
+        let message = err.to_string();
+        assert!(message.contains("team-a"));
+        assert!(message.contains("team-b"));
+        assert!(
+            !message.contains("shared-secret"),
+            "error must not leak the credential value: {message}"
+        );
+    }
+
+    #[test]
+    fn test_validate_tenant_api_key_matching_shared_api_key_rejected() {
+        let mut config = regular_mode_config();
+        config.api_key = Some("shared-secret".to_string());
+        config.tenant_api_keys = vec![TenantApiKeyEntry {
+            tenant_id: "team-a".to_string(),
+            key: "shared-secret".to_string(),
+        }];
+
+        let err = ConfigValidator::validate(&config).unwrap_err();
+        assert!(matches!(err, ConfigError::ValidationFailed { .. }));
+        let message = err.to_string();
+        assert!(message.contains("team-a"));
+        assert!(message.contains("shared api_key"));
+        assert!(
+            !message.contains("shared-secret"),
+            "error must not leak the credential value: {message}"
+        );
+    }
+
+    #[test]
+    fn test_validate_empty_tenant_id_rejected() {
+        let mut config = regular_mode_config();
+        config.tenant_api_keys = vec![TenantApiKeyEntry {
+            tenant_id: String::new(),
+            key: "some-secret".to_string(),
+        }];
+
+        let err = ConfigValidator::validate(&config).unwrap_err();
+        assert!(matches!(err, ConfigError::ValidationFailed { .. }));
+        assert!(err.to_string().contains("tenant_id"));
+    }
+
+    #[test]
+    fn test_validate_whitespace_only_tenant_id_rejected() {
+        let mut config = regular_mode_config();
+        config.tenant_api_keys = vec![TenantApiKeyEntry {
+            tenant_id: "   ".to_string(),
+            key: "some-secret".to_string(),
+        }];
+
+        assert!(ConfigValidator::validate(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_empty_key_rejected() {
+        let mut config = regular_mode_config();
+        config.tenant_api_keys = vec![TenantApiKeyEntry {
+            tenant_id: "team-a".to_string(),
+            key: String::new(),
+        }];
+
+        // An empty key would make `Authorization: Bearer ` (empty token) a
+        // valid credential for this tenant.
+        let err = ConfigValidator::validate(&config).unwrap_err();
+        assert!(matches!(err, ConfigError::ValidationFailed { .. }));
+        let message = err.to_string();
+        assert!(message.contains("team-a"));
+        assert!(message.contains("key"));
+    }
+
+    #[test]
+    fn test_validate_whitespace_only_key_rejected() {
+        let mut config = regular_mode_config();
+        config.tenant_api_keys = vec![TenantApiKeyEntry {
+            tenant_id: "team-a".to_string(),
+            key: "   ".to_string(),
+        }];
+
+        assert!(ConfigValidator::validate(&config).is_err());
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -902,7 +902,7 @@ fn parse_tenant_api_key(key_str: &str) -> ConfigResult<TenantApiKeyEntry> {
 
     Ok(TenantApiKeyEntry {
         tenant_id: tenant_id.trim().to_string(),
-        key: key.to_string(),
+        key: key.trim().to_string(),
     })
 }
 

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -8,7 +8,8 @@ use smg::{
         validate_mesh_server_name, CircuitBreakerConfig, ConfigError, ConfigResult,
         DiscoveryConfig, HealthCheckConfig, HistoryBackend, ManualAssignmentMode, MetricsConfig,
         OracleConfig, PolicyConfig, PostgresConfig, RedisConfig, RetryConfig, RouterConfig,
-        RoutingKeyOverrideConfig, RoutingMode, SchemaConfig, TokenizerCacheConfig, TraceConfig,
+        RoutingKeyOverrideConfig, RoutingMode, SchemaConfig, TenantApiKeyEntry,
+        TokenizerCacheConfig, TraceConfig,
     },
     observability::{
         metrics::PrometheusConfig,
@@ -716,6 +717,12 @@ struct CliArgs {
     #[arg(long, help_heading = "Control Plane Authentication")]
     api_key: Option<String>,
 
+    /// Per-tenant API keys for serving-path auth (format: tenant_id:key,
+    /// repeatable). Layers on top of `--api-key`, each resolving to its own
+    /// tenant identity.
+    #[arg(long = "tenant-api-key", action = ArgAction::Append, help_heading = "Data Plane Authentication")]
+    tenant_api_keys: Vec<String>,
+
     /// JWT issuer URL for OIDC authentication
     #[arg(
         long,
@@ -876,6 +883,27 @@ fn parse_control_plane_api_key(key_str: &str) -> Option<ApiKeyEntry> {
     };
 
     Some(ApiKeyEntry::new(id, name, key, role))
+}
+
+/// Parse a tenant-scoped data-plane API key from CLI format "tenant_id:key".
+/// Only checks for the ':' separator; non-empty/duplicate checks live in
+/// `ConfigValidator::validate_tenant_api_keys` so they also cover
+/// `TenantApiKeyEntry` values from a config file or language binding. Fails
+/// hard (an empty `AuthConfig` disables auth entirely, not just narrows it)
+/// and never echoes `key_str`, which may be the plaintext credential.
+fn parse_tenant_api_key(key_str: &str) -> ConfigResult<TenantApiKeyEntry> {
+    let Some((tenant_id, key)) = key_str.split_once(':') else {
+        return Err(ConfigError::InvalidValue {
+            field: "tenant-api-key".to_string(),
+            value: "<redacted>".to_string(),
+            reason: "expected 'tenant_id:key' (missing ':' separator)".to_string(),
+        });
+    };
+
+    Ok(TenantApiKeyEntry {
+        tenant_id: tenant_id.trim().to_string(),
+        key: key.to_string(),
+    })
 }
 
 impl CliArgs {
@@ -1335,6 +1363,12 @@ impl CliArgs {
 
         let schema = self.load_schema_config()?;
 
+        let tenant_api_keys = self
+            .tenant_api_keys
+            .iter()
+            .map(|k| parse_tenant_api_key(k))
+            .collect::<ConfigResult<Vec<_>>>()?;
+
         let (oracle, postgres, redis) = match history_backend {
             HistoryBackend::Oracle => (Some(self.build_oracle_config(schema)?), None, None),
             HistoryBackend::Postgres => (None, Some(self.build_postgres_config(schema)?), None),
@@ -1399,6 +1433,7 @@ impl CliArgs {
             .history_backend(history_backend)
             .log_level(&self.log_level)
             .maybe_api_key(self.api_key.as_ref())
+            .tenant_api_keys(tenant_api_keys)
             .maybe_discovery(discovery)
             .maybe_metrics(metrics)
             .maybe_trace(trace_config)

--- a/model_gateway/src/middleware/auth.rs
+++ b/model_gateway/src/middleware/auth.rs
@@ -1,7 +1,6 @@
-//! Bearer-token auth middleware backed by a precomputed SHA-256 hash.
-//!
-//! The hash is compared in constant time so the comparison cost does not
-//! leak the configured key length.
+//! Bearer-token auth. Every configured key's hash is checked in constant
+//! time with no early return, so timing can't reveal which key, if any, a
+//! token is closest to.
 
 use axum::{
     body::Body,
@@ -13,54 +12,273 @@ use axum::{
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
-use crate::tenant::DataPlaneCaller;
+use crate::{
+    config::TenantApiKeyEntry,
+    tenant::{authenticated_tenant_key_from_sha256, DataPlaneCaller, TenantIdentity, TenantKey},
+};
+
+#[derive(Clone)]
+struct GatewayApiKey {
+    tenant_key: TenantKey,
+    key_hash: [u8; 32],
+}
 
 #[derive(Clone)]
 pub struct AuthConfig {
-    /// Precomputed SHA-256 hash of the API key, used for constant-time comparison
-    /// that doesn't leak key length via timing.
-    api_key_hash: Option<[u8; 32]>,
+    keys: Vec<GatewayApiKey>,
 }
 
 impl AuthConfig {
+    /// Single shared key; every caller resolves to the same hash-derived
+    /// identity. Use [`Self::with_tenant_keys`] for per-tenant separation.
     pub fn new(api_key: Option<String>) -> Self {
-        Self {
-            api_key_hash: api_key.map(|k| Sha256::digest(k.as_bytes()).into()),
+        Self::with_tenant_keys(api_key, &[])
+    }
+
+    /// `tenant_api_keys` adds per-tenant keys on top of `api_key`, each
+    /// resolving to its own `auth:<tenant_id>` identity.
+    pub fn with_tenant_keys(
+        api_key: Option<String>,
+        tenant_api_keys: &[TenantApiKeyEntry],
+    ) -> Self {
+        let mut keys = Vec::with_capacity(tenant_api_keys.len() + 1);
+
+        if let Some(key) = api_key {
+            let key_hash = hash_key(&key);
+            keys.push(GatewayApiKey {
+                tenant_key: authenticated_tenant_key_from_sha256(key_hash),
+                key_hash,
+            });
         }
+
+        for entry in tenant_api_keys {
+            keys.push(GatewayApiKey {
+                tenant_key: TenantIdentity::Authenticated(entry.tenant_id.as_str().into())
+                    .into_key(),
+                key_hash: hash_key(&entry.key),
+            });
+        }
+
+        Self { keys }
+    }
+
+    /// Scans every configured key without early return; see module docs.
+    fn find_tenant_key(&self, token_hash: &[u8; 32]) -> Option<&TenantKey> {
+        let mut found = None;
+        for candidate in &self.keys {
+            if candidate.key_hash.ct_eq(token_hash).unwrap_u8() == 1 {
+                found = Some(&candidate.tenant_key);
+            }
+        }
+        found
+    }
+
+    /// Whether any key is configured. Empty means [`auth_middleware`]
+    /// passes every request through.
+    pub fn is_enabled(&self) -> bool {
+        !self.keys.is_empty()
     }
 }
 
-/// Middleware to validate Bearer token against configured API key.
-/// Only active when router has an API key configured.
+fn hash_key(key: &str) -> [u8; 32] {
+    Sha256::digest(key.as_bytes()).into()
+}
+
+/// Middleware to validate Bearer token against configured API key(s).
+/// Only active when the router has at least one key configured.
 pub async fn auth_middleware(
     State(auth_config): State<AuthConfig>,
     mut request: Request<Body>,
     next: Next,
 ) -> Response {
-    if let Some(expected_hash) = &auth_config.api_key_hash {
+    if !auth_config.keys.is_empty() {
         let token_hash = request
             .headers()
             .get(header::AUTHORIZATION)
             .and_then(|h| h.to_str().ok())
             .and_then(|h| h.strip_prefix("Bearer "))
-            .map(|token| {
-                let digest: [u8; 32] = Sha256::digest(token.as_bytes()).into();
-                digest
-            });
+            .map(hash_key);
 
-        let authorized = token_hash
+        let tenant_key = token_hash
             .as_ref()
-            .is_some_and(|digest| digest.ct_eq(expected_hash).unwrap_u8() == 1);
-        if !authorized {
-            return StatusCode::UNAUTHORIZED.into_response();
-        }
+            .and_then(|hash| auth_config.find_tenant_key(hash));
 
-        if let Some(token_hash) = token_hash {
-            request
-                .extensions_mut()
-                .insert(DataPlaneCaller::authenticated_from_sha256(token_hash));
-        }
+        let Some(tenant_key) = tenant_key else {
+            return StatusCode::UNAUTHORIZED.into_response();
+        };
+
+        request
+            .extensions_mut()
+            .insert(DataPlaneCaller::new(tenant_key.clone()));
     }
 
     next.run(request).await
+}
+
+/// Unconditionally rejects with 401 — for route groups that must never fall
+/// back to open just because their auth config happens to be empty.
+pub async fn deny_all_middleware(_request: Request<Body>, _next: Next) -> Response {
+    StatusCode::UNAUTHORIZED.into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        middleware::from_fn_with_state,
+        response::IntoResponse,
+        routing::get,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    use super::*;
+
+    async fn handler(request: Request<Body>) -> impl IntoResponse {
+        request
+            .extensions()
+            .get::<DataPlaneCaller>()
+            .map(|caller| caller.tenant_key().to_string())
+            .unwrap_or_else(|| "missing".to_string())
+    }
+
+    fn app(auth_config: AuthConfig) -> Router {
+        Router::new()
+            .route("/", get(handler))
+            .route_layer(from_fn_with_state(auth_config, auth_middleware))
+    }
+
+    async fn body_text(response: Response) -> String {
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        std::str::from_utf8(&body).unwrap().to_string()
+    }
+
+    #[tokio::test]
+    async fn no_key_configured_allows_any_request() {
+        let response = app(AuthConfig::new(None))
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn shared_key_resolves_to_hash_derived_tenant() {
+        let auth_config = AuthConfig::new(Some("shared-secret".to_string()));
+        let expected = authenticated_tenant_key_from_sha256(hash_key("shared-secret"));
+
+        let response = app(auth_config)
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header(header::AUTHORIZATION, "Bearer shared-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_text(response).await, expected.to_string());
+    }
+
+    #[tokio::test]
+    async fn tenant_key_resolves_to_explicit_tenant_id() {
+        let auth_config = AuthConfig::with_tenant_keys(
+            None,
+            &[TenantApiKeyEntry {
+                tenant_id: "team-red".to_string(),
+                key: "team-red-secret".to_string(),
+            }],
+        );
+
+        let response = app(auth_config)
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header(header::AUTHORIZATION, "Bearer team-red-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_text(response).await, "auth:team-red");
+    }
+
+    #[tokio::test]
+    async fn distinct_tenant_keys_resolve_to_distinct_tenants() {
+        let auth_config = AuthConfig::with_tenant_keys(
+            None,
+            &[
+                TenantApiKeyEntry {
+                    tenant_id: "team-red".to_string(),
+                    key: "red-secret".to_string(),
+                },
+                TenantApiKeyEntry {
+                    tenant_id: "team-blue".to_string(),
+                    key: "blue-secret".to_string(),
+                },
+            ],
+        );
+
+        for (key, expected_tenant) in [
+            ("red-secret", "auth:team-red"),
+            ("blue-secret", "auth:team-blue"),
+        ] {
+            let response = app(auth_config.clone())
+                .oneshot(
+                    Request::builder()
+                        .uri("/")
+                        .header(header::AUTHORIZATION, format!("Bearer {key}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(body_text(response).await, expected_tenant);
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_token_is_rejected() {
+        let auth_config = AuthConfig::with_tenant_keys(
+            None,
+            &[TenantApiKeyEntry {
+                tenant_id: "team-red".to_string(),
+                key: "team-red-secret".to_string(),
+            }],
+        );
+
+        let response = app(auth_config)
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header(header::AUTHORIZATION, "Bearer not-a-configured-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn missing_header_is_rejected_when_keys_configured() {
+        let auth_config = AuthConfig::new(Some("shared-secret".to_string()));
+
+        let response = app(auth_config)
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
 }

--- a/model_gateway/src/middleware/auth.rs
+++ b/model_gateway/src/middleware/auth.rs
@@ -1,6 +1,11 @@
-//! Bearer-token auth. Every configured key's hash is checked in constant
-//! time with no early return, so timing can't reveal which key, if any, a
-//! token is closest to.
+//! Bearer-token auth, keyed by SHA-256 hash of the presented token rather
+//! than the raw value. Hashing first — not a constant-time comparison — is
+//! what makes lookup safe: SHA-256's avalanche property means a guess that's
+//! "close" to a valid token produces an unrelated hash, so there's no
+//! byte-at-a-time timing signal to recover from a plain hash-keyed lookup,
+//! unlike comparing raw secrets.
+
+use std::collections::HashMap;
 
 use axum::{
     body::Body,
@@ -10,7 +15,6 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use sha2::{Digest, Sha256};
-use subtle::ConstantTimeEq;
 
 use crate::{
     config::TenantApiKeyEntry,
@@ -18,14 +22,8 @@ use crate::{
 };
 
 #[derive(Clone)]
-struct GatewayApiKey {
-    tenant_key: TenantKey,
-    key_hash: [u8; 32],
-}
-
-#[derive(Clone)]
 pub struct AuthConfig {
-    keys: Vec<GatewayApiKey>,
+    keys: HashMap<[u8; 32], TenantKey>,
 }
 
 impl AuthConfig {
@@ -41,36 +39,21 @@ impl AuthConfig {
         api_key: Option<String>,
         tenant_api_keys: &[TenantApiKeyEntry],
     ) -> Self {
-        let mut keys = Vec::with_capacity(tenant_api_keys.len() + 1);
+        let mut keys = HashMap::with_capacity(tenant_api_keys.len() + 1);
 
         if let Some(key) = api_key {
             let key_hash = hash_key(&key);
-            keys.push(GatewayApiKey {
-                tenant_key: authenticated_tenant_key_from_sha256(key_hash),
-                key_hash,
-            });
+            keys.insert(key_hash, authenticated_tenant_key_from_sha256(key_hash));
         }
 
         for entry in tenant_api_keys {
-            keys.push(GatewayApiKey {
-                tenant_key: TenantIdentity::Authenticated(entry.tenant_id.as_str().into())
-                    .into_key(),
-                key_hash: hash_key(&entry.key),
-            });
+            keys.insert(
+                hash_key(&entry.key),
+                TenantIdentity::Authenticated(entry.tenant_id.as_str().into()).into_key(),
+            );
         }
 
         Self { keys }
-    }
-
-    /// Scans every configured key without early return; see module docs.
-    fn find_tenant_key(&self, token_hash: &[u8; 32]) -> Option<&TenantKey> {
-        let mut found = None;
-        for candidate in &self.keys {
-            if candidate.key_hash.ct_eq(token_hash).unwrap_u8() == 1 {
-                found = Some(&candidate.tenant_key);
-            }
-        }
-        found
     }
 
     /// Whether any key is configured. Empty means [`auth_middleware`]
@@ -101,7 +84,7 @@ pub async fn auth_middleware(
 
         let tenant_key = token_hash
             .as_ref()
-            .and_then(|hash| auth_config.find_tenant_key(hash));
+            .and_then(|hash| auth_config.keys.get(hash));
 
         let Some(tenant_key) = tenant_key else {
             return StatusCode::UNAUTHORIZED.into_response();

--- a/model_gateway/src/middleware/auth.rs
+++ b/model_gateway/src/middleware/auth.rs
@@ -61,6 +61,16 @@ impl AuthConfig {
     pub fn is_enabled(&self) -> bool {
         !self.keys.is_empty()
     }
+
+    /// Whether `token` matches any configured key (shared or per-tenant).
+    /// For callers outside `auth_middleware` that need to distinguish "this
+    /// is one of our own gateway credentials" from "unrecognized token" —
+    /// e.g. `/v1/models`' BYOK short-circuit, which must not treat a
+    /// tenant-scoped key as a foreign upstream-provider credential and
+    /// forward it externally.
+    pub fn contains_token(&self, token: &str) -> bool {
+        self.keys.contains_key(&hash_key(token))
+    }
 }
 
 fn hash_key(key: &str) -> [u8; 32] {
@@ -263,5 +273,20 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn contains_token_recognizes_shared_and_tenant_keys() {
+        let auth_config = AuthConfig::with_tenant_keys(
+            Some("shared-secret".to_string()),
+            &[TenantApiKeyEntry {
+                tenant_id: "team-red".to_string(),
+                key: "team-red-secret".to_string(),
+            }],
+        );
+
+        assert!(auth_config.contains_token("shared-secret"));
+        assert!(auth_config.contains_token("team-red-secret"));
+        assert!(!auth_config.contains_token("not-a-configured-key"));
     }
 }

--- a/model_gateway/src/middleware/mod.rs
+++ b/model_gateway/src/middleware/mod.rs
@@ -15,7 +15,7 @@ pub mod tenant_resolution;
 pub mod token_bucket;
 pub mod wasm;
 
-pub use auth::{auth_middleware, AuthConfig};
+pub use auth::{auth_middleware, deny_all_middleware, AuthConfig};
 pub use concurrency::{
     concurrency_limit_middleware, ConcurrencyLimiter, QueueProcessor, QueuedRequest, TokenGuardBody,
 };

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -41,7 +41,7 @@ use tracing::{debug, info, warn};
 use crate::{
     app_context::AppContext,
     config::RoutingMode,
-    middleware::TenantRequestMeta,
+    middleware::{AuthConfig, TenantRequestMeta},
     routers::{
         common::header_utils::apply_provider_headers,
         error as route_error,
@@ -55,7 +55,12 @@ use crate::{
 pub struct RouterManager {
     worker_registry: Arc<WorkerRegistry>,
     client: reqwest::Client,
-    gateway_api_key: Option<String>,
+    /// Every credential that authenticates as *this gateway* (shared
+    /// `api_key` plus any per-tenant keys) — not just the shared key. Used
+    /// to keep `/v1/models`' BYOK short-circuit from mistaking a valid
+    /// tenant-scoped key for a foreign upstream-provider credential and
+    /// forwarding it externally.
+    gateway_auth: AuthConfig,
     routers: Arc<DashMap<RouterId, Arc<dyn RouterTrait>>>,
     default_router: Arc<std::sync::RwLock<Option<RouterId>>>,
     enable_igw: bool,
@@ -66,7 +71,7 @@ impl RouterManager {
         Self {
             worker_registry,
             client,
-            gateway_api_key: None,
+            gateway_auth: AuthConfig::new(None),
             routers: Arc::new(DashMap::new()),
             default_router: Arc::new(std::sync::RwLock::new(None)),
             enable_igw: false,
@@ -100,9 +105,10 @@ impl RouterManager {
             app_context.client.clone(),
         );
         manager.enable_igw = config.router_config.enable_igw;
-        manager
-            .gateway_api_key
-            .clone_from(&config.router_config.api_key);
+        manager.gateway_auth = AuthConfig::with_tenant_keys(
+            config.router_config.api_key.clone(),
+            &config.router_config.tenant_api_keys,
+        );
         let manager = Arc::new(manager);
 
         if config.router_config.enable_igw {
@@ -491,11 +497,12 @@ impl RouterTrait for RouterManager {
                     .map(String::from)
             });
 
-        // Short-circuit: if the token matches the gateway's own API key, skip
-        // upstream fan-out and return registry models directly.
+        // Short-circuit: if the token matches any of the gateway's own
+        // credentials (shared or per-tenant), skip upstream fan-out and
+        // return registry models directly. A tenant-scoped key must never
+        // reach the BYOK fan-out below — that would forward it externally.
         if let Some(ref token) = bearer_token {
-            let is_gateway_key = self.gateway_api_key.as_ref().is_some_and(|gw| gw == token);
-            if is_gateway_key {
+            if self.gateway_auth.contains_token(token) {
                 return self.registry_models_response();
             }
         }
@@ -887,6 +894,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        config::TenantApiKeyEntry,
         middleware::{RouteRequestMeta, TenantKey},
         routers::factory::router_ids,
         worker::{BasicWorkerBuilder, CircuitBreakerConfig, WorkerRegistry},
@@ -975,6 +983,101 @@ mod tests {
 
     fn test_tenant_meta() -> TenantRequestMeta {
         RouteRequestMeta::new(TenantKey::from("test-tenant"))
+    }
+
+    /// A tenant-scoped credential must never reach `fetch_upstream_models`:
+    /// that would forward the gateway's own secret to an external provider
+    /// as if it were the caller's BYOK token. Verified against a real mock
+    /// upstream that counts hits, since a stubbed HTTP client can't
+    /// distinguish "short-circuited" from "fell through and failed" by
+    /// response alone — both end up returning registry models on failure.
+    #[tokio::test]
+    #[expect(clippy::disallowed_methods, reason = "test infrastructure")]
+    async fn get_models_short_circuits_for_tenant_key_without_forwarding_upstream() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let hit_count = Arc::new(AtomicUsize::new(0));
+        let hit_count_clone = hit_count.clone();
+        let mock_app = axum::Router::new().route(
+            "/v1/models",
+            axum::routing::get(move || {
+                let hit_count = hit_count_clone.clone();
+                async move {
+                    hit_count.fetch_add(1, Ordering::SeqCst);
+                    Json(serde_json::json!({"object": "list", "data": []}))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, mock_app).await;
+        });
+
+        let registry = Arc::new(WorkerRegistry::new());
+        let external_worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new(format!("http://{addr}"))
+                .worker_type(WorkerType::Regular)
+                .runtime_type(RuntimeType::External)
+                .health_config(openai_protocol::worker::HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        );
+        registry.register(external_worker);
+        // A non-External worker so registry_models_response() (the
+        // short-circuit path) has something to return besides 503.
+        let internal_worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://internal.invalid:8000")
+                .worker_type(WorkerType::Regular)
+                .models(vec![ModelCard::new("internal-model")])
+                .health_config(openai_protocol::worker::HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        );
+        registry.register(internal_worker);
+
+        let mut manager = RouterManager::new(registry, reqwest::Client::new());
+        manager.gateway_auth = AuthConfig::with_tenant_keys(
+            Some("shared-secret".to_string()),
+            &[TenantApiKeyEntry {
+                tenant_id: "team-red".to_string(),
+                key: "team-red-secret".to_string(),
+            }],
+        );
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/v1/models")
+            .header(header::AUTHORIZATION, "Bearer team-red-secret")
+            .body(Body::empty())
+            .unwrap();
+        let response = manager.get_models(req).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            hit_count.load(Ordering::SeqCst),
+            0,
+            "a tenant-scoped key must never trigger upstream BYOK fan-out"
+        );
+
+        // Control: a genuinely unrecognized token should still trigger BYOK
+        // fan-out — confirms the short-circuit is keyed on the gateway's own
+        // credentials, not disabled entirely.
+        let req = Request::builder()
+            .method("GET")
+            .uri("/v1/models")
+            .header(header::AUTHORIZATION, "Bearer not-a-gateway-key")
+            .body(Body::empty())
+            .unwrap();
+        let _ = manager.get_models(req).await;
+        assert_eq!(
+            hit_count.load(Ordering::SeqCst),
+            1,
+            "an unrecognized token should still fan out to upstream providers"
+        );
     }
 
     fn generate_request_without_model() -> GenerateRequest {

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -979,6 +979,16 @@ pub fn build_app(
 }
 
 pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Error>> {
+    // Defense in depth: the CLI and Python bindings both validate via
+    // `RouterConfigBuilder::build()` before reaching here, but `RouterConfig`
+    // is public and `Deserialize`, so a Rust library caller can construct
+    // `ServerConfig` directly (or deserialize it) and call `startup` without
+    // ever going through the builder. Validate here too so `tenant_api_keys`
+    // (and everything else `ConfigValidator` checks) is enforced regardless
+    // of construction path — a bypassed empty/duplicate tenant key would
+    // otherwise silently reach `AuthConfig`.
+    config.router_config.validate()?;
+
     static LOGGING_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
     if let Some(trace_config) = &config.router_config.trace_config {
@@ -1552,4 +1562,57 @@ fn create_cors_layer(allowed_origins: Vec<String>) -> tower_http::cors::CorsLaye
     };
 
     cors.max_age(Duration::from_secs(3600))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TenantApiKeyEntry;
+
+    fn minimal_server_config(router_config: RouterConfig) -> ServerConfig {
+        ServerConfig {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            health_check_port: None,
+            runtime_worker_threads: None,
+            router_config,
+            max_payload_size: 1024,
+            log_dir: None,
+            log_level: None,
+            log_json: false,
+            service_discovery_config: None,
+            prometheus_config: None,
+            request_timeout_secs: 60,
+            request_id_headers: None,
+            shutdown_grace_period_secs: 5,
+            control_plane_auth: None,
+            mesh_server_config: None,
+            webrtc_bind_addr: None,
+            webrtc_stun_server: None,
+        }
+    }
+
+    /// `startup` must reject an invalid config even when `RouterConfig` was
+    /// built directly (struct literal or `Deserialize`), not via
+    /// `RouterConfigBuilder::build()` — a Rust library caller can construct
+    /// `ServerConfig` this way and bypass the builder's validation entirely.
+    /// Regression test for a reviewer-flagged gap: an empty tenant_api_keys
+    /// entry reaching `AuthConfig` unvalidated would make `Authorization:
+    /// Bearer ` (empty token) a valid serving credential.
+    #[tokio::test]
+    async fn startup_validates_directly_constructed_router_config() {
+        let router_config = RouterConfig {
+            tenant_api_keys: vec![TenantApiKeyEntry {
+                tenant_id: "team-a".to_string(),
+                key: String::new(),
+            }],
+            ..Default::default()
+        };
+
+        let result = startup(minimal_server_config(router_config)).await;
+        assert!(
+            result.is_err(),
+            "startup must validate router_config even when constructed directly"
+        );
+    }
 }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -741,9 +741,14 @@ fn with_admission_layer(
     }
 }
 
+/// `serving_auth_config` covers inference-serving routes and may include
+/// per-tenant keys. `admin_auth_config` is the admin/worker-management
+/// fallback (used when `control_plane_auth_state` is `None`) and must
+/// contain only the shared gateway-wide key, never per-tenant keys.
 pub fn build_app(
     app_state: Arc<AppState>,
-    auth_config: AuthConfig,
+    serving_auth_config: AuthConfig,
+    admin_auth_config: AuthConfig,
     control_plane_auth_state: Option<smg_auth::ControlPlaneAuthState>,
     max_payload_size: usize,
     request_id_headers: Vec<String>,
@@ -830,7 +835,7 @@ pub fn build_app(
         middleware::route_request_meta_middleware,
     ))
     .route_layer(axum::middleware::from_fn_with_state(
-        auth_config.clone(),
+        serving_auth_config.clone(),
         middleware::auth_middleware,
     ))
     .route_layer(axum::middleware::from_fn_with_state(
@@ -853,7 +858,7 @@ pub fn build_app(
         middleware::route_request_meta_middleware,
     ))
     .route_layer(axum::middleware::from_fn_with_state(
-        auth_config.clone(),
+        serving_auth_config.clone(),
         middleware::auth_middleware,
     ));
 
@@ -872,7 +877,7 @@ pub fn build_app(
         middleware::route_request_meta_middleware,
     ))
     .route_layer(axum::middleware::from_fn_with_state(
-        auth_config.clone(),
+        serving_auth_config.clone(),
         middleware::auth_middleware,
     ));
 
@@ -922,16 +927,23 @@ pub fn build_app(
                 .delete(delete_worker),
         );
 
-    // Apply authentication middleware to control plane routes
+    // Fallback (no control-plane auth) normally uses `admin_auth_config`.
+    // If only tenant keys are configured (no shared `--api-key`), there's no
+    // credential that should reach these routes — deny outright instead of
+    // falling back to `auth_middleware`, which would treat the empty config
+    // as "open". Neither config having any key at all is a fully open
+    // dev/test deployment, which keeps its legacy pass-through behavior.
     let apply_control_plane_auth = |routes: Router<Arc<AppState>>| {
         if let Some(ref cp_state) = control_plane_auth_state {
             routes.route_layer(axum::middleware::from_fn_with_state(
                 cp_state.clone(),
                 smg_auth::control_plane_auth_middleware,
             ))
+        } else if !admin_auth_config.is_enabled() && serving_auth_config.is_enabled() {
+            routes.route_layer(axum::middleware::from_fn(middleware::deny_all_middleware))
         } else {
             routes.route_layer(axum::middleware::from_fn_with_state(
-                auth_config.clone(),
+                admin_auth_config.clone(),
                 middleware::auth_middleware,
             ))
         }
@@ -1350,7 +1362,17 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         ]
     });
 
-    let auth_config = AuthConfig::new(config.router_config.api_key.clone());
+    // Serving routes accept both the shared key and per-tenant keys, so the
+    // rate limiter (and anything else keyed on tenant identity) can tell
+    // tenants apart. Admin/worker-management routes must NOT accept tenant
+    // keys when falling back to simple API-key auth (no control-plane auth
+    // configured) — a tenant credential must not be able to reach
+    // `/workers`, `/flush_cache`, etc. Only the shared gateway-wide key does.
+    let serving_auth_config = AuthConfig::with_tenant_keys(
+        config.router_config.api_key.clone(),
+        &config.router_config.tenant_api_keys,
+    );
+    let admin_auth_config = AuthConfig::new(config.router_config.api_key.clone());
 
     // Initialize control plane authentication if configured
     let control_plane_auth_state =
@@ -1358,7 +1380,8 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
 
     let app = build_app(
         app_state,
-        auth_config,
+        serving_auth_config,
+        admin_auth_config,
         control_plane_auth_state,
         config.max_payload_size,
         request_id_headers,

--- a/model_gateway/tests/common/test_app.rs
+++ b/model_gateway/tests/common/test_app.rs
@@ -119,7 +119,11 @@ pub fn create_test_app(
         ]
     });
 
-    let auth_config = AuthConfig::new(router_config.api_key.clone());
+    let serving_auth_config = AuthConfig::with_tenant_keys(
+        router_config.api_key.clone(),
+        &router_config.tenant_api_keys,
+    );
+    let admin_auth_config = AuthConfig::new(router_config.api_key.clone());
 
     // Use the actual server's build_app function
     #[expect(
@@ -128,7 +132,8 @@ pub fn create_test_app(
     )]
     build_app(
         app_state,
-        auth_config,
+        serving_auth_config,
+        admin_auth_config,
         None, // No control plane auth for tests
         router_config.max_payload_size,
         request_id_headers,
@@ -182,7 +187,11 @@ pub fn create_test_app_with_context(
         ]
     });
 
-    let auth_config = AuthConfig::new(router_config.api_key.clone());
+    let serving_auth_config = AuthConfig::with_tenant_keys(
+        router_config.api_key.clone(),
+        &router_config.tenant_api_keys,
+    );
+    let admin_auth_config = AuthConfig::new(router_config.api_key.clone());
 
     // Use the actual server's build_app function
     #[expect(
@@ -191,7 +200,8 @@ pub fn create_test_app_with_context(
     )]
     build_app(
         app_state,
-        auth_config,
+        serving_auth_config,
+        admin_auth_config,
         None, // No control plane auth for tests
         router_config.max_payload_size,
         request_id_headers,

--- a/model_gateway/tests/security/auth_test.rs
+++ b/model_gateway/tests/security/auth_test.rs
@@ -8,6 +8,7 @@ use axum::{
     http::{header::CONTENT_TYPE, StatusCode},
 };
 use serde_json::json;
+use smg::config::TenantApiKeyEntry;
 use tower::ServiceExt;
 
 use crate::common::{AppTestContext, TestRouterConfig, TestWorkerConfig};
@@ -200,6 +201,144 @@ mod auth_tests {
             success_count.load(Ordering::SeqCst),
             20,
             "All concurrent authenticated requests should succeed"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// A tenant key must authenticate `/generate` but not admin routes.
+    /// Configures a shared key too, so there's a real admin credential to
+    /// test against (with no shared key at all, admin routes are open
+    /// regardless — see `test_tenant_only_deployment_denies_admin_routes`).
+    #[tokio::test]
+    async fn test_tenant_key_cannot_access_admin_routes() {
+        let mut config = TestRouterConfig::round_robin(4306);
+        config.api_key = Some("shared-secret".to_string());
+        config.tenant_api_keys = vec![TenantApiKeyEntry {
+            tenant_id: "team-red".to_string(),
+            key: "team-red-secret".to_string(),
+        }];
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![TestWorkerConfig::healthy(20306)]).await;
+
+        let app = ctx.create_app();
+
+        let generate_req = |bearer: &str| {
+            let payload = json!({"text": "hi", "stream": false});
+            Request::builder()
+                .method("POST")
+                .uri("/generate")
+                .header(CONTENT_TYPE, "application/json")
+                .header(AUTH_HEADER, format!("Bearer {bearer}"))
+                .body(Body::from(serde_json::to_string(&payload).unwrap()))
+                .unwrap()
+        };
+        let workers_req = |bearer: &str| {
+            Request::builder()
+                .method("GET")
+                .uri("/workers")
+                .header(AUTH_HEADER, format!("Bearer {bearer}"))
+                .body(Body::empty())
+                .unwrap()
+        };
+
+        // Tenant key: serving route ok, admin route rejected.
+        assert_eq!(
+            app.clone()
+                .oneshot(generate_req("team-red-secret"))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::OK,
+            "Tenant key should authenticate serving-path requests"
+        );
+        assert_eq!(
+            app.clone()
+                .oneshot(workers_req("team-red-secret"))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::UNAUTHORIZED,
+            "Tenant key must not authenticate admin/worker-management routes"
+        );
+
+        // Shared key: both serving and admin routes still accept it.
+        assert_eq!(
+            app.clone()
+                .oneshot(generate_req("shared-secret"))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::OK,
+            "Shared key should still authenticate serving-path requests"
+        );
+        assert_eq!(
+            app.oneshot(workers_req("shared-secret"))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::OK,
+            "Shared key should still authenticate admin/worker-management routes"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Tenant-only deployment (no shared `--api-key`, no control-plane auth):
+    /// admin routes must be denied outright, not fall back to open.
+    #[tokio::test]
+    async fn test_tenant_only_deployment_denies_admin_routes() {
+        let mut config = TestRouterConfig::round_robin(4307);
+        config.tenant_api_keys = vec![TenantApiKeyEntry {
+            tenant_id: "team-red".to_string(),
+            key: "team-red-secret".to_string(),
+        }];
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![TestWorkerConfig::healthy(20307)]).await;
+
+        let app = ctx.create_app();
+
+        let payload = json!({"text": "hi", "stream": false});
+        let generate_req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTH_HEADER, "Bearer team-red-secret")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+        assert_eq!(
+            app.clone().oneshot(generate_req).await.unwrap().status(),
+            StatusCode::OK,
+            "Tenant key should still authenticate serving-path requests"
+        );
+
+        let workers_with_tenant_key = Request::builder()
+            .method("GET")
+            .uri("/workers")
+            .header(AUTH_HEADER, "Bearer team-red-secret")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(
+            app.clone()
+                .oneshot(workers_with_tenant_key)
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::UNAUTHORIZED,
+            "Tenant-only deployment must deny admin routes even with a valid tenant key"
+        );
+
+        let workers_no_auth = Request::builder()
+            .method("GET")
+            .uri("/workers")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(
+            app.oneshot(workers_no_auth).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED,
+            "Tenant-only deployment must deny admin routes with no credential"
         );
 
         ctx.shutdown().await;

--- a/model_gateway/tests/security/auth_test.rs
+++ b/model_gateway/tests/security/auth_test.rs
@@ -208,8 +208,8 @@ mod auth_tests {
 
     /// A tenant key must authenticate `/generate` but not admin routes.
     /// Configures a shared key too, so there's a real admin credential to
-    /// test against (with no shared key at all, admin routes are open
-    /// regardless — see `test_tenant_only_deployment_denies_admin_routes`).
+    /// test against. Tenant-only deployments deny admin routes outright;
+    /// see `test_tenant_only_deployment_denies_admin_routes`.
     #[tokio::test]
     async fn test_tenant_key_cannot_access_admin_routes() {
         let mut config = TestRouterConfig::round_robin(4306);

--- a/model_gateway/tests/wasm_test.rs
+++ b/model_gateway/tests/wasm_test.rs
@@ -208,6 +208,7 @@ async fn create_test_app_with_wasm() -> (axum::Router, Arc<AppContext>, TempDir)
     let app = build_app(
         app_state,
         smg::middleware::AuthConfig::new(None),
+        smg::middleware::AuthConfig::new(None),
         None, // No control plane auth for tests
         256 * 1024 * 1024,
         request_id_headers,


### PR DESCRIPTION
## Description

### Problem

SMG's data-plane `AuthConfig` accepts exactly one shared API key. Every
caller who presents it resolves to the same `auth:<sha256(token)>`
identity, so there is no way to distinguish tenants on the serving path.
This blocks tenant-aware rate limiting (and anything else that needs a
real per-caller identity) from having anything meaningful to key off of.

### Solution

Add a repeatable `--tenant-api-key tenant_id:key` CLI flag / config field
(`RouterConfig.tenant_api_keys: Vec<TenantApiKeyEntry>`) that layers
per-tenant credentials on top of the existing `--api-key`, without
changing its behavior for callers that don't need per-tenant separation.
Each tenant key resolves to its own `auth:<tenant_id>` identity via
`AuthConfig::with_tenant_keys`.

## Changes

- `middleware/auth.rs`: `AuthConfig` now holds a list of keys instead of
  one hash; `find_tenant_key` scans every configured key without early
  return (mirrors `crates/auth`'s existing `find_api_key` pattern) so
  comparison timing can't reveal which key a token is closest to. Added
  `AuthConfig::is_enabled()` and `deny_all_middleware`.
- `config/types.rs` / `config/builder.rs`: new `TenantApiKeyEntry`,
  `RouterConfig.tenant_api_keys`, builder method.
- `config/validation.rs`: central `ConfigValidator::validate_tenant_api_keys`
  — this is the real enforcement point, not the CLI parser, since
  `TenantApiKeyEntry` is a public deserializable struct reachable from
  config files and language bindings:
  - rejects empty `tenant_id`/`key` (an empty key would make
    `Authorization: Bearer ` a valid credential)
  - rejects two credentials sharing the same secret value (would
    otherwise silently attribute one tenant's traffic to another,
    since duplicate-value keys resolve to whichever entry is checked
    last)
  - never includes a raw key value in error output
- `main.rs`: `--tenant-api-key` CLI flag; malformed values fail startup
  instead of being warn-and-dropped (a silently dropped entry could leave
  `AuthConfig` with no keys at all, disabling auth entirely instead of
  narrowing it).
- `server.rs`: `build_app` now takes separate `serving_auth_config`
  (may include tenant keys) and `admin_auth_config` (shared key only).
  When only tenant keys are configured and no shared admin key or
  control-plane auth exists, admin/worker-management/WASM/tokenizer
  routes deny outright via `deny_all_middleware` instead of falling back
  to `auth_middleware`, which would treat the empty admin config as "no
  auth configured" and expose them. A fully open dev/test deployment
  (no keys anywhere) keeps its existing pass-through behavior.
- `docs/reference/api/openai.md`: documents the new flag.
- Tests updated/added in `tests/common/test_app.rs`,
  `tests/security/auth_test.rs`, `tests/wasm_test.rs`.

## Test Plan

New unit/integration tests, plus manual verification against the built
binary:

- `middleware::auth::tests` (6 tests): no-key passthrough, legacy
  shared-key identity unchanged, explicit tenant resolution, distinct
  tenants stay distinct, unknown token rejected, missing header rejected.
- `config::validation::tests` (7 new tests): distinct tenant keys
  accepted; duplicate tenant keys rejected; tenant key colliding with
  shared key rejected; empty/whitespace-only `tenant_id` rejected;
  empty/whitespace-only `key` rejected — each duplicate/empty-key test
  asserts the credential value never appears in the error string.
- `security/auth_test.rs` (2 new tests):
  `test_tenant_key_cannot_access_admin_routes` (tenant key: 200 on
  `/generate`, 401 on `/workers`; shared key: 200 on both) and
  `test_tenant_only_deployment_denies_admin_routes` (tenant-only config:
  `/workers` denied both with the tenant key and with no credential at
  all).
- Manual CLI verification against the built binary:
  - `--tenant-api-key not-valid-no-colon` → exit 1, no server start
  - `--tenant-api-key ":secret"` / `"team-a:"` → exit 1 via
    `ConfigValidator`, not the CLI parser (proves the check fires
    downstream of parsing, i.e. also catches directly-constructed
    entries)
  - `--tenant-api-key "team-a:shared-secret" --tenant-api-key "team-b:shared-secret"`
    → exit 1, duplicate rejected
  - `--api-key shared-secret --tenant-api-key "team-a:shared-secret"` →
    exit 1, duplicate rejected
  - Live server with only `--tenant-api-key team-red:secret1`: `curl
    /workers` → 401 with no auth, 401 with the tenant key
  - Confirmed no malformed/duplicate-key error output contains the
    plaintext credential (checked by running the binary directly, not
    via `cargo run`, which echoes its own invocation separately)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt --all -- --check` passes (silent)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
      (zero warnings/errors)
- [x] `cargo test` passes (96 test binaries, 3913 tests, 0 failures)
- [x] `make python-dev` passes (`config/types.rs` changed)
- [x] Documentation updated (`docs/reference/api/openai.md`)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added repeatable `--tenant-api-key tenant_id:key` support for tenant-scoped authentication.
  - Tenant keys now carry tenant-specific identity for serving requests.
- **Bug Fixes**
  - Strengthened tenant-key validation (duplicates, empty/whitespace values, and conflicts) without exposing secret values.
  - When admin/control-plane keys aren’t configured, those routes are explicitly denied.
  - Tenant-scoped tokens no longer trigger upstream BYOK discovery in the models registry.
- **Documentation**
  - Updated OpenAI-compatible API docs with multi-tenant authentication guidance and examples.
- **Tests**
  - Added/updated auth and routing tests for tenant-key vs admin access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->