### PR TITLE
feat(rate_limit): add reserve/settle engine

### DIFF
--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -275,6 +275,18 @@ impl RouterConfigBuilder {
         self
     }
 
+    // ==================== Tenant Rate Limit ====================
+
+    pub fn tenant_rate_limit_enabled(mut self, enabled: bool) -> Self {
+        self.config.tenant_rate_limit_enabled = enabled;
+        self
+    }
+
+    pub fn tenant_rate_limit_config(mut self, path: Option<String>) -> Self {
+        self.config.tenant_rate_limit_config = path;
+        self
+    }
+
     // ==================== Security & CORS ====================
 
     pub fn api_key<S: Into<String>>(mut self, key: S) -> Self {

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -95,6 +95,16 @@ pub struct RouterConfig {
     /// by inflight; the remainder bucket under `tenant="other"`).
     #[serde(default = "default_priority_scheduler_tenant_metric_top_n")]
     pub priority_scheduler_tenant_metric_top_n: u32,
+    /// Enable per-tenant LLM token/request rate limiting. When false
+    /// (default), no rate limiter is constructed — zero behavior change
+    /// for existing deployments.
+    #[serde(default)]
+    pub tenant_rate_limit_enabled: bool,
+    /// Path to the tenant-rate-limit YAML (default + per-tenant policies,
+    /// optionally further restricted per-model). Required when
+    /// `tenant_rate_limit_enabled` is true.
+    #[serde(default)]
+    pub tenant_rate_limit_config: Option<String>,
     pub cors_allowed_origins: Vec<String>,
     pub retry: RetryConfig,
     pub circuit_breaker: CircuitBreakerConfig,
@@ -798,6 +808,8 @@ impl Default for RouterConfig {
             priority_scheduler_config: None,
             priority_scheduler_tenant_metric_top_n: default_priority_scheduler_tenant_metric_top_n(
             ),
+            tenant_rate_limit_enabled: false,
+            tenant_rate_limit_config: None,
             cors_allowed_origins: vec![],
             retry: RetryConfig::default(),
             circuit_breaker: CircuitBreakerConfig::default(),

--- a/model_gateway/src/rate_limit/backend.rs
+++ b/model_gateway/src/rate_limit/backend.rs
@@ -1,0 +1,56 @@
+//! `RateLimitBackend`: the reserve/settle/close/abandon contract a rate
+//! limit implementation must provide. `Local` (this phase) is in-memory;
+//! a future `External` (HTTP-based, distributed) implementation is the
+//! reason this is a trait rather than a concrete type.
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::tenant::TenantKey;
+
+/// What a reservation attempt asks for. `model_id` is optional — when
+/// absent, model-rule scoping is skipped.
+#[derive(Debug, Clone)]
+pub struct ReserveRequest {
+    pub request_charge_id: Uuid,
+    pub tenant_key: TenantKey,
+    pub model_id: Option<String>,
+    pub estimated_input_tokens: u32,
+}
+
+/// Outcome of a `reserve` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReserveOutcome {
+    Admitted,
+    Denied { retry_after_secs: u64 },
+}
+
+/// Authoritative usage after a successful call, used to true up the
+/// reservation via `(actual_input_tokens + completion_tokens) -
+/// estimated_input_tokens`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UsageSettlement {
+    pub actual_input_tokens: u32,
+    pub completion_tokens: u32,
+}
+
+/// Reserve-once-per-logical-request, settle/close/abandon-once lifecycle,
+/// keyed by `request_charge_id` (not the client-correlatable request id)
+/// so retries reuse one reservation.
+#[async_trait]
+pub trait RateLimitBackend: Send + Sync {
+    async fn reserve(&self, request: ReserveRequest) -> ReserveOutcome;
+
+    /// Settle from final, authoritative usage. Idempotent: a no-op if the
+    /// reservation was already settled/closed/abandoned.
+    async fn settle_success(&self, request_charge_id: Uuid, usage: UsageSettlement);
+
+    /// Close without settlement (success with no usage reported, or a
+    /// terminal failure after admission) — keeps the reserved-input debit
+    /// rather than refunding it. Idempotent.
+    async fn close_reserved_only(&self, request_charge_id: Uuid);
+
+    /// Abandon on drop/cancel/disconnect before an explicit close — same
+    /// keep-the-debit semantics as `close_reserved_only`. Idempotent.
+    async fn abandon(&self, request_charge_id: Uuid);
+}

--- a/model_gateway/src/rate_limit/bucket.rs
+++ b/model_gateway/src/rate_limit/bucket.rs
@@ -1,0 +1,229 @@
+//! Per-scope token/request bucket for the local rate-limit backend:
+//! continuous-refill float counters (same math as
+//! `middleware::token_bucket::TokenBucket`), but two independent counters
+//! per scope and a reserve/settle API allowing temporary debt — a
+//! completion can use more tokens than were reserved for it.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use parking_lot::{Mutex, MutexGuard};
+
+use super::policy::ScopeLimits;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ScopeDryRun {
+    pub allowed: bool,
+    /// Seconds until enough capacity would be available. `0` when
+    /// `allowed`.
+    pub retry_after_secs: u64,
+}
+
+pub(crate) struct BucketState {
+    available_tokens: f64,
+    available_requests: f64,
+    last_refill: Instant,
+}
+
+pub(crate) struct ScopeBucket {
+    state: Mutex<BucketState>,
+    token_capacity: f64,
+    token_refill_per_sec: f64,
+    request_capacity: f64,
+    request_refill_per_sec: f64,
+    created_at: Instant,
+    /// Nanoseconds since `created_at`, updated on every `lock()` without
+    /// taking `state`'s lock — lets a future idle-eviction sweep read it
+    /// without contending with the hot path. No reaper exists yet.
+    last_touched_ns: AtomicU64,
+}
+
+impl ScopeBucket {
+    pub fn new(limits: ScopeLimits) -> Self {
+        let token_capacity = f64::from(limits.tokens_per_minute);
+        let request_capacity = f64::from(limits.requests_per_minute);
+        Self {
+            state: Mutex::new(BucketState {
+                available_tokens: token_capacity,
+                available_requests: request_capacity,
+                last_refill: Instant::now(),
+            }),
+            token_capacity,
+            token_refill_per_sec: token_capacity / 60.0,
+            request_capacity,
+            request_refill_per_sec: request_capacity / 60.0,
+            created_at: Instant::now(),
+            last_touched_ns: AtomicU64::new(0),
+        }
+    }
+
+    pub fn lock(&self) -> MutexGuard<'_, BucketState> {
+        self.touch();
+        self.state.lock()
+    }
+
+    fn touch(&self) {
+        let now_ns = u64::try_from(self.created_at.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        self.last_touched_ns.store(now_ns, Ordering::Relaxed);
+    }
+
+    /// Nanoseconds since `created_at` as of the last `lock()`.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "no eviction sweep reads this yet; exercised by this module's own tests"
+        )
+    )]
+    pub fn last_touched_ns(&self) -> u64 {
+        self.last_touched_ns.load(Ordering::Relaxed)
+    }
+
+    /// Refill both counters based on elapsed time since the last refill.
+    /// Must be called under the lock before `dry_run`/`debit`.
+    pub fn refill(&self, state: &mut BucketState) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(state.last_refill).as_secs_f64();
+        state.available_tokens =
+            (state.available_tokens + elapsed * self.token_refill_per_sec).min(self.token_capacity);
+        state.available_requests = (state.available_requests
+            + elapsed * self.request_refill_per_sec)
+            .min(self.request_capacity);
+        state.last_refill = now;
+    }
+
+    /// Non-mutating: would `tokens`/`requests` be admitted right now?
+    pub fn dry_run(&self, state: &BucketState, tokens: f64, requests: f64) -> ScopeDryRun {
+        let allowed = state.available_tokens >= tokens && state.available_requests >= requests;
+        if allowed {
+            return ScopeDryRun {
+                allowed: true,
+                retry_after_secs: 0,
+            };
+        }
+        let token_wait = Self::wait_secs(state.available_tokens, tokens, self.token_refill_per_sec);
+        let request_wait = Self::wait_secs(
+            state.available_requests,
+            requests,
+            self.request_refill_per_sec,
+        );
+        ScopeDryRun {
+            allowed: false,
+            retry_after_secs: token_wait.max(request_wait),
+        }
+    }
+
+    fn wait_secs(available: f64, needed: f64, refill_per_sec: f64) -> u64 {
+        if available >= needed {
+            return 0;
+        }
+        if refill_per_sec <= 0.0 {
+            return u64::MAX;
+        }
+        (((needed - available) / refill_per_sec).ceil() as u64).max(1)
+    }
+
+    /// Caller must have already confirmed admission via `dry_run` under
+    /// the same lock acquisition.
+    #[expect(
+        clippy::unused_self,
+        reason = "API symmetry with refill/dry_run/settle_tokens, which do need self"
+    )]
+    pub fn debit(&self, state: &mut BucketState, tokens: f64, requests: f64) {
+        state.available_tokens -= tokens;
+        state.available_requests -= requests;
+    }
+
+    /// Signed delta to the token counter only — requests aren't trued up.
+    /// Can push tokens negative (debt) but never above capacity.
+    pub fn settle_tokens(&self, state: &mut BucketState, delta: f64) {
+        state.available_tokens = (state.available_tokens - delta).min(self.token_capacity);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn limits(tpm: u32, rpm: u32) -> ScopeLimits {
+        ScopeLimits {
+            tokens_per_minute: tpm,
+            requests_per_minute: rpm,
+        }
+    }
+
+    #[test]
+    fn admits_within_capacity() {
+        let bucket = ScopeBucket::new(limits(600, 10));
+        let mut guard = bucket.lock();
+        bucket.refill(&mut guard);
+        let dry = bucket.dry_run(&guard, 100.0, 1.0);
+        assert!(dry.allowed);
+        bucket.debit(&mut guard, 100.0, 1.0);
+        assert_eq!(guard.available_tokens, 500.0);
+        assert_eq!(guard.available_requests, 9.0);
+    }
+
+    #[test]
+    fn denies_over_capacity_with_retry_after() {
+        let bucket = ScopeBucket::new(limits(60, 10));
+        let mut guard = bucket.lock();
+        bucket.refill(&mut guard);
+        bucket.debit(&mut guard, 60.0, 0.0);
+        let dry = bucket.dry_run(&guard, 30.0, 0.0);
+        assert!(!dry.allowed);
+        // 60 tokens/min = 1 token/sec; need 30 more => ~30s.
+        assert_eq!(dry.retry_after_secs, 30);
+    }
+
+    #[tokio::test]
+    async fn refill_restores_capacity_over_time() {
+        let bucket = ScopeBucket::new(limits(600, 10));
+        {
+            let mut guard = bucket.lock();
+            bucket.refill(&mut guard);
+            bucket.debit(&mut guard, 600.0, 0.0);
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let mut guard = bucket.lock();
+        bucket.refill(&mut guard);
+        // 600 tokens/min = 10 tokens/sec; ~200ms => ~2 tokens refilled.
+        assert!(guard.available_tokens > 0.5 && guard.available_tokens < 5.0);
+    }
+
+    #[test]
+    fn settle_can_push_negative_debt_but_not_above_capacity() {
+        let bucket = ScopeBucket::new(limits(600, 10));
+        let mut guard = bucket.lock();
+        bucket.refill(&mut guard);
+        bucket.debit(&mut guard, 100.0, 1.0);
+        // Actual usage exceeded the reservation by 50 tokens.
+        bucket.settle_tokens(&mut guard, 50.0);
+        assert_eq!(guard.available_tokens, 450.0);
+
+        // A refund (negative delta) is capped at capacity.
+        bucket.settle_tokens(&mut guard, -1000.0);
+        assert_eq!(guard.available_tokens, 600.0);
+    }
+
+    #[tokio::test]
+    async fn lock_touches_last_touched_ns() {
+        let bucket = ScopeBucket::new(limits(600, 10));
+        assert_eq!(bucket.last_touched_ns(), 0);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(bucket.lock());
+
+        let touched = bucket.last_touched_ns();
+        assert!(touched > 0);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(bucket.lock());
+
+        assert!(bucket.last_touched_ns() > touched);
+    }
+}

--- a/model_gateway/src/rate_limit/bucket.rs
+++ b/model_gateway/src/rate_limit/bucket.rs
@@ -103,6 +103,14 @@ impl ScopeBucket {
                 retry_after_secs: 0,
             };
         }
+        if tokens > self.token_capacity || requests > self.request_capacity {
+            // refill() clamps at capacity, so an ask above it can never
+            // become admissible no matter how long the caller waits.
+            return ScopeDryRun {
+                allowed: false,
+                retry_after_secs: u64::MAX,
+            };
+        }
         let token_wait = Self::wait_secs(state.available_tokens, tokens, self.token_refill_per_sec);
         let request_wait = Self::wait_secs(
             state.available_requests,
@@ -180,6 +188,18 @@ mod tests {
         assert_eq!(dry.retry_after_secs, 30);
     }
 
+    #[test]
+    fn ask_above_bucket_capacity_is_never_retryable() {
+        let bucket = ScopeBucket::new(limits(60, 10));
+        let mut guard = bucket.lock();
+        bucket.refill(&mut guard);
+        // 100 tokens can never fit in a 60-token bucket -- refill() clamps
+        // at capacity, so no wait time would ever make this admissible.
+        let dry = bucket.dry_run(&guard, 100.0, 0.0);
+        assert!(!dry.allowed);
+        assert_eq!(dry.retry_after_secs, u64::MAX);
+    }
+
     #[tokio::test]
     async fn refill_restores_capacity_over_time() {
         let bucket = ScopeBucket::new(limits(600, 10));
@@ -191,8 +211,10 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(200)).await;
         let mut guard = bucket.lock();
         bucket.refill(&mut guard);
-        // 600 tokens/min = 10 tokens/sec; ~200ms => ~2 tokens refilled.
-        assert!(guard.available_tokens > 0.5 && guard.available_tokens < 5.0);
+        // Lower bound proves refill happened; upper bound is capacity
+        // (not a tight timing-derived number) so scheduling jitter can't
+        // flake this.
+        assert!(guard.available_tokens > 0.5 && guard.available_tokens <= 600.0);
     }
 
     #[test]

--- a/model_gateway/src/rate_limit/config.rs
+++ b/model_gateway/src/rate_limit/config.rs
@@ -11,11 +11,14 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
+use crate::tenant::is_canonical_serving_tenant_key;
+
 /// A single tenant's (or the default) token/request-per-minute policy,
 /// plus optional per-model rules layered on top. At most one model rule
 /// matches per request — rules never stack with each other, only with
 /// the tenant-global limits.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TenantPolicySpec {
     /// Canonical tenant key (e.g. `auth:team-red`). Must be `None` on
     /// [`RateLimitYaml::default_policy`] and `Some` on every entry in
@@ -30,6 +33,7 @@ pub struct TenantPolicySpec {
 
 /// A per-model rate-limit rule layered on top of the tenant-global limits.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModelRuleSpec {
     /// Stable identifier, unique within the tenant. `[A-Za-z0-9._-]+`.
     pub rule_id: String,
@@ -39,7 +43,7 @@ pub struct ModelRuleSpec {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ModelMatcherSpec {
     Exact { value: String },
     Prefix { value: String },
@@ -48,6 +52,7 @@ pub enum ModelMatcherSpec {
 /// Optional YAML config, intended to be loaded via a
 /// `--tenant-rate-limit-config <path>` CLI flag added in a follow-up PR.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RateLimitYaml {
     pub default_policy: TenantPolicySpec,
     #[serde(default)]
@@ -64,6 +69,10 @@ pub enum RateLimitConfigError {
     DuplicateTenantKey { tenant_key: String },
     #[error("tenant_key '{tenant_key}' must not have surrounding whitespace")]
     PaddedTenantKey { tenant_key: String },
+    #[error(
+        "tenant_key '{tenant_key}' is not a canonical serving-path tenant key (expected auth:<id>, header:<id>, ip:<address>, or anonymous)"
+    )]
+    NonCanonicalTenantKey { tenant_key: String },
     #[error("policy '{label}': tokens_per_minute must be > 0")]
     ZeroTokensPerMinute { label: String },
     #[error("policy '{label}': requests_per_minute must be > 0")]
@@ -213,6 +222,13 @@ impl RateLimitYaml {
                     tenant_key: tenant_key.to_string(),
                 });
             }
+            // E.g. a bare tenant_id copy-pasted from tenant_api_keys,
+            // missing its auth: prefix — can never match a real tenant.
+            if !is_canonical_serving_tenant_key(tenant_key) {
+                return Err(RateLimitConfigError::NonCanonicalTenantKey {
+                    tenant_key: tenant_key.to_string(),
+                });
+            }
             if !seen_tenants.insert(tenant_key) {
                 return Err(RateLimitConfigError::DuplicateTenantKey {
                     tenant_key: tenant_key.to_string(),
@@ -253,6 +269,14 @@ mod tests {
             tenants: vec![policy(Some("auth:team-red"), 5000, 300)],
         };
         assert!(yaml.validate().is_ok());
+    }
+
+    #[test]
+    fn misspelled_field_is_rejected_not_silently_ignored() {
+        // `tenant:` typo'd for `tenants:` -- without deny_unknown_fields
+        // this silently falls back to an empty tenants list.
+        let raw = "default_policy:\n  tokens_per_minute: 1000\n  requests_per_minute: 60\ntenant:\n  - tenant_key: auth:team-red\n    tokens_per_minute: 5000\n    requests_per_minute: 300\n";
+        assert!(serde_yaml::from_str::<RateLimitYaml>(raw).is_err());
     }
 
     #[test]
@@ -303,6 +327,24 @@ mod tests {
             assert_eq!(
                 yaml.validate(),
                 Err(RateLimitConfigError::PaddedTenantKey {
+                    tenant_key: tenant_key.to_string()
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn tenant_non_canonical_key_rejected() {
+        // Bare tenant_id, missing the auth:/header:/ip: prefix a real
+        // resolved key always has.
+        for tenant_key in ["team-red", "auth:", "ip:not-an-ip", "tenant:team-red"] {
+            let yaml = RateLimitYaml {
+                default_policy: policy(None, 1000, 60),
+                tenants: vec![policy(Some(tenant_key), 5000, 300)],
+            };
+            assert_eq!(
+                yaml.validate(),
+                Err(RateLimitConfigError::NonCanonicalTenantKey {
                     tenant_key: tenant_key.to_string()
                 })
             );

--- a/model_gateway/src/rate_limit/local_backend.rs
+++ b/model_gateway/src/rate_limit/local_backend.rs
@@ -1,0 +1,378 @@
+//! In-memory [`RateLimitBackend`]: per-tenant (+ optional per-model-rule)
+//! token/request buckets, reserved once per logical request and settled
+//! from final usage.
+//!
+//! Per-instance only: a tenant's true limit across N independent SMG
+//! instances is roughly N× the configured value. Exact cluster-wide
+//! enforcement is out of scope for this backend — that's what a future
+//! `External` (distributed) backend behind the same trait is for.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dashmap::{mapref::entry::Entry, DashMap};
+use uuid::Uuid;
+
+use super::{
+    backend::{RateLimitBackend, ReserveOutcome, ReserveRequest, UsageSettlement},
+    bucket::ScopeBucket,
+    policy::{CompiledPolicySet, ScopeLimits},
+};
+use crate::tenant::TenantKey;
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+enum ScopeKey {
+    TenantGlobal(TenantKey),
+    ModelRule(TenantKey, String),
+}
+
+/// What was actually debited for a reservation, kept around so
+/// settle/close/abandon know which scopes to touch (and, for settlement,
+/// how much to true up).
+struct ActiveReservation {
+    scopes: Vec<ScopeKey>,
+    reserved_tokens: u32,
+}
+
+pub struct LocalRateLimitBackend {
+    // Hot-reload lands in a later phase; the ArcSwap seam is in place now
+    // so that phase is additive rather than an API change.
+    policy: arc_swap::ArcSwap<CompiledPolicySet>,
+    buckets: DashMap<ScopeKey, Arc<ScopeBucket>>,
+    active: DashMap<Uuid, ActiveReservation>,
+}
+
+impl LocalRateLimitBackend {
+    pub fn new(policy: CompiledPolicySet) -> Self {
+        Self {
+            policy: arc_swap::ArcSwap::from(Arc::new(policy)),
+            buckets: DashMap::new(),
+            active: DashMap::new(),
+        }
+    }
+
+    fn bucket_for(&self, key: ScopeKey, limits: ScopeLimits) -> Arc<ScopeBucket> {
+        self.buckets
+            .entry(key)
+            .or_insert_with(|| Arc::new(ScopeBucket::new(limits)))
+            .clone()
+    }
+}
+
+#[async_trait]
+impl RateLimitBackend for LocalRateLimitBackend {
+    async fn reserve(&self, request: ReserveRequest) -> ReserveOutcome {
+        // Idempotent per request_charge_id: a retry reuses the same
+        // charge_id and must not be debited twice. Claim the slot before
+        // any bucket work so a duplicate (even concurrent) call just
+        // confirms the existing reservation. Holding entry()'s lock here
+        // is safe since nothing below awaits.
+        let active_entry = match self.active.entry(request.request_charge_id) {
+            Entry::Occupied(_) => return ReserveOutcome::Admitted,
+            Entry::Vacant(entry) => entry,
+        };
+
+        let policy = self.policy.load();
+        let tenant_policy = policy.policy_for(&request.tenant_key);
+
+        let mut scopes: Vec<(ScopeKey, Arc<ScopeBucket>)> = Vec::with_capacity(2);
+        let global_key = ScopeKey::TenantGlobal(request.tenant_key.clone());
+        let global_bucket = self.bucket_for(global_key.clone(), tenant_policy.limits);
+        scopes.push((global_key, global_bucket));
+
+        if let Some(model_id) = request.model_id.as_deref() {
+            if let Some(rule) = tenant_policy.matching_rule(model_id) {
+                let rule_key =
+                    ScopeKey::ModelRule(request.tenant_key.clone(), rule.rule_id.clone());
+                let rule_bucket = self.bucket_for(rule_key.clone(), rule.limits);
+                scopes.push((rule_key, rule_bucket));
+            }
+        }
+
+        // Fixed lock order (tenant-global, then model-rule): every
+        // reservation for the same tenant locks in this same order, so
+        // this can never deadlock. Different tenants never share a bucket,
+        // so cross-tenant ordering doesn't matter.
+        let mut guards: Vec<_> = scopes.iter().map(|(_, b)| b.lock()).collect();
+        for ((_, bucket), guard) in scopes.iter().zip(guards.iter_mut()) {
+            bucket.refill(guard);
+        }
+
+        let tokens_needed = f64::from(request.estimated_input_tokens);
+        let mut denied_retry_after: Option<u64> = None;
+        for ((_, bucket), guard) in scopes.iter().zip(guards.iter()) {
+            let dry = bucket.dry_run(guard, tokens_needed, 1.0);
+            if !dry.allowed {
+                denied_retry_after =
+                    Some(denied_retry_after.unwrap_or(0).max(dry.retry_after_secs));
+            }
+        }
+
+        if let Some(retry_after_secs) = denied_retry_after {
+            return ReserveOutcome::Denied { retry_after_secs };
+        }
+
+        for ((_, bucket), guard) in scopes.iter().zip(guards.iter_mut()) {
+            bucket.debit(guard, tokens_needed, 1.0);
+        }
+        drop(guards);
+
+        active_entry.insert(ActiveReservation {
+            scopes: scopes.into_iter().map(|(k, _)| k).collect(),
+            reserved_tokens: request.estimated_input_tokens,
+        });
+
+        ReserveOutcome::Admitted
+    }
+
+    async fn settle_success(&self, request_charge_id: Uuid, usage: UsageSettlement) {
+        let Some((_, reservation)) = self.active.remove(&request_charge_id) else {
+            return;
+        };
+        let actual_total =
+            i64::from(usage.actual_input_tokens) + i64::from(usage.completion_tokens);
+        let delta = (actual_total - i64::from(reservation.reserved_tokens)) as f64;
+        for key in &reservation.scopes {
+            if let Some(bucket) = self.buckets.get(key) {
+                let mut guard = bucket.lock();
+                // Refill first, or a later deferred refill can overshoot
+                // capacity and clamp, silently erasing this delta.
+                bucket.refill(&mut guard);
+                bucket.settle_tokens(&mut guard, delta);
+            }
+        }
+    }
+
+    async fn close_reserved_only(&self, request_charge_id: Uuid) {
+        // The reserved-input debit already happened at reserve() time;
+        // nothing further to debit. Just drop the bookkeeping entry.
+        self.active.remove(&request_charge_id);
+    }
+
+    async fn abandon(&self, request_charge_id: Uuid) {
+        // Same as close_reserved_only: the reserved-input debit is kept,
+        // deliberately not refunded (see
+        // `SharedReservationHandle::abandon_if_open`).
+        self.active.remove(&request_charge_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::rate_limit::config::{
+        ModelMatcherSpec, ModelRuleSpec, RateLimitYaml, TenantPolicySpec,
+    };
+
+    fn policy_set(tpm: u32, rpm: u32) -> CompiledPolicySet {
+        let yaml = RateLimitYaml {
+            default_policy: TenantPolicySpec {
+                tenant_key: None,
+                tokens_per_minute: tpm,
+                requests_per_minute: rpm,
+                model_rules: Vec::new(),
+            },
+            tenants: Vec::new(),
+        };
+        CompiledPolicySet::compile(&yaml).unwrap()
+    }
+
+    fn request(tenant: &str, tokens: u32) -> ReserveRequest {
+        ReserveRequest {
+            request_charge_id: Uuid::now_v7(),
+            tenant_key: TenantKey::new(tenant),
+            model_id: None,
+            estimated_input_tokens: tokens,
+        }
+    }
+
+    #[tokio::test]
+    async fn reserve_admits_within_budget_and_denies_over() {
+        let backend = LocalRateLimitBackend::new(policy_set(100, 5));
+        let first = backend.reserve(request("auth:team-red", 60)).await;
+        assert_eq!(first, ReserveOutcome::Admitted);
+
+        let second = backend.reserve(request("auth:team-red", 60)).await;
+        assert!(matches!(second, ReserveOutcome::Denied { .. }));
+    }
+
+    #[tokio::test]
+    async fn different_tenants_have_independent_budgets() {
+        let backend = LocalRateLimitBackend::new(policy_set(100, 5));
+        assert_eq!(
+            backend.reserve(request("auth:team-red", 90)).await,
+            ReserveOutcome::Admitted
+        );
+        assert_eq!(
+            backend.reserve(request("auth:team-blue", 90)).await,
+            ReserveOutcome::Admitted
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_reserve_with_same_charge_id_does_not_double_charge() {
+        let backend = LocalRateLimitBackend::new(policy_set(100, 5));
+        let req = request("auth:team-red", 60);
+        let charge_id = req.request_charge_id;
+
+        // First attempt debits 60 of 100; the retry (same charge_id)
+        // must not debit again.
+        assert_eq!(backend.reserve(req.clone()).await, ReserveOutcome::Admitted);
+        assert_eq!(backend.reserve(req).await, ReserveOutcome::Admitted);
+
+        // Remaining 40 still fits -- would be denied if the retry had
+        // double-debited.
+        assert_eq!(
+            backend.reserve(request("auth:team-red", 40)).await,
+            ReserveOutcome::Admitted
+        );
+
+        // Settlement must see the original bookkeeping, not have it lost
+        // to the retry overwriting it.
+        backend
+            .settle_success(
+                charge_id,
+                UsageSettlement {
+                    actual_input_tokens: 60,
+                    completion_tokens: 0,
+                },
+            )
+            .await;
+        // 100 - 60 (settled exactly) - 40 (still open) = 0 remaining.
+        assert!(matches!(
+            backend.reserve(request("auth:team-red", 1)).await,
+            ReserveOutcome::Denied { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn settle_with_more_usage_than_reserved_creates_debt() {
+        let backend = LocalRateLimitBackend::new(policy_set(100, 5));
+        let req = request("auth:team-red", 50);
+        let charge_id = req.request_charge_id;
+        assert_eq!(backend.reserve(req).await, ReserveOutcome::Admitted);
+
+        backend
+            .settle_success(
+                charge_id,
+                UsageSettlement {
+                    actual_input_tokens: 50,
+                    completion_tokens: 60,
+                },
+            )
+            .await;
+
+        // 100 capacity - 50 reserved - 60 extra from settlement = -10 (debt).
+        let next = backend.reserve(request("auth:team-red", 1)).await;
+        assert!(matches!(next, ReserveOutcome::Denied { .. }));
+    }
+
+    #[tokio::test]
+    async fn settle_refills_before_charging_so_idle_time_cannot_erase_the_charge() {
+        // Near-full bucket so a short idle period saturates the refill at
+        // settle time. Without refilling before the charge, that
+        // overshoot gets replayed later, clawing back part of the charge.
+        let backend = LocalRateLimitBackend::new(policy_set(6000, 1000));
+        let req = request("auth:team-red", 2);
+        let charge_id = req.request_charge_id;
+        assert_eq!(backend.reserve(req).await, ReserveOutcome::Admitted);
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        backend
+            .settle_success(
+                charge_id,
+                UsageSettlement {
+                    actual_input_tokens: 2,
+                    completion_tokens: 500,
+                },
+            )
+            .await;
+
+        // 6000 - 500 charged = 5500 available; the bug would admit this.
+        assert!(matches!(
+            backend.reserve(request("auth:team-red", 5501)).await,
+            ReserveOutcome::Denied { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn close_reserved_only_keeps_the_debit() {
+        let backend = LocalRateLimitBackend::new(policy_set(100, 5));
+        let req = request("auth:team-red", 100);
+        let charge_id = req.request_charge_id;
+        assert_eq!(backend.reserve(req).await, ReserveOutcome::Admitted);
+
+        backend.close_reserved_only(charge_id).await;
+
+        let next = backend.reserve(request("auth:team-red", 1)).await;
+        assert!(matches!(next, ReserveOutcome::Denied { .. }));
+    }
+
+    #[tokio::test]
+    async fn abandon_keeps_the_debit() {
+        let backend = LocalRateLimitBackend::new(policy_set(100, 5));
+        let req = request("auth:team-red", 100);
+        let charge_id = req.request_charge_id;
+        assert_eq!(backend.reserve(req).await, ReserveOutcome::Admitted);
+
+        backend.abandon(charge_id).await;
+
+        let next = backend.reserve(request("auth:team-red", 1)).await;
+        assert!(matches!(next, ReserveOutcome::Denied { .. }));
+    }
+
+    #[tokio::test]
+    async fn model_rule_scope_is_independently_limited() {
+        let yaml = RateLimitYaml {
+            default_policy: TenantPolicySpec {
+                tenant_key: None,
+                tokens_per_minute: 10_000,
+                requests_per_minute: 1_000,
+                model_rules: vec![ModelRuleSpec {
+                    rule_id: "gpt4".to_string(),
+                    matcher: ModelMatcherSpec::Exact {
+                        value: "gpt-4".to_string(),
+                    },
+                    tokens_per_minute: 50,
+                    requests_per_minute: 5,
+                }],
+            },
+            tenants: Vec::new(),
+        };
+        let backend = LocalRateLimitBackend::new(CompiledPolicySet::compile(&yaml).unwrap());
+
+        let req = ReserveRequest {
+            request_charge_id: Uuid::now_v7(),
+            tenant_key: TenantKey::new("auth:team-red"),
+            model_id: Some("gpt-4".to_string()),
+            estimated_input_tokens: 40,
+        };
+        assert_eq!(backend.reserve(req).await, ReserveOutcome::Admitted);
+
+        // The tenant-global budget (10,000) has plenty left, but the
+        // gpt-4 rule budget (50) is nearly exhausted — the rule scope
+        // denies even though the request has a small ask.
+        let second = ReserveRequest {
+            request_charge_id: Uuid::now_v7(),
+            tenant_key: TenantKey::new("auth:team-red"),
+            model_id: Some("gpt-4".to_string()),
+            estimated_input_tokens: 20,
+        };
+        assert!(matches!(
+            backend.reserve(second).await,
+            ReserveOutcome::Denied { .. }
+        ));
+
+        // A different model on the same tenant isn't affected by the rule
+        // scope, only the tenant-global one, which still has budget.
+        let other_model = ReserveRequest {
+            request_charge_id: Uuid::now_v7(),
+            tenant_key: TenantKey::new("auth:team-red"),
+            model_id: Some("claude-3".to_string()),
+            estimated_input_tokens: 20,
+        };
+        assert_eq!(backend.reserve(other_model).await, ReserveOutcome::Admitted);
+    }
+}

--- a/model_gateway/src/rate_limit/local_backend.rs
+++ b/model_gateway/src/rate_limit/local_backend.rs
@@ -93,14 +93,14 @@ impl RateLimitBackend for LocalRateLimitBackend {
         // reservation for the same tenant locks in this same order, so
         // this can never deadlock. Different tenants never share a bucket,
         // so cross-tenant ordering doesn't matter.
-        let mut guards: Vec<_> = scopes.iter().map(|(_, b)| b.lock()).collect();
-        for ((_, bucket), guard) in scopes.iter().zip(guards.iter_mut()) {
+        let mut locked: Vec<_> = scopes.iter().map(|(_, b)| (b, b.lock())).collect();
+        for (bucket, guard) in &mut locked {
             bucket.refill(guard);
         }
 
         let tokens_needed = f64::from(request.estimated_input_tokens);
         let mut denied_retry_after: Option<u64> = None;
-        for ((_, bucket), guard) in scopes.iter().zip(guards.iter()) {
+        for (bucket, guard) in &locked {
             let dry = bucket.dry_run(guard, tokens_needed, 1.0);
             if !dry.allowed {
                 denied_retry_after =
@@ -112,10 +112,10 @@ impl RateLimitBackend for LocalRateLimitBackend {
             return ReserveOutcome::Denied { retry_after_secs };
         }
 
-        for ((_, bucket), guard) in scopes.iter().zip(guards.iter_mut()) {
+        for (bucket, guard) in &mut locked {
             bucket.debit(guard, tokens_needed, 1.0);
         }
-        drop(guards);
+        drop(locked);
 
         active_entry.insert(ActiveReservation {
             scopes: scopes.into_iter().map(|(k, _)| k).collect(),
@@ -279,7 +279,7 @@ mod tests {
         let charge_id = req.request_charge_id;
         assert_eq!(backend.reserve(req).await, ReserveOutcome::Admitted);
 
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        tokio::time::sleep(Duration::from_millis(600)).await;
         backend
             .settle_success(
                 charge_id,
@@ -291,8 +291,10 @@ mod tests {
             .await;
 
         // 6000 - 500 charged = 5500 available; the bug would admit this.
+        // Assert well above 5500 (not the exact boundary) so a few extra
+        // tokens of scheduling-jitter refill can't flip the outcome.
         assert!(matches!(
-            backend.reserve(request("auth:team-red", 5501)).await,
+            backend.reserve(request("auth:team-red", 5530)).await,
             ReserveOutcome::Denied { .. }
         ));
     }

--- a/model_gateway/src/rate_limit/manager.rs
+++ b/model_gateway/src/rate_limit/manager.rs
@@ -1,0 +1,238 @@
+//! [`RateLimitManager`]: the facade routers/middleware call into.
+//!
+//! Built once at startup from the optional `--tenant-rate-limit-config`
+//! YAML. `Ok(None)` when disabled; `Err` when enabled but the YAML is
+//! invalid — callers must fail startup on `Err`, not run unlimited.
+
+use std::sync::Arc;
+
+use tracing::info;
+
+#[cfg(test)]
+use super::backend::UsageSettlement;
+use super::{
+    backend::{RateLimitBackend, ReserveOutcome, ReserveRequest},
+    config::RateLimitYaml,
+    local_backend::LocalRateLimitBackend,
+    policy::CompiledPolicySet,
+    reservation::SharedReservationHandle,
+};
+use crate::config::types::RouterConfig;
+
+/// Outcome of [`RateLimitManager::reserve`] — bundles admission with the
+/// handle, since every admitted caller needs one immediately.
+/// [`ReserveOutcome`] is the lighter backend-trait-level result.
+pub enum Reservation {
+    Admitted(Arc<SharedReservationHandle>),
+    Denied { retry_after_secs: u64 },
+}
+
+/// Call [`Self::reserve`] once per logical request, before any internal
+/// retry loop, and resolve the returned handle exactly once at the end.
+/// Each call builds an independent handle, so calling it again mid-retry
+/// risks one handle abandoning a reservation another still intends to
+/// settle.
+pub struct RateLimitManager {
+    backend: Arc<dyn RateLimitBackend>,
+}
+
+impl RateLimitManager {
+    fn new(backend: Arc<dyn RateLimitBackend>) -> Self {
+        Self { backend }
+    }
+
+    pub fn from_config(rc: &RouterConfig) -> Result<Option<Arc<Self>>, String> {
+        if !rc.tenant_rate_limit_enabled {
+            return Ok(None);
+        }
+        let manager = Self::try_build(rc)?;
+        info!("tenant rate limiter enabled");
+        Ok(Some(Arc::new(manager)))
+    }
+
+    fn try_build(rc: &RouterConfig) -> Result<Self, String> {
+        let yaml = load_yaml(rc.tenant_rate_limit_config.as_deref())?;
+        // header: overrides are unreachable without trust_tenant_header --
+        // tenant_resolution never constructs that key form otherwise.
+        if !rc.tenant_resolution.trust_tenant_header {
+            if let Some(tenant_key) = yaml.tenants.iter().find_map(|t| {
+                t.tenant_key
+                    .as_deref()
+                    .filter(|key| key.starts_with("header:"))
+            }) {
+                return Err(format!(
+                    "tenant_rate_limit_config has tenant_key '{tenant_key}' but tenant_resolution.trust_tenant_header is not set -- this override can never match a real request"
+                ));
+            }
+        }
+        let compiled = CompiledPolicySet::compile(&yaml).map_err(|e| e.to_string())?;
+        let backend: Arc<dyn RateLimitBackend> = Arc::new(LocalRateLimitBackend::new(compiled));
+        Ok(Self::new(backend))
+    }
+
+    pub async fn reserve(&self, request: ReserveRequest) -> Reservation {
+        let request_charge_id = request.request_charge_id;
+        match self.backend.reserve(request).await {
+            ReserveOutcome::Admitted => Reservation::Admitted(Arc::new(
+                SharedReservationHandle::new(Arc::clone(&self.backend), request_charge_id),
+            )),
+            ReserveOutcome::Denied { retry_after_secs } => Reservation::Denied { retry_after_secs },
+        }
+    }
+}
+
+fn load_yaml(path: Option<&str>) -> Result<RateLimitYaml, String> {
+    let path = path.ok_or_else(|| {
+        "tenant_rate_limit_enabled is set but tenant_rate_limit_config is not".to_string()
+    })?;
+    let contents = std::fs::read_to_string(path).map_err(|e| format!("reading {path}: {e}"))?;
+    serde_yaml::from_str(&contents).map_err(|e| format!("parsing {path}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{rate_limit::config::TenantPolicySpec, tenant::TenantKey};
+
+    fn manager_with_limits(tpm: u32, rpm: u32) -> RateLimitManager {
+        let yaml = RateLimitYaml {
+            default_policy: TenantPolicySpec {
+                tenant_key: None,
+                tokens_per_minute: tpm,
+                requests_per_minute: rpm,
+                model_rules: Vec::new(),
+            },
+            tenants: Vec::new(),
+        };
+        let compiled = CompiledPolicySet::compile(&yaml).unwrap();
+        let backend: Arc<dyn RateLimitBackend> = Arc::new(LocalRateLimitBackend::new(compiled));
+        RateLimitManager::new(backend)
+    }
+
+    fn request(tenant: &str, tokens: u32) -> ReserveRequest {
+        ReserveRequest {
+            request_charge_id: Uuid::now_v7(),
+            tenant_key: TenantKey::new(tenant),
+            model_id: None,
+            estimated_input_tokens: tokens,
+        }
+    }
+
+    #[tokio::test]
+    async fn admitted_reservation_carries_a_handle() {
+        let manager = manager_with_limits(100, 5);
+        match manager.reserve(request("auth:team-red", 50)).await {
+            Reservation::Admitted(handle) => {
+                // The handle is independently usable -- settle through it,
+                // not through the backend directly.
+                handle.settle_success(UsageSettlement::default()).await;
+            }
+            Reservation::Denied { .. } => panic!("expected admission"),
+        }
+    }
+
+    #[tokio::test]
+    async fn denied_reservation_carries_no_handle() {
+        let manager = manager_with_limits(100, 5);
+        assert!(matches!(
+            manager.reserve(request("auth:team-red", 200)).await,
+            Reservation::Denied { .. }
+        ));
+    }
+
+    fn router_config(enabled: bool, config_path: Option<String>) -> RouterConfig {
+        RouterConfig::builder()
+            .worker_startup_timeout_secs(1)
+            .tenant_rate_limit_enabled(enabled)
+            .tenant_rate_limit_config(config_path)
+            .build_unchecked()
+    }
+
+    #[test]
+    fn disabled_returns_ok_none() {
+        let rc = router_config(false, None);
+        assert!(matches!(RateLimitManager::from_config(&rc), Ok(None)));
+    }
+
+    #[test]
+    fn enabled_without_config_path_fails_startup() {
+        let rc = router_config(true, None);
+        assert!(RateLimitManager::from_config(&rc).is_err());
+    }
+
+    #[test]
+    fn enabled_with_missing_file_fails_startup() {
+        let rc = router_config(true, Some("/nonexistent/path/rate_limit.yaml".to_string()));
+        assert!(RateLimitManager::from_config(&rc).is_err());
+    }
+
+    #[test]
+    fn enabled_with_invalid_policy_fails_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rate_limit.yaml");
+        // default_policy must not set tenant_key -- this is invalid.
+        std::fs::write(
+            &path,
+            "default_policy:\n  tenant_key: auth:oops\n  tokens_per_minute: 1000\n  requests_per_minute: 60\n",
+        )
+        .unwrap();
+
+        let rc = router_config(true, Some(path.to_str().unwrap().to_string()));
+        assert!(RateLimitManager::from_config(&rc).is_err());
+    }
+
+    #[test]
+    fn enabled_with_valid_policy_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rate_limit.yaml");
+        std::fs::write(
+            &path,
+            "default_policy:\n  tokens_per_minute: 1000\n  requests_per_minute: 60\n",
+        )
+        .unwrap();
+
+        let rc = router_config(true, Some(path.to_str().unwrap().to_string()));
+        assert!(matches!(RateLimitManager::from_config(&rc), Ok(Some(_))));
+    }
+
+    #[test]
+    fn header_tenant_key_without_trust_tenant_header_fails_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rate_limit.yaml");
+        std::fs::write(
+            &path,
+            "default_policy:\n  tokens_per_minute: 1000\n  requests_per_minute: 60\ntenants:\n  - tenant_key: header:team-red\n    tokens_per_minute: 500\n    requests_per_minute: 30\n",
+        )
+        .unwrap();
+
+        // trust_tenant_header defaults to false, so this override could
+        // never match a real request.
+        let rc = RouterConfig::builder()
+            .worker_startup_timeout_secs(1)
+            .tenant_rate_limit_enabled(true)
+            .tenant_rate_limit_config(Some(path.to_str().unwrap().to_string()))
+            .build_unchecked();
+        assert!(RateLimitManager::from_config(&rc).is_err());
+    }
+
+    #[test]
+    fn header_tenant_key_with_trust_tenant_header_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rate_limit.yaml");
+        std::fs::write(
+            &path,
+            "default_policy:\n  tokens_per_minute: 1000\n  requests_per_minute: 60\ntenants:\n  - tenant_key: header:team-red\n    tokens_per_minute: 500\n    requests_per_minute: 30\n",
+        )
+        .unwrap();
+
+        let rc = RouterConfig::builder()
+            .worker_startup_timeout_secs(1)
+            .tenant_rate_limit_enabled(true)
+            .tenant_rate_limit_config(Some(path.to_str().unwrap().to_string()))
+            .trust_tenant_header(true)
+            .build_unchecked();
+        assert!(matches!(RateLimitManager::from_config(&rc), Ok(Some(_))));
+    }
+}

--- a/model_gateway/src/rate_limit/mod.rs
+++ b/model_gateway/src/rate_limit/mod.rs
@@ -1,16 +1,23 @@
 //! Per-tenant LLM token/request rate limiting.
 //!
-//! This is the policy layer only: config schema, validation, and
-//! compilation into an immutable, cheap-to-look-up `CompiledPolicySet`.
-//! Nothing here does any rate-limit accounting or enforcement yet — the
-//! reserve/settle engine, in-memory backend, and CLI/startup wiring land in
-//! a follow-up change. This module is not yet reachable from any request
-//! path.
+//! Config schema, policy compilation, the reserve/settle engine, and an
+//! in-memory backend. Nothing in the request path calls `reserve()` yet
+//! — that's wired in per protocol in a later phase.
 
+mod backend;
+mod bucket;
 mod config;
+mod local_backend;
+mod manager;
 mod policy;
+mod rejection;
+mod reservation;
 
+pub use backend::{RateLimitBackend, ReserveOutcome, ReserveRequest, UsageSettlement};
 pub use config::{
     ModelMatcherSpec, ModelRuleSpec, RateLimitConfigError, RateLimitYaml, TenantPolicySpec,
 };
+pub use manager::{RateLimitManager, Reservation};
 pub use policy::{CompiledPolicySet, ScopeLimits};
+pub use rejection::{rejection_response, RATE_LIMIT_ERROR_CODE};
+pub use reservation::{ReservationAttachment, SharedReservationHandle};

--- a/model_gateway/src/rate_limit/policy.rs
+++ b/model_gateway/src/rate_limit/policy.rs
@@ -13,19 +13,8 @@ pub struct ScopeLimits {
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by the reserve/settle engine landing in a follow-up change; exercised by this module's own tests today"
-    )
-)]
 pub(crate) struct CompiledModelRule {
     pub rule_id: String,
-    #[expect(
-        dead_code,
-        reason = "consumed by the reserve/settle engine landing in a follow-up change; not read by this module's own tests"
-    )]
     pub limits: ScopeLimits,
 }
 
@@ -39,13 +28,6 @@ pub(crate) struct CompiledPrefixRule {
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "consumed by the reserve/settle engine landing in a follow-up change; exercised by this module's own tests today"
-    )
-)]
 pub(crate) struct CompiledTenantPolicy {
     pub limits: ScopeLimits,
     /// O(1) lookup — exact matches never need to scan.
@@ -57,17 +39,8 @@ pub(crate) struct CompiledTenantPolicy {
 }
 
 impl CompiledTenantPolicy {
-    /// The single model rule (if any) that matches `model_id`: exact wins
-    /// over prefix; among prefixes, the longest wins (guaranteed by
-    /// `prefix_model_rules`'s compile-time sort). Rules never stack — at
-    /// most one is returned.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the reserve/settle engine landing in a follow-up change; exercised by this module's own tests today"
-        )
-    )]
+    /// The single matching rule, if any: exact wins over prefix, longest
+    /// wins among prefixes. Rules never stack.
     pub(crate) fn matching_rule(&self, model_id: &str) -> Option<&CompiledModelRule> {
         if let Some(exact) = self.exact_model_rules.get(model_id) {
             return Some(exact);
@@ -145,13 +118,6 @@ impl CompiledPolicySet {
         Ok(Self { default, tenants })
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the reserve/settle engine landing in a follow-up change; exercised by this module's own tests today"
-        )
-    )]
     pub(crate) fn policy_for(&self, tenant: &TenantKey) -> &CompiledTenantPolicy {
         self.tenants.get(tenant).unwrap_or(&self.default)
     }

--- a/model_gateway/src/rate_limit/rejection.rs
+++ b/model_gateway/src/rate_limit/rejection.rs
@@ -1,0 +1,53 @@
+//! Builds the tenant-rate-limit rejection response: `429`, the standard
+//! SMG error envelope, and `Retry-After` when a wait time is known.
+
+use axum::{
+    http::{header::RETRY_AFTER, HeaderValue},
+    response::Response,
+};
+
+use crate::routers::error;
+
+pub const RATE_LIMIT_ERROR_CODE: &str = "tenant_rate_limit_exceeded";
+
+/// `retry_after_secs` of `0` omits the `Retry-After` header (nothing to
+/// wait for is a caller bug, not a real rejection state).
+pub fn rejection_response(retry_after_secs: u64) -> Response {
+    let mut response = error::too_many_requests(
+        RATE_LIMIT_ERROR_CODE,
+        "Tenant rate limit exceeded for this request",
+    );
+    if retry_after_secs > 0 {
+        if let Ok(value) = HeaderValue::from_str(&retry_after_secs.to_string()) {
+            response.headers_mut().insert(RETRY_AFTER, value);
+        }
+    }
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+
+    use super::*;
+
+    #[test]
+    fn sets_status_code_and_retry_after() {
+        let response = rejection_response(30);
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers().get(RETRY_AFTER).unwrap(), "30");
+        assert_eq!(
+            response
+                .headers()
+                .get(error::HEADER_X_SMG_ERROR_CODE)
+                .unwrap(),
+            RATE_LIMIT_ERROR_CODE
+        );
+    }
+
+    #[test]
+    fn zero_retry_after_omits_header() {
+        let response = rejection_response(0);
+        assert!(response.headers().get(RETRY_AFTER).is_none());
+    }
+}

--- a/model_gateway/src/rate_limit/reservation.rs
+++ b/model_gateway/src/rate_limit/reservation.rs
@@ -1,0 +1,196 @@
+//! Abort-safe reservation lifecycle: [`SharedReservationHandle`] is held
+//! by whoever owns a reservation, and [`ReservationAttachment`] (paired
+//! with `AttachedBody::wrap_response`) can be attached to a response body
+//! so an aborted/disconnected stream still releases it.
+
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc,
+};
+
+use uuid::Uuid;
+
+use super::backend::{RateLimitBackend, UsageSettlement};
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReservationState {
+    Open = 0,
+    Settled = 1,
+    Closed = 2,
+    Abandoned = 3,
+}
+
+/// Shared handle to an in-flight reservation. Only the first of
+/// [`Self::settle_success`], [`Self::close_reserved_only`], or
+/// [`Self::abandon_if_open`] takes effect; later calls are no-ops, which
+/// makes `Drop`-triggered `abandon_if_open` safe even after an explicit
+/// settle/close.
+pub struct SharedReservationHandle {
+    state: AtomicU8,
+    backend: Arc<dyn RateLimitBackend>,
+    request_charge_id: Uuid,
+}
+
+impl SharedReservationHandle {
+    pub(crate) fn new(backend: Arc<dyn RateLimitBackend>, request_charge_id: Uuid) -> Self {
+        Self {
+            state: AtomicU8::new(ReservationState::Open as u8),
+            backend,
+            request_charge_id,
+        }
+    }
+
+    fn try_transition(&self, target: ReservationState) -> bool {
+        self.state
+            .compare_exchange(
+                ReservationState::Open as u8,
+                target as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Settle from final, authoritative usage.
+    pub async fn settle_success(&self, usage: UsageSettlement) {
+        if self.try_transition(ReservationState::Settled) {
+            self.backend
+                .settle_success(self.request_charge_id, usage)
+                .await;
+        }
+    }
+
+    /// Close without settlement (success-with-no-usage, or terminal
+    /// failure after admission) — keeps the reserved-input debit.
+    pub async fn close_reserved_only(&self) {
+        if self.try_transition(ReservationState::Closed) {
+            self.backend
+                .close_reserved_only(self.request_charge_id)
+                .await;
+        }
+    }
+
+    /// Abandon on drop/cancel/disconnect before an explicit close — keeps
+    /// the debit rather than refunding it (already-admitted budget
+    /// shouldn't be silently returned).
+    fn abandon_if_open(self: &Arc<Self>) {
+        if self.try_transition(ReservationState::Abandoned) {
+            let backend = Arc::clone(&self.backend);
+            let request_charge_id = self.request_charge_id;
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "best-effort abandon cleanup; must not block the caller's Drop"
+            )]
+            tokio::spawn(async move {
+                backend.abandon(request_charge_id).await;
+            });
+        }
+    }
+}
+
+/// RAII guard: pair with `AttachedBody::wrap_response` on a response so an
+/// aborted/disconnected stream still abandons an open reservation instead
+/// of leaking it as permanently reserved.
+pub struct ReservationAttachment {
+    handle: Arc<SharedReservationHandle>,
+}
+
+impl ReservationAttachment {
+    pub fn new(handle: Arc<SharedReservationHandle>) -> Self {
+        Self { handle }
+    }
+}
+
+impl Drop for ReservationAttachment {
+    fn drop(&mut self) {
+        self.handle.abandon_if_open();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::rate_limit::backend::{ReserveOutcome, ReserveRequest};
+
+    #[derive(Default)]
+    struct CountingBackend {
+        settle_calls: AtomicUsize,
+        close_calls: AtomicUsize,
+        abandon_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl RateLimitBackend for CountingBackend {
+        async fn reserve(&self, _request: ReserveRequest) -> ReserveOutcome {
+            ReserveOutcome::Admitted
+        }
+
+        async fn settle_success(&self, _request_charge_id: Uuid, _usage: UsageSettlement) {
+            self.settle_calls.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+
+        async fn close_reserved_only(&self, _request_charge_id: Uuid) {
+            self.close_calls.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+
+        async fn abandon(&self, _request_charge_id: Uuid) {
+            self.abandon_calls.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn settle_then_drop_does_not_also_abandon() {
+        let backend = Arc::new(CountingBackend::default());
+        let handle = Arc::new(SharedReservationHandle::new(
+            backend.clone() as Arc<dyn RateLimitBackend>,
+            Uuid::now_v7(),
+        ));
+        handle.settle_success(UsageSettlement::default()).await;
+        assert_eq!(backend.settle_calls.load(AtomicOrdering::SeqCst), 1);
+
+        let attachment = ReservationAttachment::new(handle);
+        drop(attachment);
+        // Give the spawned abandon task (if any) a chance to run.
+        tokio::task::yield_now().await;
+
+        assert_eq!(backend.settle_calls.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(backend.close_calls.load(AtomicOrdering::SeqCst), 0);
+        assert_eq!(backend.abandon_calls.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn drop_without_explicit_settle_abandons_exactly_once() {
+        let backend = Arc::new(CountingBackend::default());
+        let handle = Arc::new(SharedReservationHandle::new(
+            backend.clone() as Arc<dyn RateLimitBackend>,
+            Uuid::now_v7(),
+        ));
+        let attachment = ReservationAttachment::new(handle);
+        drop(attachment);
+        tokio::task::yield_now().await;
+
+        assert_eq!(backend.abandon_calls.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(backend.settle_calls.load(AtomicOrdering::SeqCst), 0);
+        assert_eq!(backend.close_calls.load(AtomicOrdering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn double_close_is_a_no_op() {
+        let backend = Arc::new(CountingBackend::default());
+        let handle = Arc::new(SharedReservationHandle::new(
+            backend.clone() as Arc<dyn RateLimitBackend>,
+            Uuid::now_v7(),
+        ));
+        handle.close_reserved_only().await;
+        handle.close_reserved_only().await;
+        handle.settle_success(UsageSettlement::default()).await;
+
+        assert_eq!(backend.close_calls.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(backend.settle_calls.load(AtomicOrdering::SeqCst), 0);
+    }
+}

--- a/model_gateway/src/routers/error.rs
+++ b/model_gateway/src/routers/error.rs
@@ -40,6 +40,10 @@ pub fn service_unavailable(code: impl Into<String>, message: impl Into<String>) 
     create_error(StatusCode::SERVICE_UNAVAILABLE, code, message)
 }
 
+pub fn too_many_requests(code: impl Into<String>, message: impl Into<String>) -> Response {
+    create_error(StatusCode::TOO_MANY_REQUESTS, code, message)
+}
+
 pub fn failed_dependency(code: impl Into<String>, message: impl Into<String>) -> Response {
     create_error(StatusCode::FAILED_DEPENDENCY, code, message)
 }

--- a/model_gateway/src/tenant.rs
+++ b/model_gateway/src/tenant.rs
@@ -151,6 +151,44 @@ pub fn canonical_tenant_key(identity: TenantIdentity) -> TenantKey {
     identity.into_key()
 }
 
+/// Whether `key` is a form [`TenantIdentity::into_key`] can actually
+/// produce for a *serving-path* request — i.e. one of `auth:<non-empty>`,
+/// `header:<non-empty>`, `ip:<valid address>`, or exactly `anonymous`.
+///
+/// Deliberately excludes [`TenantIdentity::Explicit`]'s raw, unprefixed
+/// form: that variant is only ever constructed by
+/// [`resolve_admin_target_tenant_key`] for admin routes, never by
+/// [`middleware::tenant_resolution`](crate::middleware::tenant_resolution)'s
+/// serving-path resolver. Any consumer that only ever looks keys up
+/// against serving-path-resolved tenants (e.g. rate-limit policy) can use
+/// this to catch a key that can never match a real request instead of
+/// silently never applying.
+#[must_use]
+pub fn is_canonical_serving_tenant_key(key: &str) -> bool {
+    if key == "anonymous" {
+        return true;
+    }
+    if let Some(id) = key.strip_prefix("auth:") {
+        return !id.is_empty();
+    }
+    if let Some(id) = key.strip_prefix("header:") {
+        // Must match what a real header can decode to: trimmed, and
+        // within HeaderValue::to_str()'s alphabet (HTAB or 0x20..=0x7E --
+        // verified empirically; non-ASCII always fails to_str()).
+        return !id.is_empty()
+            && id.trim() == id
+            && id.bytes().all(|b| b == b'\t' || (0x20..=0x7e).contains(&b));
+    }
+    if let Some(addr) = key.strip_prefix("ip:") {
+        // Must round-trip: parse() accepts non-canonical forms (e.g.
+        // expanded IPv6) that into_key() would never produce.
+        return addr
+            .parse::<IpAddr>()
+            .is_ok_and(|parsed| parsed.to_string() == addr);
+    }
+    false
+}
+
 #[inline]
 #[must_use]
 pub fn authenticated_tenant_key_from_sha256(hash: [u8; 32]) -> TenantKey {
@@ -180,4 +218,59 @@ pub fn resolve_admin_target_tenant_id(
     tenant_key: &str,
 ) -> Result<RouteRequestMeta, TenantResolutionError> {
     resolve_admin_target_tenant_key(tenant_key).map(RouteRequestMeta::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_forms_accepted() {
+        assert!(is_canonical_serving_tenant_key("anonymous"));
+        assert!(is_canonical_serving_tenant_key("auth:team-red"));
+        assert!(is_canonical_serving_tenant_key("header:team-red"));
+        assert!(is_canonical_serving_tenant_key("ip:127.0.0.1"));
+        assert!(is_canonical_serving_tenant_key("ip:::1"));
+    }
+
+    #[test]
+    fn non_canonical_forms_rejected() {
+        // Unprefixed (Explicit-only, admin-not-serving-path form).
+        assert!(!is_canonical_serving_tenant_key("team-red"));
+        // Empty id after a valid prefix.
+        assert!(!is_canonical_serving_tenant_key("auth:"));
+        assert!(!is_canonical_serving_tenant_key("header:"));
+        // Padded id -- the header value is always trimmed first.
+        assert!(!is_canonical_serving_tenant_key("header: team-red"));
+        assert!(!is_canonical_serving_tenant_key("header:team-red "));
+        // Outside to_str()'s alphabet.
+        assert!(!is_canonical_serving_tenant_key("header:héllo"));
+        assert!(!is_canonical_serving_tenant_key("header:team\u{1}red"));
+        // Not a real IP address.
+        assert!(!is_canonical_serving_tenant_key("ip:not-an-ip"));
+        // Parseable but non-canonical: expanded/uppercase IPv6 never
+        // matches the compressed lowercase form `into_key()` produces.
+        assert!(!is_canonical_serving_tenant_key(
+            "ip:2001:0DB8:0000:0000:0000:0000:0000:0001"
+        ));
+        // Unknown prefix.
+        assert!(!is_canonical_serving_tenant_key("tenant:team-red"));
+        assert!(!is_canonical_serving_tenant_key(""));
+    }
+
+    #[test]
+    fn matches_what_tenant_identity_actually_produces() {
+        assert!(is_canonical_serving_tenant_key(
+            canonical_tenant_key(TenantIdentity::Authenticated(Arc::from("team-red"))).as_str()
+        ));
+        assert!(is_canonical_serving_tenant_key(
+            canonical_tenant_key(TenantIdentity::Header(Arc::from("team-red"))).as_str()
+        ));
+        assert!(is_canonical_serving_tenant_key(
+            canonical_tenant_key(TenantIdentity::IpAddress("127.0.0.1".parse().unwrap())).as_str()
+        ));
+        assert!(is_canonical_serving_tenant_key(
+            canonical_tenant_key(TenantIdentity::Anonymous).as_str()
+        ));
+    }
 }


### PR DESCRIPTION
## Description

### Problem

SMG needs per-tenant LLM token/request rate limiting, distinct from the existing concurrency-only admission scheduler (`middleware::scheduler`) and the flat `TokenBucket`, neither of which count model input/output tokens. The policy schema (config + compilation) is already merged; this PR adds the actual reserve/settle accounting engine on top of it.

### Solution

Adds an in-memory reserve/settle engine: `ScopeBucket` (continuous-refill token/request bucket with signed settlement, allowing temporary debt when actual usage exceeds the reservation), the `RateLimitBackend` trait plus its `LocalRateLimitBackend` implementation, and an abort-safe reservation lifecycle (`SharedReservationHandle` + `ReservationAttachment`, Drop-triggered abandon for disconnected/cancelled requests) plus the 429 rejection response builder. Also adds tenant-key canonicalization and config validation that catch a misconfigured policy at load time instead of letting it silently never apply.

Not constructed or reachable from any request path yet — CLI/startup wiring lands in a follow-up PR, and request-path calls to `reserve()` are a later phase (gRPC pipeline prepare/execute split and per-router wiring).

## Changes

- `ScopeBucket`: continuous-refill token/request bucket, signed settlement
- `RateLimitBackend` trait + `LocalRateLimitBackend` (reserve/settle/close/abandon, idempotent per `request_charge_id`)
- `SharedReservationHandle` + `ReservationAttachment`: abort-safe reservation lifecycle (first of settle/close/abandon wins)
- 429 rejection response builder
- `is_canonical_serving_tenant_key` + config validation: `deny_unknown_fields`, non-canonical/padded key and matcher rejection, `header:`-vs-`trust_tenant_header` cross-check
- Two new `RouterConfig` control fields (`tenant_rate_limit_enabled`/`tenant_rate_limit_config`) needed for `RateLimitManager::from_config` to compile

## Test Plan

- `cargo test -p smg --lib` — full suite green
- `cargo +nightly fmt --all` clean
- `cargo clippy -p smg --all-targets -- -D warnings` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-tenant request and token rate limiting.
  * Supports optional model-specific limits and YAML-based policies.
  * Requests exceeding limits receive a clear 429 response with retry guidance.
  * Reservations safely reconcile actual usage and handle interrupted requests.

* **Bug Fixes**
  * Invalid or misspelled rate-limit configuration fields are now rejected.
  * Non-canonical tenant identifiers and incompatible header-based configurations now produce validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->