### PR TITLE
chore(deps): bump TensorRT-LLM to 1.3.0rc22

### DIFF
--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -2,7 +2,7 @@ name: Release SMG+TRTLLM Docker Image
 
 run-name: >-
   SMG+TRTLLM |
-  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18') }} |
+  ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22') }} |
   engine=${{ inputs.trtllm_commit || 'latest' }} |
   smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18). Empty = build from source.'
-        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18'
+        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22). Empty = build from source.'
+        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22'
         required: false
         type: string
       trtllm_repo:
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base_image: ${{ github.event_name == 'push' && fromJSON('["nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc17","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc16"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18')) }}
+        base_image: ${{ github.event_name == 'push' && fromJSON('["nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21","nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20"]') || fromJSON(format('["{0}"]', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22')) }}
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: trtllm

--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -56,7 +56,7 @@ COPY --from=sources /opt/engine-src   /opt/engine-src
 COPY --from=sources /tmp/smg-src      /opt/smg-src
 COPY --from=sources /tmp/scripts/     /tmp/scripts/
 
-# NGC TRT-LLM bases (1.3.0rc18) ship a debian-owned PyYAML with no pip RECORD
+# NGC TRT-LLM 1.3.0rc bases ship a debian-owned PyYAML with no pip RECORD
 # file, which pip refuses to uninstall when install-smg.sh resolves smg's
 # pyyaml dependency ("uninstall-no-record-file"). Shadow it with a pip-managed
 # copy (--ignore-installed leaves the distro files alone); the smg install can

--- a/scripts/ci_install_trtllm.sh
+++ b/scripts/ci_install_trtllm.sh
@@ -3,7 +3,7 @@
 #
 # The gRPC serve command from PR #11037 and the Harmony parser fixes (#12045,
 # #12467) referenced by SMG #801 first shipped in 1.3.0rc14 (released
-# 2026-05-07) and remain included in the pinned 1.3.0rc18 pre-release wheel.
+# 2026-05-07) and remain included in the pinned 1.3.0rc22 pre-release wheel.
 # We install it directly from PyPI instead of building TensorRT-LLM from
 # source, which saves ~30 min of CMake compile time per CI run. See git
 # history for the previous source-build logic.
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-TRTLLM_VERSION="1.3.0rc18"
+TRTLLM_VERSION="1.3.0rc22"
 NCCL_VERSION_CONSTRAINT="nvidia-nccl-cu13>=2.28.9,<=2.29.2"
 
 # Activate venv if it exists
@@ -67,6 +67,11 @@ pip install --no-cache-dir --pre \
     --extra-index-url https://pypi.nvidia.com \
     --extra-index-url https://download.pytorch.org/whl/cu130 \
     "tensorrt-llm==${TRTLLM_VERSION}"
+
+# typer >= 0.26 leaks click.exceptions.Exit through its main on CLI exit, so
+# every `hf` invocation (model downloads) exits 1 even on success. The
+# transformers pulled by tensorrt-llm has an unbounded typer dependency.
+pip install --no-cache-dir "typer<0.26"
 
 # ── Setup LD_LIBRARY_PATH ────────────────────────────────────────────────────
 SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")


### PR DESCRIPTION
## Description

### Problem

CI installs TensorRT-LLM 1.3.0rc18 and the release-docker matrix builds rc18/rc17/rc16; NVIDIA's index is at 1.3.0rc22 (the GA line on pypi.org is still 1.2.x, so the rc channel remains the right track for the gRPC serve command).

### Solution

- `scripts/ci_install_trtllm.sh`: `TRTLLM_VERSION="1.3.0rc22"` (wheel present on pypi.nvidia.com); header note about the serve-command/Harmony fixes updated — they shipped in rc14 and remain in rc22.
- `release-trtllm-docker.yml`: matrix → `release:1.3.0rc22 / rc21 / rc20`, defaults and examples → rc22. All three NGC image tags verified via manifest inspect.
- `docker/engine.Dockerfile`: the PyYAML shadow for NGC bases is kept (harmless if a base ever ships a pip-managed PyYAML); its comment now says "1.3.0rc bases" instead of naming rc18.

- rc22's dependency tree (via its `transformers` pin, which leaves `typer` unbounded) resolves typer 0.27.0, whose CLI exit path leaks `click.exceptions.Exit` — every `hf` model download exits 1 *after succeeding*, failing the e2e model-fetch step on repeat attempts. The installer now pins `typer<0.26` after the TensorRT-LLM install (0.25.1 verified working against click 8.3.3, reproduced and bisected locally).

## Test Plan

- Real validation is this PR's e2e matrix: trtllm legs (1-GPU chat, 4-GPU chat).
- Locally: `bash -n` clean; rc22 wheel present on pypi.nvidia.com; `release:1.3.0rc22/rc21/rc20` image manifests verified.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated TensorRT-LLM Docker release builds to use newer NGC base images (defaulting to 1.3.0rc22, with the build matrix aligned).
  * Updated CI installation to pin and install the newer TensorRT-LLM pre-release wheel (1.3.0rc22).
  * Improved build consistency across engine image generation and CI workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
