### PR TITLE
fix(tool_parser): ignore <|END_ACTION|> inside Cohere JSON strings

### DIFF
--- a/crates/tool_parser/src/parsers/cohere.rs
+++ b/crates/tool_parser/src/parsers/cohere.rs
@@ -154,9 +154,9 @@ impl CohereParser {
     }
 
     /// Offset of END_ACTION in `s`, ignoring occurrences inside JSON strings.
-    ///
-    /// If quotes never close, fall back to a plain search so a later real
-    /// delimiter still ends the action (malformed-JSON recovery).
+    /// Incomplete / unclosed quotes return None so streaming can wait for more
+    /// input (no find/rfind fallback — that breaks mid-string streams and can
+    /// swallow a following action).
     fn find_end_action_outside_strings(s: &str) -> Option<usize> {
         let mut in_string = false;
         let mut escape = false;
@@ -191,11 +191,6 @@ impl CohereParser {
                 return Some(i);
             }
             i += 1;
-        }
-        if in_string {
-            // Prefer the last marker: an earlier one may sit inside the
-            // unclosed string before the real closing delimiter.
-            return s.rfind(END_ACTION);
         }
         None
     }

--- a/crates/tool_parser/src/parsers/cohere.rs
+++ b/crates/tool_parser/src/parsers/cohere.rs
@@ -140,22 +140,56 @@ impl CohereParser {
             .collect()
     }
 
-    /// Extract JSON content between START_ACTION and END_ACTION
+    /// Extract JSON between START_ACTION and END_ACTION (skip markers inside strings).
     fn extract_action_json(text: &str) -> Option<(usize, &str, usize)> {
         let start_idx = text.find(START_ACTION)?;
         let json_start = start_idx + START_ACTION.len();
+        let end_offset = Self::find_end_action_outside_strings(&text[json_start..])?;
+        let json_str = &text[json_start..json_start + end_offset];
+        Some((
+            start_idx,
+            json_str,
+            json_start + end_offset + END_ACTION.len(),
+        ))
+    }
 
-        if let Some(end_offset) = text[json_start..].find(END_ACTION) {
-            let json_str = &text[json_start..json_start + end_offset];
-            Some((
-                start_idx,
-                json_str,
-                json_start + end_offset + END_ACTION.len(),
-            ))
-        } else {
-            // Incomplete - no END_ACTION yet
-            None
+    /// Offset of END_ACTION in `s`, ignoring occurrences inside JSON strings.
+    fn find_end_action_outside_strings(s: &str) -> Option<usize> {
+        let mut in_string = false;
+        let mut escape = false;
+        let bytes = s.as_bytes();
+        let needle = END_ACTION.as_bytes();
+        let mut i = 0;
+        while i + needle.len() <= bytes.len() {
+            if escape {
+                escape = false;
+                i += 1;
+                continue;
+            }
+            let b = bytes[i];
+            if in_string {
+                if b == b'\\' {
+                    escape = true;
+                    i += 1;
+                    continue;
+                }
+                if b == b'"' {
+                    in_string = false;
+                }
+                i += 1;
+                continue;
+            }
+            if b == b'"' {
+                in_string = true;
+                i += 1;
+                continue;
+            }
+            if bytes[i..].starts_with(needle) {
+                return Some(i);
+            }
+            i += 1;
         }
+        None
     }
 }
 
@@ -244,7 +278,7 @@ impl ToolParser for CohereParser {
 
             ParseState::InAction => {
                 // Check if we have END_ACTION
-                if let Some(pos) = self.buffer.find(END_ACTION) {
+                if let Some(pos) = Self::find_end_action_outside_strings(&self.buffer) {
                     // We have complete JSON - extract it before modifying buffer
                     let json_content = self.buffer[..pos].to_string();
 

--- a/crates/tool_parser/src/parsers/cohere.rs
+++ b/crates/tool_parser/src/parsers/cohere.rs
@@ -154,6 +154,9 @@ impl CohereParser {
     }
 
     /// Offset of END_ACTION in `s`, ignoring occurrences inside JSON strings.
+    ///
+    /// If quotes never close, fall back to a plain search so a later real
+    /// delimiter still ends the action (malformed-JSON recovery).
     fn find_end_action_outside_strings(s: &str) -> Option<usize> {
         let mut in_string = false;
         let mut escape = false;
@@ -184,10 +187,13 @@ impl CohereParser {
                 i += 1;
                 continue;
             }
-            if bytes[i..].starts_with(needle) {
+            if Some(&b) == needle.first() && bytes[i..].starts_with(needle) {
                 return Some(i);
             }
             i += 1;
+        }
+        if in_string {
+            return s.find(END_ACTION);
         }
         None
     }

--- a/crates/tool_parser/src/parsers/cohere.rs
+++ b/crates/tool_parser/src/parsers/cohere.rs
@@ -193,7 +193,9 @@ impl CohereParser {
             i += 1;
         }
         if in_string {
-            return s.find(END_ACTION);
+            // Prefer the last marker: an earlier one may sit inside the
+            // unclosed string before the real closing delimiter.
+            return s.rfind(END_ACTION);
         }
         None
     }

--- a/crates/tool_parser/tests/tool_parser_cohere.rs
+++ b/crates/tool_parser/tests/tool_parser_cohere.rs
@@ -350,16 +350,12 @@ async fn test_cohere_end_action_marker_inside_string_param() {
 }
 
 #[tokio::test]
-async fn test_cohere_unclosed_string_prefers_last_end_action() {
+async fn test_cohere_unclosed_string_does_not_false_terminate() {
     let parser = CohereParser::new();
-    // Missing closing quote before the real delimiter; first END_ACTION is inside
-    // the unclosed string, the second is the real close.
+    // Unclosed quote: do not treat an in-string END_ACTION (or a later one via
+    // find/rfind fallback) as a complete action — streaming may still be open.
     let input = r#"<|START_ACTION|>{"tool_name": "echo", "parameters": {"text": "say <|END_ACTION|> please}<|END_ACTION|>"#;
     let (normal, tools) = parser.parse_complete(input).await.unwrap();
-    assert!(
-        !normal.contains("<|END_ACTION|>"),
-        "leftover delimiter in normal text: {normal:?}"
-    );
-    // JSON is still malformed so tools may be empty; termination is the contract here.
-    let _ = tools;
+    assert!(tools.is_empty());
+    assert!(normal.contains("<|START_ACTION|>"));
 }

--- a/crates/tool_parser/tests/tool_parser_cohere.rs
+++ b/crates/tool_parser/tests/tool_parser_cohere.rs
@@ -336,3 +336,15 @@ async fn test_cohere_tool_call_id_field() {
     assert_eq!(tools[0].function.name, "search");
     // Note: tool_call_id is currently ignored - this test documents current behavior
 }
+
+#[tokio::test]
+async fn test_cohere_end_action_marker_inside_string_param() {
+    let parser = CohereParser::new();
+    let input = r#"<|START_ACTION|>{"tool_name": "echo", "parameters": {"text": "say <|END_ACTION|> please"}}<|END_ACTION|>"#;
+
+    let (_, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "echo");
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["text"], "say <|END_ACTION|> please");
+}

--- a/crates/tool_parser/tests/tool_parser_cohere.rs
+++ b/crates/tool_parser/tests/tool_parser_cohere.rs
@@ -348,3 +348,18 @@ async fn test_cohere_end_action_marker_inside_string_param() {
     let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert_eq!(args["text"], "say <|END_ACTION|> please");
 }
+
+#[tokio::test]
+async fn test_cohere_unclosed_string_prefers_last_end_action() {
+    let parser = CohereParser::new();
+    // Missing closing quote before the real delimiter; first END_ACTION is inside
+    // the unclosed string, the second is the real close.
+    let input = r#"<|START_ACTION|>{"tool_name": "echo", "parameters": {"text": "say <|END_ACTION|> please}<|END_ACTION|>"#;
+    let (normal, tools) = parser.parse_complete(input).await.unwrap();
+    assert!(
+        !normal.contains("<|END_ACTION|>"),
+        "leftover delimiter in normal text: {normal:?}"
+    );
+    // JSON is still malformed so tools may be empty; termination is the contract here.
+    let _ = tools;
+}


### PR DESCRIPTION
## Description

### Problem

Cohere tool calls are delimited by `<|START_ACTION|>…<|END_ACTION|>`. A parameter value that literally mentions `<|END_ACTION|>` was truncated at the first marker match, so the action JSON became invalid and the tool call was dropped.

### Solution

Scan for `END_ACTION` only outside JSON string literals (with escape awareness), matching how sibling parsers treat delimiter markers inside payloads.

## Changes

- `crates/tool_parser/src/parsers/cohere.rs`: string-aware `END_ACTION` locator for complete and streaming paths
- `crates/tool_parser/tests/tool_parser_cohere.rs`: regression for a marker inside a string param

## Test Plan

Before (pristine main): input
`<|START_ACTION|>{"tool_name": "echo", "parameters": {"text": "say <|END_ACTION|> please"}}<|END_ACTION|>`
yields 0 tools (JSON cut mid-string).

After: 1 tool named `echo` with `text == "say <|END_ACTION|> please"`.

```bash
cargo +nightly fmt --all -- --check
cargo clippy -p tool-parser --all-targets -- -D warnings
cargo test -p tool-parser --test tool_parser_cohere
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets` on `tool-parser` with `-D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call parsing when the action-end marker appears inside JSON string values.
  * Prevented streaming responses from terminating prematurely in this scenario.

* **Tests**
  * Added coverage confirming marker text is preserved correctly in tool-call arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->