### PR TITLE
fix(e2e): wait for gateway readiness

### DIFF
--- a/e2e_test/infra/process_utils.py
+++ b/e2e_test/infra/process_utils.py
@@ -181,9 +181,9 @@ def wait_for_workers_ready(
                         except ValueError:
                             readiness_data = {}
                         if isinstance(readiness_data, dict):
-                            readiness_reason = readiness_data.get(
-                                "reason", readiness_data.get("status", readiness_reason)
-                            )
+                            reason = readiness_data.get("reason") or readiness_data.get("status")
+                            if isinstance(reason, str):
+                                readiness_reason = reason
                         else:
                             readiness_data = {}
                         healthy_workers = readiness_data.get("healthy_workers", 0)

--- a/e2e_test/infra/process_utils.py
+++ b/e2e_test/infra/process_utils.py
@@ -186,9 +186,20 @@ def wait_for_workers_ready(
                             )
                         else:
                             readiness_data = {}
+                        healthy_workers = readiness_data.get("healthy_workers", 0)
+                        if not isinstance(healthy_workers, int):
+                            healthy_workers = 0
+                        if (
+                            readiness_data.get("status") == "ready"
+                            and healthy_workers < expected_workers
+                        ):
+                            readiness_reason = (
+                                f"healthy workers {healthy_workers}/{expected_workers}"
+                            )
                         if (
                             readiness_resp.status_code == 200
                             and readiness_data.get("status") == "ready"
+                            and healthy_workers >= expected_workers
                         ):
                             logger.info(
                                 "All %d workers connected and gateway ready after %.1fs",

--- a/e2e_test/infra/process_utils.py
+++ b/e2e_test/infra/process_utils.py
@@ -175,10 +175,17 @@ def wait_for_workers_ready(
                         readiness_resp = session.get(
                             f"{router_url}/readiness", headers=headers, timeout=5
                         )
-                        readiness_data = readiness_resp.json()
-                        readiness_reason = readiness_data.get(
-                            "reason", readiness_data.get("status", "unknown")
-                        )
+                        readiness_reason = f"status {readiness_resp.status_code}"
+                        try:
+                            readiness_data = readiness_resp.json()
+                        except ValueError:
+                            readiness_data = {}
+                        if isinstance(readiness_data, dict):
+                            readiness_reason = readiness_data.get(
+                                "reason", readiness_data.get("status", readiness_reason)
+                            )
+                        else:
+                            readiness_data = {}
                         if (
                             readiness_resp.status_code == 200
                             and readiness_data.get("status") == "ready"

--- a/e2e_test/infra/process_utils.py
+++ b/e2e_test/infra/process_utils.py
@@ -151,7 +151,7 @@ def wait_for_workers_ready(
     timeout: float = 300,
     api_key: str | None = None,
 ) -> None:
-    """Wait for router to have all workers connected.
+    """Wait for all workers to connect and for the router to become ready.
 
     Args:
         router_url: Base URL of the router
@@ -161,6 +161,8 @@ def wait_for_workers_ready(
     """
     start = time.perf_counter()
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    connected_workers = 0
+    readiness_reason = "not checked"
 
     with requests.Session() as session:
         while time.perf_counter() - start < timeout:
@@ -168,20 +170,34 @@ def wait_for_workers_ready(
                 resp = session.get(f"{router_url}/workers", headers=headers, timeout=5)
                 if resp.status_code == 200:
                     data = resp.json()
-                    total = data.get("total", len(data.get("workers", [])))
-                    if total >= expected_workers:
-                        logger.info(
-                            "All %d workers connected after %.1fs",
-                            expected_workers,
-                            time.perf_counter() - start,
+                    connected_workers = data.get("total", len(data.get("workers", [])))
+                    if connected_workers >= expected_workers:
+                        readiness_resp = session.get(
+                            f"{router_url}/readiness", headers=headers, timeout=5
                         )
-                        return
-            except requests.RequestException:
+                        readiness_data = readiness_resp.json()
+                        readiness_reason = readiness_data.get(
+                            "reason", readiness_data.get("status", "unknown")
+                        )
+                        if (
+                            readiness_resp.status_code == 200
+                            and readiness_data.get("status") == "ready"
+                        ):
+                            logger.info(
+                                "All %d workers connected and gateway ready after %.1fs",
+                                expected_workers,
+                                time.perf_counter() - start,
+                            )
+                            return
+                    else:
+                        readiness_reason = "waiting for workers"
+            except (requests.RequestException, ValueError):
                 pass
             time.sleep(2)
 
     raise TimeoutError(
-        f"Router at {router_url} did not get {expected_workers} workers within {timeout}s"
+        f"Router at {router_url} did not become ready within {timeout}s "
+        f"(workers: {connected_workers}/{expected_workers}, readiness: {readiness_reason})"
     )
 
 


### PR DESCRIPTION
## Description

### Problem

The E2E gateway startup helper returned once the expected workers appeared
in `/workers`. For gRPC workers, tokenizer registration may still be in
progress, causing requests to fail with `tokenizer_not_found`.

Closes #1842

### Solution

Wait for the expected worker count and for `/readiness` to report
`status: "ready"` before declaring the gateway ready.

## Changes

- Poll `/readiness` after the expected workers connect.
- Include worker count and readiness state in timeout errors.

## Test Plan

Before the change, a simulated sequence where `/workers` reported one worker
and `/readiness` returned 503 showed that the helper returned without checking
readiness.

After the change, the helper continued polling until `/readiness` returned 200
with `status: "ready"`.

Local checks:

- `ruff check e2e_test/infra/process_utils.py`
- `ruff format --check e2e_test/infra/process_utils.py`
- `python -m py_compile e2e_test/infra/process_utils.py`

The GPU E2E test was not run locally because TRT-LLM requires Linux and NVIDIA
CUDA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness validation by ensuring the expected number of connected workers is reached and the router reports a ready status.
  * Enhanced readiness checking by also consulting the router’s readiness endpoint and treating intermittent JSON parsing issues as non-fatal.
  * Updated timeout messages to include worker connection progress and the latest readiness details for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->