### PR TITLE
chore(deps): bump vLLM floor to 0.26 and refresh docker matrix

### DIFF
--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -2,7 +2,7 @@ name: Release SMG+vLLM Docker Image
 
 run-name: >-
   SMG+vLLM |
-  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.22.1') }} |
+  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.26.0') }} |
   engine=${{ inputs.vllm_commit || 'latest' }} |
   smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. vllm/vllm-openai:v0.22.1)'
-        default: 'vllm/vllm-openai:v0.22.1'
+        description: 'Base image (e.g. vllm/vllm-openai:v0.26.0)'
+        default: 'vllm/vllm-openai:v0.26.0'
         required: true
         type: string
       vllm_repo:
@@ -47,7 +47,7 @@ on:
         default: 'v1.8.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.8.0-vllm-v0.22.1)'
+        description: 'Override image tag (e.g. v1.8.0-vllm-v0.26.0)'
         required: false
         type: string
 
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["vllm/vllm-openai:v0.22.1","vllm/vllm-openai:v0.21.0","vllm/vllm-openai:v0.20.0"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'vllm/vllm-openai:v0.22.1')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["vllm/vllm-openai:v0.26.0","vllm/vllm-openai:v0.25.0","vllm/vllm-openai:v0.23.0"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'vllm/vllm-openai:v0.26.0')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: vllm

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -19,14 +19,12 @@ fi
 
 echo "Using uv version: $(uv --version)"
 
-# Floor 0.25.0: older vllm releases do not guarantee torchcodec, while the
-# import canary below deliberately validates it. This line also admits only
-# transformers >= 5.5.3, preserving e5-mistral last-token pooling.
-# FastAPI 0.137 makes vLLM's prometheus-fastapi-instrumentator health route
-# crash on _IncludedRouter entries; keep the last known-good FastAPI line.
+# Floor 0.26.0: older vllm releases do not guarantee torchcodec, while the
+# import canary below deliberately validates it, and 0.26 caps
+# fastapi<0.137 (0.137 breaks the prometheus-fastapi-instrumentator health route).
 # --torch-backend=auto matches the torch CUDA variant to the pod's driver.
 echo "Installing vLLM..."
-uv pip install "vllm>=0.25.0" "fastapi<0.137" --torch-backend=auto
+uv pip install "vllm>=0.26.0" --torch-backend=auto
 
 # vLLM >=0.25 eagerly imports torchcodec, which dlopens the FFmpeg shared
 # libraries (libavutil/libavcodec/libavformat/...) at import time. The runner


### PR DESCRIPTION
## Description

### Problem

The CI installer floors vLLM at 0.25.0 with a manual `fastapi<0.137` pin, and the release-docker matrix tops out at `v0.22.1` — four minor versions behind upstream 0.26.0.

### Solution

- `scripts/ci_install_vllm.sh`: floor raised to `vllm>=0.26.0`; the explicit `fastapi<0.137` pin is dropped because 0.26's own metadata caps `fastapi[standard]<0.137.0,>=0.133.0` (verified from the wheel's requires_dist). The torchcodec/FFmpeg canary and `--torch-backend=auto` are unchanged.
- `release-vllm-docker.yml`: 3-version matrix → `v0.26.0 / v0.25.0 / v0.23.0`, defaults and examples → `v0.26.0`. All three tags verified on Docker Hub; note there is no `v0.24.x` `vllm-openai` tag, hence `v0.23.0` as the third entry.
- `grpc_servicer`'s `vllm>=0.19.0` floor is untouched.

## Test Plan

- Real validation is this PR's e2e matrix: vllm legs across 1-GPU chat/completions/embeddings and 2-GPU PD with both NIXL and Mooncake KV backends.
- Locally: `bash -n` clean; 0.26.0 requires_dist verified for the fastapi cap; all matrix image tags verified.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker release workflows to use vLLM 0.26.0 as the default base image.
  * Updated release input guidance and image tag examples for vLLM 0.26.0.
  * Updated CI installation requirements to use vLLM 0.26.0 or newer.
  * Simplified the CI installation command by removing the explicit FastAPI version constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->