### PR TITLE
feat(rate_limit): wire tenant rate limiter into CLI and AppContext

### DIFF
--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -19,6 +19,7 @@ use crate::{
     middleware::TokenBucket,
     observability::inflight_tracker::InFlightRequestTracker,
     policies::PolicyRegistry,
+    rate_limit::RateLimitManager,
     routers::{
         common::{openai_bridge::FormatRegistry, realtime::RealtimeRegistry},
         grpc::multimodal::MultimodalConfigRegistry,
@@ -52,6 +53,7 @@ pub struct AppContext {
     pub client: Client,
     pub router_config: RouterConfig,
     pub rate_limiter: Option<Arc<TokenBucket>>,
+    pub rate_limit_manager: Option<Arc<RateLimitManager>>,
     pub tokenizer_registry: Arc<TokenizerRegistry>,
     pub multimodal_config_registry: Arc<MultimodalConfigRegistry>,
     pub reasoning_parser_factory: Option<ReasoningParserFactory>,
@@ -92,6 +94,7 @@ pub struct AppContextBuilder {
     client: Option<Client>,
     router_config: Option<RouterConfig>,
     rate_limiter: Option<Arc<TokenBucket>>,
+    rate_limit_manager: Option<Arc<RateLimitManager>>,
     tokenizer_registry: Option<Arc<TokenizerRegistry>>,
     reasoning_parser_factory: Option<ReasoningParserFactory>,
     tool_parser_factory: Option<ToolParserFactory>,
@@ -145,6 +148,7 @@ impl AppContextBuilder {
             client: None,
             router_config: None,
             rate_limiter: None,
+            rate_limit_manager: None,
             tokenizer_registry: None,
             reasoning_parser_factory: None,
             tool_parser_factory: None,
@@ -178,6 +182,14 @@ impl AppContextBuilder {
 
     pub fn rate_limiter(mut self, rate_limiter: Option<Arc<TokenBucket>>) -> Self {
         self.rate_limiter = rate_limiter;
+        self
+    }
+
+    /// Build the tenant rate limiter from config. `None` (feature
+    /// disabled, or config failed to load — logged at ERROR) is a valid,
+    /// non-fatal outcome.
+    fn maybe_rate_limit_manager(mut self, config: &RouterConfig) -> Self {
+        self.rate_limit_manager = RateLimitManager::from_config(config);
         self
     }
 
@@ -338,6 +350,7 @@ impl AppContextBuilder {
                 .ok_or(AppContextBuildError::MissingField("client"))?,
             router_config,
             rate_limiter: self.rate_limiter,
+            rate_limit_manager: self.rate_limit_manager,
             tokenizer_registry: self
                 .tokenizer_registry
                 .ok_or(AppContextBuildError::MissingField("tokenizer_registry"))?,
@@ -390,6 +403,7 @@ impl AppContextBuilder {
         Ok(Self::new()
             .with_client(&router_config, request_timeout_secs)?
             .maybe_rate_limiter(&router_config)
+            .maybe_rate_limit_manager(&router_config)
             .with_tokenizer_registry()
             .with_reasoning_parser_factory()
             .with_tool_parser_factory()

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -753,4 +753,41 @@ mod tests {
             overload_token_usage_threshold: 1.0,
         }));
     }
+
+    #[test]
+    fn maybe_rate_limit_manager_disabled_is_ok_none() {
+        let config = RouterConfig::default();
+        let result = AppContextBuilder::new().maybe_rate_limit_manager(&config);
+        assert!(result.is_ok());
+        assert!(result.unwrap().rate_limit_manager.is_none());
+    }
+
+    #[test]
+    fn maybe_rate_limit_manager_enabled_with_missing_file_fails_startup() {
+        let config = RouterConfig::builder()
+            .tenant_rate_limit_enabled(true)
+            .tenant_rate_limit_config(Some("/nonexistent/rate_limit.yaml".to_string()))
+            .build_unchecked();
+        assert!(AppContextBuilder::new()
+            .maybe_rate_limit_manager(&config)
+            .is_err());
+    }
+
+    #[test]
+    fn maybe_rate_limit_manager_enabled_with_valid_policy_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rate_limit.yaml");
+        std::fs::write(
+            &path,
+            "default_policy:\n  tokens_per_minute: 1000\n  requests_per_minute: 60\n",
+        )
+        .unwrap();
+        let config = RouterConfig::builder()
+            .tenant_rate_limit_enabled(true)
+            .tenant_rate_limit_config(Some(path.to_str().unwrap().to_string()))
+            .build_unchecked();
+        let result = AppContextBuilder::new().maybe_rate_limit_manager(&config);
+        assert!(result.is_ok());
+        assert!(result.unwrap().rate_limit_manager.is_some());
+    }
 }

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -185,12 +185,14 @@ impl AppContextBuilder {
         self
     }
 
-    /// Build the tenant rate limiter from config. `None` (feature
-    /// disabled, or config failed to load — logged at ERROR) is a valid,
-    /// non-fatal outcome.
-    fn maybe_rate_limit_manager(mut self, config: &RouterConfig) -> Self {
-        self.rate_limit_manager = RateLimitManager::from_config(config);
-        self
+    /// Build the tenant rate limiter from config. `Ok(None)` (feature
+    /// disabled) is a valid, non-fatal outcome. `Err` (enabled but the
+    /// policy YAML failed to load/parse/validate) fails startup — an
+    /// operator who explicitly turned rate limiting on must not get a
+    /// gateway that silently runs unlimited.
+    fn maybe_rate_limit_manager(mut self, config: &RouterConfig) -> Result<Self, String> {
+        self.rate_limit_manager = RateLimitManager::from_config(config)?;
+        Ok(self)
     }
 
     pub fn tokenizer_registry(mut self, tokenizer_registry: Arc<TokenizerRegistry>) -> Self {
@@ -403,7 +405,7 @@ impl AppContextBuilder {
         Ok(Self::new()
             .with_client(&router_config, request_timeout_secs)?
             .maybe_rate_limiter(&router_config)
-            .maybe_rate_limit_manager(&router_config)
+            .maybe_rate_limit_manager(&router_config)?
             .with_tokenizer_registry()
             .with_reasoning_parser_factory()
             .with_tool_parser_factory()

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -468,6 +468,17 @@ struct CliArgs {
     #[arg(long, default_value_t = 32, help_heading = "Priority Scheduler")]
     priority_scheduler_tenant_metric_top_n: u32,
 
+    // ==================== Tenant Rate Limit ====================
+    /// Enable per-tenant LLM token/request rate limiting. When unset
+    /// (default), no rate limiter is constructed.
+    #[arg(long, help_heading = "Tenant Rate Limit")]
+    tenant_rate_limit_enabled: bool,
+
+    /// Path to the tenant-rate-limit YAML. Required when
+    /// `--tenant-rate-limit-enabled` is set.
+    #[arg(long, help_heading = "Tenant Rate Limit")]
+    tenant_rate_limit_config: Option<String>,
+
     /// Token bucket refill rate (tokens per second)
     #[arg(long, help_heading = "Rate Limiting")]
     rate_limit_tokens_per_second: Option<i32>,
@@ -1399,6 +1410,8 @@ impl CliArgs {
             .priority_scheduler_default_max_class(self.priority_scheduler_default_max_class.clone())
             .priority_scheduler_config(self.priority_scheduler_config.clone())
             .priority_scheduler_tenant_metric_top_n(self.priority_scheduler_tenant_metric_top_n)
+            .tenant_rate_limit_enabled(self.tenant_rate_limit_enabled)
+            .tenant_rate_limit_config(self.tenant_rate_limit_config.clone())
             .cors_allowed_origins(self.cors_allowed_origins.clone())
             .retry_config(RetryConfig {
                 max_retries: self.retry_max_retries,

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1321,6 +1321,7 @@ mod tests {
             client: reqwest::Client::new(),
             router_config: router_config.clone(),
             rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),
+            rate_limit_manager: None,
             worker_registry: worker_registry.clone(),
             policy_registry: Arc::new(crate::policies::PolicyRegistry::with_override(
                 router_config.policy.clone(),

--- a/model_gateway/src/workflow/steps/local/drain_workers.rs
+++ b/model_gateway/src/workflow/steps/local/drain_workers.rs
@@ -149,6 +149,7 @@ mod tests {
             client: reqwest::Client::new(),
             router_config: router_config.clone(),
             rate_limiter: Some(Arc::new(TokenBucket::new(1000, 1000))),
+            rate_limit_manager: None,
             worker_registry: Arc::clone(&registry),
             policy_registry: Arc::new(crate::policies::PolicyRegistry::new(
                 router_config.policy.clone(),


### PR DESCRIPTION
## Description

### Problem

The reserve/settle engine (#1966, merged) isn't constructed or reachable anywhere yet — there's no way to enable it at startup.

### Solution

Adds `--tenant-rate-limit-enabled` / `--tenant-rate-limit-config <path>` CLI flags (mirroring the priority scheduler's pattern) and constructs `RateLimitManager` as `AppContext.rate_limit_manager` at startup. Threads `RateLimitManager::from_config`'s `Result` through `AppContextBuilder::maybe_rate_limit_manager`, so a misconfigured policy fails gateway startup instead of silently running unlimited.

Still no request path calls `reserve()` yet — that's the gRPC pipeline prepare/execute split and per-router wiring, in a later phase.

## Changes

- `main.rs`: `--tenant-rate-limit-enabled` / `--tenant-rate-limit-config` CLI flags
- `app_context.rs`: `AppContext.rate_limit_manager: Option<Arc<RateLimitManager>>`, built via `AppContextBuilder::maybe_rate_limit_manager`, which now returns `Result<Self, String>` and fails the async `from_config()` chain (and thus startup) on `Err`
- `service_discovery.rs` / `workflow/steps/local/drain_workers.rs`: test-fixture updates for the new `AppContext` field

## Test Plan

- `cargo test -p smg --lib` — full suite green
- `cargo +nightly fmt --all` clean
- `cargo clippy -p smg --all-targets -- -D warnings` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant rate limiting configuration through the command-line interface.
  * Administrators can enable rate limiting and provide a YAML policy file.
  * Policies are validated during startup, with clear failures for missing or invalid configurations.
  * Rate limiting remains disabled when not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->