### PR TITLE
fix(mcp): preserve explicit tool_choice for the initial responses request

### DIFF
--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -34,6 +34,7 @@ use crate::{
             },
         },
         error,
+        openai::responses::utils,
     },
 };
 
@@ -348,8 +349,42 @@ pub(crate) fn prepare_mcp_tools_as_functions(payload: &mut Value, session: &McpT
     tools_json.extend(session_tools);
 
     if !tools_json.is_empty() {
+        let tool_choice = remap_tool_choice_for_functions(obj.get("tool_choice"), &tools_json);
         obj.insert("tools".to_string(), Value::Array(tools_json));
-        obj.insert("tool_choice".to_string(), Value::String("auto".to_string()));
+        obj.insert("tool_choice".to_string(), tool_choice);
+    }
+}
+
+/// Remap an explicit `tool_choice` through the MCP/hosted→function rewrite for
+/// the initial request; resume payloads switch to "auto" so the loop can end.
+///
+/// String options pass through. Object choices resolve by name against the
+/// rewritten function tools (hosted types like `image_generation` match the
+/// function of the same name); anything unmappable falls back to "auto", since
+/// the referenced tool no longer exists in `tools`.
+fn remap_tool_choice_for_functions(tool_choice: Option<&Value>, tools: &[Value]) -> Value {
+    let selected = match tool_choice {
+        Some(Value::String(choice)) => return Value::String(choice.clone()),
+        Some(choice) if choice.is_object() => {
+            choice.get("name").and_then(Value::as_str).or_else(|| {
+                choice
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .filter(|choice_type| *choice_type != ItemType::FUNCTION)
+            })
+        }
+        _ => None,
+    };
+
+    match selected {
+        Some(name)
+            if tools
+                .iter()
+                .any(|tool| utils::function_tool_name(tool) == Some(name)) =>
+        {
+            json!({ "type": ItemType::FUNCTION, "name": name })
+        }
+        _ => Value::String("auto".to_string()),
     }
 }
 
@@ -393,6 +428,9 @@ pub(crate) fn build_resume_payload(
     if let Some(tools_arr) = tools_json.as_array() {
         if !tools_arr.is_empty() {
             obj.insert("tools".to_string(), tools_json.clone());
+            // The tool call already happened; "auto" lets the model answer
+            // instead of looping a preserved "required" until the call limit.
+            obj.insert("tool_choice".to_string(), Value::String("auto".to_string()));
         }
     }
 
@@ -1898,5 +1936,132 @@ mod tests {
             super::approval_request_item_id_source("raw_id"),
             "mcpr_raw_id"
         );
+    }
+
+    async fn function_tool_session() -> (McpOrchestrator, Vec<McpServerBinding>) {
+        let orchestrator = McpOrchestrator::new(McpConfig {
+            servers: vec![McpServerConfig {
+                name: "wiki-server".to_string(),
+                transport: McpTransport::Sse {
+                    url: "http://localhost:3000/sse".to_string(),
+                    token: None,
+                    headers: Default::default(),
+                },
+                proxy: None,
+                required: false,
+                tools: None,
+                builtin_type: None,
+                builtin_tool_name: None,
+                internal: false,
+            }],
+            ..Default::default()
+        })
+        .await
+        .expect("orchestrator");
+        orchestrator
+            .tool_inventory()
+            .insert_entry(ToolEntry::from_server_tool(
+                "wiki-server",
+                test_tool("ask_wiki"),
+            ));
+        let bindings = vec![McpServerBinding {
+            label: "wiki".to_string(),
+            server_key: "wiki-server".to_string(),
+            allowed_tools: None,
+        }];
+        (orchestrator, bindings)
+    }
+
+    #[tokio::test]
+    async fn prepare_preserves_explicit_tool_choice() {
+        let (orchestrator, bindings) = function_tool_session().await;
+        let session = McpToolSession::new(&orchestrator, bindings, "test-request");
+
+        let mut payload = json!({
+            "model": "m",
+            "input": "q",
+            "tools": [{"type": "mcp", "server_label": "wiki"}],
+            "tool_choice": "required"
+        });
+        super::prepare_mcp_tools_as_functions(&mut payload, &session);
+
+        assert_eq!(payload["tool_choice"], json!("required"));
+        assert_eq!(payload["tools"][0]["type"], json!("function"));
+    }
+
+    #[tokio::test]
+    async fn prepare_remaps_hosted_tool_choice_to_function() {
+        let (orchestrator, bindings) = function_tool_session().await;
+        orchestrator
+            .tool_inventory()
+            .insert_entry(ToolEntry::from_server_tool(
+                "wiki-server",
+                test_tool("image_generation"),
+            ));
+        let session = McpToolSession::new(&orchestrator, bindings, "test-request");
+
+        let mut payload = json!({
+            "model": "m",
+            "input": "q",
+            "tools": [{"type": "image_generation"}],
+            "tool_choice": {"type": "image_generation"}
+        });
+        super::prepare_mcp_tools_as_functions(&mut payload, &session);
+
+        assert_eq!(
+            payload["tool_choice"],
+            json!({"type": "function", "name": "image_generation"})
+        );
+    }
+
+    #[tokio::test]
+    async fn prepare_downgrades_unmappable_tool_choice_to_auto() {
+        let (orchestrator, bindings) = function_tool_session().await;
+        let session = McpToolSession::new(&orchestrator, bindings, "test-request");
+
+        let mut payload = json!({
+            "model": "m",
+            "input": "q",
+            "tools": [{"type": "mcp", "server_label": "wiki"}],
+            "tool_choice": {"type": "web_search_preview"}
+        });
+        super::prepare_mcp_tools_as_functions(&mut payload, &session);
+
+        assert_eq!(payload["tool_choice"], json!("auto"));
+    }
+
+    #[tokio::test]
+    async fn prepare_defaults_missing_tool_choice_to_auto() {
+        let (orchestrator, bindings) = function_tool_session().await;
+        let session = McpToolSession::new(&orchestrator, bindings, "test-request");
+
+        let mut payload = json!({
+            "model": "m",
+            "input": "q",
+            "tools": [{"type": "mcp", "server_label": "wiki"}]
+        });
+        super::prepare_mcp_tools_as_functions(&mut payload, &session);
+
+        assert_eq!(payload["tool_choice"], json!("auto"));
+    }
+
+    #[test]
+    fn resume_payload_forces_auto_tool_choice() {
+        let base = json!({
+            "model": "m",
+            "input": "q",
+            "tools": [{"type": "function", "name": "ask_wiki"}],
+            "tool_choice": "required"
+        });
+        let resumed = super::build_resume_payload(
+            &base,
+            &[],
+            &ResponseInput::Text("q".to_string()),
+            &json!([{"type": "function", "name": "ask_wiki"}]),
+            false,
+        )
+        .expect("resume payload");
+
+        assert_eq!(resumed["tool_choice"], json!("auto"));
     }
 }

--- a/model_gateway/src/routers/openai/responses/mod.rs
+++ b/model_gateway/src/routers/openai/responses/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod history;
 mod non_streaming;
 pub(crate) mod route;
 mod streaming;
-mod utils;
+pub(crate) mod utils;
 
 // Re-exported for openai::mcp::tool_handler (cross-module dependency)
 pub(crate) use accumulator::StreamingResponseAccumulator;

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -401,7 +401,7 @@ fn strip_internal_mcp_output_items(
     });
 }
 
-fn function_tool_name(tool: &Value) -> Option<&str> {
+pub(crate) fn function_tool_name(tool: &Value) -> Option<&str> {
     let tool_type = tool.get("type").and_then(|value| value.as_str());
     if tool_type != Some("function") {
         return None;


### PR DESCRIPTION
## Description

### Problem

The OpenAI router's MCP tool loop rewrote every `tool_choice` to `"auto"` in `prepare_mcp_tools_as_functions` before the *initial* model request, silently dropping explicit `"required"`, `"none"`, and specific-function choices (#1945). A model that only calls tools under `"required"` could skip the MCP call entirely.

### Solution

Exactly the semantics the reporter proposed, which the gRPC responses loops already implement per-iteration:

- **Initial request**: an explicit string `tool_choice` (`"required"`/`"none"`/`"auto"`) is preserved. Object choices are **remapped through the MCP/hosted→function rewrite**: they resolve by name against the rewritten function tools (a hosted type like `{"type": "image_generation"}` matches the function of the same name and becomes `{"type": "function", "name": "image_generation"}`); anything unmappable falls back to `"auto"`, since the referenced tool no longer exists in the rewritten array. Naive verbatim preservation would 400 upstream — the `openai-responses` e2e caught exactly that (`Tool choice 'image_generation' not found in 'tools'`) on the first revision of this PR.
- **Resume payloads** (`build_resume_payload`): `tool_choice` is forced to `"auto"` — the tool call already happened, and a cloned `"required"` would otherwise loop until the tool-call limit.
- Requests that sent `"auto"` (or nothing) behave exactly as before.

The two other `tool_choice` writes in the OpenAI router are response-side echo normalization and are untouched — with this fix a preserved `"required"` now also echoes back faithfully. The gRPC responses loops (regular + Harmony) already had iteration-0-preserves/then-auto logic and need no change.

## Changes

- `routers/openai/mcp/tool_loop.rs` — `prepare_mcp_tools_as_functions` inserts `"auto"` only when `tool_choice` is absent/null; `build_resume_payload` sets `"auto"` alongside the resumed tools.
- Unit tests: string choice preserved through tool rewriting, hosted-typed choice remapped to its function form, unmappable object choice downgraded to `"auto"`, missing choice defaults to `"auto"`, resume forces `"auto"` over a preserved `"required"`.

## Test Plan

- `cargo test -p smg`: lib 1258 passed (19 tool-loop tests incl. the 5 new); all integration binaries green (api 106, routing 94, spec 96, security 50, …; 0 failures).
- `cargo clippy --all-targets -- -D warnings`, `cargo +nightly fmt --check`.
- Repro from the issue: `tool_choice: "required"` with a `deepwiki` MCP tool now reaches the upstream model as `"required"` on the first request and `"auto"` on post-tool iterations.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicit tool selection preferences when translating MCP tools into OpenAI function tools, including remapping supported tool choices to their rewritten counterparts.
  * When a provided tool choice can’t be mapped, it now safely falls back to automatic selection.
  * Ensured resumed requests continue tool execution reliably by forcing automatic tool choice when resumed with a non-empty tools set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
