### PR TITLE
chore(deps): bump SGLang to 0.5.16

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -2,7 +2,7 @@ name: Release SMG+SGLang Docker Image
 
 run-name: >-
   SMG+SGLang |
-  ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.12.post1' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.12.post1') }} |
+  ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.16' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.16') }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
   smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. lmsysorg/sglang:v0.5.12.post1)'
-        default: 'lmsysorg/sglang:v0.5.12.post1'
+        description: 'Base image (e.g. lmsysorg/sglang:v0.5.16)'
+        default: 'lmsysorg/sglang:v0.5.16'
         required: true
         type: string
       sglang_repo:
@@ -47,7 +47,7 @@ on:
         default: 'v1.8.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.8.0-sglang-v0.5.12.post1)'
+        description: 'Override image tag (e.g. v1.8.0-sglang-v0.5.16)'
         required: false
         type: string
 
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["lmsysorg/sglang:v0.5.12.post1"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.12.post1')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["lmsysorg/sglang:v0.5.16"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.16')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: sglang

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 vllm = ["vllm>=0.19.0", "pyzmq>=25.0.0", "msgspec>=0.18.0"]
 # 0.5.13 is the first release with the shmem load snapshots that replaced
 # the WatchLoadUpdateReq piggyback path (removed upstream in v0.5.14).
-sglang = ["sglang>=0.5.13"]
+sglang = ["sglang>=0.5.16"]
 # smg-grpc-proto>=0.4.7 is the first release that ships mlx_engine_pb2;
 # without this floor, installing [mlx] against an older proto build would
 # crash at import time when smg_grpc_servicer.mlx.server runs.

--- a/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
@@ -25,13 +25,12 @@ from sglang.srt.managers.io_struct import (
     BatchTokenIDOutput,
     FlushCacheReqOutput,
     GetInternalStateReqOutput,
-    GetLoadsReqInput,
-    GetLoadsReqOutput,
     HealthCheckOutput,
     ProfileReqOutput,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
 )
+from sglang.srt.managers.load_snapshot import LoadSnapshot, create_load_snapshot_reader
 from sglang.srt.observability.req_time_stats import (
     APIServerReqTimeStats,
     calibrate_time_diff,
@@ -238,11 +237,14 @@ class GrpcRequestManager:
         # Bootstrap server (passed from serve_grpc, not started here)
         self.bootstrap_server = bootstrap_server
 
+        # Schedulers publish per-dp-rank LoadSnapshots (SHM; zmq for
+        # multi-node DP). This manager fills sglang's TokenizerManager role.
+        self.load_snapshot_reader = create_load_snapshot_reader(
+            server_args, port_args, caller="TokenizerManager"
+        )
+
         # Communicators for request/response patterns with scheduler
         # Note: These must be initialized after send_to_scheduler socket is created
-        self.get_loads_communicator = _GrpcCommunicator(
-            self.send_to_scheduler, fan_out=server_args.dp_size
-        )
         self.profile_communicator = _GrpcCommunicator(
             self.send_to_scheduler, fan_out=server_args.dp_size
         )
@@ -567,8 +569,6 @@ class GrpcRequestManager:
             self.flush_cache_communicator.handle_recv(recv_obj)
         elif isinstance(recv_obj, GetInternalStateReqOutput):
             self.get_internal_state_communicator.handle_recv(recv_obj)
-        elif isinstance(recv_obj, GetLoadsReqOutput):
-            self.get_loads_communicator.handle_recv(recv_obj)
         else:
             return False
         return True
@@ -938,6 +938,11 @@ class GrpcRequestManager:
             except Exception as e:
                 logger.warning(f"Error shutting down bootstrap server: {e}")
 
+        try:
+            self.load_snapshot_reader.close()
+        except Exception as e:
+            logger.warning(f"Error closing load snapshot reader: {e}")
+
         # Close ZMQ sockets
         self.recv_from_scheduler.close()
         if self.recv_from_tokenizer is not None:
@@ -957,30 +962,41 @@ class GrpcRequestManager:
             "last_receive_time": self.last_receive_tstamp,
         }
 
-    async def get_loads(
-        self, include: list[str], dp_rank: int | None = None
-    ) -> list[GetLoadsReqOutput]:
+    async def get_loads(self, include: list[str], dp_rank: int | None = None) -> list[LoadSnapshot]:
         """
-        Get comprehensive load metrics from the scheduler.
-
-        This method uses the communicator pattern to send GetLoadsReqInput to the
-        scheduler and wait for GetLoadsReqOutput responses.
+        Get load metrics from the schedulers' published LoadSnapshots.
 
         Args:
             include: List of metric sections to include (core, memory, spec, lora, disagg, queues, all)
             dp_rank: Optional DP rank filter (None for all ranks)
 
         Returns:
-            List of GetLoadsReqOutput objects, one per scheduler/DP rank
+            List of LoadSnapshot objects, one per scheduler/DP rank
         """
-        req = GetLoadsReqInput(include=include, dp_rank=dp_rank)
-        results = await self.get_loads_communicator(req)
+        sections = set(include) if include else {"all"}
+        invalid = sections - LoadSnapshot.VALID_SECTIONS
+        if invalid:
+            raise ValueError(
+                f"Invalid include sections: {sorted(invalid)}. "
+                f"Valid options: {sorted(LoadSnapshot.VALID_SECTIONS)}"
+            )
 
-        # Filter by dp_rank if specified
+        snapshots = self.load_snapshot_reader.read_all()
         if dp_rank is not None:
-            results = [r for r in results if r.dp_rank == dp_rank]
-
-        return results
+            snapshots = [s for s in snapshots if s.dp_rank == dp_rank]
+        if "all" not in sections:
+            for snapshot in snapshots:
+                if "memory" not in sections:
+                    snapshot.memory = None
+                if "spec" not in sections:
+                    snapshot.speculative = None
+                if "lora" not in sections:
+                    snapshot.lora = None
+                if "disagg" not in sections:
+                    snapshot.disaggregation = None
+                if "queues" not in sections:
+                    snapshot.queues = None
+        return snapshots
 
     # Communicators that callers may address through send_communicator_req.
     _PUBLIC_COMMUNICATORS = frozenset(
@@ -988,7 +1004,6 @@ class GrpcRequestManager:
             "profile_communicator",
             "flush_cache_communicator",
             "get_internal_state_communicator",
-            "get_loads_communicator",
         }
     )
 

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -38,16 +38,21 @@ from sglang.srt.disaggregation.kv_events import (
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
 from sglang.srt.managers.io_struct import (
     FlushCacheReqInput,
-    GetLoadsReqOutput,
     ProfileReq,
     ProfileReqType,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
 )
-from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem, MultimodalInputs
+from sglang.srt.managers.load_snapshot import LoadSnapshot
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalProcessorOutput,
+)
 from sglang.srt.sampling.sampling_params import SamplingParams as SGLSamplingParams
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_bool_env_var
+from sglang.srt.utils.hf_transformers_utils import get_tokenizer
 from sglang.utils import get_exception_traceback
 from smg_grpc_proto import sglang_scheduler_pb2, sglang_scheduler_pb2_grpc
 from smg_grpc_proto.generated import common_pb2
@@ -93,9 +98,9 @@ def _filtered_sampling_defaults(params: dict | None) -> dict:
 
 
 def _convert_loads_to_protobuf(
-    result: GetLoadsReqOutput,
+    result: LoadSnapshot,
 ) -> sglang_scheduler_pb2.SchedulerLoad:
-    """Convert GetLoadsReqOutput dataclass to protobuf SchedulerLoad message."""
+    """Convert a LoadSnapshot to a protobuf SchedulerLoad message."""
     scheduler_load = sglang_scheduler_pb2.SchedulerLoad(
         dp_rank=result.dp_rank,
         num_running_reqs=result.num_running_reqs,
@@ -211,6 +216,18 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         self.scheduler_info = scheduler_info
         self.start_time = time.time()
         self.health_servicer = health_servicer
+        # SamplingParams.normalize requires a tokenizer whenever string stops
+        # are used; the scheduler matches them with its own tokenizer.
+        if server_args.skip_tokenizer_init:
+            self.tokenizer = None
+        else:
+            self.tokenizer = get_tokenizer(
+                server_args.tokenizer_path,
+                tokenizer_mode=server_args.tokenizer_mode,
+                trust_remote_code=server_args.trust_remote_code,
+                revision=server_args.revision,
+                tokenizer_backend=server_args.tokenizer_backend,
+            )
         self.mm_receiver = None
         if (
             self.server_args.language_only
@@ -365,7 +382,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
 
         # Create a special health check request
         sampling_params = SGLSamplingParams(max_new_tokens=1, temperature=0.0)
-        sampling_params.normalize(tokenizer=None)
+        sampling_params.normalize(tokenizer=self.tokenizer)
 
         # Create health check request
         is_generation = self.scheduler_info.get("is_generation")
@@ -377,12 +394,14 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 rid=rid,
                 input_text="",
                 input_ids=to_token_id_array([0]),
+                input_embeds=None,
+                mm_inputs=None,
+                token_type_ids=None,
                 sampling_params=sampling_params,
                 return_logprob=False,
                 logprob_start_len=-1,
                 top_logprobs_num=0,
                 stream=False,
-                mm_inputs=None,
                 token_ids_logprob=None,
                 require_reasoning=False,
             )
@@ -396,7 +415,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 rid=rid,
                 input_text="",
                 input_ids=to_token_id_array([0]),
-                image_inputs=None,
+                mm_inputs=None,
                 token_type_ids=[0],
                 sampling_params=sampling_params,
             )
@@ -586,8 +605,8 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         """
         Get comprehensive load metrics for all DP ranks.
 
-        Uses the communicator pattern to fetch real-time metrics,
-        providing full parity with the HTTP /v1/loads endpoint.
+        Reads the schedulers' published LoadSnapshots, providing full
+        parity with the HTTP /v1/loads endpoint.
         """
         logger.debug("Receive get loads request")
 
@@ -676,7 +695,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         )
 
         req = ProfileReq(
-            type=ProfileReqType.START_PROFILE,
+            req_type=ProfileReqType.START_PROFILE,
             output_dir=request.output_dir if request.HasField("output_dir") else None,
             start_step=request.start_step if request.HasField("start_step") else None,
             num_steps=request.num_steps if request.HasField("num_steps") else None,
@@ -695,7 +714,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
     ) -> common_pb2.ProfileResponse:
         """Stop the profiler and export traces."""
         logger.debug("Receive stop profile request")
-        req = ProfileReq(type=ProfileReqType.STOP_PROFILE)
+        req = ProfileReq(req_type=ProfileReqType.STOP_PROFILE)
         return await self._run_profile_req(req, "Stop profiling", context)
 
     async def _run_profile_req(
@@ -921,7 +940,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
             image_urls=image_urls,
             rid=grpc_req.request_id,
         )
-        tokenized_req.need_wait_for_image = bool(encode_req.need_wait_for_image)
+        tokenized_req.need_wait_for_mm_inputs = bool(encode_req.need_wait_for_mm_inputs)
         tokenized_req.num_items_assigned = encode_req.num_items_assigned
 
     # Helper methods for request/response conversion
@@ -940,7 +959,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
 
         # Convert sampling params
         sampling_params = self._convert_sampling_params(grpc_req.sampling_params)
-        sampling_params.normalize(tokenizer=None)
+        sampling_params.normalize(tokenizer=self.tokenizer)
 
         # Extract disaggregated params if present
         bootstrap_host = None
@@ -974,7 +993,9 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
             rid=grpc_req.request_id,
             input_text=input_text,
             input_ids=input_ids,
+            input_embeds=None,
             mm_inputs=mm_inputs,
+            token_type_ids=None,
             sampling_params=sampling_params,
             return_logprob=grpc_req.return_logprob,
             logprob_start_len=(
@@ -1001,8 +1022,8 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         arr = np.frombuffer(tensor_data.data, dtype=np_dtype).reshape(shape)
         return torch.from_numpy(arr)
 
-    def _parse_mm_inputs(self, mm_proto) -> MultimodalInputs:
-        """Parse proto MultimodalInputs into a MultimodalInputs object for the scheduler."""
+    def _parse_mm_inputs(self, mm_proto) -> MultimodalProcessorOutput:
+        """Parse proto MultimodalInputs into a MultimodalProcessorOutput for the scheduler."""
         # Decode pixel_values from typed TensorData field
         pixel_values = self._decode_tensor_data(mm_proto.pixel_values)
 
@@ -1030,7 +1051,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
 
         im_token_id = mm_proto.im_token_id if mm_proto.HasField("im_token_id") else None
 
-        return MultimodalInputs(
+        return MultimodalProcessorOutput(
             mm_items=[mm_item],
             im_token_id=im_token_id,
         )
@@ -1054,13 +1075,13 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         # The scheduler logic expects an integer, not None.
         sampling_params.max_new_tokens = 0
 
-        sampling_params.normalize(tokenizer=None)
+        sampling_params.normalize(tokenizer=self.tokenizer)
 
         return TokenizedEmbeddingReqInput(
             rid=grpc_req.request_id,
             input_text=input_text,
             input_ids=input_ids,
-            image_inputs=None,
+            mm_inputs=None,
             token_type_ids=list(grpc_req.token_type_ids),
             sampling_params=sampling_params,
         )

--- a/grpc_servicer/smg_grpc_servicer/sglang/utils.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/utils.py
@@ -2,53 +2,27 @@
 
 from __future__ import annotations
 
-import os
 from array import array
 from collections.abc import Iterable
 from http import HTTPStatus
 
 import grpc
 
-# Toggle between the legacy list contract and the new array("q") contract for
-# token IDs handed to the SGLang scheduler. Defaults to the legacy list contract
-# for compatibility with older SGLang builds whose scheduler expects
-# ``list[int]``. Set ``SGLANG_GRPC_TOKEN_ID_ARRAY=1`` (or true/yes) to emit
-# ``array("q")``, which current SGLang requires (see ``to_token_id_array``).
-_TOKEN_ID_ARRAY_ENV = "SGLANG_GRPC_TOKEN_ID_ARRAY"
-_TRUTHY = ("1", "true", "yes")
-_USE_TOKEN_ID_ARRAY = os.getenv(_TOKEN_ID_ARRAY_ENV, "false").strip().lower() in _TRUTHY
 
+def to_token_id_array(token_ids: Iterable[int] | None) -> array | None:
+    """Coerce a token-id sequence to the ``array("q")`` the SGLang scheduler expects.
 
-def _use_token_id_array() -> bool:
-    """Whether to emit ``array("q")`` (new contract) vs ``list`` (old contract)."""
-    return _USE_TOKEN_ID_ARRAY
-
-
-def to_token_id_array(token_ids: Iterable[int] | None) -> array | list | None:
-    """Coerce a token-id sequence to the container the SGLang scheduler expects.
-
-    By default this returns a plain ``list`` (the legacy contract). Setting
-    ``SGLANG_GRPC_TOKEN_ID_ARRAY=1`` (or true/yes) switches to ``array("q")``
-    (signed 64-bit ints), which current SGLang requires.
-
-    Current SGLang declares ``TokenizedGenerateReqInput.input_ids`` /
+    SGLang declares ``TokenizedGenerateReqInput.input_ids`` /
     ``TokenizedEmbeddingReqInput.input_ids`` as ``Optional[array[int]]`` and its
-    ``Req`` concatenates ``origin_input_ids + output_ids`` where ``output_ids`` is
-    ``array("q")``. Passing a plain ``list`` (as gRPC repeated fields decode to)
-    makes that concatenation raise ``TypeError: can only concatenate list (not
-    "array.array") to list`` on every request. Enabling the array contract mirrors
-    what SGLang's own HTTP ``TokenizerManager`` does before handing IDs to the
-    scheduler.
-
-    ``array("q", x)`` accepts any iterable of ints (list, protobuf
-    ``RepeatedScalarContainer``, or an existing ``array``), so this is safe to
-    apply at every call site. Returns ``None`` for ``None`` input.
+    ``Req`` concatenates ``origin_input_ids + output_ids`` where ``output_ids``
+    is ``array("q")``; a plain ``list`` (as gRPC repeated fields decode to) makes
+    that concatenation raise ``TypeError``. ``array("q", x)`` accepts any
+    iterable of ints, so this is safe at every call site. Returns ``None`` for
+    ``None`` input.
     """
     if token_ids is None:
         return None
-    if _use_token_id_array():
-        return array("q", token_ids)
-    return list(token_ids)
+    return array("q", token_ids)
 
 
 _HTTP_TO_GRPC_CODE = {

--- a/grpc_servicer/tests/test_token_id_array.py
+++ b/grpc_servicer/tests/test_token_id_array.py
@@ -1,16 +1,12 @@
-"""Unit tests for ``to_token_id_array`` — the token-id type fix.
-
-Regression coverage for the SMG+SGLang gRPC crash:
-
-    schedule_batch.py  self.fill_ids = self.origin_input_ids + self.output_ids
-    TypeError: can only concatenate list (not "array.array") to list
+"""Unit tests for ``to_token_id_array`` — the token-id type coercion.
 
 SGLang declares ``input_ids: Optional[array[int]]`` and concatenates
 ``origin_input_ids + output_ids`` where ``output_ids`` is ``array("q")``. The
-gRPC servicer used to pass a plain ``list`` (gRPC repeated fields decode to a
-list), which made that concatenation raise on every request. ``to_token_id_array``
-coerces to ``array("q")`` to match SGLang's contract — exactly what SGLang's own
-HTTP ``TokenizerManager`` does before reaching the scheduler.
+gRPC servicer receives token ids as plain lists (gRPC repeated fields decode to
+a list), which would make that concatenation raise on every request.
+``to_token_id_array`` coerces to ``array("q")`` to match SGLang's contract —
+exactly what SGLang's own HTTP ``TokenizerManager`` does before reaching the
+scheduler.
 
 The helper lives in ``smg_grpc_servicer.sglang.utils`` (stdlib + grpc only), so
 these tests need no sglang stack.
@@ -45,21 +41,6 @@ def to_token_id_array(token_ids):
     return _load_utils().to_token_id_array(token_ids)
 
 
-# Env var that toggles the array("q") (new) vs list (old) SGLang contract.
-_TOKEN_ID_ARRAY_ENV = "SGLANG_GRPC_TOKEN_ID_ARRAY"
-
-
-@pytest.fixture(autouse=True)
-def _array_contract_on(monkeypatch):
-    """The coercion tests below exercise the array("q") path, which is opt-in.
-
-    Production defaults the toggle OFF (legacy list contract); enable it here so
-    these tests target array behavior without per-test setup. Toggle/default
-    tests override this via their own ``monkeypatch`` call.
-    """
-    monkeypatch.setenv(_TOKEN_ID_ARRAY_ENV, "1")
-
-
 def test_list_becomes_array_q():
     out = to_token_id_array([1, 2, 3])
     assert isinstance(out, array)
@@ -91,46 +72,13 @@ def test_accepts_arbitrary_int_iterable():
     assert list(out) == [0, 1, 2, 3]
 
 
-def test_documents_the_bug_being_fixed():
+def test_concatenates_with_scheduler_output_ids():
     """The concatenation SGLang performs: array+array works, list+array raises."""
     output_ids = array("q")  # how SGLang initializes Req.output_ids
 
-    # Fixed path: helper output concatenates cleanly with SGLang's output_ids.
-    origin_fixed = to_token_id_array([1, 2, 3])
-    assert list(origin_fixed + output_ids) == [1, 2, 3]
+    origin = to_token_id_array([1, 2, 3])
+    assert list(origin + output_ids) == [1, 2, 3]
 
-    # Pre-fix path: a raw list + array("q") is exactly the crash we eliminated.
+    # A raw list + array("q") is exactly the crash the coercion prevents.
     with pytest.raises(TypeError):
         _ = [1, 2, 3] + output_ids
-
-
-@pytest.mark.parametrize("value", ["0", "false", "False", "no", "NO", "off", ""])
-def test_legacy_contract_returns_list(monkeypatch, value):
-    """SGLANG_GRPC_TOKEN_ID_ARRAY falsey => plain list (old SGLang contract)."""
-    monkeypatch.setenv(_TOKEN_ID_ARRAY_ENV, value)
-    out = to_token_id_array([1, 2, 3])
-    assert isinstance(out, list)
-    assert out == [1, 2, 3]
-
-
-@pytest.mark.parametrize("value", ["1", "true", "True", "yes", "YES"])
-def test_array_contract_when_enabled(monkeypatch, value):
-    """SGLANG_GRPC_TOKEN_ID_ARRAY truthy => array("q") (current SGLang contract)."""
-    monkeypatch.setenv(_TOKEN_ID_ARRAY_ENV, value)
-    out = to_token_id_array([1, 2, 3])
-    assert isinstance(out, array)
-    assert out.typecode == "q"
-    assert list(out) == [1, 2, 3]
-
-
-def test_legacy_list_is_the_default(monkeypatch):
-    """Unset env defaults to the legacy list contract for older SGLang builds."""
-    monkeypatch.delenv(_TOKEN_ID_ARRAY_ENV, raising=False)
-    out = to_token_id_array([1, 2, 3])
-    assert isinstance(out, list)
-    assert out == [1, 2, 3]
-
-
-def test_legacy_contract_none_still_returns_none(monkeypatch):
-    monkeypatch.setenv(_TOKEN_ID_ARRAY_ENV, "0")
-    assert to_token_id_array(None) is None

--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -21,7 +21,7 @@ echo "Using uv version: $(uv --version)"
 # Install CUDA toolkit (nvcc) — required for SGLang JIT kernel compilation.
 # SGLang >= 0.5.9 JIT-compiles CUDA kernels (RoPE, etc.) at runtime via tvm_ffi,
 # which invokes nvcc. The CI runners have CUDA runtime (driver) but not the compiler.
-# sglang 0.5.12 pins torch==2.11.0, whose default PyPI wheels are CUDA 13, so the
+# sglang 0.5.16 pins torch==2.11.0, whose default PyPI wheels are CUDA 13, so the
 # compiler must be nvcc 13 to match the runtime headers (a 12.x nvcc is replaced).
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 if [ ! -x "${CUDA_HOME}/bin/nvcc" ] || ! "${CUDA_HOME}/bin/nvcc" --version | grep -q "release 13\."; then
@@ -43,18 +43,7 @@ fi
 
 # Install SGLang with all dependencies
 echo "Installing SGLang..."
-uv pip install --prerelease=allow "sglang[all]==0.5.12.post1"
-
-# Work around NVIDIA/cutlass#3259 until the fix ships in CUTLASS 4.6.
-uv pip install --force-reinstall --no-deps "nvidia-cutlass-dsl-libs-cu13==4.5.2"
-
-# sglang 0.5.12.post1 leaves its `kernels` dependency unpinned, so the resolver
-# picks kernels >=0.15, which requires LayerRepository(revision=/version=) —
-# an argument the transformers 5.6.0 hub_kernels integration (pinned by sglang)
-# does not pass. `import sglang` then dies at module load with
-# "ValueError: Either a revision or a version must be specified."
-# Pin to the band sglang upstream main now uses; drop once a release carries it.
-uv pip install "kernels>=0.14.1,<0.15"
+uv pip install --prerelease=allow "sglang[all]==0.5.16"
 
 # Install flashinfer-jit-cache: sglang bundles flashinfer_python but only for attention ops.
 # Multi-GPU models need trtllm_comm kernels (fused allreduce + layernorm) which FlashInfer
@@ -72,13 +61,13 @@ fi
 
 # Install mooncake for SGLang PD disaggregation (KV transfer)
 # Mooncake's native transfer engine requires InfiniBand/RDMA libraries at runtime.
-# Package and pin track upstream sglang v0.5.12.post1 CI on the cu13 stack
+# Package and pin track upstream sglang v0.5.16 CI on the cu13 stack
 # (cuda13 wheel variant + nvrtc, since torch 2.11 defaults to CUDA 13):
-# https://github.com/sgl-project/sglang/blob/v0.5.12.post1/scripts/ci/cuda/ci_install_dependency.sh
+# https://github.com/sgl-project/sglang/blob/v0.5.16/scripts/ci/cuda/ci_install_dependency.sh
 echo "Installing mooncake system dependencies..."
 sudo apt-get install -y --no-install-recommends libnuma-dev libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils
 echo "Installing mooncake..."
-uv pip install mooncake-transfer-engine-cuda13==0.3.10.post2 nvidia-cuda-nvrtc
+uv pip install mooncake-transfer-engine-cuda13==0.3.11.post1 nvidia-cuda-nvrtc
 
 # Install gRPC packages from source (not PyPI) so PR changes are always tested
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."


### PR DESCRIPTION
## Description

### Problem

CI and release images pin SGLang 0.5.12.post1; upstream is at 0.5.16. Two of our installer workarounds were explicitly waiting on a release that has now shipped — and 0.5.16 makes two breaking changes the gRPC servicer was built on: it removes the legacy `get_loads` IPC (sglang#30525), which the first e2e run surfaced as every gRPC worker dying at import, and it rewrites the scheduler IPC structs as kw-only msgspec Structs, which the second e2e run surfaced as warmup requests failing construction (`Missing required argument 'input_embeds'`).

### Solution

- `scripts/ci_install_sglang.sh`: `sglang[all]==0.5.16`. Dropped two now-obsolete workarounds, both confirmed against the 0.5.16 wheel metadata: the forced `nvidia-cutlass-dsl-libs-cu13==4.5.2` reinstall (0.5.16 pins `nvidia-cutlass-dsl[cu13]==4.6.0`, which carries the cutlass#3259 fix the comment was waiting for) and the `kernels>=0.14.1,<0.15` band pin (0.5.16 pins `kernels<0.15,>=0.14.1` itself). Torch stays 2.11.0/CUDA-13, so the nvcc-13 setup is unchanged.
- Mooncake bumped to `mooncake-transfer-engine-cuda13==0.3.11.post1`, tracking upstream v0.5.16 CI (`scripts/ci/cuda/ci_install_dependency.sh`); tracking links updated.
- `release-sglang-docker.yml`: base image matrix/defaults/examples → `lmsysorg/sglang:v0.5.16` (tag verified on Docker Hub).
- **gRPC servicer ported to `LoadSnapshot`**: schedulers now publish per-dp-rank snapshots (SHM, zmq for multi-node DP) unconditionally, so the request manager creates a `create_load_snapshot_reader(..., caller="TokenizerManager")` and `get_loads` reads published snapshots instead of round-tripping `GetLoadsReqInput/Output` through a communicator. `LoadSnapshot` carries the identical fields the proto conversion already reads, so `GetLoads` RPC wire behavior is unchanged; include-section filtering (previously scheduler-side) now happens in the manager with the same validation error. The `get_loads_communicator` is removed (including from the public communicator set — the 0.5.16 HTTP sidecar's /v1/loads uses snapshot readers too). Reader is closed on shutdown.
- **gRPC servicer ported to the msgspec IPC structs**: `TokenizedGenerateReqInput` construction now passes the newly required `input_embeds`/`token_type_ids`; `TokenizedEmbeddingReqInput`'s `image_inputs` is renamed `mm_inputs`; the scheduler consumes `mm_inputs` via `MultimodalInputs.from_processor_output(...)`, so `_parse_mm_inputs` returns a `MultimodalProcessorOutput` instead of a pre-built `MultimodalInputs`; slotted structs reject undeclared attributes, so the EPD encode hook sets the real `need_wait_for_mm_inputs` field (`need_wait_for_image` was never declared — the old assignment was a silent no-op that msgspec turns into an `AttributeError`); and `Req` now concatenates `origin_input_ids` with `array("q")` output ids, making the array token-id contract mandatory — `to_token_id_array` always emits `array("q")` and its legacy-list env toggle (`SGLANG_GRPC_TOKEN_ID_ARRAY`) is removed. Additionally, 0.5.16's `SamplingParams.normalize` rejects string stop sequences when called without a tokenizer. The scheduler matches stop strings with its own tokenizer (`skip_tokenizer_init` is never set in this deployment), so the servicer now loads the model tokenizer exactly as sglang's `TokenizerManager` does and passes it to `normalize` — engine-side early stopping and `finish_reason="stop"` semantics are preserved (and `stop_str_max_len` is now computed in real tokens rather than the tokenizer-less character approximation); and `ProfileReq.type` is renamed `req_type`. Wire format is unaffected: 0.5.16 defaults to pickle IPC (`SGLANG_USE_PICKLE_IPC=True`), matching the manager's existing `send_pyobj`.
- `grpc_servicer`'s sglang extra floor rises to `>=0.5.16` (the old IPC no longer exists, and the previous `>=0.5.13` floor was above what CI installed anyway).

### Breaking change

`smg-grpc-servicer` now requires SGLang >= 0.5.16 and no longer runs against older engines; upgrade SGLang and the servicer together (pip enforces the floor). Suggested release-note entry:

> ⚠️ **Breaking change**: `smg-grpc-servicer` now requires SGLang >= 0.5.16. SGLang 0.5.16 removed the legacy `get_loads` IPC and rewrote scheduler IPC structs as msgspec Structs; the servicer now reads scheduler-published `LoadSnapshot`s and speaks the new struct contract. Older servicer releases will not start on SGLang 0.5.16+, and this servicer will not install against SGLang < 0.5.16 — upgrade both together.

## Test Plan

- Real validation is the e2e matrix on this PR: sglang legs across 1-GPU chat/completions/embeddings/responses and 2-GPU PD (incl. mooncake KV transfer).
- Locally: `bash -n` clean; 0.5.16 wheel metadata verified for the dropped workarounds; `v0.5.16` image tag verified; grpc_servicer python suite green after the port (77 passed, 3 skipped); every `TokenizedGenerateReqInput`/`TokenizedEmbeddingReqInput` construction site statically checked against the 0.5.16 wheel's struct definitions (no missing required fields, no unknown kwargs).

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Upgraded SGLang-based builds and CI installs to SGLang **0.5.16**.
  * Updated the related Mooncake CUDA 13 transfer engine package versions.
  * Refreshed published Docker image tag examples to match the new baseline.
* **Bug Fixes / Improvements**
  * Updated load-metrics reporting to rely on scheduler-published snapshots, improving consistency with the `/v1/loads` behavior.
  * Updated the `GetLoads` endpoint documentation and response mapping accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
