### PR TITLE
feat(rate_limit): add tenant rate-limit policy schema and compilation

### DIFF
--- a/model_gateway/src/lib.rs
+++ b/model_gateway/src/lib.rs
@@ -5,6 +5,7 @@ pub mod mesh;
 pub mod middleware;
 pub mod observability;
 pub mod policies;
+pub mod rate_limit;
 pub mod routers;
 pub mod server;
 pub mod service_discovery;

--- a/model_gateway/src/rate_limit/config.rs
+++ b/model_gateway/src/rate_limit/config.rs
@@ -1,9 +1,11 @@
 //! Multi-tenant rate limit config: on-disk YAML shape + validation.
 //!
-//! Loaded once at startup via `--tenant-rate-limit-config <path>`,
-//! mirroring the priority scheduler's `PrioritySchedulerYaml`
-//! (`middleware::scheduler::config`) — kept separate from `RouterConfig`
-//! so the actual policy content isn't crammed into the main config struct.
+//! Intended to be loaded once at startup via a `--tenant-rate-limit-config
+//! <path>` CLI flag — added in a follow-up PR alongside the reserve/settle
+//! engine, not wired up yet here. Mirrors the priority scheduler's
+//! `PrioritySchedulerYaml` (`middleware::scheduler::config`) — kept
+//! separate from `RouterConfig` so the actual policy content isn't
+//! crammed into the main config struct.
 
 use std::collections::{HashMap, HashSet};
 
@@ -43,7 +45,8 @@ pub enum ModelMatcherSpec {
     Prefix { value: String },
 }
 
-/// Optional YAML config loaded via `--tenant-rate-limit-config <path>`.
+/// Optional YAML config, intended to be loaded via a
+/// `--tenant-rate-limit-config <path>` CLI flag added in a follow-up PR.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RateLimitYaml {
     pub default_policy: TenantPolicySpec,

--- a/model_gateway/src/rate_limit/config.rs
+++ b/model_gateway/src/rate_limit/config.rs
@@ -169,6 +169,14 @@ impl RateLimitYaml {
             let Some(tenant_key) = spec.tenant_key.as_deref() else {
                 return Err(RateLimitConfigError::MissingTenantKey { index });
             };
+            // Empty/whitespace-only is functionally the same as missing: it
+            // would compile into a `TenantKey` that can never match a real
+            // resolved tenant identity (those are always `auth:`/`header:`/
+            // `ip:`-prefixed or `anonymous`), so the entry would silently
+            // never apply to anything.
+            if tenant_key.trim().is_empty() {
+                return Err(RateLimitConfigError::MissingTenantKey { index });
+            }
             if !seen_tenants.insert(tenant_key) {
                 return Err(RateLimitConfigError::DuplicateTenantKey {
                     tenant_key: tenant_key.to_string(),
@@ -233,6 +241,20 @@ mod tests {
             yaml.validate(),
             Err(RateLimitConfigError::MissingTenantKey { index: 0 })
         );
+    }
+
+    #[test]
+    fn tenant_empty_or_whitespace_key_rejected() {
+        for key in ["", "   "] {
+            let yaml = RateLimitYaml {
+                default_policy: policy(None, 1000, 60),
+                tenants: vec![policy(Some(key), 5000, 300)],
+            };
+            assert_eq!(
+                yaml.validate(),
+                Err(RateLimitConfigError::MissingTenantKey { index: 0 })
+            );
+        }
     }
 
     #[test]

--- a/model_gateway/src/rate_limit/config.rs
+++ b/model_gateway/src/rate_limit/config.rs
@@ -1,0 +1,445 @@
+//! Multi-tenant rate limit config: on-disk YAML shape + validation.
+//!
+//! Loaded once at startup via `--tenant-rate-limit-config <path>`,
+//! mirroring the priority scheduler's `PrioritySchedulerYaml`
+//! (`middleware::scheduler::config`) — kept separate from `RouterConfig`
+//! so the actual policy content isn't crammed into the main config struct.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+/// A single tenant's (or the default) token/request-per-minute policy,
+/// plus optional per-model rules layered on top. At most one model rule
+/// matches per request — rules never stack with each other, only with
+/// the tenant-global limits.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TenantPolicySpec {
+    /// Canonical tenant key (e.g. `auth:team-red`). Must be `None` on
+    /// [`RateLimitYaml::default_policy`] and `Some` on every entry in
+    /// [`RateLimitYaml::tenants`].
+    #[serde(default)]
+    pub tenant_key: Option<String>,
+    pub tokens_per_minute: u32,
+    pub requests_per_minute: u32,
+    #[serde(default)]
+    pub model_rules: Vec<ModelRuleSpec>,
+}
+
+/// A per-model rate-limit rule layered on top of the tenant-global limits.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ModelRuleSpec {
+    /// Stable identifier, unique within the tenant. `[A-Za-z0-9._-]+`.
+    pub rule_id: String,
+    pub matcher: ModelMatcherSpec,
+    pub tokens_per_minute: u32,
+    pub requests_per_minute: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ModelMatcherSpec {
+    Exact { value: String },
+    Prefix { value: String },
+}
+
+/// Optional YAML config loaded via `--tenant-rate-limit-config <path>`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitYaml {
+    pub default_policy: TenantPolicySpec,
+    #[serde(default)]
+    pub tenants: Vec<TenantPolicySpec>,
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum RateLimitConfigError {
+    #[error("default_policy must not set tenant_key")]
+    DefaultPolicyHasTenantKey,
+    #[error("tenants[{index}] is missing tenant_key")]
+    MissingTenantKey { index: usize },
+    #[error("duplicate tenant_key '{tenant_key}'")]
+    DuplicateTenantKey { tenant_key: String },
+    #[error("policy '{label}': tokens_per_minute must be > 0")]
+    ZeroTokensPerMinute { label: String },
+    #[error("policy '{label}': requests_per_minute must be > 0")]
+    ZeroRequestsPerMinute { label: String },
+    #[error("policy '{label}': rule_id '{rule_id}' must match [A-Za-z0-9._-]+")]
+    InvalidRuleId { label: String, rule_id: String },
+    #[error("policy '{label}': duplicate rule_id '{rule_id}'")]
+    DuplicateRuleId { label: String, rule_id: String },
+    #[error("policy '{label}': rule '{rule_id}' tokens_per_minute must be > 0")]
+    ZeroRuleTokensPerMinute { label: String, rule_id: String },
+    #[error("policy '{label}': rule '{rule_id}' requests_per_minute must be > 0")]
+    ZeroRuleRequestsPerMinute { label: String, rule_id: String },
+    #[error("policy '{label}': rule '{rule_id}' matcher value must not be empty")]
+    EmptyMatcherValue { label: String, rule_id: String },
+    #[error("policy '{label}': rule '{rule_id}' matcher duplicates rule '{other_rule_id}'")]
+    DuplicateMatcher {
+        label: String,
+        rule_id: String,
+        other_rule_id: String,
+    },
+}
+
+fn is_valid_rule_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+}
+
+fn validate_policy(label: &str, spec: &TenantPolicySpec) -> Result<(), RateLimitConfigError> {
+    if spec.tokens_per_minute == 0 {
+        return Err(RateLimitConfigError::ZeroTokensPerMinute {
+            label: label.to_string(),
+        });
+    }
+    if spec.requests_per_minute == 0 {
+        return Err(RateLimitConfigError::ZeroRequestsPerMinute {
+            label: label.to_string(),
+        });
+    }
+
+    let mut seen_rule_ids = HashSet::new();
+    // Owned rather than borrowed: this only runs once at startup, so the
+    // clones are irrelevant, and it sidesteps borrowing two different
+    // locals (`seen_exact`/`seen_prefix`) through the same match arm.
+    let mut seen_exact: HashMap<String, String> = HashMap::new();
+    let mut seen_prefix: HashMap<String, String> = HashMap::new();
+
+    for rule in &spec.model_rules {
+        if !is_valid_rule_id(&rule.rule_id) {
+            return Err(RateLimitConfigError::InvalidRuleId {
+                label: label.to_string(),
+                rule_id: rule.rule_id.clone(),
+            });
+        }
+        if !seen_rule_ids.insert(rule.rule_id.as_str()) {
+            return Err(RateLimitConfigError::DuplicateRuleId {
+                label: label.to_string(),
+                rule_id: rule.rule_id.clone(),
+            });
+        }
+        if rule.tokens_per_minute == 0 {
+            return Err(RateLimitConfigError::ZeroRuleTokensPerMinute {
+                label: label.to_string(),
+                rule_id: rule.rule_id.clone(),
+            });
+        }
+        if rule.requests_per_minute == 0 {
+            return Err(RateLimitConfigError::ZeroRuleRequestsPerMinute {
+                label: label.to_string(),
+                rule_id: rule.rule_id.clone(),
+            });
+        }
+
+        let (value, table): (&str, &mut HashMap<String, String>) = match &rule.matcher {
+            ModelMatcherSpec::Exact { value } => (value.as_str(), &mut seen_exact),
+            ModelMatcherSpec::Prefix { value } => (value.as_str(), &mut seen_prefix),
+        };
+        if value.is_empty() {
+            return Err(RateLimitConfigError::EmptyMatcherValue {
+                label: label.to_string(),
+                rule_id: rule.rule_id.clone(),
+            });
+        }
+        if let Some(other_rule_id) = table.insert(value.to_string(), rule.rule_id.clone()) {
+            return Err(RateLimitConfigError::DuplicateMatcher {
+                label: label.to_string(),
+                rule_id: rule.rule_id.clone(),
+                other_rule_id,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+impl RateLimitYaml {
+    /// Positive limits, unique tenant keys, unique+valid rule ids per
+    /// tenant, no duplicate exact/prefix matcher within a tenant, no empty
+    /// matcher value. Rejects at load time rather than at first use.
+    pub fn validate(&self) -> Result<(), RateLimitConfigError> {
+        if self.default_policy.tenant_key.is_some() {
+            return Err(RateLimitConfigError::DefaultPolicyHasTenantKey);
+        }
+        validate_policy("default", &self.default_policy)?;
+
+        let mut seen_tenants = HashSet::new();
+        for (index, spec) in self.tenants.iter().enumerate() {
+            let Some(tenant_key) = spec.tenant_key.as_deref() else {
+                return Err(RateLimitConfigError::MissingTenantKey { index });
+            };
+            if !seen_tenants.insert(tenant_key) {
+                return Err(RateLimitConfigError::DuplicateTenantKey {
+                    tenant_key: tenant_key.to_string(),
+                });
+            }
+            validate_policy(tenant_key, spec)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy(tenant_key: Option<&str>, tpm: u32, rpm: u32) -> TenantPolicySpec {
+        TenantPolicySpec {
+            tenant_key: tenant_key.map(str::to_string),
+            tokens_per_minute: tpm,
+            requests_per_minute: rpm,
+            model_rules: Vec::new(),
+        }
+    }
+
+    fn rule(rule_id: &str, matcher: ModelMatcherSpec, tpm: u32, rpm: u32) -> ModelRuleSpec {
+        ModelRuleSpec {
+            rule_id: rule_id.to_string(),
+            matcher,
+            tokens_per_minute: tpm,
+            requests_per_minute: rpm,
+        }
+    }
+
+    #[test]
+    fn valid_yaml_passes() {
+        let yaml = RateLimitYaml {
+            default_policy: policy(None, 1000, 60),
+            tenants: vec![policy(Some("auth:team-red"), 5000, 300)],
+        };
+        assert!(yaml.validate().is_ok());
+    }
+
+    #[test]
+    fn default_policy_with_tenant_key_rejected() {
+        let yaml = RateLimitYaml {
+            default_policy: policy(Some("auth:oops"), 1000, 60),
+            tenants: vec![],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::DefaultPolicyHasTenantKey)
+        );
+    }
+
+    #[test]
+    fn tenant_missing_key_rejected() {
+        let yaml = RateLimitYaml {
+            default_policy: policy(None, 1000, 60),
+            tenants: vec![policy(None, 5000, 300)],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::MissingTenantKey { index: 0 })
+        );
+    }
+
+    #[test]
+    fn duplicate_tenant_key_rejected() {
+        let yaml = RateLimitYaml {
+            default_policy: policy(None, 1000, 60),
+            tenants: vec![
+                policy(Some("auth:team-red"), 5000, 300),
+                policy(Some("auth:team-red"), 1000, 60),
+            ],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::DuplicateTenantKey {
+                tenant_key: "auth:team-red".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn zero_tokens_per_minute_rejected() {
+        let yaml = RateLimitYaml {
+            default_policy: policy(None, 0, 60),
+            tenants: vec![],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::ZeroTokensPerMinute {
+                label: "default".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn zero_requests_per_minute_rejected() {
+        let yaml = RateLimitYaml {
+            default_policy: policy(None, 1000, 0),
+            tenants: vec![],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::ZeroRequestsPerMinute {
+                label: "default".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn invalid_rule_id_rejected() {
+        let mut default_policy = policy(None, 1000, 60);
+        default_policy.model_rules.push(rule(
+            "bad id!",
+            ModelMatcherSpec::Exact {
+                value: "gpt-4".to_string(),
+            },
+            100,
+            10,
+        ));
+        let yaml = RateLimitYaml {
+            default_policy,
+            tenants: vec![],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::InvalidRuleId {
+                label: "default".to_string(),
+                rule_id: "bad id!".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn duplicate_rule_id_rejected() {
+        let mut default_policy = policy(None, 1000, 60);
+        default_policy.model_rules.push(rule(
+            "gpt4",
+            ModelMatcherSpec::Exact {
+                value: "gpt-4".to_string(),
+            },
+            100,
+            10,
+        ));
+        default_policy.model_rules.push(rule(
+            "gpt4",
+            ModelMatcherSpec::Exact {
+                value: "gpt-4-turbo".to_string(),
+            },
+            100,
+            10,
+        ));
+        let yaml = RateLimitYaml {
+            default_policy,
+            tenants: vec![],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::DuplicateRuleId {
+                label: "default".to_string(),
+                rule_id: "gpt4".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn zero_rule_limit_rejected() {
+        let mut default_policy = policy(None, 1000, 60);
+        default_policy.model_rules.push(rule(
+            "gpt4",
+            ModelMatcherSpec::Exact {
+                value: "gpt-4".to_string(),
+            },
+            0,
+            10,
+        ));
+        let yaml = RateLimitYaml {
+            default_policy,
+            tenants: vec![],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::ZeroRuleTokensPerMinute {
+                label: "default".to_string(),
+                rule_id: "gpt4".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn empty_matcher_value_rejected() {
+        let mut default_policy = policy(None, 1000, 60);
+        default_policy.model_rules.push(rule(
+            "catchall",
+            ModelMatcherSpec::Prefix {
+                value: String::new(),
+            },
+            100,
+            10,
+        ));
+        let yaml = RateLimitYaml {
+            default_policy,
+            tenants: vec![],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::EmptyMatcherValue {
+                label: "default".to_string(),
+                rule_id: "catchall".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn duplicate_exact_matcher_rejected() {
+        let mut default_policy = policy(None, 1000, 60);
+        default_policy.model_rules.push(rule(
+            "gpt4-a",
+            ModelMatcherSpec::Exact {
+                value: "gpt-4".to_string(),
+            },
+            100,
+            10,
+        ));
+        default_policy.model_rules.push(rule(
+            "gpt4-b",
+            ModelMatcherSpec::Exact {
+                value: "gpt-4".to_string(),
+            },
+            200,
+            20,
+        ));
+        let yaml = RateLimitYaml {
+            default_policy,
+            tenants: vec![],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::DuplicateMatcher {
+                label: "default".to_string(),
+                rule_id: "gpt4-b".to_string(),
+                other_rule_id: "gpt4-a".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn exact_and_prefix_same_value_both_allowed() {
+        let mut default_policy = policy(None, 1000, 60);
+        default_policy.model_rules.push(rule(
+            "exact",
+            ModelMatcherSpec::Exact {
+                value: "gpt-4".to_string(),
+            },
+            100,
+            10,
+        ));
+        default_policy.model_rules.push(rule(
+            "prefix",
+            ModelMatcherSpec::Prefix {
+                value: "gpt-4".to_string(),
+            },
+            200,
+            20,
+        ));
+        let yaml = RateLimitYaml {
+            default_policy,
+            tenants: vec![],
+        };
+        assert!(yaml.validate().is_ok());
+    }
+}

--- a/model_gateway/src/rate_limit/config.rs
+++ b/model_gateway/src/rate_limit/config.rs
@@ -62,6 +62,8 @@ pub enum RateLimitConfigError {
     MissingTenantKey { index: usize },
     #[error("duplicate tenant_key '{tenant_key}'")]
     DuplicateTenantKey { tenant_key: String },
+    #[error("tenant_key '{tenant_key}' must not have surrounding whitespace")]
+    PaddedTenantKey { tenant_key: String },
     #[error("policy '{label}': tokens_per_minute must be > 0")]
     ZeroTokensPerMinute { label: String },
     #[error("policy '{label}': requests_per_minute must be > 0")]
@@ -172,13 +174,25 @@ impl RateLimitYaml {
             let Some(tenant_key) = spec.tenant_key.as_deref() else {
                 return Err(RateLimitConfigError::MissingTenantKey { index });
             };
+            let trimmed = tenant_key.trim();
             // Empty/whitespace-only is functionally the same as missing: it
             // would compile into a `TenantKey` that can never match a real
             // resolved tenant identity (those are always `auth:`/`header:`/
             // `ip:`-prefixed or `anonymous`), so the entry would silently
             // never apply to anything.
-            if tenant_key.trim().is_empty() {
+            if trimmed.is_empty() {
                 return Err(RateLimitConfigError::MissingTenantKey { index });
+            }
+            // A padded key (leading/trailing whitespace, no surrounding
+            // quotes involved) would compile verbatim into `TenantKey` via
+            // `TenantKey::from`, but resolved auth/header tenant keys are
+            // always canonicalized without surrounding whitespace — the
+            // override would silently never be found, and the tenant
+            // falls back to the default policy instead.
+            if trimmed != tenant_key {
+                return Err(RateLimitConfigError::PaddedTenantKey {
+                    tenant_key: tenant_key.to_string(),
+                });
             }
             if !seen_tenants.insert(tenant_key) {
                 return Err(RateLimitConfigError::DuplicateTenantKey {
@@ -258,6 +272,20 @@ mod tests {
                 Err(RateLimitConfigError::MissingTenantKey { index: 0 })
             );
         }
+    }
+
+    #[test]
+    fn tenant_padded_key_rejected() {
+        let yaml = RateLimitYaml {
+            default_policy: policy(None, 1000, 60),
+            tenants: vec![policy(Some("auth:team-red "), 5000, 300)],
+        };
+        assert_eq!(
+            yaml.validate(),
+            Err(RateLimitConfigError::PaddedTenantKey {
+                tenant_key: "auth:team-red ".to_string()
+            })
+        );
     }
 
     #[test]

--- a/model_gateway/src/rate_limit/config.rs
+++ b/model_gateway/src/rate_limit/config.rs
@@ -78,6 +78,12 @@ pub enum RateLimitConfigError {
     ZeroRuleRequestsPerMinute { label: String, rule_id: String },
     #[error("policy '{label}': rule '{rule_id}' matcher value must not be empty")]
     EmptyMatcherValue { label: String, rule_id: String },
+    #[error("policy '{label}': rule '{rule_id}' matcher value '{value}' must not have surrounding whitespace")]
+    PaddedMatcherValue {
+        label: String,
+        rule_id: String,
+        value: String,
+    },
     #[error("policy '{label}': rule '{rule_id}' matcher duplicates rule '{other_rule_id}'")]
     DuplicateMatcher {
         label: String,
@@ -141,10 +147,23 @@ fn validate_policy(label: &str, spec: &TenantPolicySpec) -> Result<(), RateLimit
             ModelMatcherSpec::Exact { value } => (value.as_str(), &mut seen_exact),
             ModelMatcherSpec::Prefix { value } => (value.as_str(), &mut seen_prefix),
         };
-        if value.is_empty() {
+        let trimmed_value = value.trim();
+        if trimmed_value.is_empty() {
             return Err(RateLimitConfigError::EmptyMatcherValue {
                 label: label.to_string(),
                 rule_id: rule.rule_id.clone(),
+            });
+        }
+        // A padded value (e.g. `"gpt-4 "`) would compile verbatim and never
+        // match a real request's model id — `matching_rule` does raw
+        // `HashMap::get`/`starts_with` checks against the model id as
+        // reported by the request, which is never padded — so the rule
+        // would silently never apply.
+        if trimmed_value != value {
+            return Err(RateLimitConfigError::PaddedMatcherValue {
+                label: label.to_string(),
+                rule_id: rule.rule_id.clone(),
+                value: value.to_string(),
             });
         }
         if let Some(other_rule_id) = table.insert(value.to_string(), rule.rule_id.clone()) {
@@ -276,16 +295,18 @@ mod tests {
 
     #[test]
     fn tenant_padded_key_rejected() {
-        let yaml = RateLimitYaml {
-            default_policy: policy(None, 1000, 60),
-            tenants: vec![policy(Some("auth:team-red "), 5000, 300)],
-        };
-        assert_eq!(
-            yaml.validate(),
-            Err(RateLimitConfigError::PaddedTenantKey {
-                tenant_key: "auth:team-red ".to_string()
-            })
-        );
+        for tenant_key in [" auth:team-red", "auth:team-red "] {
+            let yaml = RateLimitYaml {
+                default_policy: policy(None, 1000, 60),
+                tenants: vec![policy(Some(tenant_key), 5000, 300)],
+            };
+            assert_eq!(
+                yaml.validate(),
+                Err(RateLimitConfigError::PaddedTenantKey {
+                    tenant_key: tenant_key.to_string()
+                })
+            );
+        }
     }
 
     #[test]
@@ -435,6 +456,33 @@ mod tests {
                 rule_id: "catchall".to_string()
             })
         );
+    }
+
+    #[test]
+    fn padded_matcher_value_rejected() {
+        for value in [" gpt-4", "gpt-4 "] {
+            let mut default_policy = policy(None, 1000, 60);
+            default_policy.model_rules.push(rule(
+                "gpt4",
+                ModelMatcherSpec::Exact {
+                    value: value.to_string(),
+                },
+                100,
+                10,
+            ));
+            let yaml = RateLimitYaml {
+                default_policy,
+                tenants: vec![],
+            };
+            assert_eq!(
+                yaml.validate(),
+                Err(RateLimitConfigError::PaddedMatcherValue {
+                    label: "default".to_string(),
+                    rule_id: "gpt4".to_string(),
+                    value: value.to_string(),
+                })
+            );
+        }
     }
 
     #[test]

--- a/model_gateway/src/rate_limit/mod.rs
+++ b/model_gateway/src/rate_limit/mod.rs
@@ -1,0 +1,16 @@
+//! Per-tenant LLM token/request rate limiting.
+//!
+//! This is the policy layer only: config schema, validation, and
+//! compilation into an immutable, cheap-to-look-up `CompiledPolicySet`.
+//! Nothing here does any rate-limit accounting or enforcement yet — the
+//! reserve/settle engine, in-memory backend, and CLI/startup wiring land in
+//! a follow-up change. This module is not yet reachable from any request
+//! path.
+
+mod config;
+mod policy;
+
+pub use config::{
+    ModelMatcherSpec, ModelRuleSpec, RateLimitConfigError, RateLimitYaml, TenantPolicySpec,
+};
+pub use policy::{CompiledPolicySet, ScopeLimits};

--- a/model_gateway/src/rate_limit/policy.rs
+++ b/model_gateway/src/rate_limit/policy.rs
@@ -1,0 +1,276 @@
+//! Compiles a validated [`RateLimitYaml`] into an immutable, cheap-to-look-up
+//! policy set.
+
+use std::collections::HashMap;
+
+use super::config::{ModelMatcherSpec, RateLimitConfigError, RateLimitYaml, TenantPolicySpec};
+use crate::tenant::TenantKey;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScopeLimits {
+    pub tokens_per_minute: u32,
+    pub requests_per_minute: u32,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by the reserve/settle engine landing in a follow-up change; exercised by this module's own tests today"
+    )
+)]
+pub(crate) struct CompiledModelRule {
+    pub rule_id: String,
+    #[expect(
+        dead_code,
+        reason = "consumed by the reserve/settle engine landing in a follow-up change; not read by this module's own tests"
+    )]
+    pub limits: ScopeLimits,
+}
+
+/// A prefix rule plus the prefix it matches on, kept alongside each other
+/// since [`CompiledTenantPolicy::prefix_model_rules`] is a plain sorted
+/// `Vec` rather than a map (there's nothing to key a prefix scan on).
+#[derive(Debug, Clone)]
+pub(crate) struct CompiledPrefixRule {
+    prefix: String,
+    rule: CompiledModelRule,
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed by the reserve/settle engine landing in a follow-up change; exercised by this module's own tests today"
+    )
+)]
+pub(crate) struct CompiledTenantPolicy {
+    pub limits: ScopeLimits,
+    /// O(1) lookup — exact matches never need to scan.
+    exact_model_rules: HashMap<String, CompiledModelRule>,
+    /// Sorted longest-prefix-first once at compile time, so matching is a
+    /// single linear scan that returns on the first hit rather than a
+    /// scan-then-`max_by_key` at request time.
+    prefix_model_rules: Vec<CompiledPrefixRule>,
+}
+
+impl CompiledTenantPolicy {
+    /// The single model rule (if any) that matches `model_id`: exact wins
+    /// over prefix; among prefixes, the longest wins (guaranteed by
+    /// `prefix_model_rules`'s compile-time sort). Rules never stack — at
+    /// most one is returned.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by the reserve/settle engine landing in a follow-up change; exercised by this module's own tests today"
+        )
+    )]
+    pub(crate) fn matching_rule(&self, model_id: &str) -> Option<&CompiledModelRule> {
+        if let Some(exact) = self.exact_model_rules.get(model_id) {
+            return Some(exact);
+        }
+        self.prefix_model_rules
+            .iter()
+            .find(|r| model_id.starts_with(r.prefix.as_str()))
+            .map(|r| &r.rule)
+    }
+
+    fn compile(spec: &TenantPolicySpec) -> Self {
+        let mut exact_model_rules = HashMap::new();
+        let mut prefix_model_rules = Vec::new();
+
+        for r in &spec.model_rules {
+            let rule = CompiledModelRule {
+                rule_id: r.rule_id.clone(),
+                limits: ScopeLimits {
+                    tokens_per_minute: r.tokens_per_minute,
+                    requests_per_minute: r.requests_per_minute,
+                },
+            };
+            match &r.matcher {
+                ModelMatcherSpec::Exact { value } => {
+                    exact_model_rules.insert(value.clone(), rule);
+                }
+                ModelMatcherSpec::Prefix { value } => {
+                    prefix_model_rules.push(CompiledPrefixRule {
+                        prefix: value.clone(),
+                        rule,
+                    });
+                }
+            }
+        }
+        // Longest-first so `matching_rule`'s linear scan can return on the
+        // first hit instead of comparing lengths at request time.
+        prefix_model_rules.sort_by_key(|r| std::cmp::Reverse(r.prefix.len()));
+
+        Self {
+            limits: ScopeLimits {
+                tokens_per_minute: spec.tokens_per_minute,
+                requests_per_minute: spec.requests_per_minute,
+            },
+            exact_model_rules,
+            prefix_model_rules,
+        }
+    }
+}
+
+/// Immutable, compiled rate-limit policy: a default plus per-tenant
+/// overrides, resolved in O(1) by [`Self::policy_for`].
+#[derive(Debug, Clone)]
+pub struct CompiledPolicySet {
+    default: CompiledTenantPolicy,
+    tenants: HashMap<TenantKey, CompiledTenantPolicy>,
+}
+
+impl CompiledPolicySet {
+    pub fn compile(yaml: &RateLimitYaml) -> Result<Self, RateLimitConfigError> {
+        yaml.validate()?;
+        let default = CompiledTenantPolicy::compile(&yaml.default_policy);
+        let tenants = yaml
+            .tenants
+            .iter()
+            .filter_map(|spec| {
+                // `yaml.validate()?` above already rejected any `tenants`
+                // entry with a missing `tenant_key`, so `None` here is
+                // unreachable — skip rather than panic if that invariant
+                // is ever violated.
+                spec.tenant_key
+                    .clone()
+                    .map(|k| (TenantKey::from(k), CompiledTenantPolicy::compile(spec)))
+            })
+            .collect();
+        Ok(Self { default, tenants })
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by the reserve/settle engine landing in a follow-up change; exercised by this module's own tests today"
+        )
+    )]
+    pub(crate) fn policy_for(&self, tenant: &TenantKey) -> &CompiledTenantPolicy {
+        self.tenants.get(tenant).unwrap_or(&self.default)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rate_limit::config::{ModelRuleSpec, TenantPolicySpec};
+
+    fn spec_with_rules(rules: Vec<ModelRuleSpec>) -> TenantPolicySpec {
+        TenantPolicySpec {
+            tenant_key: None,
+            tokens_per_minute: 1000,
+            requests_per_minute: 60,
+            model_rules: rules,
+        }
+    }
+
+    fn rule(rule_id: &str, matcher: ModelMatcherSpec) -> ModelRuleSpec {
+        ModelRuleSpec {
+            rule_id: rule_id.to_string(),
+            matcher,
+            tokens_per_minute: 100,
+            requests_per_minute: 10,
+        }
+    }
+
+    #[test]
+    fn unknown_tenant_falls_back_to_default() {
+        let yaml = RateLimitYaml {
+            default_policy: spec_with_rules(vec![]),
+            tenants: vec![],
+        };
+        let compiled = CompiledPolicySet::compile(&yaml).unwrap();
+        let policy = compiled.policy_for(&TenantKey::new("anonymous"));
+        assert_eq!(policy.limits.tokens_per_minute, 1000);
+    }
+
+    #[test]
+    fn known_tenant_overrides_default() {
+        let mut tenant_spec = spec_with_rules(vec![]);
+        tenant_spec.tenant_key = Some("auth:team-red".to_string());
+        tenant_spec.tokens_per_minute = 5000;
+        let yaml = RateLimitYaml {
+            default_policy: spec_with_rules(vec![]),
+            tenants: vec![tenant_spec],
+        };
+        let compiled = CompiledPolicySet::compile(&yaml).unwrap();
+        let policy = compiled.policy_for(&TenantKey::new("auth:team-red"));
+        assert_eq!(policy.limits.tokens_per_minute, 5000);
+    }
+
+    #[test]
+    fn exact_wins_over_prefix() {
+        let spec = spec_with_rules(vec![
+            rule(
+                "prefix",
+                ModelMatcherSpec::Prefix {
+                    value: "gpt-".to_string(),
+                },
+            ),
+            rule(
+                "exact",
+                ModelMatcherSpec::Exact {
+                    value: "gpt-4".to_string(),
+                },
+            ),
+        ]);
+        let yaml = RateLimitYaml {
+            default_policy: spec,
+            tenants: vec![],
+        };
+        let compiled = CompiledPolicySet::compile(&yaml).unwrap();
+        let policy = compiled.policy_for(&TenantKey::new("anonymous"));
+        let matched = policy.matching_rule("gpt-4").unwrap();
+        assert_eq!(matched.rule_id, "exact");
+    }
+
+    #[test]
+    fn longest_prefix_wins() {
+        let spec = spec_with_rules(vec![
+            rule(
+                "short",
+                ModelMatcherSpec::Prefix {
+                    value: "gpt-".to_string(),
+                },
+            ),
+            rule(
+                "long",
+                ModelMatcherSpec::Prefix {
+                    value: "gpt-4-".to_string(),
+                },
+            ),
+        ]);
+        let yaml = RateLimitYaml {
+            default_policy: spec,
+            tenants: vec![],
+        };
+        let compiled = CompiledPolicySet::compile(&yaml).unwrap();
+        let policy = compiled.policy_for(&TenantKey::new("anonymous"));
+        let matched = policy.matching_rule("gpt-4-turbo").unwrap();
+        assert_eq!(matched.rule_id, "long");
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let spec = spec_with_rules(vec![rule(
+            "gpt4",
+            ModelMatcherSpec::Exact {
+                value: "gpt-4".to_string(),
+            },
+        )]);
+        let yaml = RateLimitYaml {
+            default_policy: spec,
+            tenants: vec![],
+        };
+        let compiled = CompiledPolicySet::compile(&yaml).unwrap();
+        let policy = compiled.policy_for(&TenantKey::new("anonymous"));
+        assert!(policy.matching_rule("claude-3").is_none());
+    }
+}

--- a/model_gateway/src/rate_limit/policy.rs
+++ b/model_gateway/src/rate_limit/policy.rs
@@ -133,10 +133,10 @@ impl CompiledPolicySet {
             .tenants
             .iter()
             .filter_map(|spec| {
-                // `yaml.validate()?` above already rejected any `tenants`
-                // entry with a missing `tenant_key`, so `None` here is
-                // unreachable — skip rather than panic if that invariant
-                // is ever violated.
+                // INVARIANT: `yaml.validate()?` above already rejected any
+                // `tenants` entry with a missing `tenant_key`, so `None`
+                // here is unreachable — skip rather than panic if that
+                // invariant is ever violated.
                 spec.tenant_key
                     .clone()
                     .map(|k| (TenantKey::from(k), CompiledTenantPolicy::compile(spec)))


### PR DESCRIPTION
## Description

### Problem

SMG has no per-tenant, token-aware rate limiting today — only a flat
global `TokenBucket` that counts requests, not model tokens, and applies
uniformly across every caller. This is the first of a multi-phase effort
to add tenant/model-aware token rate limiting; it needs a policy schema
and a compiled representation before anything can enforce against it.

### Solution

Add the policy layer only: an on-disk YAML schema for per-tenant (and
optionally per-model) `tokens_per_minute`/`requests_per_minute` limits,
validation, and compilation into an immutable `CompiledPolicySet` that
resolves a tenant + model to its effective limits in O(1).

Not yet reachable from any request path, CLI flag, or `RouterConfig`
field — that wiring, plus the reserve/settle engine and in-memory
backend, land in a follow-up PR stacked on this one.

## Changes

- `rate_limit/config.rs` (new): `RateLimitYaml { default_policy, tenants }`,
  `TenantPolicySpec { tenant_key, tokens_per_minute, requests_per_minute,
  model_rules }`, `ModelRuleSpec` with `Exact`/`Prefix` matchers.
  Validation rejects non-positive limits, duplicate tenant keys,
  invalid/duplicate `rule_id`s (`[A-Za-z0-9._-]+`), and duplicate/empty
  matchers within a tenant.
- `rate_limit/policy.rs` (new): compiles `RateLimitYaml` into
  `CompiledPolicySet`. Per-tenant model rules are split by matcher kind —
  `exact_model_rules: HashMap<String, CompiledModelRule>` for O(1) exact
  lookup, `prefix_model_rules: Vec<CompiledPrefixRule>` sorted
  longest-first once at compile time so request-time matching is a
  single linear scan that returns on the first hit. Exact always wins
  over prefix; rules never stack.
- `rate_limit/mod.rs` (new) / `lib.rs`: module wiring.

## Test Plan

- 17 new unit tests covering config validation and policy
  compilation/matching (exact-vs-prefix precedence, longest-prefix-wins,
  tenant override vs default fallback).
- Full `cargo test -p smg --lib` suite green — no existing behavior
  touched.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable rate-limit policy layer with default tenant rules and tenant-specific model overrides.
  * Added a YAML policy schema with startup-time validation for tenant keys, positive token/request limits, and well-formed model matchers and rule IDs.
  * Added compilation into an immutable policy set with exact-match priority and longest-prefix matching, including fallback to default policies.
* **Tests**
  * Added unit tests covering configuration validation error cases and compiled policy selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->