### PR TITLE
docs(grpc-pipeline): document XGrammar and fix its pipeline order

### DIFF
--- a/docs/assets/images/architecture-detailed.svg
+++ b/docs/assets/images/architecture-detailed.svg
@@ -184,18 +184,18 @@
   </g>
   <g>
     <rect x="485" y="200" width="70" height="45" rx="6" fill="#334155" stroke="#10b981" stroke-width="1"/>
-    <text x="520" y="220" text-anchor="middle" class="sublabel" font-size="9">XGrammar</text>
-    <text x="520" y="233" text-anchor="middle" class="small">Generate</text>
+    <text x="520" y="220" text-anchor="middle" class="sublabel" font-size="9">Chat</text>
+    <text x="520" y="233" text-anchor="middle" class="small">Template</text>
   </g>
   <g>
     <rect x="570" y="200" width="70" height="45" rx="6" fill="#334155" stroke="#10b981" stroke-width="1"/>
-    <text x="605" y="220" text-anchor="middle" class="sublabel" font-size="9">Chat</text>
-    <text x="605" y="233" text-anchor="middle" class="small">Template</text>
+    <text x="605" y="220" text-anchor="middle" class="sublabel" font-size="9">Tokenize</text>
+    <text x="605" y="233" text-anchor="middle" class="small">+ Cache</text>
   </g>
   <g>
     <rect x="655" y="200" width="70" height="45" rx="6" fill="#334155" stroke="#10b981" stroke-width="1"/>
-    <text x="690" y="220" text-anchor="middle" class="sublabel" font-size="9">Tokenize</text>
-    <text x="690" y="233" text-anchor="middle" class="small">+ Cache</text>
+    <text x="690" y="220" text-anchor="middle" class="sublabel" font-size="9">XGrammar</text>
+    <text x="690" y="233" text-anchor="middle" class="small">Generate</text>
   </g>
   <g>
     <rect x="740" y="200" width="65" height="45" rx="6" fill="#334155" stroke="#f59e0b" stroke-width="1"/>

--- a/docs/concepts/architecture/grpc-pipeline.md
+++ b/docs/concepts/architecture/grpc-pipeline.md
@@ -44,6 +44,14 @@ Parse function calls and execute MCP tools with automatic result injection.
 
 </div>
 
+<div class="card" markdown>
+
+### :material-lock-check: Constrained Decoding
+
+XGrammar-enforced tool calls and structured outputs, guaranteed to match declared schemas.
+
+</div>
+
 </div>
 
 ---
@@ -86,6 +94,7 @@ SMG handles routing, load balancing, and failover. Workers run full OpenAI-compa
 |------------|--------------------|--------------------|
 | Chat template | Gateway | Worker |
 | Tokenization | Gateway (cached) | Worker |
+| Constrained decoding (XGrammar) | Gateway builds, worker enforces | Worker |
 | Load balancing | Token-aware | Request count |
 | Reasoning extraction | Gateway | Worker |
 | Tool call parsing | Gateway | Worker |
@@ -286,6 +295,35 @@ Qwen3-Coder / Qwen3.5+ XML format with parameter tags.
 3. **Execute**: Run MCP tools or return to client
 4. **Inject**: Add tool results back to conversation
 5. **Continue**: Resume generation if needed
+
+---
+
+## Constrained Decoding (XGrammar)
+
+When a request declares `tools` or a structured `response_format`, SMG builds a **constraint** during chat preparation and sends it with the gRPC request. The backend engine compiles it with XGrammar and enforces it token-by-token during decoding, so tool-call framing and JSON arguments are guaranteed to conform to the declared schemas before SMG's own parsers ever see the output.
+
+### Where It Runs in the Pipeline
+
+In the regular gRPC pipeline, the constraint is generated **after chat template rendering and tokenization** (`model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs`):
+
+1. Filter tools by `tool_choice`
+2. Apply chat template
+3. Tokenize
+4. **Build tool constraint** (`generate_tool_constraint`)
+5. Build stop decoder → worker selection → dispatch
+
+The Harmony pipeline (GPT-OSS) differs: it generates the constraint before encoding (`model_gateway/src/routers/grpc/harmony/stages/preparation.rs`). The architecture diagrams follow the regular pipeline order.
+
+### Constraint Types
+
+| Type | When used | What it constrains |
+|------|-----------|--------------------|
+| `structural_tag` | Configured tool parser has a native tag builder (`mistral`, `kimik2`, `kimi_k3`, `inkling`) | Full tool-call format: trigger tokens, tool-call framing, and argument JSON |
+| `json_schema` | Fallback for `required` / specific-function `tool_choice` | Argument JSON only |
+
+### Enforcement
+
+The constraint travels on `GenerateRequest`'s `constraint` oneof (`crates/grpc_client/proto/`), which also carries structured-output controls (`json_schema`, `regex`, `grammar`, `json_object`, `choice`). Engines compile these through XGrammar-guided decoding, and SMG's tool/reasoning parsers then extract the already well-formed calls from the response.
 
 ---
 


### PR DESCRIPTION
## Description

### Problem

#1544: `architecture-detailed.svg` shows XGrammar as the **first** step of the gRPC path (`gRPC Router → XGrammar Generate → Chat Template → Tokenize + Cache → …`), but in the regular gRPC pipeline the tool constraint is built **after** chat template rendering and tokenization. The XGrammar-first order only matches the Harmony (GPT-OSS) pipeline, while the diagram represents the general gRPC path. Separately, `grpc-pipeline.md` — the main page describing the gRPC pipeline stages — does not mention XGrammar / constrained decoding at all.

Closes #1544

### Solution

- Reorder the gRPC path in `architecture-detailed.svg` to match the code: `gRPC Router → Chat Template → Tokenize + Cache → XGrammar → Load Balance → gRPC Backend`.
- Add a **Constrained Decoding (XGrammar)** section to `grpc-pipeline.md`, plus an overview card and a responsibility-comparison row.

## Changes

- `docs/assets/images/architecture-detailed.svg` — swapped the Chat Template / Tokenize / XGrammar boxes into code order (coordinate-only swap of equal-width boxes; arrows unchanged; `xmllint --noout` passes)
- `docs/concepts/architecture/grpc-pipeline.md`:
  - New section covering where constraint generation runs in the regular vs Harmony pipeline, `structural_tag` vs `json_schema` constraint types, and engine enforcement via `GenerateRequest`'s `constraint` oneof
  - Overview card for constrained decoding
  - Responsibility-table row: gRPC mode = gateway builds / worker enforces, HTTP mode = worker

## Test Plan

Docs-only change; every claim verified against the source of truth on `main`:

- **Ordering**: `model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs` — chat template (step 2) → tokenize (step 3) → `generate_tool_constraint` (step 4). Harmony builds the constraint before encoding (`model_gateway/src/routers/grpc/harmony/stages/preparation.rs`).
- **Constraint types**: `ToolConstraint::{StructuralTag, JsonSchema}` in `crates/tool_parser/src/factory.rs`; native tag builders registered for `mistral`, `kimik2`, `kimi_k3`, `inkling`.
- **Transport/enforcement**: `constraint` oneof (`json_schema` / `regex` / `grammar` / `structural_tag` / `json_object` / `choice`) in `crates/grpc_client/proto/{vllm_engine,sglang_scheduler,tokenspeed_scheduler}.proto`.
- SVG validated with `xmllint --noout`.
- Docs site not built locally (mkdocs not installed); markdown follows the page's existing MkDocs Material patterns (cards/grids/tables).

Before/after: previously the diagram's second box was "XGrammar Generate" (between gRPC Router and Chat Template); it now sits between "Tokenize + Cache" and "Load Balance", matching preparation-stage order.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes — N/A, docs-only (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes — N/A, docs-only
- [x] (Optional) Documentation updated — this is the documentation update
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on constrained decoding with XGrammar in the gRPC pipeline.
  * Documented how structured outputs and tool calls are validated against declared schemas.
  * Clarified the responsibilities of the gateway and worker when building and enforcing decoding constraints.
  * Described supported constraint types and their handling across regular and Harmony pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->