### PR TITLE
fix(ci): repair crate publication order

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -8,6 +8,8 @@ on:
     branches: [main]
     paths:
       - '**/Cargo.toml'
+      - '.github/workflows/release-crates.yml'
+      - '.github/actions/publish-crate/**'
   workflow_dispatch:
 
 env:
@@ -31,12 +33,12 @@ jobs:
             path: crates/data_connector
           - crate: wfaas
             path: crates/workflow
-          - crate: smg-wasm
-            path: crates/wasm
           - crate: smg-auth
             path: crates/auth
-          - crate: llm-tokenizer
-            path: crates/tokenizer
+          - crate: smg-mcp
+            path: crates/mcp
+          - crate: smg-mm-rdma
+            path: crates/mm_rdma
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/publish-crate
@@ -55,14 +57,16 @@ jobs:
         include:
           - crate: tool-parser
             path: crates/tool_parser
-          - crate: smg-mcp
-            path: crates/mcp
           - crate: smg-grpc-client
             path: crates/grpc_client
-          - crate: llm-multimodal
-            path: crates/multimodal
+          - crate: smg-client
+            path: clients/rust
           - crate: smg-mesh
             path: crates/mesh
+          - crate: smg-wasm
+            path: crates/wasm
+          - crate: llm-tokenizer
+            path: crates/tokenizer
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/publish-crate
@@ -71,9 +75,21 @@ jobs:
           path: ${{ matrix.path }}
           token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-  # Tier 3: Main crate depending on all others
+  # Tier 3: Crates depending on tier 2
   tier3:
     needs: tier2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/publish-crate
+        with:
+          crate: llm-multimodal
+          path: crates/multimodal
+          token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Tier 4: Main crate depending on all others
+  tier4:
+    needs: tier3
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ llm-tokenizer = { version = "1.5.0", path = "crates/tokenizer" }
 smg-auth = { version = "1.2.2", path = "crates/auth" }
 smg-mcp = { version = "2.3.2", path = "crates/mcp" }
 kv-index = { version = "1.3.2", path = "crates/kv_index" }
-smg-data-connector = { version = "2.3.2", path = "crates/data_connector", package = "data-connector" }
+smg-data-connector = { version = "2.3.3", path = "crates/data_connector", package = "data-connector" }
 llm-multimodal = { version = "1.8.0", path = "crates/multimodal" }
 smg-wasm = { version = "1.1.3", path = "crates/wasm", package = "smg-wasm" }
 smg-mesh = { version = "1.4.2", path = "crates/mesh", package = "smg-mesh" }

--- a/crates/data_connector/Cargo.toml
+++ b/crates/data_connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-connector"
-version = "2.3.2"
+version = "2.3.3"
 edition = "2021"
 description = "Storage backends for conversations and responses"
 license = "Apache-2.0"

--- a/model_gateway/src/routers/grpc/multimodal/assemble.rs
+++ b/model_gateway/src/routers/grpc/multimodal/assemble.rs
@@ -719,7 +719,9 @@ fn hash_hex_strings<'a>(hashes: impl Iterator<Item = &'a str>) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use std::{mem::size_of, path::Path, sync::Arc};
+    #[cfg(target_os = "linux")]
+    use std::path::Path;
+    use std::{mem::size_of, sync::Arc};
 
     use llm_multimodal::{
         audio::DecodedAudio, AudioClip, AudioSource, ImageDetail, ImageFrame, VideoClip,
@@ -727,6 +729,7 @@ mod tests {
     use ndarray::{ArrayD, IxDyn};
 
     use super::*;
+    #[cfg(target_os = "linux")]
     use crate::routers::grpc::proto_wrapper::write_tokenspeed_shm_with;
 
     #[cfg(target_os = "linux")]

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -59,6 +59,7 @@ escape_version() {
 # ---------------------------------------------------------------------------
 CRATES=(
     "openai-protocol|crates/protocols|openai-protocol"
+    "smg-mm-rdma|crates/mm_rdma|smg-mm-rdma"
     "reasoning-parser|crates/reasoning_parser|reasoning-parser"
     "tool-parser|crates/tool_parser|tool-parser"
     "wfaas|crates/workflow|wfaas"


### PR DESCRIPTION
## Description

The v1.8.0 crate release failed when publishing `smg` because its unpublished `smg-mm-rdma` dependency was missing from the release workflow. The dependency audit also found crates in invalid tiers and the publishable `smg-client` crate absent from the workflow.

Failed run: https://github.com/lightseekorg/smg/actions/runs/29648333758

## Changes

- Add `smg-mm-rdma` to tier 1 and release-version tracking.
- Move `smg-mcp` to tier 1; move `smg-wasm` and `llm-tokenizer` to tier 2.
- Add `smg-client` to tier 2.
- Publish `llm-multimodal` in tier 3 and `smg` in tier 4.
- Trigger the release workflow when the workflow or publish action itself changes.
- Bump `data-connector` from 2.3.2 to 2.3.3 so the changes merged after the v1.8.0 release branch are published before retrying `smg`.
- Gate Linux-only test imports to keep all-feature clippy clean on macOS.

## Test Plan

- `./scripts/check_release_versions.sh v1.7.0`
- Structured manifest/workflow audit: all 16 publishable crates are present in valid dependency order
- `cargo publish --dry-run -p smg-mm-rdma --allow-dirty`
- `cargo publish --dry-run -p data-connector --allow-dirty`
- `cargo +nightly fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Improved automated crate publishing so releases are triggered by relevant workflow and publishing updates.
  * Reorganized publishing stages to support a clearer sequence across crate tiers.
  * Added additional crates to release version consistency checks.

* **Bug Fixes**
  * Improved cross-platform handling for multimodal components, particularly outside Linux environments.

* **Maintenance**
  * Updated the data connector package to version 2.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->