### PR TITLE
feat(gateway): derive backend request ids from rid and the middleware request id

### DIFF
--- a/bindings/golang/client.go
+++ b/bindings/golang/client.go
@@ -197,6 +197,8 @@ type ChatCompletionRequest struct {
 	Logprobs            bool             `json:"logprobs,omitempty"`
 	TopLogprobs         *int             `json:"top_logprobs,omitempty"`
 	User                string           `json:"user,omitempty"`
+	// Rid is forwarded to the backend as the request id for log correlation
+	Rid *string `json:"rid,omitempty"`
 }
 
 // StreamOptions controls streaming behavior options.

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -789,6 +789,7 @@ mod tests {
             session_params: None,
             return_hidden_states: false,
             sampling_seed: None,
+            rid: None,
             other: Default::default(),
         }
     }

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -324,6 +324,9 @@ pub struct ChatCompletionRequest {
     /// Random seed for sampling for deterministic outputs
     pub sampling_seed: Option<u64>,
 
+    /// Request ID forwarded to the backend for log correlation (SGLang extension)
+    pub rid: Option<String>,
+
     /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
     #[serde(flatten)]
     pub other: Map<String, Value>,

--- a/crates/protocols/src/completion.rs
+++ b/crates/protocols/src/completion.rs
@@ -140,6 +140,9 @@ pub struct CompletionRequest {
     /// Sampling seed for deterministic outputs
     pub sampling_seed: Option<u64>,
 
+    /// Request ID forwarded to the backend for log correlation (SGLang extension)
+    pub rid: Option<String>,
+
     /// Additional fields including bootstrap info for PD routing
     #[serde(flatten)]
     pub other: Map<String, Value>,

--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -74,6 +74,9 @@ pub struct CreateMessageRequest {
     /// MCP servers to be utilized in this request (beta).
     pub mcp_servers: Option<Vec<McpServerConfig>>,
 
+    /// Request ID forwarded to the backend for log correlation (SGLang extension)
+    pub rid: Option<String>,
+
     /// Additional fields not explicitly defined above (e.g. beta features like
     /// context_management, output_config). Captured and forwarded to backends.
     #[serde(flatten)]
@@ -2017,6 +2020,7 @@ mod tests {
             top_p: None,
             container: None,
             mcp_servers: None,
+            rid: None,
             other: Map::new(),
         }
     }

--- a/docs/getting-started/logging.md
+++ b/docs/getting-started/logging.md
@@ -356,6 +356,13 @@ curl -H "X-Request-ID: my-trace-123" \
   -d '{"model": "llama", "messages": [{"role": "user", "content": "Hi"}]}'
 ```
 
+Backend (engine) request ids derive from the same id, so gateway and worker
+logs correlate: gRPC requests are dispatched as `{request-id}-{uuid}` (the
+suffix keeps retries and tool-loop iterations unique), and the response body
+`id` matches. A protocol-level `rid` field (chat, completions, messages,
+generate, embeddings, classify) overrides this and is used verbatim outside
+PD mode.
+
 ### Trace a Request
 
 ```bash

--- a/e2e_test/chat_completions/test_openai_server.py
+++ b/e2e_test/chat_completions/test_openai_server.py
@@ -472,3 +472,38 @@ class TestChatCompletionGptOss(TestChatCompletion):
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])
 class TestChatCompletionGptOss120B(TestChatCompletionGptOss):
     """Tests for chat completions API with Harmony model (GPT-OSS 120B, 4 GPU)."""
+
+
+# =============================================================================
+# Request-id passthrough
+# =============================================================================
+
+
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
+@pytest.mark.gpu(1)
+@pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestRequestIdPassthrough:
+    """Backend request ids derive from client correlation signals."""
+
+    def test_rid_becomes_response_id(self, model, api_client):
+        """A protocol `rid` is used as the backend request id verbatim."""
+        resp = api_client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Say hi"}],
+            max_tokens=8,
+            extra_body={"rid": "my-correlation-id-1"},
+        )
+
+        assert resp.id == "my-correlation-id-1"
+
+    def test_x_request_id_header_prefixes_response_id(self, model, api_client):
+        """The middleware request id (client x-request-id) prefixes backend ids."""
+        resp = api_client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "Say hi"}],
+            max_tokens=8,
+            extra_headers={"x-request-id": "corr-abc"},
+        )
+
+        assert resp.id.startswith("corr-abc-")

--- a/e2e_test/completions/test_basic.py
+++ b/e2e_test/completions/test_basic.py
@@ -143,6 +143,19 @@ class TestCompletionBasic:
             response.usage.prompt_tokens + response.usage.completion_tokens
         )
 
+    def test_rid_becomes_response_id(self, model, api_client):
+        """A protocol `rid` is used as the backend request id verbatim."""
+
+        response = api_client.completions.create(
+            model=model,
+            prompt="Hello",
+            max_tokens=5,
+            temperature=0,
+            extra_body={"rid": "cmpl-correlation-1"},
+        )
+
+        assert response.id == "cmpl-correlation-1"
+
     @pytest.mark.skip_for_runtime("vllm", reason="vLLM rejects max_tokens=0")
     def test_non_streaming_echo_max_tokens_zero(self, model, api_client):
         """Test that echo=True with max_tokens=0 returns just the prompt."""
@@ -353,6 +366,20 @@ class TestCompletionBatch:
         assert len(choices) == len(self.PROMPTS)
         for prompt_index, prompt in enumerate(self.PROMPTS):
             assert choices[prompt_index].text.startswith(prompt)
+
+    def test_batch_rid_is_shared_response_id(self, model, api_client):
+        """A protocol `rid` becomes the shared response id for a prompt array."""
+
+        response = api_client.completions.create(
+            model=model,
+            prompt=self.PROMPTS,
+            max_tokens=5,
+            temperature=0,
+            extra_body={"rid": "batch-correlation-1"},
+        )
+
+        assert response.id == "batch-correlation-1"
+        assert sorted(choice.index for choice in response.choices) == [0, 1]
 
     def test_batch_streaming(self, model, api_client):
         """Test streaming with a prompt array and n > 1: global per-choice deltas

--- a/model_gateway/benches/request_processing.rs
+++ b/model_gateway/benches/request_processing.rs
@@ -127,6 +127,7 @@ fn default_completion_request() -> CompletionRequest {
         session_params: None,
         return_hidden_states: false,
         sampling_seed: None,
+        rid: None,
         other: serde_json::Map::new(),
     }
 }

--- a/model_gateway/src/middleware/request_id.rs
+++ b/model_gateway/src/middleware/request_id.rs
@@ -19,14 +19,18 @@ const REQUEST_ID_CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst
 
 /// Generate OpenAI-compatible request ID based on endpoint.
 pub(super) fn generate_request_id(path: &str) -> String {
-    let prefix = if path.contains("/chat/completions") {
+    // Suffix compares, not substring scans; `/chat/completions` must precede
+    // `/completions`.
+    let prefix = if path.ends_with("/chat/completions") {
         "chatcmpl-"
-    } else if path.contains("/completions") {
+    } else if path.ends_with("/completions") {
         "cmpl-"
-    } else if path.contains("/generate") {
+    } else if path.ends_with("/generate") {
         "gnt-"
-    } else if path.contains("/responses") {
+    } else if path.ends_with("/responses") {
         "resp-"
+    } else if path.ends_with("/messages") {
+        "msg_"
     } else {
         "req-"
     };
@@ -125,5 +129,27 @@ where
 
             Ok(response)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_ids_use_endpoint_prefixes() {
+        for (path, prefix) in [
+            ("/v1/chat/completions", "chatcmpl-"),
+            ("/v1/completions", "cmpl-"),
+            ("/generate", "gnt-"),
+            ("/v1/responses", "resp-"),
+            ("/v1/messages", "msg_"),
+            ("/v1/embeddings", "req-"),
+        ] {
+            assert!(
+                generate_request_id(path).starts_with(prefix),
+                "path {path} must generate a {prefix} id"
+            );
+        }
     }
 }

--- a/model_gateway/src/middleware/tenant_resolution.rs
+++ b/model_gateway/src/middleware/tenant_resolution.rs
@@ -10,6 +10,7 @@ use axum::{
     response::Response,
 };
 
+use super::request_id::RequestId;
 use crate::{
     config::{RouterConfig, TenantResolutionConfig},
     tenant::{canonical_tenant_key, DataPlaneCaller, RouteRequestMeta, TenantIdentity, TenantKey},
@@ -68,7 +69,13 @@ pub fn resolve_route_request_meta(
     state: &TenantResolutionState,
     request: &Request<Body>,
 ) -> RouteRequestMeta {
-    RouteRequestMeta::new(resolve_raw_tenant_key(state, request))
+    let meta = RouteRequestMeta::new(resolve_raw_tenant_key(state, request));
+    // Carry the middleware request id so backend request ids derive from it
+    // (RequestIdLayer runs outside this middleware).
+    match request.extensions().get::<RequestId>() {
+        Some(request_id) => meta.with_extension(request_id.clone()),
+        None => meta,
+    }
 }
 
 pub async fn route_request_meta_middleware(
@@ -166,6 +173,23 @@ mod tests {
 
         let request_meta = resolve_route_request_meta(&state, &request);
         assert_eq!(request_meta.tenant_key().as_str(), "ip:203.0.113.42");
+    }
+
+    #[tokio::test]
+    async fn request_meta_carries_middleware_request_id() {
+        let state = resolution_state();
+        let mut request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        request
+            .extensions_mut()
+            .insert(RequestId("chatcmpl-abc123".to_string()));
+
+        let request_meta = resolve_route_request_meta(&state, &request);
+        assert_eq!(
+            request_meta
+                .extension::<RequestId>()
+                .map(|request_id| request_id.0.as_str()),
+            Some("chatcmpl-abc123")
+        );
     }
 
     #[tokio::test]

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -11,6 +11,7 @@ use smg_grpc_client::{
 use tracing::{debug, warn};
 
 use crate::{
+    middleware::{RequestId, TenantRequestMeta},
     routers::grpc::{
         context::{RequestType, WorkerSelection},
         proto_wrapper::ProtoGenerateRequest,
@@ -76,6 +77,45 @@ impl SamplingDefaultsMask {
 
     fn any(self) -> bool {
         self.temperature || self.top_p || self.top_k || self.min_p || self.repetition_penalty
+    }
+}
+
+/// The middleware-assigned request id (client-sent via a configured header,
+/// else generated; see `middleware/request_id.rs`), carried on the tenant
+/// request metadata.
+pub(crate) fn middleware_request_id(tenant_meta: Option<&TenantRequestMeta>) -> Option<&str> {
+    tenant_meta
+        .and_then(|meta| meta.extension::<RequestId>())
+        .map(|request_id| request_id.0.as_str())
+}
+
+/// Backend request id for any endpoint.
+///
+/// Priority: the protocol `rid`, else the middleware request id, else a fresh
+/// `{prefix}{uuid}`.
+///
+/// Engine ids must be unique per dispatch — PD retries re-run request
+/// building while a NIXL-tagged prefill keeps the id alive until the KV lease
+/// expires, and responses tool loops re-execute the pipeline per iteration —
+/// so middleware-derived ids always get a per-execution suffix. A bare `rid`
+/// outside PD is used exactly: its value is the caller's contract (matching
+/// /generate's long-standing behavior).
+pub(crate) fn resolve_request_id(
+    request_type: &RequestType,
+    tenant_meta: Option<&TenantRequestMeta>,
+    prefix: &str,
+    disaggregated: bool,
+) -> String {
+    if let Some(rid) = request_type.rid() {
+        return if disaggregated {
+            format!("{rid}-{}", uuid::Uuid::now_v7())
+        } else {
+            rid.to_string()
+        };
+    }
+    match middleware_request_id(tenant_meta) {
+        Some(request_id) => format!("{request_id}-{}", uuid::Uuid::now_v7()),
+        None => format!("{prefix}{}", uuid::Uuid::now_v7()),
     }
 }
 
@@ -332,5 +372,65 @@ pub(crate) fn maybe_inject_pd_rendezvous(
             "Injected PD rendezvous: host={}, port={}, room={}",
             hostname, bootstrap_port, room_id
         );
+    }
+}
+
+#[cfg(test)]
+mod request_id_tests {
+    use std::sync::Arc;
+
+    use openai_protocol::chat::ChatCompletionRequest;
+
+    use super::*;
+    use crate::tenant::TenantKey;
+
+    fn chat_request_type(rid: Option<&str>) -> RequestType {
+        RequestType::Chat(Arc::new(ChatCompletionRequest {
+            rid: rid.map(str::to_string),
+            ..Default::default()
+        }))
+    }
+
+    fn meta_with_request_id(id: &str) -> TenantRequestMeta {
+        TenantRequestMeta::new(TenantKey::new("test-tenant"))
+            .with_extension(RequestId(id.to_string()))
+    }
+
+    #[test]
+    fn rid_is_used_exactly_outside_pd() {
+        let request_type = chat_request_type(Some("client-rid"));
+        let meta = meta_with_request_id("chatcmpl-mw");
+
+        let id = resolve_request_id(&request_type, Some(&meta), "chatcmpl-", false);
+        assert_eq!(id, "client-rid");
+    }
+
+    #[test]
+    fn rid_gets_per_attempt_suffix_in_pd() {
+        let request_type = chat_request_type(Some("client-rid"));
+
+        let id = resolve_request_id(&request_type, None, "chatcmpl-", true);
+        assert!(id.starts_with("client-rid-") && id != "client-rid");
+    }
+
+    #[test]
+    fn middleware_id_is_base_with_per_execution_suffix() {
+        let request_type = chat_request_type(None);
+        let meta = meta_with_request_id("chatcmpl-mw");
+
+        let first = resolve_request_id(&request_type, Some(&meta), "chatcmpl-", false);
+        let second = resolve_request_id(&request_type, Some(&meta), "chatcmpl-", false);
+        assert!(first.starts_with("chatcmpl-mw-"));
+        assert!(second.starts_with("chatcmpl-mw-"));
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn falls_back_to_prefixed_mint_without_rid_or_middleware_id() {
+        let request_type = chat_request_type(None);
+        let meta = TenantRequestMeta::new(TenantKey::new("test-tenant"));
+
+        let id = resolve_request_id(&request_type, Some(&meta), "chatcmpl-", false);
+        assert!(id.starts_with("chatcmpl-"));
     }
 }

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -66,6 +66,22 @@ pub(crate) enum RequestType {
     Messages(Arc<CreateMessageRequest>),
 }
 
+impl RequestType {
+    /// Client-supplied backend request id (`rid`), where the protocol carries
+    /// one. Responses ids are storage-owned (`resp_*`) and never client-set.
+    pub fn rid(&self) -> Option<&str> {
+        match self {
+            Self::Chat(r) => r.rid.as_deref(),
+            Self::Generate(r) => r.rid.as_deref(),
+            Self::Completion(r) => r.rid.as_deref(),
+            Self::Embedding(r) => r.rid.as_deref(),
+            Self::Classify(r) => r.rid.as_deref(),
+            Self::Messages(r) => r.rid.as_deref(),
+            Self::Responses(_) => None,
+        }
+    }
+}
+
 impl std::fmt::Display for RequestType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use axum::response::Response;
 use smg_grpc_client::SglangGenerateRequestOptions;
 use tracing::{debug, error};
-use uuid::Uuid;
 
 use crate::routers::{
     error,
@@ -81,9 +80,20 @@ impl PipelineStage for HarmonyRequestBuildingStage {
         };
 
         // Generate request_id based on request type
+        let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
         let request_id = match &ctx.input.request_type {
-            RequestType::Chat(_) => format!("chatcmpl-{}", Uuid::now_v7()),
-            RequestType::Responses(_) => format!("responses-{}", Uuid::now_v7()),
+            RequestType::Chat(_) => helpers::resolve_request_id(
+                &ctx.input.request_type,
+                ctx.input.tenant_request_meta.as_ref(),
+                "chatcmpl-",
+                disaggregated,
+            ),
+            RequestType::Responses(_) => helpers::resolve_request_id(
+                &ctx.input.request_type,
+                ctx.input.tenant_request_meta.as_ref(),
+                "responses-",
+                disaggregated,
+            ),
             request_type @ (RequestType::Generate(_)
             | RequestType::Completion(_)
             | RequestType::Embedding(_)

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -3,7 +3,6 @@
 use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
-use uuid::Uuid;
 
 use crate::routers::{
     error,
@@ -80,7 +79,13 @@ impl PipelineStage for ChatRequestBuildingStage {
         };
 
         // Build chat request
-        let request_id = format!("chatcmpl-{}", Uuid::now_v7());
+        let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
+        let request_id = helpers::resolve_request_id(
+            &ctx.input.request_type,
+            ctx.input.tenant_request_meta.as_ref(),
+            "chatcmpl-",
+            disaggregated,
+        );
 
         // `encode_outputs` set by EncodeStage selects the pixel-drop assembly path.
         let is_encode_routed = ctx.state.encode_outputs.is_some();

--- a/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
@@ -138,7 +138,7 @@ impl PipelineStage for CompletionRequestBuildingStage {
             ClientSelection::Disaggregated { prefill, .. } => prefill,
         };
 
-        let shared_request_id = format!("cmpl_{}", Uuid::now_v7());
+        let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
         let request_type = &ctx.input.request_type;
         let workers = ctx.state.workers.as_ref();
 
@@ -153,7 +153,12 @@ impl PipelineStage for CompletionRequestBuildingStage {
                 self.plan_kind,
                 self.build_proto_request(
                     builder_client,
-                    shared_request_id,
+                    helpers::resolve_request_id(
+                        request_type,
+                        ctx.input.tenant_request_meta.as_ref(),
+                        "cmpl_",
+                        disaggregated,
+                    ),
                     item,
                     &completion_request,
                     request_type,
@@ -161,11 +166,29 @@ impl PipelineStage for CompletionRequestBuildingStage {
                 )?,
             ),
             batch_items => {
+                // The shared id (client rid or middleware request id) stays
+                // clean for the response; per-sub engine ids get a uniqueness
+                // suffix in PD mode and whenever the shared id is stable
+                // across pipeline executions (middleware-derived).
+                let middleware_id =
+                    helpers::middleware_request_id(ctx.input.tenant_request_meta.as_ref());
+                let (shared_request_id, always_unique_subs) = match request_type.rid() {
+                    Some(rid) => (rid.to_string(), false),
+                    None => match middleware_id {
+                        Some(request_id) => (request_id.to_string(), true),
+                        None => (format!("cmpl_{}", Uuid::now_v7()), false),
+                    },
+                };
                 let mut requests = Vec::with_capacity(batch_items.len());
                 for (i, item) in batch_items.iter().enumerate() {
+                    let sub_request_id = if disaggregated || always_unique_subs {
+                        format!("{shared_request_id}-p{i}-{}", Uuid::now_v7())
+                    } else {
+                        format!("{shared_request_id}-p{i}")
+                    };
                     requests.push(self.build_proto_request(
                         builder_client,
-                        format!("{shared_request_id}-p{i}"),
+                        sub_request_id,
                         item,
                         &completion_request,
                         request_type,

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
@@ -3,13 +3,12 @@
 use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
-use uuid::Uuid;
 
 use crate::routers::{
     error,
     grpc::{
         client::GrpcClient,
-        common::stages::PipelineStage,
+        common::stages::{helpers, PipelineStage},
         context::{ExecutionPlan, RequestContext, RequestType},
         proto_wrapper::ProtoEmbedRequest,
     },
@@ -56,12 +55,17 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
                 error::internal_error("client_missing", "Client not selected")
             })?;
 
-        // Generate request ID with appropriate prefix based on request type
-        let request_id = match &ctx.input.request_type {
-            RequestType::Embedding(_) => format!("embed-{}", Uuid::now_v7()),
-            RequestType::Classify(_) => format!("classify-{}", Uuid::now_v7()),
-            _ => format!("embed-{}", Uuid::now_v7()), // fallback
+        // Embeddings/classify are single-worker only (never disaggregated).
+        let prefix = match &ctx.input.request_type {
+            RequestType::Classify(_) => "classify-",
+            _ => "embed-",
         };
+        let request_id = helpers::resolve_request_id(
+            &ctx.input.request_type,
+            ctx.input.tenant_request_meta.as_ref(),
+            prefix,
+            false,
+        );
 
         // Build backend-specific embed request
         let original_text = prep_output.routing_text().map(String::from);

--- a/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -3,7 +3,6 @@
 use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
-use uuid::Uuid;
 
 use crate::routers::{
     error,
@@ -60,15 +59,13 @@ impl PipelineStage for GenerateRequestBuildingStage {
             ClientSelection::Disaggregated { prefill, .. } => prefill,
         };
 
-        // Build generate request. PD retries re-run this stage, and a NIXL-tagged
-        // prefill keeps the request_id alive on the worker until the KV lease
-        // expires, so client rids get a unique per-attempt engine id in PD mode.
         let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
-        let request_id = match generate_request.rid.clone() {
-            Some(rid) if disaggregated => format!("{rid}-{}", Uuid::now_v7()),
-            Some(rid) => rid,
-            None => format!("gen-{}", Uuid::now_v7()),
-        };
+        let request_id = helpers::resolve_request_id(
+            &ctx.input.request_type,
+            ctx.input.tenant_request_meta.as_ref(),
+            "gen-",
+            disaggregated,
+        );
 
         // Build proto request using centralized dispatch
         let mut proto_request = builder_client

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use axum::response::Response;
 use openai_protocol::messages;
 use tracing::error;
-use uuid::Uuid;
 
 use crate::routers::{
     error,
@@ -82,7 +81,13 @@ impl PipelineStage for MessageRequestBuildingStage {
         };
 
         // Build message request
-        let request_id = format!("msg_{}", Uuid::now_v7());
+        let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
+        let request_id = helpers::resolve_request_id(
+            &ctx.input.request_type,
+            ctx.input.tenant_request_meta.as_ref(),
+            "msg_",
+            disaggregated,
+        );
 
         // `encode_outputs` set by EncodeStage selects the pixel-drop assembly path.
         let is_encode_routed = ctx.state.encode_outputs.is_some();

--- a/model_gateway/src/routers/grpc/utils/message_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/message_utils.rs
@@ -789,6 +789,7 @@ mod tests {
             top_p: None,
             container: None,
             mcp_servers: None,
+            rid: None,
             other: serde_json::Map::new(),
         };
         assert_eq!(get_history_tool_calls_count_messages(&request), 0);
@@ -838,6 +839,7 @@ mod tests {
             top_p: None,
             container: None,
             mcp_servers: None,
+            rid: None,
             other: serde_json::Map::new(),
         };
         assert_eq!(get_history_tool_calls_count_messages(&request), 2);

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -94,6 +94,7 @@ fn create_minimal_completion_request() -> CompletionRequest {
         session_params: None,
         return_hidden_states: false,
         sampling_seed: None,
+        rid: None,
         other: serde_json::Map::new(),
     }
 }


### PR DESCRIPTION
## Description

### Problem

`rid` passthrough existed on generate/embeddings/classify/rerank but not chat or completions (#1874) — and on gRPC it was only honored by `/generate`: embeddings/classify minted `embed-`/`classify-` ids ignoring their own `rid` fields. Worse, every request-building stage minted its own id independently of the request-id middleware (`middleware/request_id.rs`), so three ids existed per request — the middleware id in gateway logs, the stage-minted id in engine logs and the response body, and whatever the client sent — none correlated.

### Solution

One resolver, every path. `helpers::resolve_request_id` is now the single source of backend request ids for all gRPC request-building stages (chat, harmony chat/responses, messages, completions incl. batch, generate, embeddings, classify):

1. **Protocol `rid`** (added to chat, completions, and messages; already on generate/embeddings/classify) — used verbatim outside PD; per-attempt `-{uuid}` suffix in PD (matching `/generate`'s long-standing NIXL-lease rule).
2. **Else the middleware request id** — client-sent via the configured headers (`x-request-id`, `x-correlation-id`, …) or middleware-generated; carried into the pipeline on the tenant request metadata (tenant resolution runs inside `RequestIdLayer` and copies the extension — zero router-signature changes). Always suffixed `-{uuid}` per execution, which keeps retries, PD attempts, and responses tool-loop iterations unique while staying grep-able by prefix.
3. **Else** the endpoint-prefixed mint, as before (fixture/test contexts).

HTTP mode needs no mechanism: the typed `rid` fields serialize through natively, and the middleware already echoes `x-request-id`.

Net effect: gateway log id, engine log id, and response body `id` are one lineage for every request — `rid` when given, the middleware id otherwise. Batched completions keep the clean shared id on the response and suffix per-sub engine ids.

Behavior notes:
- Response body ids for default traffic become `{middleware-id}-{uuid}` (e.g. `chatcmpl-Abc…-0198…`); endpoint prefixes are preserved, including a new `msg_` arm in the middleware generator so Anthropic message ids keep their shape.
- The middleware's path matching switched from ordered `contains` scans to `ends_with` suffix compares — sub-resource paths (e.g. `GET /v1/responses/{id}`) now generate the generic `req-` log id instead of `resp-`; those ids never reach response bodies.
- gRPC responses tool-loop iterations now log under `{request-id}-{uuid}` per iteration, correlating engine work back to the originating request.

## Changes

- `crates/protocols`: `rid: Option<String>` on `ChatCompletionRequest`, `CompletionRequest`, `CreateMessageRequest` (typed field replaces the `other`-flatten passthrough on HTTP).
- `grpc/common/stages/helpers.rs`: `resolve_request_id` + `middleware_request_id`; `RequestType::rid()` accessor in `context.rs`.
- All six request-building stages route through the resolver; batch completions compose `{shared}-p{i}` with the same uniqueness rules.
- `middleware/tenant_resolution.rs`: carries `RequestId` on the request meta; `middleware/request_id.rs`: `msg_` arm + `ends_with` matching.
- Go SDK: optional `Rid` on `ChatCompletionRequest`.
- Docs: backend-id derivation note in the logging guide.

## Test Plan

- Unit: resolver priority/suffix rules (4 tests), middleware prefix mapping, tenant-meta carries `RequestId`.
- `cargo test -p smg -p openai-protocol -p smg-grpc-client`: all green (smg lib 1233; api 106, routing 94, spec 96, security 50, …; protocols 84+126; grpc_client 65) — full-server api_tests exercise the new id lineage end-to-end.
- e2e: chat `rid` → `response.id == rid`; chat `x-request-id: corr-abc` → `response.id` starts with `corr-abc-`; completions scalar + batch `rid` → response id equals rid.
- `cargo clippy --all-targets -- -D warnings`, `cargo +nightly fmt --check`, `ruff` clean; Go SDK package builds (`go build .`; examples need `libsmg_go`, unchanged).

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional request ID (`rid`) support to chat, completion, messages, and other request types.
  * Client-provided `rid` is forwarded for backend log correlation and reflected in response `id`s.
* **Documentation**
  * Clarified request-correlation behavior and how engine/gateway request IDs are derived.
* **Bug Fixes**
  * Improved endpoint-specific request ID prefixing and middleware request ID propagation.
  * Enhanced request ID generation rules for retries, batch prompts, and disaggregated mode.
* **Tests**
  * Added e2e and unit tests covering request ID passthrough and response `id` formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->