### PR TITLE
chore(deps): bump TokenSpeed to 0f68676

### DIFF
--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -18,14 +18,11 @@ if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
 fi
 
-# Pinned SHA from lightseekorg/tokenspeed main. Bump explicitly (ideally via
-# a scheduled bump-and-CI routine) rather than floating against ``main`` —
-# upstream has renamed APIs before and the gRPC servicer broke until we
-# caught up.
-# This pin includes the EPD package promotion (tokenspeed #743):
-# ``tokenspeed.runtime.pd.epd`` moved to ``tokenspeed.runtime.epd``. Keep the
-# encoder-servicer import in sync when advancing it.
-TOKENSPEED_REF="${TOKENSPEED_REF:-815f50cfb21742f41cc1f9a27ee78a1b8e2b04a5}"
+# Pinned SHA from lightseekorg/tokenspeed main. Bump explicitly (the
+# engine-watch workflow files an issue when this drifts) rather than
+# floating against ``main`` — upstream has renamed APIs before and the
+# gRPC servicer broke until we caught up.
+TOKENSPEED_REF="${TOKENSPEED_REF:-0f68676069141857a605b8805c13131d9f53e901}"
 TOKENSPEED_REPO="${TOKENSPEED_REPO:-https://github.com/lightseekorg/tokenspeed.git}"
 TOKENSPEED_DIR="${TOKENSPEED_DIR:-/tmp/tokenspeed-src}"
 
@@ -123,6 +120,11 @@ export TOKENSPEED_KERNEL_BACKEND="${TOKENSPEED_KERNEL_BACKEND:-cuda}"
 # every install below resolves the CUDA-13 torch + nvidia deps.
 export PIP_EXTRA_INDEX_URL="${PIP_EXTRA_INDEX_URL:-https://download.pytorch.org/whl/cu130}"
 export UV_EXTRA_INDEX_URL="${UV_EXTRA_INDEX_URL:-https://download.pytorch.org/whl/cu130}"
+# Match pip's cross-index best-version semantics (what upstream's pip-based
+# install_deps.sh relies on). uv's default first-index strategy pins each
+# package to the first index carrying it, so the cu130 index's stale
+# ``packaging`` (<=24.1) would block flashinfer-python's packaging>=24.2.
+export UV_INDEX_STRATEGY="${UV_INDEX_STRATEGY:-unsafe-best-match}"
 
 # Keep Cutlass DSL and quack versioning owned by TokenSpeed's requirements.
 # Duplicating those exact pins here makes the install unsatisfiable when


### PR DESCRIPTION
## Description

### Problem

The TokenSpeed source-build pin (`815f50c`, 2026-07-20) trails upstream main — flagged by the engine-watch automation in #1980.

### Solution

- `scripts/ci_install_tokenspeed.sh`: `TOKENSPEED_REF` → `0f68676069141857a605b8805c13131d9f53e901`, the merge commit of Kimi K3 integration (tokenspeed#822). The window brings MiniMax M3 support (+ Eagle3.1 draft checkpoints, NVFP4 mixed precision, FP8 KV cache), Kimi K3, DeepSeek EAGLE MLA / Kimi K2.7 Code EAGLE3.1, GDN flashinfer decode + MoE/MSA/attention kernel optimizations, and properly declared runtime dependencies (tokenspeed#783).
- Torch co-pin unchanged: TokenSpeed's `pyproject.toml` still requires `torch==2.11.0` at this ref, so `torch==2.11.0+cu130` stays.
- No other pin sites: the release workflow and `docker/engine.Dockerfile` receive the commit via inputs; upstream's `tokenspeed-smg-grpc-*` dists (bumped upstream in tokenspeed#824) are uninstalled by this script in favor of source installs, so they don't constrain the pin.
- `UV_INDEX_STRATEGY=unsafe-best-match`: tokenspeed-kernel at this ref pins `flashinfer-python==0.6.15.post1` (needs `packaging>=24.2`), and uv's default first-index strategy resolved `packaging` exclusively from the cu130 extra index (stale, <=24.1) — upstream's pip-based installer merges indexes best-version, so this restores the semantics upstream relies on. `torch` still resolves from the cu130 index via its `+cu130` local-version pin.
- Dropped the pin comment's stale reference to the EPD package promotion (tokenspeed#743) — included in any ref newer than the previous pin.

Closes #1980

## Test Plan

- Static: every `tokenspeed` import statement across `grpc_servicer/smg_grpc_servicer` (22 sites, including lazy in-function imports) resolves against the `0f68676` tree — modules and symbols verified by ast scan.
- Real validation: `e2e-1gpu-chat (tokenspeed)` and `e2e-4gpu-epd (tokenspeed)` legs on this PR build the pinned ref from source and run the full suites.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TokenSpeed source revision used for automated CI installations to a newer fixed commit.
  * Set an explicit default for `uv`’s index selection strategy (`UV_INDEX_STRATEGY=unsafe-best-match`) to improve consistency when resolving packages across the configured indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->