### PR TITLE
feat(grpc): implement GetTokenizer RPC for TokenSpeed backend

### DIFF
--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -30,6 +30,11 @@ service TokenSpeedScheduler {
   // Stop the profiler and export traces
   rpc StopProfile(smg.grpc.common.StopProfileRequest) returns (smg.grpc.common.ProfileResponse);
 
+  // Stream tokenizer artifacts so the gateway can construct the tokenizer
+  // remotely when it cannot read the tokenizer path locally (e.g. the model
+  // files live only on the scheduler host).
+  rpc GetTokenizer(smg.grpc.common.GetTokenizerRequest) returns (stream smg.grpc.common.GetTokenizerChunk);
+
   // Subscribe to KV cache events (server-streaming). Lets the gateway's
   // cache-aware router track which prefixes this scheduler has cached.
   rpc SubscribeKvEvents(smg.grpc.common.SubscribeKvEventsRequest)

--- a/crates/grpc_client/src/tokenspeed_scheduler.rs
+++ b/crates/grpc_client/src/tokenspeed_scheduler.rs
@@ -172,6 +172,7 @@ impl TokenSpeedSchedulerClient {
         Ok(response.into_inner())
     }
 
+    crate::impl_get_tokenizer!();
     crate::impl_admin_ops!();
     crate::impl_subscribe_kv_events!();
 

--- a/crates/mock_worker/src/grpc.rs
+++ b/crates/mock_worker/src/grpc.rs
@@ -52,11 +52,14 @@ struct MockScheduler {
 
 type GenStream = Pin<Box<dyn Stream<Item = Result<ts::GenerateResponse, Status>> + Send>>;
 type KvEventStream = Pin<Box<dyn Stream<Item = Result<common::KvEventBatch, Status>> + Send>>;
+type TokenizerStream =
+    Pin<Box<dyn Stream<Item = Result<common::GetTokenizerChunk, Status>> + Send>>;
 
 #[tonic::async_trait]
 impl TokenSpeedScheduler for MockScheduler {
     type GenerateStream = GenStream;
     type SubscribeKvEventsStream = KvEventStream;
+    type GetTokenizerStream = TokenizerStream;
 
     async fn generate(
         &self,
@@ -254,6 +257,15 @@ impl TokenSpeedScheduler for MockScheduler {
         &self,
         _request: Request<common::StopProfileRequest>,
     ) -> Result<Response<common::ProfileResponse>, Status> {
+        Err(Status::unimplemented("mock-worker"))
+    }
+
+    async fn get_tokenizer(
+        &self,
+        _request: Request<common::GetTokenizerRequest>,
+    ) -> Result<Response<Self::GetTokenizerStream>, Status> {
+        // The mock has no tokenizer artifacts to serve; the gateway's
+        // remote-tokenizer fallback treats Unimplemented as "not supported".
         Err(Status::unimplemented("mock-worker"))
     }
 }

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -2,8 +2,9 @@
 
 Implements ``tokenspeed.grpc.scheduler.TokenSpeedScheduler`` on top of
 :class:`tokenspeed.runtime.engine.async_llm.AsyncLLM`. The proto field set
-is intentionally minimal — generative LLM serving, precomputed multimodal, and
-KV-cache-event streaming for cache-aware routing; no Embed / GetTokenizer /
+is intentionally minimal — generative LLM serving, precomputed multimodal,
+KV-cache-event streaming for cache-aware routing, and tokenizer-bundle
+streaming (GetTokenizer) for remote tokenizer construction; no Embed /
 PD-disaggregated / LoRA / hidden states / classifier outputs.
 """
 
@@ -11,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import hashlib
 import json
 import logging
 import os
@@ -18,6 +20,7 @@ import re
 import time
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import grpc
@@ -40,6 +43,7 @@ from tokenspeed.runtime.pd.kv_events import KVEventBatch
 
 from smg_grpc_servicer.kv_events import endpoint_for_rank, stream_kv_events
 from smg_grpc_servicer.mm_rdma import RdmaPixelPuller
+from smg_grpc_servicer.tokenizer_bundle import CHUNK_SIZE, build_tokenizer_zip
 from smg_grpc_servicer.tokenspeed.health_servicer import TokenSpeedHealthServicer
 from smg_grpc_servicer.tokenspeed.kv_events import resolve_kv_events_config
 
@@ -803,6 +807,56 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             return
 
         return common_pb2.ProfileResponse(success=True, message="Stop profiling succeeded")
+
+    async def GetTokenizer(
+        self,
+        _request: common_pb2.GetTokenizerRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncIterator[common_pb2.GetTokenizerChunk]:
+        """Stream tokenizer artifacts as a ZIP bundle.
+
+        Lets the gateway build the tokenizer remotely when it cannot read the
+        tokenizer path locally (e.g. the model files live only on this host).
+        Resolves the tokenizer directory from server_args, zips the relevant
+        tokenizer files, and streams them as GetTokenizerChunk messages; the
+        final chunk carries the SHA-256 fingerprint of the full archive.
+        """
+        logger.info("Receive GetTokenizer request")
+
+        # Upstream renamed ``tokenizer_path`` → ``tokenizer``; accept either so
+        # the servicer works against both old and new builds (see GetModelInfo).
+        tokenizer_path = getattr(self.server_args, "tokenizer", None) or getattr(
+            self.server_args, "tokenizer_path", ""
+        )
+        if not tokenizer_path:
+            await context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "Tokenizer path is not configured on this server.",
+            )
+            return
+
+        try:
+            zip_buffer = build_tokenizer_zip(Path(tokenizer_path))
+        except Exception as e:  # noqa: BLE001
+            logger.exception("Failed to build tokenizer ZIP")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+            return
+
+        zip_data = zip_buffer.getbuffer()
+        sha256 = hashlib.sha256(zip_data).hexdigest()
+        total = len(zip_data)
+        logger.info("Streaming tokenizer bundle: %d bytes, sha256=%s", total, sha256)
+
+        # Stream chunks; SHA-256 rides only on the final chunk.
+        offset = 0
+        while offset < total:
+            end = min(offset + CHUNK_SIZE, total)
+            is_last = end == total
+            yield common_pb2.GetTokenizerChunk(
+                data=bytes(zip_data[offset:end]),
+                sha256=sha256 if is_last else "",
+            )
+            offset = end
 
     # ------------------------------------------------------------------
     # Helpers

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -379,11 +379,7 @@ impl GrpcClient {
             Self::Vllm(client) => client.get_tokenizer().await,
             Self::Trtllm(client) => client.get_tokenizer().await,
             Self::Mlx(client) => client.get_tokenizer().await,
-            Self::TokenSpeed(_) => {
-                return Err(Box::new(tonic::Status::unimplemented(
-                    "TokenSpeed backend does not support GetTokenizer RPC",
-                )));
-            }
+            Self::TokenSpeed(client) => client.get_tokenizer().await,
         }?;
 
         tokenizer_bundle::validate_bundle_sha256(&bundle).map_err(|e| {


### PR DESCRIPTION
## Description

### Problem

TokenSpeed is the only gRPC backend that does not implement a `GetTokenizer` RPC (SGLang, vLLM, TRT-LLM, and MLX all do). The gateway's tokenizer registration falls back to fetching the tokenizer bundle from a healthy worker (`fetch_tokenizer_from_worker` in `tokenizer_registration.rs`) whenever it cannot construct the tokenizer from the configured source locally — e.g. when the source is a path like `/raid/models/...` that exists only on the scheduler node and not on the gateway host.

For TokenSpeed workers that fallback failed with `Status::unimplemented("TokenSpeed backend does not support GetTokenizer RPC")`, so tokenizer registration could not complete.

### Solution

Implement `GetTokenizer` for TokenSpeed end to end, mirroring the existing SGLang/vLLM implementation and reusing all shared plumbing (the common proto messages, the shared `impl_get_tokenizer!` Rust macro, and the shared `build_tokenizer_zip` helper). The gateway now dispatches `GetTokenizer` to the TokenSpeed client, so the remote-tokenizer fallback works for TokenSpeed workers exactly as it does for the other backends.

## Changes

- **proto** (`crates/grpc_client/proto/tokenspeed_scheduler.proto`): add `rpc GetTokenizer(common.GetTokenizerRequest) returns (stream common.GetTokenizerChunk);` to the `TokenSpeedScheduler` service.
- **grpc_client** (`crates/grpc_client/src/tokenspeed_scheduler.rs`): wire the shared `crate::impl_get_tokenizer!();` macro into `TokenSpeedSchedulerClient`.
- **gateway** (`model_gateway/src/routers/grpc/client.rs`): dispatch the `TokenSpeed` arm to `client.get_tokenizer().await` instead of returning `Unimplemented`.
- **servicer** (`grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py`): implement `GetTokenizer` — resolve the tokenizer directory from `server_args.tokenizer`/`tokenizer_path`, zip it via the shared `build_tokenizer_zip`, and stream `GetTokenizerChunk`s with the SHA-256 fingerprint on the final chunk. Updated the module docstring accordingly.

## Test Plan

- `cargo build -p smg-grpc-client` — tonic-generated `get_tokenizer` and the `impl_get_tokenizer!` macro compile for TokenSpeed.
- `cargo build -p smg` — the gateway dispatch change compiles.
- `cargo clippy -p smg-grpc-client --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p smg-grpc-client` — 65 passed, 0 failed.
- `cargo +nightly fmt --all -- --check` — clean.
- `ruff check` + `ruff format --check` on the servicer — clean; `python -m py_compile` on the servicer passes.

> Note: `cargo clippy --all-features` for the `smg` crate could not be run in my local env (`--all-features` pulls in `opencv4`, which needs a system `pkg-config`/opencv install). Relying on CI for the full-workspace `--all-features` clippy gate.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (deferred to CI — see note above)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `GetTokenizer` gRPC streaming endpoint to retrieve tokenizer bundles remotely.
  - Tokenizer bundles are streamed in fixed-size chunks, with a SHA-256 fingerprint provided in the final chunk.
  - TokenSpeed backends now route tokenizer retrieval through the gateway.

- **Bug Fixes**
  - Replaced the previous unsupported tokenizer-retrieval response with functional forwarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->