### PR TITLE
fix(gateway): scrape engine metrics via base URL under --dp-aware

### DIFF
--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -50,6 +50,12 @@ struct WorkerResponse {
 }
 
 /// Fan out requests to workers in parallel
+///
+/// Requests are addressed to `worker.base_url()`, so under `--dp-aware`
+/// every rank of the same base worker targets the rank-free endpoint —
+/// `worker.url()` carries an `@{dp_rank}` suffix that is SMG-internal and
+/// not a valid server address (#1993). Callers that want one request per
+/// base worker must dedupe by base URL first (see `get_engine_metrics`).
 async fn fan_out(
     workers: &[Arc<dyn Worker>],
     client: &reqwest::Client,
@@ -60,7 +66,7 @@ async fn fan_out(
         .iter()
         .map(|worker| {
             let client = client.clone();
-            let url = worker.url().to_string();
+            let url = worker.base_url().to_string();
             let full_url = format!("{url}/{endpoint}");
             let api_key = worker.api_key().cloned();
             let method = method.clone();
@@ -989,6 +995,15 @@ impl WorkerManager {
             return EngineMetricsResult::Err("No available workers".to_string());
         }
 
+        // Scrape each base worker once: under `--dp-aware` all ranks share
+        // the base URL, so per-rank fan-out would repeat identical scrapes
+        // (#1993).
+        let mut seen = HashSet::new();
+        let workers: Vec<Arc<dyn Worker>> = workers
+            .into_iter()
+            .filter(|w| seen.insert(w.base_url().to_string()))
+            .collect();
+
         let responses = fan_out(&workers, client, "metrics", reqwest::Method::GET).await;
 
         let mut metric_packs = Vec::new();
@@ -1018,7 +1033,13 @@ impl WorkerManager {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
 
     use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
@@ -1039,6 +1060,89 @@ mod tests {
                 })
                 .build(),
         )
+    }
+
+    fn make_dp_worker(base: &str, rank: usize, size: usize) -> Arc<dyn Worker> {
+        let spec: openai_protocol::worker::WorkerSpec = serde_json::from_value(serde_json::json!({
+            "url": format!("{base}@{rank}"),
+            "dp_base_url": base,
+            "dp_rank": rank,
+            "dp_size": size,
+        }))
+        .expect("dp worker spec");
+        Arc::new(BasicWorkerBuilder::from_spec(spec).build())
+    }
+
+    /// Tiny HTTP stub counting GET /metrics hits; returns its base URL.
+    async fn start_metrics_stub(hits: Arc<AtomicUsize>) -> String {
+        let app = axum::Router::new().route(
+            "/metrics",
+            axum::routing::get(move || {
+                let hits = hits.clone();
+                async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    "# HELP test_metric stub\n# TYPE test_metric gauge\ntest_metric 1\n"
+                }
+            }),
+        );
+        let port = portpicker::pick_unused_port().expect("free port");
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+            .await
+            .expect("bind stub");
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test stub server lives for the duration of the test process"
+        )]
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("stub serve");
+        });
+        format!("http://127.0.0.1:{port}")
+    }
+
+    #[tokio::test]
+    async fn engine_metrics_scrapes_dp_workers_via_base_url_once() {
+        // Two DP ranks share one base worker. The `@{rank}` suffix in
+        // worker.url() is not a valid endpoint; metrics must be scraped
+        // from base_url(), once per base worker (#1993).
+        let hits = Arc::new(AtomicUsize::new(0));
+        let base = start_metrics_stub(hits.clone()).await;
+
+        let registry = WorkerRegistry::new();
+        registry.register(make_dp_worker(&base, 0, 2)).unwrap();
+        registry.register(make_dp_worker(&base, 1, 2)).unwrap();
+
+        let client = reqwest::Client::new();
+        let result = WorkerManager::get_engine_metrics(&registry, &client).await;
+
+        assert!(
+            matches!(result, EngineMetricsResult::Ok(_)),
+            "expected metrics scrape to succeed"
+        );
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            1,
+            "base worker must be scraped once, not per DP rank"
+        );
+    }
+
+    #[tokio::test]
+    async fn engine_metrics_scrapes_each_distinct_base_worker() {
+        let hits_a = Arc::new(AtomicUsize::new(0));
+        let base_a = start_metrics_stub(hits_a.clone()).await;
+        let hits_b = Arc::new(AtomicUsize::new(0));
+        let base_b = start_metrics_stub(hits_b.clone()).await;
+
+        let registry = WorkerRegistry::new();
+        registry.register(make_dp_worker(&base_a, 0, 2)).unwrap();
+        registry.register(make_dp_worker(&base_a, 1, 2)).unwrap();
+        registry.register(make_dp_worker(&base_b, 0, 1)).unwrap();
+
+        let client = reqwest::Client::new();
+        let result = WorkerManager::get_engine_metrics(&registry, &client).await;
+
+        assert!(matches!(result, EngineMetricsResult::Ok(_)));
+        assert_eq!(hits_a.load(Ordering::SeqCst), 1);
+        assert_eq!(hits_b.load(Ordering::SeqCst), 1);
     }
 
     fn cfg(success_threshold: u32, failure_threshold: u32) -> HealthCheckConfig {

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -1085,10 +1085,10 @@ mod tests {
                 }
             }),
         );
-        let port = portpicker::pick_unused_port().expect("free port");
-        let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind stub");
+        let addr = listener.local_addr().expect("stub address");
         #[expect(
             clippy::disallowed_methods,
             reason = "test stub server lives for the duration of the test process"
@@ -1096,7 +1096,7 @@ mod tests {
         tokio::spawn(async move {
             axum::serve(listener, app).await.expect("stub serve");
         });
-        format!("http://127.0.0.1:{port}")
+        format!("http://{addr}")
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

#1993: with `--dp-aware`, `worker.url()` is formatted as `http://{ip}:{port}@{dp_rank}`. The `@rank` suffix is an SMG-internal routing convention, not a real server address — so `GET /engine_metrics` fanned out to `http://ip:port@rank/metrics`, an invalid endpoint, and every scrape failed with **"All backend requests failed"** (HTTP 500). Additionally, each DP rank was scraped individually even though all ranks share one base worker's metrics endpoint.

Closes #1993

### Solution

- `fan_out` now addresses `worker.base_url()` (rank-free endpoint) instead of `worker.url()`. Its only caller is `get_engine_metrics` — admin fan-outs (`flush_cache`, profiling) use a separate path and are unaffected.
- `get_engine_metrics` dedupes workers by `base_url()` before the fan-out, so each base worker is scraped **once per call**, not once per DP rank. The `worker_addr` metric label now identifies the base worker.

Heads-up: touches `get_engine_metrics`/`fan_out`, which #1774 (W1, assigned) also modifies — small surface, should merge cleanly either way.

## Changes

- `model_gateway/src/worker/manager.rs`
  - `fan_out`: request URL from `worker.base_url()` + doc comment on the contract
  - `get_engine_metrics`: dedupe by base URL before fan-out
  - 2 new end-to-end tests with a loopback HTTP stub

## Test Plan

Repro from #1993: `--dp-aware` fleet, `GET /engine_metrics` previously 500'd with "All backend requests failed"; now returns aggregated metrics with one scrape per base worker.

New tests (loopback axum stub counting `/metrics` hits):

- `engine_metrics_scrapes_dp_workers_via_base_url_once` — two DP ranks on one base: returns metrics, stub hit **exactly once** (pre-fix: all requests to `http://127.0.0.1:port@rank/metrics` fail → `Err`, reproducing the bug)
- `engine_metrics_scrapes_each_distinct_base_worker` — DP pair + another base: each base scraped once

Both failed pre-fix for the right reason (TDD).

Gate output (macOS, rustc 1.97.1 stable):

- `cargo test -p smg --lib` — **1325 passed, 0 failed** (1323 + 2 new)
- `cargo +nightly fmt --all` — silent success
- `cargo clippy -p smg --all-targets -- -D warnings` — only the pre-existing `unneeded_wildcard_pattern` at `model_gateway/src/worker/monitor.rs:744` (untouched here, as noted in #1975/#1977); changed file lint-clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (changed file clean; one pre-existing lint elsewhere, noted above)
- [ ] (Optional) Documentation updated — N/A
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated routing for data-parallel workers to use their shared base endpoints, avoiding misdirected fan-out.
  * Prevented duplicate `/metrics` requests when multiple ranks share the same worker base.
  * Ensured monitoring reflects one scrape per distinct shared base worker per call.

* **Tests**
  * Added coverage to verify DP-aware metrics scraping behavior, including shared-base deduping and distinct-base scraping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->