### PR TITLE
fix(tool_parser): keep literal </arg_value> inside GLM-4 arg values

### DIFF
--- a/crates/tool_parser/src/parsers/glm4_moe.rs
+++ b/crates/tool_parser/src/parsers/glm4_moe.rs
@@ -27,9 +27,6 @@ pub struct Glm4MoeParser {
     tool_call_extractor: Regex,
     /// Regex for extracting function details
     func_detail_extractor: Regex,
-    /// Regex for extracting argument key-value pairs
-    arg_extractor: Regex,
-
     /// Buffer for accumulating incomplete patterns across chunks
     buffer: String,
 
@@ -65,13 +62,9 @@ impl Glm4MoeParser {
 
         let func_detail_extractor = Regex::new(func_detail_pattern).expect("Valid regex pattern");
 
-        let arg_pattern = r"(?s)<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>";
-        let arg_extractor = Regex::new(arg_pattern).expect("Valid regex pattern");
-
         Self {
             tool_call_extractor,
             func_detail_extractor,
-            arg_extractor,
             buffer: String::new(),
             prev_tool_call_arr: Vec::new(),
             current_tool_id: -1,
@@ -94,24 +87,64 @@ impl Glm4MoeParser {
     /// Parse arguments, coercing each value by its declared schema type and
     /// falling back to [`infer_value`] when the type is unknown.
     fn parse_arguments(
-        &self,
         args_text: &str,
         param_types: &HashMap<String, String>,
     ) -> serde_json::Map<String, Value> {
         let mut arguments = serde_json::Map::new();
-
-        for capture in self.arg_extractor.captures_iter(args_text) {
-            let key = capture.get(1).map_or("", |m| m.as_str()).trim();
-            let value_str = capture.get(2).map_or("", |m| m.as_str()).trim();
-
+        let mut rest = args_text;
+        while let Some(key_rel) = rest.find("<arg_key>") {
+            rest = &rest[key_rel + "<arg_key>".len()..];
+            let Some(key_end) = rest.find("</arg_key>") else {
+                break;
+            };
+            let key = rest[..key_end].trim();
+            rest = &rest[key_end + "</arg_key>".len()..];
+            let trimmed = rest.trim_start();
+            if !trimmed.starts_with("<arg_value>") {
+                continue;
+            }
+            rest = &trimmed["<arg_value>".len()..];
+            let Some(close_rel) = Self::find_arg_value_close(rest) else {
+                break;
+            };
+            let value_str = rest[..close_rel].trim();
             let value =
                 helpers::coerce_by_schema_type(value_str, param_types.get(key).map(String::as_str))
                     .unwrap_or_else(|| infer_value(value_str));
-
             arguments.insert(key.to_string(), value);
+            rest = &rest[close_rel + "</arg_value>".len()..];
         }
 
         arguments
+    }
+
+    /// First `</arg_value>` whose follower is end-of-args or a real next key pair.
+    fn find_arg_value_close(value_and_rest: &str) -> Option<usize> {
+        let needle = "</arg_value>";
+        let mut from = 0;
+        while let Some(rel) = value_and_rest[from..].find(needle) {
+            let abs = from + rel;
+            let after = &value_and_rest[abs + needle.len()..];
+            if after.trim_start().is_empty() || Self::follows_with_real_arg_key(after) {
+                return Some(abs);
+            }
+            from = abs + needle.len();
+        }
+        None
+    }
+
+    fn follows_with_real_arg_key(after: &str) -> bool {
+        let trimmed = after.trim_start();
+        if !trimmed.starts_with("<arg_key>") {
+            return false;
+        }
+        let rest = &trimmed["<arg_key>".len()..];
+        let Some(key_end) = rest.find("</arg_key>") else {
+            return false;
+        };
+        rest[key_end + "</arg_key>".len()..]
+            .trim_start()
+            .starts_with("<arg_value>")
     }
 
     /// Parse a single tool call block
@@ -124,7 +157,7 @@ impl Glm4MoeParser {
             let args_text = captures.get(2).map_or("", |m| m.as_str());
 
             let param_types = helpers::param_types_for_function(tools, func_name);
-            let arguments = self.parse_arguments(args_text, &param_types);
+            let arguments = Self::parse_arguments(args_text, &param_types);
 
             let arguments_str = serde_json::to_string(&arguments)
                 .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;

--- a/crates/tool_parser/src/parsers/glm4_moe.rs
+++ b/crates/tool_parser/src/parsers/glm4_moe.rs
@@ -125,7 +125,13 @@ impl Glm4MoeParser {
         while let Some(rel) = value_and_rest[from..].find(needle) {
             let abs = from + rel;
             let after = &value_and_rest[abs + needle.len()..];
-            if after.trim_start().is_empty() || Self::follows_with_real_arg_key(after) {
+            // Last close wins when nothing else follows as another close tag
+            // (trailing garbage / incomplete next key), without taking an
+            // earlier literal </arg_value> inside the value.
+            if after.trim_start().is_empty()
+                || Self::follows_with_real_arg_key(after)
+                || !after.contains(needle)
+            {
                 return Some(abs);
             }
             from = abs + needle.len();

--- a/crates/tool_parser/tests/tool_parser_glm47_moe.rs
+++ b/crates/tool_parser/tests/tool_parser_glm47_moe.rs
@@ -134,6 +134,20 @@ async fn test_python_literals() {
 }
 
 #[tokio::test]
+async fn test_glm47_arg_value_close_tag_inside_value() {
+    let parser = Glm4MoeParser::glm47();
+
+    let input = r"<tool_call>echo<arg_key>text</arg_key><arg_value>use </arg_value> in docs</arg_value></tool_call>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "echo");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["text"], "use </arg_value> in docs");
+}
+
+#[tokio::test]
 async fn test_glm47_nested_json_in_arg_values() {
     let parser = Glm4MoeParser::glm47();
 
@@ -145,4 +159,15 @@ async fn test_glm47_nested_json_in_arg_values() {
     let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
     assert!(args["data"].is_object());
     assert!(args["list"].is_array());
+}
+
+#[tokio::test]
+async fn test_glm47_arg_value_with_literal_arg_key_tag() {
+    let parser = Glm4MoeParser::glm47();
+    let input = r"<tool_call>echo<arg_key>text</arg_key><arg_value>see <arg_key> docs</arg_value><arg_key>n</arg_key><arg_value>2</arg_value></tool_call>";
+    let (_normal, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["text"], "see <arg_key> docs");
+    assert_eq!(args["n"], 2);
 }

--- a/crates/tool_parser/tests/tool_parser_glm4_moe.rs
+++ b/crates/tool_parser/tests/tool_parser_glm4_moe.rs
@@ -149,6 +149,39 @@ async fn test_python_literals() {
 }
 
 #[tokio::test]
+async fn test_glm4_arg_value_close_tag_inside_value() {
+    let parser = Glm4MoeParser::glm45();
+
+    let input = r"<tool_call>echo
+<arg_key>text</arg_key>
+<arg_value>use </arg_value> in docs</arg_value>
+</tool_call>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "echo");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["text"], "use </arg_value> in docs");
+}
+
+#[tokio::test]
+async fn test_glm4_arg_value_with_literal_arg_key_tag() {
+    let parser = Glm4MoeParser::glm45();
+    let input = r"<tool_call>echo
+<arg_key>text</arg_key>
+<arg_value>see <arg_key> docs</arg_value>
+<arg_key>n</arg_key>
+<arg_value>2</arg_value>
+</tool_call>";
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["text"], "see <arg_key> docs");
+    assert_eq!(args["n"], 2);
+}
+
+#[tokio::test]
 async fn test_glm4_nested_json_in_arg_values() {
     let parser = Glm4MoeParser::glm45();
 


### PR DESCRIPTION
## Description

### Problem

GLM-4 MoE argument parsing used a non-greedy `</arg_value>` match. A value that mentions the close tag (for example `use </arg_value> in docs`) was truncated at the first occurrence, so later keys were lost or values were wrong.

### Solution

Accept a candidate `</arg_value>` only when what follows is end-of-args or a real `<arg_key>…</arg_key><arg_value>` pair. Applies to both GLM-4.5 and GLM-4.7 extractors.

## Changes

- `crates/tool_parser/src/parsers/glm4_moe.rs`: scan-based close detection instead of non-greedy regex capture
- Regression tests in `tool_parser_glm4_moe.rs` and `tool_parser_glm47_moe.rs`

## Test Plan

Before: `<arg_value>use </arg_value> in docs</arg_value>` stores only `use`.

After: stores `use </arg_value> in docs`, and a following real key still parses.

```bash
cargo +nightly fmt --all -- --check
cargo clippy -p tool-parser --all-targets -- -D warnings
cargo test -p tool-parser --test tool_parser_glm4_moe --test tool_parser_glm47_moe
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets` on `tool-parser` with `-D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-call argument parsing when tag-like text appears inside argument values.
  * Preserved embedded closing and opening argument tags as literal content instead of ending values prematurely.
  * Continued supporting schema-based value conversion, including numeric arguments.

* **Tests**
  * Added coverage for complete and incremental parsing scenarios involving embedded tag text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->