### PR TITLE
chore: bump versions for v1.8.0 release

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+SGLang |
   ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.12.post1' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.12.post1') }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.7.0'
+        default: 'v1.8.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.7.0-sglang-v0.5.12.post1)'
+        description: 'Override image tag (e.g. v1.8.0-sglang-v0.5.12.post1)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+TRTLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18') }} |
   engine=${{ inputs.trtllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.7.0'
+        default: 'v1.8.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.7.0-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.8.0-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
       source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+vLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.22.1') }} |
   engine=${{ inputs.vllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.7.0'
+        default: 'v1.8.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.7.0-vllm-v0.22.1)'
+        description: 'Override image tag (e.g. v1.8.0-vllm-v0.22.1)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.7.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,20 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.9.0", path = "crates/protocols" }
+openai-protocol = { version = "1.10.0", path = "crates/protocols" }
 smg-mm-rdma = { version = "0.1.0", path = "crates/mm_rdma" }
-reasoning-parser = { version = "1.4.0", path = "crates/reasoning_parser" }
-tool-parser = { version = "1.4.0", path = "crates/tool_parser" }
+reasoning-parser = { version = "1.5.0", path = "crates/reasoning_parser" }
+tool-parser = { version = "1.5.0", path = "crates/tool_parser" }
 wfaas = { version = "1.0.5", path = "crates/workflow" }
-llm-tokenizer = { version = "1.4.2", path = "crates/tokenizer" }
+llm-tokenizer = { version = "1.5.0", path = "crates/tokenizer" }
 smg-auth = { version = "1.2.2", path = "crates/auth" }
 smg-mcp = { version = "2.3.2", path = "crates/mcp" }
 kv-index = { version = "1.3.2", path = "crates/kv_index" }
 smg-data-connector = { version = "2.3.2", path = "crates/data_connector", package = "data-connector" }
-llm-multimodal = { version = "1.7.1", path = "crates/multimodal" }
+llm-multimodal = { version = "1.8.0", path = "crates/multimodal" }
 smg-wasm = { version = "1.1.3", path = "crates/wasm", package = "smg-wasm" }
 smg-mesh = { version = "1.4.2", path = "crates/mesh", package = "smg-mesh" }
-smg-grpc-client = { version = "1.8.0", path = "crates/grpc_client" }
+smg-grpc-client = { version = "1.9.0", path = "crates/grpc_client" }
 
 # Shared dependencies
 anyhow = "1.0"

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.7.0"
+version = "1.8.0"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-grpc-client"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2021"
 description = "gRPC clients for vLLM, TensorRT-LLM, MLX, TokenSpeed, and SGLang backends"
 license = "Apache-2.0"

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-multimodal"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/crates/reasoning_parser/Cargo.toml
+++ b/crates/reasoning_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasoning-parser"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"

--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-tokenizer"
-version = "1.4.2"
+version = "1.5.0"
 edition = "2021"
 description = "LLM tokenizer library with caching and chat template support"
 license = "Apache-2.0"

--- a/crates/tool_parser/Cargo.toml
+++ b/crates/tool_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool-parser"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 description = "Tool/function call parser for LLM model outputs"
 license = "Apache-2.0"

--- a/deploy/helm/smg/Chart.yaml
+++ b/deploy/helm/smg/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: smg
 description: "Shepherd Model Gateway - high-performance inference router for LLM deployments"
 type: application
-version: 1.7.0
-appVersion: "1.7.0"
+version: 1.8.0
+appVersion: "1.8.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/lightseekorg/smg
 sources:

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-servicer"
-version = "0.6.0"
+version = "0.7.0"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, MLX, TokenSpeed, SGLang)"
 requires-python = ">=3.10"
 dependencies = [

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description

Version bumps for the **SMG v1.8.0** release, generated by `make check-versions` against tag `v1.7.0`.

This is a **version-bump-only** release. Engine base images are unchanged; the Docker workflow changes only update SMG references from `v1.7.0` to `v1.8.0`.

## Changes

- `smg` 1.7.0 -> **1.8.0**
- Synced Python, Go, Helm, and Docker workflow versions to **1.8.0**
- `openai-protocol` 1.9.0 -> **1.10.0**
- `reasoning-parser` 1.4.0 -> **1.5.0**
- `tool-parser` 1.4.0 -> **1.5.0**
- `llm-tokenizer` 1.4.2 -> **1.5.0**
- `llm-multimodal` 1.7.1 -> **1.8.0**
- `smg-grpc-client` 1.8.0 -> **1.9.0**
- `smg-grpc-servicer` 0.6.0 -> **0.7.0**
- `smg-grpc-proto` was already bumped to **0.4.14**

## Test Plan

- `make check-versions`: **All versions consistent**
- `git diff --cached --check`
- Version metadata only; no engine base-image changes
- `Cargo.lock` is gitignored and refreshes at build time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Updates**
  * Updated default SMG version to **v1.8.0** for Docker release workflows and aligned run naming/build parameters accordingly.
  * Bumped released versions across **Docker/Helm** (chart **1.8.0**) and **language bindings** (Go + Python to **1.8.0**).
  * Updated component and protocol-related package versions, including **gRPC service to 0.7.0**, **gRPC client to 1.9.0**, and related parsing/tokenization/multimodal/token/tool/protocol packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->