### PR TITLE
fix(tool_parser): keep prose <tool_call> mentions in Qwen normal text

### DIFF
--- a/crates/tool_parser/src/parsers/qwen.rs
+++ b/crates/tool_parser/src/parsers/qwen.rs
@@ -119,12 +119,11 @@ impl ToolParser for QwenParser {
             return Ok((text.to_string(), vec![]));
         }
 
-        // Find where the first tool call begins
-        // Safe: has_tool_markers() already confirmed the marker exists
-        let idx = text
-            .find("<tool_call>")
-            .ok_or_else(|| ParserError::ParsingFailed("tool_call marker not found".to_string()))?;
-        let normal_text = text[..idx].to_string();
+        // Split on the first complete <tool_call>\n...\n</tool_call>, not a prose mention.
+        let Some(first) = self.extractor.find(text) else {
+            return Ok((text.to_string(), vec![]));
+        };
+        let normal_text = text[..first.start()].to_string();
 
         // Extract tool calls
         let mut tools = Vec::new();

--- a/crates/tool_parser/tests/tool_parser_qwen.rs
+++ b/crates/tool_parser/tests/tool_parser_qwen.rs
@@ -304,3 +304,16 @@ async fn test_qwen_xml_tag_arrives_in_parts() {
 
     assert!(got_tool_name, "Should have parsed tool name");
 }
+
+#[tokio::test]
+async fn test_qwen_prose_mentions_tool_call_before_real_block() {
+    let parser = QwenParser::new();
+    let input = r#"Explain the <tool_call> XML tag.
+<tool_call>
+{"name": "search", "arguments": {"q": "x"}}
+</tool_call>"#;
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(normal_text, "Explain the <tool_call> XML tag.\n");
+}


### PR DESCRIPTION
## Description

### Problem

Qwen `parse_complete` split normal text at the first `<tool_call>` substring. Prose that mentions the tag before a real newline-anchored block lost that mention (`Explain the <tool_call> XML tag.` became `Explain the `).

### Solution

Split normal text at the same regex-anchored extractor match used for tool extraction, so only a real tool block starts the cut.

## Changes

- `crates/tool_parser/src/parsers/qwen.rs`: use extractor match start for the prose/tool split
- `crates/tool_parser/tests/tool_parser_qwen.rs`: regression for a prose mention before a real block

## Test Plan

Before: `Explain the <tool_call> XML tag.\n<tool_call>\n{"name":"search",...}\n</tool_call>` → `normal_text == "Explain the "`.

After: `normal_text` keeps the full mention line and the tool still parses.

```bash
cargo +nightly fmt --all -- --check
cargo clippy -p tool-parser --all-targets -- -D warnings
cargo test -p tool-parser --test tool_parser_qwen
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets` on `tool-parser` with `-D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>