### PR TITLE
fix(data_connector): use JSON types for PostgreSQL columns

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -261,6 +261,20 @@ jobs:
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: smg_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d smg_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v7
 
@@ -311,6 +325,8 @@ jobs:
         run: |
           source "$HOME/.cargo/env"
           cargo test
+          SMG_TEST_POSTGRES_URL=postgres://postgres:postgres@localhost:5432/smg_test \
+            cargo test -p data-connector --test postgres_json -- --ignored
 
       - name: Show sccache stats
         if: always()

--- a/crates/data_connector/src/common.rs
+++ b/crates/data_connector/src/common.rs
@@ -106,7 +106,7 @@ pub(super) fn resolve_extra_column_values<'a>(
 
 /// Parse raw JSON string into `ConversationMetadata` (`JsonMap<String, Value>`).
 ///
-/// Shared across Postgres, Redis, and Oracle conversation storage backends.
+/// Shared across the Redis and Oracle conversation storage backends.
 /// Returns `Ok(None)` for `None`, empty strings, and the literal `"null"`.
 pub(super) fn parse_conversation_metadata(
     raw: Option<String>,

--- a/crates/data_connector/src/postgres.rs
+++ b/crates/data_connector/src/postgres.rs
@@ -9,10 +9,7 @@ use serde_json::Value;
 use tokio_postgres::{NoTls, Row};
 
 use crate::{
-    common::{
-        build_response_select_base, extra_column_defs, parse_json_value, parse_raw_response,
-        resolve_extra_column_values,
-    },
+    common::{build_response_select_base, extra_column_defs, resolve_extra_column_values},
     config::PostgresConfig,
     context::current_extra_columns,
     core::{
@@ -25,6 +22,11 @@ use crate::{
     postgres_migrations::POSTGRES_HISTORY_MIGRATIONS,
     schema::SchemaConfig,
 };
+
+fn get_optional_json(row: &Row, column: &str) -> Result<Option<Value>, String> {
+    row.try_get::<_, Option<Value>>(column)
+        .map_err(|err| format!("error retrieving JSON column {column}: {err}"))
+}
 
 // ── Store ────────────────────────────────────────────────────────────────
 
@@ -139,10 +141,15 @@ impl PostgresConversationStorage {
     }
 
     fn parse_metadata(
-        metadata: Option<String>,
+        metadata: Option<Value>,
     ) -> Result<Option<ConversationMetadata>, ConversationStorageError> {
-        crate::common::parse_conversation_metadata(metadata)
-            .map_err(ConversationStorageError::StorageError)
+        match metadata {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::Object(metadata)) => Ok(Some(metadata)),
+            Some(_) => Err(ConversationStorageError::StorageError(
+                "conversation metadata must be a JSON object or null".to_string(),
+            )),
+        }
     }
 }
 
@@ -155,11 +162,7 @@ impl ConversationStorage for PostgresConversationStorage {
         let conversation = Conversation::new(input);
         let id_str = conversation.id.0.as_str();
         let created_at: DateTime<Utc> = conversation.created_at;
-        let metadata_json = conversation
-            .metadata
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()?;
+        let metadata_json = conversation.metadata.clone().map(Value::Object);
 
         let s = &self.store.schema.conversations;
         let table = s.qualified_table(self.store.schema.owner.as_deref());
@@ -246,10 +249,11 @@ impl ConversationStorage for PostgresConversationStorage {
         } else {
             row.get(s.col("created_at"))
         };
-        let metadata_json: Option<String> = if s.is_skipped("metadata") {
+        let metadata_json: Option<Value> = if s.is_skipped("metadata") {
             None
         } else {
-            row.get(s.col("metadata"))
+            get_optional_json(row, s.col("metadata"))
+                .map_err(ConversationStorageError::StorageError)?
         };
         let metadata = Self::parse_metadata(metadata_json)?;
         Ok(Some(Conversation::with_parts(
@@ -293,7 +297,7 @@ impl ConversationStorage for PostgresConversationStorage {
             )));
         }
 
-        let metadata_json = metadata.as_ref().map(serde_json::to_string).transpose()?;
+        let metadata_json = metadata.clone().map(Value::Object);
         let col_meta = s.col("metadata");
 
         let (_, created_at) = if s.is_skipped("created_at") {
@@ -432,8 +436,6 @@ impl ConversationItemStorage for PostgresConversationItemStorage {
         } = item;
         let id = opt_id.unwrap_or_else(|| make_item_id(&item_type));
         let created_at = Utc::now();
-        let content_json = serde_json::to_string(&content)?;
-
         let si = &self.store.schema.conversation_items;
         let table = si.qualified_table(self.store.schema.owner.as_deref());
 
@@ -454,7 +456,7 @@ impl ConversationItemStorage for PostgresConversationItemStorage {
         }
         if !si.is_skipped("content") {
             col_names.push(si.col("content"));
-            params.push(&content_json);
+            params.push(&content);
         }
         if !si.is_skipped("status") {
             col_names.push(si.col("status"));
@@ -786,11 +788,9 @@ fn build_item_from_row(
     let content: Value = if si.is_skipped("content") {
         Value::Null
     } else {
-        let content_raw: Option<String> = row.get(si.col("content"));
-        match content_raw {
-            Some(s) => serde_json::from_str(&s).map_err(ConversationItemStorageError::from)?,
-            None => Value::Null,
-        }
+        get_optional_json(row, si.col("content"))
+            .map_err(ConversationItemStorageError::StorageError)?
+            .unwrap_or(Value::Null)
     };
     let status: Option<String> = if si.is_skipped("status") {
         None
@@ -892,10 +892,10 @@ impl PostgresResponseStorage {
         } else {
             row.get(s.col("previous_response_id"))
         };
-        let input_json: Option<String> = if s.is_skipped("input") {
+        let input_json: Option<Value> = if s.is_skipped("input") {
             None
         } else {
-            row.get(s.col("input"))
+            get_optional_json(row, s.col("input"))?
         };
         let created_at: DateTime<Utc> = if s.is_skipped("created_at") {
             Utc::now()
@@ -912,15 +912,15 @@ impl PostgresResponseStorage {
         } else {
             row.get(s.col("model"))
         };
-        let raw_response_json: Option<String> = if s.is_skipped("raw_response") {
+        let raw_response_json: Option<Value> = if s.is_skipped("raw_response") {
             None
         } else {
-            row.get(s.col("raw_response"))
+            get_optional_json(row, s.col("raw_response"))?
         };
 
         let previous_response_id = previous.map(ResponseId);
-        let raw_response = parse_raw_response(raw_response_json)?;
-        let input = parse_json_value(input_json)?;
+        let raw_response = raw_response_json.unwrap_or(Value::Null);
+        let input = input_json.unwrap_or_else(|| Value::Array(Vec::new()));
 
         Ok(StoredResponse {
             id: ResponseId(id),
@@ -1145,5 +1145,47 @@ impl ResponseStorage for PostgresResponseStorage {
             .await
             .map_err(|e| ResponseStorageError::StorageError(e.to_string()))?;
         Ok(rows_deleted as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parse_metadata_preserves_json_object() {
+        let value = json!({
+            "nested": {"enabled": true},
+            "count": 2
+        });
+        let expected = value.as_object().cloned();
+
+        let parsed = PostgresConversationStorage::parse_metadata(Some(value)).unwrap();
+
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn parse_metadata_maps_sql_and_json_null_to_none() {
+        assert_eq!(
+            PostgresConversationStorage::parse_metadata(None).unwrap(),
+            None
+        );
+        assert_eq!(
+            PostgresConversationStorage::parse_metadata(Some(Value::Null)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_metadata_rejects_non_object_json() {
+        let result = PostgresConversationStorage::parse_metadata(Some(json!(["not", "metadata"])));
+
+        assert!(matches!(
+            result,
+            Err(ConversationStorageError::StorageError(_))
+        ));
     }
 }

--- a/crates/data_connector/src/postgres.rs
+++ b/crates/data_connector/src/postgres.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
 use serde_json::Value;
-use tokio_postgres::{NoTls, Row};
+use tokio_postgres::{types::Json, NoTls, Row};
 
 use crate::{
     common::{build_response_select_base, extra_column_defs, resolve_extra_column_values},
@@ -162,7 +162,7 @@ impl ConversationStorage for PostgresConversationStorage {
         let conversation = Conversation::new(input);
         let id_str = conversation.id.0.as_str();
         let created_at: DateTime<Utc> = conversation.created_at;
-        let metadata_json = conversation.metadata.clone().map(Value::Object);
+        let metadata_json = conversation.metadata.as_ref().map(Json);
 
         let s = &self.store.schema.conversations;
         let table = s.qualified_table(self.store.schema.owner.as_deref());
@@ -297,7 +297,7 @@ impl ConversationStorage for PostgresConversationStorage {
             )));
         }
 
-        let metadata_json = metadata.clone().map(Value::Object);
+        let metadata_json = metadata.as_ref().map(Json);
         let col_meta = s.col("metadata");
 
         let (_, created_at) = if s.is_skipped("created_at") {

--- a/crates/data_connector/tests/postgres_json.rs
+++ b/crates/data_connector/tests/postgres_json.rs
@@ -1,0 +1,196 @@
+//! PostgreSQL integration coverage for JSON columns.
+//!
+//! Run with a disposable database:
+//! ```text
+//! SMG_TEST_POSTGRES_URL=postgres://postgres:postgres@localhost/smg_test \
+//!   cargo test -p data-connector --test postgres_json -- --ignored
+//! ```
+
+use std::env;
+
+use chrono::Utc;
+use data_connector::{
+    create_storage, HistoryBackend, ListParams, NewConversation, NewConversationItem,
+    PostgresConfig, SchemaConfig, SortOrder, StorageFactoryConfig, StoredResponse,
+};
+use serde_json::json;
+
+#[tokio::test]
+#[ignore = "requires a PostgreSQL instance configured through SMG_TEST_POSTGRES_URL"]
+async fn json_columns_round_trip() {
+    let db_url = env::var("SMG_TEST_POSTGRES_URL")
+        .expect("SMG_TEST_POSTGRES_URL must point to a disposable PostgreSQL database");
+    let schema = SchemaConfig {
+        auto_migrate: true,
+        ..Default::default()
+    };
+    let postgres = PostgresConfig {
+        db_url,
+        pool_max: 4,
+        schema: Some(schema),
+    };
+    let backend = HistoryBackend::Postgres;
+    let storage = create_storage(StorageFactoryConfig {
+        backend: &backend,
+        oracle: None,
+        postgres: Some(&postgres),
+        redis: None,
+        hook: None,
+    })
+    .await
+    .expect("PostgreSQL storage should initialize");
+
+    let first_input = json!([{
+        "role": "user",
+        "content": [{"type": "input_text", "text": "remember PG-HISTORY-TEST"}]
+    }]);
+    let first_raw_response = json!({
+        "id": "response-one",
+        "output": [{"type": "message", "content": [{"text": "stored"}]}]
+    });
+    let mut first = StoredResponse::new(None);
+    first.input = first_input.clone();
+    first.raw_response = first_raw_response.clone();
+    let first_id = storage
+        .response_storage
+        .store_response(first)
+        .await
+        .expect("first response should be stored");
+
+    let loaded = storage
+        .response_storage
+        .get_response(&first_id)
+        .await
+        .expect("first response should be read")
+        .expect("first response should exist");
+    assert_eq!(loaded.input, first_input);
+    assert_eq!(loaded.raw_response, first_raw_response);
+
+    let second_input = json!([{"role": "user", "content": "what was the token?"}]);
+    let second_raw_response = json!({"id": "response-two", "status": "completed"});
+    let mut second = StoredResponse::new(Some(first_id.clone()));
+    second.input = second_input.clone();
+    second.raw_response = second_raw_response.clone();
+    let second_id = storage
+        .response_storage
+        .store_response(second)
+        .await
+        .expect("second response should be stored");
+
+    let chain = storage
+        .response_storage
+        .get_response_chain(&second_id, None)
+        .await
+        .expect("response chain should be read");
+    assert_eq!(chain.responses.len(), 2);
+    assert_eq!(chain.responses[0].id, first_id);
+    assert_eq!(chain.responses[0].input, first_input);
+    assert_eq!(chain.responses[0].raw_response, first_raw_response);
+    assert_eq!(chain.responses[1].id, second_id);
+    assert_eq!(
+        chain.responses[1].previous_response_id,
+        Some(first_id.clone())
+    );
+    assert_eq!(chain.responses[1].input, second_input);
+    assert_eq!(chain.responses[1].raw_response, second_raw_response);
+
+    let metadata = json!({"tenant": "acme", "nested": {"retention": 7}})
+        .as_object()
+        .expect("metadata fixture should be an object")
+        .clone();
+    let conversation = storage
+        .conversation_storage
+        .create_conversation(NewConversation {
+            id: None,
+            metadata: Some(metadata.clone()),
+        })
+        .await
+        .expect("conversation should be stored");
+    let loaded_conversation = storage
+        .conversation_storage
+        .get_conversation(&conversation.id)
+        .await
+        .expect("conversation should be read")
+        .expect("conversation should exist");
+    assert_eq!(loaded_conversation.metadata, Some(metadata));
+
+    let updated_metadata = json!({"tenant": "acme", "updated": true})
+        .as_object()
+        .expect("metadata fixture should be an object")
+        .clone();
+    let updated = storage
+        .conversation_storage
+        .update_conversation(&conversation.id, Some(updated_metadata.clone()))
+        .await
+        .expect("conversation should be updated")
+        .expect("conversation should exist");
+    assert_eq!(updated.metadata, Some(updated_metadata));
+    let loaded_updated = storage
+        .conversation_storage
+        .get_conversation(&conversation.id)
+        .await
+        .expect("updated conversation should be read")
+        .expect("conversation should exist");
+    assert_eq!(loaded_updated.metadata, updated.metadata);
+
+    let cleared = storage
+        .conversation_storage
+        .update_conversation(&conversation.id, None)
+        .await
+        .expect("conversation metadata should be cleared")
+        .expect("conversation should exist");
+    assert_eq!(cleared.metadata, None);
+    let loaded_cleared = storage
+        .conversation_storage
+        .get_conversation(&conversation.id)
+        .await
+        .expect("conversation should be read after clearing metadata")
+        .expect("conversation should exist");
+    assert_eq!(loaded_cleared.metadata, None);
+
+    let item_content = json!([{
+        "type": "input_text",
+        "text": "nested content",
+        "annotations": [{"kind": "test", "value": 1}]
+    }]);
+    let item = storage
+        .conversation_item_storage
+        .create_item(NewConversationItem {
+            id: None,
+            response_id: Some(second_id.0.clone()),
+            item_type: "message".to_string(),
+            role: Some("user".to_string()),
+            content: item_content.clone(),
+            status: Some("completed".to_string()),
+        })
+        .await
+        .expect("conversation item should be stored");
+    let loaded_item = storage
+        .conversation_item_storage
+        .get_item(&item.id)
+        .await
+        .expect("conversation item should be read")
+        .expect("conversation item should exist");
+    assert_eq!(loaded_item.content, item_content);
+
+    storage
+        .conversation_item_storage
+        .link_item(&conversation.id, &item.id, Utc::now())
+        .await
+        .expect("conversation item should be linked");
+    let listed = storage
+        .conversation_item_storage
+        .list_items(
+            &conversation.id,
+            ListParams {
+                limit: 10,
+                order: SortOrder::Asc,
+                after: None,
+            },
+        )
+        .await
+        .expect("conversation items should be listed");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, item.id);
+    assert_eq!(listed[0].content, item_content);
+}


### PR DESCRIPTION
## Description

### Problem

The PostgreSQL backend declares built-in payload columns as `JSON`, but several paths bind or decode them as `String` / `Option<String>`. `tokio-postgres` rejects those conversions. In particular, loading a stored response through `previous_response_id` panics while decoding `responses.input` and closes the HTTP connection without a response.

### Solution

Bind and decode PostgreSQL JSON columns as `serde_json::Value` / `Option<Value>` consistently. JSON reads now use `try_get()` so an unexpected database type is returned as a storage error instead of panicking the request task.

No schema migration is required.

Closes #1930

## Changes

- Bind `conversations.metadata` and `conversation_items.content` as JSON values instead of serialized strings.
- Decode `conversations.metadata`, `conversation_items.content`, `responses.input`, and `responses.raw_response` as nullable JSON values.
- Preserve existing SQL `NULL` and JSON `null` defaults for metadata, item content, response input, and raw responses.
- Add a PostgreSQL round-trip integration test covering responses, response chains, conversation metadata, and conversation items.
- Run the integration test in the Rust CI job against PostgreSQL 16.

## Test Plan

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p data-connector --all-targets --all-features -- -D warnings`
- `cargo test -p data-connector` — 218 passed, 0 failed.
- PostgreSQL 16 (`postgres:16-alpine`):
  `SMG_TEST_POSTGRES_URL=postgres://postgres:postgres@127.0.0.1:55432/smg_test cargo test -p data-connector --test postgres_json -- --ignored`
  - Stores and retrieves nested `input` and `raw_response` JSON.
  - Walks a two-response `previous_response_id` chain.
  - Creates, retrieves, updates, and clears conversation metadata.
  - Creates, retrieves, links, and lists a conversation item with nested JSON content.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] Changed crate passes Clippy with all targets, all features, and warnings denied
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL JSON handling for conversation metadata, stored responses, and conversation item content.
  * Preserved nested JSON structures end-to-end when saving and retrieving.
  * Added validation so conversation metadata is accepted only as a JSON object or cleared/empty.

* **Tests**
  * Added PostgreSQL-backed integration tests covering JSON round-tripping across responses, conversations, and conversation items.
  * Enabled the new PostgreSQL test in the CI workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->