### PR TITLE
fix(data_connector): decode Postgres JSON columns as Value, not String

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -307,11 +307,10 @@ jobs:
           python crates/multimodal/scripts/generate_vision_golden.py
 
       - name: Create isolated Postgres test database
-        # Don't let a flaky/restarting shared Postgres service fail the
-        # whole job — the ~100 non-Postgres unit tests below don't need a
-        # database. The Postgres integration tests are skipped (not failed)
-        # if DATA_CONNECTOR_TEST_POSTGRES_URL never gets set.
-        continue-on-error: true
+        # No continue-on-error here: the Postgres regression suite must
+        # actually run in CI, not silently no-op if this step fails (see PR
+        # #1935 review discussion). `check --postgres` retries on its own
+        # for transient pod-restart flakiness.
         run: |
           bash scripts/ci_agentic_svc_deps.sh check --postgres postgres-db
           bash scripts/ci_agentic_svc_deps.sh create-postgres-db postgres-db
@@ -321,11 +320,7 @@ jobs:
         run: |
           source "$HOME/.cargo/env"
           cargo test
-          if [ -n "${DATA_CONNECTOR_TEST_POSTGRES_URL:-}" ]; then
-            cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1
-          else
-            echo "::warning::Skipping Postgres integration tests — DATA_CONNECTOR_TEST_POSTGRES_URL not set (isolated database creation failed or was skipped)"
-          fi
+          cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1
 
       - name: Cleanup Postgres test database
         if: always()

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -306,22 +306,16 @@ jobs:
           python -m pip install transformers pillow numpy scipy
           python crates/multimodal/scripts/generate_vision_golden.py
 
+      - name: Create isolated Postgres test database
+        run: |
+          bash scripts/ci_agentic_svc_deps.sh check --postgres postgres-db
+          bash scripts/ci_agentic_svc_deps.sh create-postgres-db postgres-db
+
       - name: Run Rust tests
         timeout-minutes: 30
         run: |
           source "$HOME/.cargo/env"
           cargo test
-
-      - name: Check Postgres shared service
-        run: bash scripts/ci_agentic_svc_deps.sh check --postgres postgres-db
-
-      - name: Create isolated Postgres test database
-        run: bash scripts/ci_agentic_svc_deps.sh create-postgres-db postgres-db
-
-      - name: Run Postgres data-connector integration tests
-        timeout-minutes: 10
-        run: |
-          source "$HOME/.cargo/env"
           cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1
 
       - name: Cleanup Postgres test database

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -307,6 +307,11 @@ jobs:
           python crates/multimodal/scripts/generate_vision_golden.py
 
       - name: Create isolated Postgres test database
+        # Don't let a flaky/restarting shared Postgres service fail the
+        # whole job — the ~100 non-Postgres unit tests below don't need a
+        # database. The Postgres integration tests are skipped (not failed)
+        # if DATA_CONNECTOR_TEST_POSTGRES_URL never gets set.
+        continue-on-error: true
         run: |
           bash scripts/ci_agentic_svc_deps.sh check --postgres postgres-db
           bash scripts/ci_agentic_svc_deps.sh create-postgres-db postgres-db
@@ -316,7 +321,11 @@ jobs:
         run: |
           source "$HOME/.cargo/env"
           cargo test
-          cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1
+          if [ -n "${DATA_CONNECTOR_TEST_POSTGRES_URL:-}" ]; then
+            cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1
+          else
+            echo "::warning::Skipping Postgres integration tests — DATA_CONNECTOR_TEST_POSTGRES_URL not set (isolated database creation failed or was skipped)"
+          fi
 
       - name: Cleanup Postgres test database
         if: always()

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -315,13 +315,18 @@ jobs:
       - name: Check Postgres shared service
         run: bash scripts/ci_agentic_svc_deps.sh check --postgres postgres-db
 
+      - name: Create isolated Postgres test database
+        run: bash scripts/ci_agentic_svc_deps.sh create-postgres-db postgres-db
+
       - name: Run Postgres data-connector integration tests
         timeout-minutes: 10
-        env:
-          DATA_CONNECTOR_TEST_POSTGRES_URL: postgres://postgres:postgres@postgres-db:5432/smg_ci_test
         run: |
           source "$HOME/.cargo/env"
           cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1
+
+      - name: Cleanup Postgres test database
+        if: always()
+        run: bash scripts/ci_agentic_svc_deps.sh cleanup-postgres-db postgres-db
 
       - name: Show sccache stats
         if: always()

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -312,6 +312,17 @@ jobs:
           source "$HOME/.cargo/env"
           cargo test
 
+      - name: Check Postgres shared service
+        run: bash scripts/ci_agentic_svc_deps.sh check --postgres postgres-db
+
+      - name: Run Postgres data-connector integration tests
+        timeout-minutes: 10
+        env:
+          DATA_CONNECTOR_TEST_POSTGRES_URL: postgres://postgres:postgres@postgres-db:5432/smg_ci_test
+        run: |
+          source "$HOME/.cargo/env"
+          cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1
+
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats

--- a/crates/data_connector/src/postgres.rs
+++ b/crates/data_connector/src/postgres.rs
@@ -9,10 +9,7 @@ use serde_json::Value;
 use tokio_postgres::{NoTls, Row};
 
 use crate::{
-    common::{
-        build_response_select_base, extra_column_defs, parse_json_value, parse_raw_response,
-        resolve_extra_column_values,
-    },
+    common::{build_response_select_base, extra_column_defs, resolve_extra_column_values},
     config::PostgresConfig,
     context::current_extra_columns,
     core::{
@@ -138,11 +135,19 @@ impl PostgresConversationStorage {
         Ok(Self { store })
     }
 
+    /// Postgres stores metadata as a native `JSON` column, so it round-trips as
+    /// `serde_json::Value` rather than the text that Oracle/Redis persist —
+    /// `tokio-postgres` rejects decoding a `JSON` column as `String`.
     fn parse_metadata(
-        metadata: Option<String>,
+        metadata: Option<Value>,
     ) -> Result<Option<ConversationMetadata>, ConversationStorageError> {
-        crate::common::parse_conversation_metadata(metadata)
-            .map_err(ConversationStorageError::StorageError)
+        match metadata {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::Object(map)) => Ok(Some(map)),
+            Some(other) => Err(ConversationStorageError::StorageError(format!(
+                "expected JSON object for conversation metadata, got: {other}"
+            ))),
+        }
     }
 }
 
@@ -155,11 +160,11 @@ impl ConversationStorage for PostgresConversationStorage {
         let conversation = Conversation::new(input);
         let id_str = conversation.id.0.as_str();
         let created_at: DateTime<Utc> = conversation.created_at;
-        let metadata_json = conversation
-            .metadata
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()?;
+        // Bind the JSON column as `Value`, not a serialized `String`: Postgres
+        // reports the placeholder's type as `json`/`jsonb` from the target
+        // column, and `tokio-postgres` rejects a `String` value for that
+        // parameter type instead of implicitly casting it.
+        let metadata_value: Option<Value> = conversation.metadata.clone().map(Value::Object);
 
         let s = &self.store.schema.conversations;
         let table = s.qualified_table(self.store.schema.owner.as_deref());
@@ -172,7 +177,7 @@ impl ConversationStorage for PostgresConversationStorage {
         }
         if !s.is_skipped("metadata") {
             col_names.push(s.col("metadata"));
-            params.push(&metadata_json);
+            params.push(&metadata_value);
         }
 
         // Append extra columns from hooks or defaults
@@ -246,10 +251,16 @@ impl ConversationStorage for PostgresConversationStorage {
         } else {
             row.get(s.col("created_at"))
         };
-        let metadata_json: Option<String> = if s.is_skipped("metadata") {
+        // Use `try_get` (not `get`) so schema drift or malformed data in the
+        // `JSON` column returns an error instead of panicking the request task.
+        let metadata_json: Option<Value> = if s.is_skipped("metadata") {
             None
         } else {
-            row.get(s.col("metadata"))
+            row.try_get(s.col("metadata")).map_err(|e| {
+                ConversationStorageError::StorageError(format!(
+                    "failed to decode metadata column: {e}"
+                ))
+            })?
         };
         let metadata = Self::parse_metadata(metadata_json)?;
         Ok(Some(Conversation::with_parts(
@@ -293,13 +304,15 @@ impl ConversationStorage for PostgresConversationStorage {
             )));
         }
 
-        let metadata_json = metadata.as_ref().map(serde_json::to_string).transpose()?;
+        // Bind the JSON column as `Value`, not a serialized `String` (see
+        // `create_conversation` for why `tokio-postgres` requires this).
+        let metadata_value: Option<Value> = metadata.clone().map(Value::Object);
         let col_meta = s.col("metadata");
 
         let (_, created_at) = if s.is_skipped("created_at") {
             let sql = format!("UPDATE {table} SET {col_meta} = $1 WHERE {col_id} = $2");
             let rows_affected = client
-                .execute(&sql, &[&metadata_json, &id.0.as_str()])
+                .execute(&sql, &[&metadata_value, &id.0.as_str()])
                 .await
                 .map_err(|e| ConversationStorageError::StorageError(e.to_string()))?;
             if rows_affected == 0 {
@@ -312,7 +325,7 @@ impl ConversationStorage for PostgresConversationStorage {
                 "UPDATE {table} SET {col_meta} = $1 WHERE {col_id} = $2 RETURNING {col_created}"
             );
             let rows = client
-                .query(&sql, &[&metadata_json, &id.0.as_str()])
+                .query(&sql, &[&metadata_value, &id.0.as_str()])
                 .await
                 .map_err(|e| ConversationStorageError::StorageError(e.to_string()))?;
             if rows.is_empty() {
@@ -432,7 +445,6 @@ impl ConversationItemStorage for PostgresConversationItemStorage {
         } = item;
         let id = opt_id.unwrap_or_else(|| make_item_id(&item_type));
         let created_at = Utc::now();
-        let content_json = serde_json::to_string(&content)?;
 
         let si = &self.store.schema.conversation_items;
         let table = si.qualified_table(self.store.schema.owner.as_deref());
@@ -454,7 +466,10 @@ impl ConversationItemStorage for PostgresConversationItemStorage {
         }
         if !si.is_skipped("content") {
             col_names.push(si.col("content"));
-            params.push(&content_json);
+            // Bind the JSON column as `Value`, not a serialized `String`
+            // (see `create_conversation` for why `tokio-postgres` requires
+            // this for a `json`/`jsonb`-typed parameter).
+            params.push(&content);
         }
         if !si.is_skipped("status") {
             col_names.push(si.col("status"));
@@ -786,11 +801,16 @@ fn build_item_from_row(
     let content: Value = if si.is_skipped("content") {
         Value::Null
     } else {
-        let content_raw: Option<String> = row.get(si.col("content"));
-        match content_raw {
-            Some(s) => serde_json::from_str(&s).map_err(ConversationItemStorageError::from)?,
-            None => Value::Null,
-        }
+        // `content` is a native Postgres `JSON` column; it decodes as
+        // `serde_json::Value`, not `String` (see `build_response_from_row`).
+        // Use `try_get` (not `get`) so schema drift or malformed data
+        // returns an error instead of panicking the request task.
+        let content_raw: Option<Value> = row.try_get(si.col("content")).map_err(|e| {
+            ConversationItemStorageError::StorageError(format!(
+                "failed to decode content column: {e}"
+            ))
+        })?;
+        content_raw.unwrap_or(Value::Null)
     };
     let status: Option<String> = if si.is_skipped("status") {
         None
@@ -878,7 +898,7 @@ impl PostgresResponseStorage {
     pub fn build_response_from_row(
         row: &Row,
         schema: &SchemaConfig,
-    ) -> Result<StoredResponse, String> {
+    ) -> Result<StoredResponse, ResponseStorageError> {
         let s = &schema.responses;
 
         let id: String = row.get(s.col("id"));
@@ -892,10 +912,17 @@ impl PostgresResponseStorage {
         } else {
             row.get(s.col("previous_response_id"))
         };
-        let input_json: Option<String> = if s.is_skipped("input") {
+        // `input` and `raw_response` are native Postgres `JSON` columns, so they
+        // decode as `serde_json::Value` — `tokio-postgres` panics if a `JSON`
+        // column is fetched as `String` (see WrongType in issue #1930). Use
+        // `try_get` (not `get`) so schema drift or malformed data returns an
+        // error instead of panicking the request task.
+        let input_json: Option<Value> = if s.is_skipped("input") {
             None
         } else {
-            row.get(s.col("input"))
+            row.try_get(s.col("input")).map_err(|e| {
+                ResponseStorageError::StorageError(format!("failed to decode input column: {e}"))
+            })?
         };
         let created_at: DateTime<Utc> = if s.is_skipped("created_at") {
             Utc::now()
@@ -912,15 +939,19 @@ impl PostgresResponseStorage {
         } else {
             row.get(s.col("model"))
         };
-        let raw_response_json: Option<String> = if s.is_skipped("raw_response") {
+        let raw_response_json: Option<Value> = if s.is_skipped("raw_response") {
             None
         } else {
-            row.get(s.col("raw_response"))
+            row.try_get(s.col("raw_response")).map_err(|e| {
+                ResponseStorageError::StorageError(format!(
+                    "failed to decode raw_response column: {e}"
+                ))
+            })?
         };
 
         let previous_response_id = previous.map(ResponseId);
-        let raw_response = parse_raw_response(raw_response_json)?;
-        let input = parse_json_value(input_json)?;
+        let raw_response = raw_response_json.unwrap_or(Value::Null);
+        let input = input_json.unwrap_or_else(|| Value::Array(Vec::new()));
 
         Ok(StoredResponse {
             id: ResponseId(id),
@@ -1040,9 +1071,7 @@ impl ResponseStorage for PostgresResponseStorage {
         if rows.is_empty() {
             return Ok(None);
         }
-        Self::build_response_from_row(&rows[0], &self.store.schema)
-            .map(Some)
-            .map_err(|err| ResponseStorageError::StorageError(err.to_string()))
+        Self::build_response_from_row(&rows[0], &self.store.schema).map(Some)
     }
 
     async fn delete_response(&self, response_id: &ResponseId) -> ResponseResult<()> {
@@ -1113,9 +1142,7 @@ impl ResponseStorage for PostgresResponseStorage {
         let schema = &self.store.schema;
         let mut out = Vec::with_capacity(rows.len());
         for row in rows {
-            let resp = Self::build_response_from_row(&row, schema)
-                .map_err(ResponseStorageError::StorageError)?;
-            out.push(resp);
+            out.push(Self::build_response_from_row(&row, schema)?);
         }
 
         Ok(out)
@@ -1145,5 +1172,41 @@ impl ResponseStorage for PostgresResponseStorage {
             .await
             .map_err(|e| ResponseStorageError::StorageError(e.to_string()))?;
         Ok(rows_deleted as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parse_metadata_none_returns_ok_none() {
+        assert!(PostgresConversationStorage::parse_metadata(None)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn parse_metadata_json_null_returns_ok_none() {
+        assert!(
+            PostgresConversationStorage::parse_metadata(Some(Value::Null))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn parse_metadata_object_round_trips() {
+        let obj = json!({"key": "value"}).as_object().unwrap().clone();
+        let parsed =
+            PostgresConversationStorage::parse_metadata(Some(Value::Object(obj.clone()))).unwrap();
+        assert_eq!(parsed, Some(obj));
+    }
+
+    #[test]
+    fn parse_metadata_non_object_is_error() {
+        assert!(PostgresConversationStorage::parse_metadata(Some(json!("not an object"))).is_err());
     }
 }

--- a/crates/data_connector/src/postgres.rs
+++ b/crates/data_connector/src/postgres.rs
@@ -100,6 +100,19 @@ impl Clone for PostgresStore {
     }
 }
 
+/// Name of a JSON value's type, for error messages that must not echo
+/// caller-supplied content (metadata is arbitrary and may hold secrets/PII).
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
 pub(super) struct PostgresConversationStorage {
     store: PostgresStore,
 }
@@ -144,8 +157,12 @@ impl PostgresConversationStorage {
         match metadata {
             None | Some(Value::Null) => Ok(None),
             Some(Value::Object(map)) => Ok(Some(map)),
+            // Don't interpolate the value itself: metadata is arbitrary
+            // caller-supplied JSON, and this error is rendered via Display
+            // into logs/API responses.
             Some(other) => Err(ConversationStorageError::StorageError(format!(
-                "expected JSON object for conversation metadata, got: {other}"
+                "expected JSON object for conversation metadata, got JSON {}",
+                json_type_name(&other)
             ))),
         }
     }

--- a/crates/data_connector/tests/postgres_integration.rs
+++ b/crates/data_connector/tests/postgres_integration.rs
@@ -168,6 +168,41 @@ async fn conversation_metadata_round_trips_json_column() {
         .expect("get_conversation must not panic on the JSON metadata column")
         .expect("conversation should exist");
     assert_eq!(fetched.metadata, Some(metadata));
+
+    // `update_conversation` has the same String-vs-Value bind bug as
+    // `create_conversation` did — cover both setting new metadata and
+    // clearing it back to SQL NULL.
+    let mut updated_metadata = serde_json::Map::new();
+    updated_metadata.insert("key".to_string(), json!("updated"));
+    updated_metadata.insert("nested".to_string(), json!({"count": 2}));
+
+    let updated = conv
+        .update_conversation(&created.id, Some(updated_metadata.clone()))
+        .await
+        .expect("update_conversation must not fail serializing the JSON metadata column")
+        .expect("conversation should exist");
+    assert_eq!(updated.metadata, Some(updated_metadata.clone()));
+
+    let fetched_after_update = conv
+        .get_conversation(&created.id)
+        .await
+        .expect("get_conversation must not panic after update")
+        .expect("conversation should exist");
+    assert_eq!(fetched_after_update.metadata, Some(updated_metadata));
+
+    let cleared = conv
+        .update_conversation(&created.id, None)
+        .await
+        .expect("update_conversation must not fail clearing the JSON metadata column")
+        .expect("conversation should exist");
+    assert_eq!(cleared.metadata, None);
+
+    let fetched_after_clear = conv
+        .get_conversation(&created.id)
+        .await
+        .expect("get_conversation must not panic after clearing metadata")
+        .expect("conversation should exist");
+    assert_eq!(fetched_after_clear.metadata, None);
 }
 
 #[tokio::test]

--- a/crates/data_connector/tests/postgres_integration.rs
+++ b/crates/data_connector/tests/postgres_integration.rs
@@ -9,8 +9,10 @@
 //! `get_item`) against a real server, since that panic can't be triggered
 //! through a unit test with no database.
 //!
-//! No CI service currently provisions Postgres for this crate's `cargo test`
-//! job, so these are opt-in. Run locally with:
+//! These stay opt-in (`#[ignore]`) rather than running under plain
+//! `cargo test`, since they need a real database. CI provisions a shared
+//! Postgres instance (`postgres-db` in `agentic-services.yaml`) and runs
+//! these with `--ignored` as a dedicated step. To run locally:
 //!
 //!   docker run -d -e POSTGRES_PASSWORD=test -e POSTGRES_DB=smg_test \
 //!       -p 5432:5432 postgres:16

--- a/crates/data_connector/tests/postgres_integration.rs
+++ b/crates/data_connector/tests/postgres_integration.rs
@@ -1,0 +1,201 @@
+//! Integration tests for the Postgres backend against a live PostgreSQL instance.
+//!
+//! Regression coverage for https://github.com/lightseekorg/smg/issues/1930: the
+//! `responses.input`/`responses.raw_response`, `conversations.metadata`, and
+//! `conversation_items.content` columns are native Postgres `JSON` columns.
+//! `tokio-postgres` panics with `WrongType` if a `JSON` column is fetched as
+//! `String` instead of `serde_json::Value` — these tests exercise the real
+//! read paths (`get_response`, `get_response_chain`, `get_conversation`,
+//! `get_item`) against a real server, since that panic can't be triggered
+//! through a unit test with no database.
+//!
+//! No CI service currently provisions Postgres for this crate's `cargo test`
+//! job, so these are opt-in. Run locally with:
+//!
+//!   docker run -d -e POSTGRES_PASSWORD=test -e POSTGRES_DB=smg_test \
+//!       -p 5432:5432 postgres:16
+//!   DATA_CONNECTOR_TEST_POSTGRES_URL=postgres://postgres:test@localhost:5432/smg_test \
+//!       cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1
+//!
+//! `--test-threads=1` matters: each test independently calls `create_storage`,
+//! which runs `CREATE TABLE IF NOT EXISTS` and schema migrations as a side
+//! effect. Postgres doesn't serialize concurrent first-time DDL on the same
+//! table name, so running these in parallel against a fresh database races.
+
+use data_connector::{
+    create_storage, HistoryBackend, NewConversation, NewConversationItem, PostgresConfig,
+    SchemaConfig, StorageBundle, StorageFactoryConfig, StoredResponse,
+};
+use serde_json::json;
+
+fn test_db_url() -> Option<String> {
+    std::env::var("DATA_CONNECTOR_TEST_POSTGRES_URL").ok()
+}
+
+async fn postgres_bundle(db_url: &str) -> Result<StorageBundle, String> {
+    let postgres_cfg = PostgresConfig {
+        db_url: db_url.to_string(),
+        pool_max: 4,
+        // The shared test database starts with no migrations applied; opt in
+        // to auto-migrate so `create_storage` doesn't require a human to run
+        // the pending migrations by hand first.
+        schema: Some(SchemaConfig {
+            auto_migrate: true,
+            ..Default::default()
+        }),
+    };
+    create_storage(StorageFactoryConfig {
+        backend: &HistoryBackend::Postgres,
+        oracle: None,
+        postgres: Some(&postgres_cfg),
+        redis: None,
+        hook: None,
+    })
+    .await
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres database; set DATA_CONNECTOR_TEST_POSTGRES_URL and run with -- --ignored"]
+async fn store_and_get_response_round_trips_json_columns() {
+    let Some(db_url) = test_db_url() else {
+        return;
+    };
+    let bundle = postgres_bundle(&db_url)
+        .await
+        .expect("failed to initialize Postgres storage");
+    let resp = bundle.response_storage;
+
+    // Mirrors the issue's repro: store an initial response, then a follow-up
+    // that continues from it via `previous_response_id`.
+    let mut first = StoredResponse::new(None);
+    first.input = json!(["Remember the token PG-HISTORY-TEST."]);
+    first.raw_response = json!({"output": [{"type": "message", "content": "ok"}]});
+    let first_id = resp
+        .store_response(first.clone())
+        .await
+        .expect("store first response");
+
+    let mut second = StoredResponse::new(Some(first_id.clone()));
+    second.input = json!(["What token did I ask you to remember?"]);
+    second.raw_response = json!({"output": [{"type": "message", "content": "PG-HISTORY-TEST"}]});
+    let second_id = resp
+        .store_response(second.clone())
+        .await
+        .expect("store follow-up response");
+
+    // This is the exact panic path from issue #1930: fetching a response
+    // whose `input`/`raw_response` are native Postgres `JSON` columns must
+    // decode cleanly instead of panicking with `WrongType`.
+    let fetched_first = resp
+        .get_response(&first_id)
+        .await
+        .expect("get_response must not panic on JSON columns")
+        .expect("first response should exist");
+    assert_eq!(fetched_first.input, first.input);
+    assert_eq!(fetched_first.raw_response, first.raw_response);
+
+    let fetched_second = resp
+        .get_response(&second_id)
+        .await
+        .expect("get_response must not panic on JSON columns")
+        .expect("second response should exist");
+    assert_eq!(fetched_second.previous_response_id, Some(first_id));
+    assert_eq!(fetched_second.input, second.input);
+    assert_eq!(fetched_second.raw_response, second.raw_response);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres database; set DATA_CONNECTOR_TEST_POSTGRES_URL and run with -- --ignored"]
+async fn get_response_chain_walks_json_columns() {
+    let Some(db_url) = test_db_url() else {
+        return;
+    };
+    let bundle = postgres_bundle(&db_url)
+        .await
+        .expect("failed to initialize Postgres storage");
+    let resp = bundle.response_storage;
+
+    let mut r1 = StoredResponse::new(None);
+    r1.input = json!(["first"]);
+    let id1 = resp.store_response(r1).await.expect("store r1");
+
+    let mut r2 = StoredResponse::new(Some(id1.clone()));
+    r2.input = json!(["second"]);
+    let id2 = resp.store_response(r2).await.expect("store r2");
+
+    let mut r3 = StoredResponse::new(Some(id2.clone()));
+    r3.input = json!(["third"]);
+    let id3 = resp.store_response(r3).await.expect("store r3");
+
+    // The default `get_response_chain` implementation walks
+    // `previous_response_id` links via repeated `get_response()` calls, so
+    // this exercises the same JSON-column decoding for every hop.
+    let chain = resp
+        .get_response_chain(&id3, None)
+        .await
+        .expect("get_response_chain must not panic on JSON columns");
+    let ids: Vec<_> = chain.responses.iter().map(|r| r.id.clone()).collect();
+    assert_eq!(ids, vec![id1, id2, id3]);
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres database; set DATA_CONNECTOR_TEST_POSTGRES_URL and run with -- --ignored"]
+async fn conversation_metadata_round_trips_json_column() {
+    let Some(db_url) = test_db_url() else {
+        return;
+    };
+    let bundle = postgres_bundle(&db_url)
+        .await
+        .expect("failed to initialize Postgres storage");
+    let conv = bundle.conversation_storage;
+
+    let mut metadata = serde_json::Map::new();
+    metadata.insert("key".to_string(), json!("value"));
+
+    let created = conv
+        .create_conversation(NewConversation {
+            id: None,
+            metadata: Some(metadata.clone()),
+        })
+        .await
+        .expect("create_conversation");
+
+    let fetched = conv
+        .get_conversation(&created.id)
+        .await
+        .expect("get_conversation must not panic on the JSON metadata column")
+        .expect("conversation should exist");
+    assert_eq!(fetched.metadata, Some(metadata));
+}
+
+#[tokio::test]
+#[ignore = "requires a live Postgres database; set DATA_CONNECTOR_TEST_POSTGRES_URL and run with -- --ignored"]
+async fn conversation_item_content_round_trips_json_column() {
+    let Some(db_url) = test_db_url() else {
+        return;
+    };
+    let bundle = postgres_bundle(&db_url)
+        .await
+        .expect("failed to initialize Postgres storage");
+    let items = bundle.conversation_item_storage;
+
+    let content = json!([{"type": "text", "text": "hello"}]);
+    let item = items
+        .create_item(NewConversationItem {
+            id: None,
+            response_id: None,
+            item_type: "message".to_string(),
+            role: Some("user".to_string()),
+            content: content.clone(),
+            status: Some("completed".to_string()),
+        })
+        .await
+        .expect("create_item");
+
+    let fetched = items
+        .get_item(&item.id)
+        .await
+        .expect("get_item must not panic on the JSON content column")
+        .expect("item should exist");
+    assert_eq!(fetched.content, content);
+}

--- a/crates/data_connector/tests/postgres_integration.rs
+++ b/crates/data_connector/tests/postgres_integration.rs
@@ -11,8 +11,9 @@
 //!
 //! These stay opt-in (`#[ignore]`) rather than running under plain
 //! `cargo test`, since they need a real database. CI provisions a shared
-//! Postgres instance (`postgres-db` in `agentic-services.yaml`) and runs
-//! these with `--ignored` as a dedicated step. To run locally:
+//! Postgres instance (`postgres-db` in `agentic-services.yaml`), creates a
+//! database unique to the run, and runs these with `--ignored` at the end
+//! of the `Run Rust tests` step. To run locally:
 //!
 //!   docker run -d -e POSTGRES_PASSWORD=test -e POSTGRES_DB=smg_test \
 //!       -p 5432:5432 postgres:16

--- a/scripts/ci_agentic_svc_deps.sh
+++ b/scripts/ci_agentic_svc_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# CI helper for shared services (Oracle DB, Brave Search MCP).
+# CI helper for shared services (Oracle DB, Postgres DB, Brave Search MCP).
 # Usage:
-#   bash ci_agentic_svc_deps.sh check [--oracle <host>] [--brave <host>]
+#   bash ci_agentic_svc_deps.sh check [--oracle <host>] [--postgres <host>] [--brave <host>]
 #   bash ci_agentic_svc_deps.sh setup-oracle-client
 #   bash ci_agentic_svc_deps.sh create-oracle-user <host>
 #   bash ci_agentic_svc_deps.sh cleanup-oracle-user <host>
@@ -58,6 +58,12 @@ cmd_check() {
                     check_port "Oracle DB" "$2" 1521 || failed=1; shift 2
                 else
                     check_port "Oracle DB" "oracle-db" 1521 || failed=1; shift
+                fi ;;
+            --postgres)
+                if [[ -n "${2:-}" && "$2" != --* ]]; then
+                    check_port "Postgres DB" "$2" 5432 || failed=1; shift 2
+                else
+                    check_port "Postgres DB" "postgres-db" 5432 || failed=1; shift
                 fi ;;
             --brave)
                 if [[ -n "${2:-}" && "$2" != --* ]]; then

--- a/scripts/ci_agentic_svc_deps.sh
+++ b/scripts/ci_agentic_svc_deps.sh
@@ -12,15 +12,28 @@
 
 set -uo pipefail
 
+# Retries with a short backoff so a shared service that's mid-restart
+# (pod rollout, transient network blip) doesn't fail CI outright — but
+# still hard-fails (non-zero exit) once attempts are exhausted, so a
+# genuinely-down service still fails the job instead of being silently
+# skipped downstream.
 check_port() {
     local name="$1" host="$2" port="$3"
-    echo -n "Checking $name on $host:$port... "
-    if python3 -c "import socket; s=socket.create_connection(('$host', $port), 5); s.close()" 2>/dev/null; then
-        echo "ok"
-    else
-        echo "FAILED"
-        return 1
-    fi
+    local attempts="${CHECK_PORT_RETRIES:-6}" delay="${CHECK_PORT_RETRY_DELAY:-5}"
+    local i
+    for ((i = 1; i <= attempts; i++)); do
+        echo -n "Checking $name on $host:$port (attempt $i/$attempts)... "
+        if python3 -c "import socket; s=socket.create_connection(('$host', $port), 5); s.close()" 2>/dev/null; then
+            echo "ok"
+            return 0
+        fi
+        echo "not ready"
+        if [ "$i" -lt "$attempts" ]; then
+            sleep "$delay"
+        fi
+    done
+    echo "FAILED: $name on $host:$port not reachable after $attempts attempts"
+    return 1
 }
 
 ci_oracle_username() {

--- a/scripts/ci_agentic_svc_deps.sh
+++ b/scripts/ci_agentic_svc_deps.sh
@@ -7,6 +7,8 @@
 #   bash ci_agentic_svc_deps.sh cleanup-oracle-user <host>
 #   bash ci_agentic_svc_deps.sh create-oracle-flyway-user <host>
 #   bash ci_agentic_svc_deps.sh cleanup-oracle-flyway-user <host>
+#   bash ci_agentic_svc_deps.sh create-postgres-db <host>
+#   bash ci_agentic_svc_deps.sh cleanup-postgres-db <host>
 
 set -uo pipefail
 
@@ -43,6 +45,29 @@ ci_oracle_username() {
     printf "%s_%s\n" "$prefix" "${tag:0:$max_tag_len}"
 }
 
+# Unique-per-run Postgres database name, so concurrent workflow runs sharing
+# the `postgres-db` service don't race on first-time `CREATE TABLE`/migration
+# DDL against the same database (see PR #1935 review discussion).
+ci_postgres_dbname() {
+    local random="${CI_POSTGRES_NAME_RANDOM:-$(openssl rand -hex 3)}"
+    random=$(printf "%s" "$random" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9')
+
+    local tag
+    if [ -n "${GITHUB_RUN_ID:-}" ]; then
+        local run_tail="${GITHUB_RUN_ID: -10}"
+        local attempt="${GITHUB_RUN_ATTEMPT:-0}"
+        tag="${run_tail}_${attempt}_${random}"
+    else
+        # Fallback for local/manual runs: keep the old hostname signal, plus entropy.
+        local raw_name
+        raw_name=$(echo "${HOSTNAME:-runner}" | rev | cut -d'-' -f1,2 | rev | tr '[:upper:]-' '[:lower:]_')
+        tag="${raw_name}_${random}"
+    fi
+
+    tag=$(printf "%s" "$tag" | tr -cd 'a-z0-9_')
+    printf "smg_ci_test_%s\n" "${tag:0:40}"
+}
+
 append_github_env() {
     if [ -n "${GITHUB_ENV:-}" ]; then
         echo "$1" >> "$GITHUB_ENV"
@@ -75,6 +100,37 @@ cmd_check() {
         esac
     done
     return $failed
+}
+
+cmd_create_postgres_db() {
+    set -e
+    local postgres_host="${1:-postgres-db}"
+    local admin_url="postgresql://postgres:postgres@${postgres_host}:5432/postgres"
+
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq postgresql-client
+
+    TEST_DB="$(ci_postgres_dbname)"
+    echo "Creating Postgres test database: $TEST_DB"
+
+    psql "$admin_url" -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"$TEST_DB\";"
+
+    append_github_env "CI_POSTGRES_TEST_DB=$TEST_DB"
+    append_github_env "DATA_CONNECTOR_TEST_POSTGRES_URL=postgresql://postgres:postgres@${postgres_host}:5432/${TEST_DB}"
+}
+
+cmd_cleanup_postgres_db() {
+    local postgres_host="${1:-postgres-db}"
+    local admin_url="postgresql://postgres:postgres@${postgres_host}:5432/postgres"
+
+    if [ -z "${CI_POSTGRES_TEST_DB:-}" ]; then
+        echo "No Postgres test database to clean up"
+        return 0
+    fi
+
+    echo "Dropping Postgres test database: $CI_POSTGRES_TEST_DB"
+    psql "$admin_url" -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS \"$CI_POSTGRES_TEST_DB\" WITH (FORCE);" \
+        || echo "Warning: failed to drop Postgres test database $CI_POSTGRES_TEST_DB"
 }
 
 cmd_setup_oracle_client() {
@@ -283,5 +339,7 @@ case "$COMMAND" in
     cleanup-oracle-user)  cmd_cleanup_oracle_user "$@" ;;
     create-oracle-flyway-user)   cmd_create_oracle_flyway_user "$@" ;;
     cleanup-oracle-flyway-user)  cmd_cleanup_oracle_flyway_user "$@" ;;
+    create-postgres-db)   cmd_create_postgres_db "$@" ;;
+    cleanup-postgres-db)  cmd_cleanup_postgres_db "$@" ;;
     *)                    echo "Unknown command: $COMMAND"; exit 1 ;;
 esac

--- a/scripts/k8s-runner-resources/agentic-services.yaml
+++ b/scripts/k8s-runner-resources/agentic-services.yaml
@@ -71,6 +71,74 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: postgres-db
+  namespace: actions-runner-system
+  labels:
+    app: postgres-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres-db
+  template:
+    metadata:
+      labels:
+        app: postgres-db
+    spec:
+      containers:
+        - name: postgres-db
+          image: docker.io/library/postgres:16
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_PASSWORD
+              value: postgres
+            - name: POSTGRES_DB
+              value: smg_ci_test
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          startupProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 30
+            successThreshold: 1
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-db
+  namespace: actions-runner-system
+  labels:
+    app: postgres-db
+spec:
+  selector:
+    app: postgres-db
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: brave-search-mcp
   namespace: actions-runner-system
   labels:


### PR DESCRIPTION
## Description

### Problem

Closes #1930

The Postgres backend in `data-connector` declares `responses.input`,
`responses.raw_response`, `conversations.metadata`, and
`conversation_items.content` as native Postgres `JSON` columns, but
handled them as `String` on both sides of the wire:

- **Reads** used `Row::get::<Option<String>>(...)`. `tokio-postgres`'s
  typed decoder rejects a `JSON`-typed column fetched as `String`, and
  `Row::get` panics on the mismatch (`WrongType`). This killed the
  request task with no HTTP response — reproducible via `/v1/responses`
  continuation through `previous_response_id` (store a response, then
  fetch it back).
- **Writes** (`create_conversation`, `update_conversation`,
  `create_item`) serialized the JSON value to a `String` first, then
  bound that `String` as the parameter. `tokio-postgres` resolves the
  placeholder's type from the target column (`json`/`jsonb`) and
  rejects a `String` value for it at the parameter-binding layer
  (`error serializing parameter`) — this one doesn't show up from unit
  tests, only against a real server.

### Solution

Read and write these four columns as `serde_json::Value` directly,
matching what `tokio-postgres` actually decodes/encodes `JSON`/`JSONB`
as under the `with-serde_json-1` feature (already enabled). Reads use
`try_get` (not `get`) so schema drift or malformed data returns an
error instead of panicking the request task.

## Changes

- `crates/data_connector/src/postgres.rs`:
  - `build_response_from_row`, `build_item_from_row`,
    `PostgresConversationStorage::get_conversation` now `try_get` the
    JSON columns as `Option<Value>` and propagate decode errors
    instead of panicking.
  - `create_conversation`, `update_conversation`, `create_item` now
    bind `Value` directly for the JSON columns instead of a
    pre-serialized `String`.
  - `PostgresConversationStorage::parse_metadata` now operates on
    `Value` instead of routing through the Oracle/Redis text-based
    `parse_conversation_metadata` helper (Postgres already gives us a
    parsed `Value`, not text to parse).
- `crates/data_connector/tests/postgres_integration.rs` (new): opt-in
  integration tests (env-gated, `#[ignore]`) covering
  `store_response` → `get_response` (the exact issue #1930 repro),
  `get_response_chain`, and conversation/item JSON round-trips.
- `scripts/k8s-runner-resources/agentic-services.yaml`: adds a shared
  `postgres-db` Deployment + Service in the `actions-runner-system`
  namespace, mirroring the existing `oracle-db` pattern.
- `scripts/ci_agentic_svc_deps.sh`: adds a `--postgres <host>`
  reachability check, mirroring `--oracle`.
- `.github/workflows/pr-test-rust.yml`: `unit-tests` job now checks
  the Postgres shared service and runs the new integration tests
  (`--ignored --test-threads=1`) so this regression is covered by CI
  going forward, not just local unit tests.

## Test Plan

Reproduced the exact panic from #1930 locally, then verified the fix
against both a local run and the shared `postgres-db` service in the
`fra-dev` cluster (same instance CI now points at):

```
DATA_CONNECTOR_TEST_POSTGRES_URL=postgres://postgres:postgres@<host>:5432/smg_ci_test \
  cargo test -p data-connector --test postgres_integration -- --ignored --test-threads=1

running 4 tests
test conversation_item_content_round_trips_json_column ... ok
test conversation_metadata_round_trips_json_column ... ok
test get_response_chain_walks_json_columns ... ok
test store_and_get_response_round_trips_json_columns ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Also ran, all clean:

```
cargo +nightly fmt --all -- --check          # no output
cargo clippy --workspace --all-targets -- -D warnings   # 0 warnings
cargo test --workspace --exclude smg         # 77 passed, 0 failed
cargo test -p smg                            # 20 passed, 0 failed
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL handling for JSON conversation metadata, conversation item content, and stored responses by using native JSON decoding/binding.
  * Enhanced error handling and defaults for NULL/missing values and non-object JSON metadata, with clearer storage errors.

* **Tests**
  * Added unit coverage for metadata parsing edge-cases.
  * Added opt-in PostgreSQL integration tests for JSON round-trips, response chains, and conversation updates.
  * Updated CI to provision an isolated Postgres test database, run targeted Postgres tests with a timeout, and always clean up afterward.

* **Chores**
  * Added CI/Kubernetes Postgres support, including new helper commands, retrying port checks, and a dedicated runner Postgres deployment/service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->