### PR TITLE
ci: run engine version watch weekly

### DIFF
--- a/.github/workflows/engine-version-watch.yml
+++ b/.github/workflows/engine-version-watch.yml
@@ -1,12 +1,12 @@
 name: Engine Version Watch
 
-# Every 3 days: detect newer engine releases and have Claude file one
+# Weekly: detect newer engine releases and have Claude file one
 # researched upgrade issue per engine (deduped against open issues, so a
 # version is only reported once).
 
 on:
   schedule:
-    - cron: '23 8 */3 * *'
+    - cron: '23 8 * * 1' # Mondays 08:23 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description

### Problem

The engine watch cron `23 8 */3 * *` fires on days 1, 4, 7, … 31 of each month — spacing wobbles at month boundaries (the 31st is followed by the 1st), and every-3-days is more often than the issue stream needs.

### Solution

Weekly on Mondays 08:23 UTC (`23 8 * * 1`). Dedup against open engine-watch issues is unchanged, so cadence only affects detection latency, never duplicate issues.

## Test Plan

- Cron-only change; syntax matches the existing schedule entry. First scheduled run: next Monday 08:23 UTC (manual `workflow_dispatch` still available).

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the engine version monitoring schedule to run weekly on Mondays at 08:23 UTC instead of every three days.
  * Existing monitoring jobs and workflow behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->