### PR TITLE
fix(protocols): accept function tools without parameters field

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -872,4 +872,21 @@ mod tests {
             assert_eq!(serialized.get("return_audio"), Some(&Value::Bool(value)));
         }
     }
+
+    #[test]
+    fn chat_request_accepts_function_tool_without_parameters() {
+        // https://github.com/lightseekorg/smg/issues/1974 — omitting
+        // `parameters` is spec-legal and must not reject the request.
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [
+                {"type": "function", "function": {"name": "web_search", "description": ""}}
+            ],
+        });
+        let request: ChatCompletionRequest =
+            serde_json::from_value(value).expect("request must deserialize");
+        let tools = request.tools.expect("tools must be present");
+        assert_eq!(tools[0].function.parameters, json!({}));
+    }
 }

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -416,11 +416,18 @@ pub struct Tool {
     pub function: Function,
 }
 
+/// Per the OpenAI spec, omitting `parameters` defines a function with an
+/// empty parameter list, so a missing field deserializes to an empty schema.
+fn empty_parameters_schema() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct Function {
     pub name: String,
     pub description: Option<String>,
+    #[serde(default = "empty_parameters_schema")]
     pub parameters: Value, // JSON Schema
     /// Whether to enable strict schema adherence (OpenAI structured outputs)
     pub strict: Option<bool>,
@@ -899,5 +906,14 @@ mod tests {
         assert!(ConversationRef::Id(String::new()).is_empty());
         assert!(!ConversationRef::Id("conv_1".to_string()).is_empty());
         assert!(ConversationRef::Object { id: String::new() }.is_empty());
+    }
+
+    #[test]
+    fn function_deserializes_without_parameters() {
+        // Per the OpenAI spec, omitting `parameters` defines a function with
+        // an empty parameter list.
+        let value = json!({"name": "web_search", "description": ""});
+        let function: Function = serde_json::from_value(value).expect("parameterless function");
+        assert_eq!(function.parameters, json!({}));
     }
 }


### PR DESCRIPTION
## Description

### Problem

`Function.parameters` in `openai-protocol` is a required field, so Chat Completions requests carrying spec-legal parameterless function tools are rejected with HTTP 400 (`missing field \`parameters\``) during request deserialization, before routing. This breaks clients/proxies that send Anthropic-style built-in server tools (e.g. `web_search_20250305`) translated to OpenAI format, which legitimately carry no input schema.

Closes #1974

### Solution

Add `#[serde(default = "empty_parameters_schema")]` so an omitted `parameters` field deserializes to an empty JSON Schema object (`{}`), matching the spec: "Omitting `parameters` defines a function with an empty parameter list." The field remains `pub Value`; serialization and the public API are unchanged, so downstream consumers observe the same `Value` as if the client had sent `{}`.

## Changes

- `crates/protocols/src/common.rs` — serde default for `Function.parameters` via new `empty_parameters_schema` helper; unit test for parameterless function deserialization
- `crates/protocols/src/chat.rs` — regression test mirroring the issue repro: a `ChatCompletionRequest` whose `tools` array contains a function tool without `parameters` now deserializes

## Test Plan

Repro (from #1974), now passing:

```rust
let req = json!({
    "model": "test-model",
    "messages": [{"role": "user", "content": "hello"}],
    "tools": [{"type": "function", "function": {"name": "web_search", "description": ""}}],
});
let req: ChatCompletionRequest = serde_json::from_value(req).unwrap();
assert_eq!(req.tools.unwrap()[0].function.parameters, json!({}));
```

Gate output (run locally on macOS, rustc 1.97.1 stable):

- `cargo test -p openai-protocol` — **83 unit + 126 integration tests pass**, including new `common::tests::function_deserializes_without_parameters` and `chat::tests::chat_request_accepts_function_tool_without_parameters`. Both tests were verified to fail pre-fix with `missing field \`parameters\``.
- `cargo test -p smg --lib` — **1320 passed, 0 failed**
- `cargo check -p smg --all-targets` / `cargo check -p smg-python -p smg-golang` — compiles clean (bindings affected transitively via `smg`)
- `cargo +nightly fmt --all` — silent success
- `cargo clippy -p openai-protocol --all-targets -- -D warnings` — zero warnings
- Note: `cargo clippy --workspace --all-targets -- -D warnings` fails on a **pre-existing** lint at `model_gateway/src/worker/monitor.rs:744` (`clippy::unneeded_wildcard_pattern`, clippy 1.97.1) in code untouched by this PR. Left alone to keep this PR one concern.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (changed crate clean; one pre-existing lint elsewhere noted above)
- [ ] (Optional) Documentation updated — not needed, behavior now matches the documented OpenAI spec
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Function tools can now be used without specifying a `parameters` field.
  * Requests missing tool parameters are accepted and default to an empty schema (`{}`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->