### PR TITLE
chore(release): bump versions for v1.9.0

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+SGLang |
   ${{ github.event_name == 'push' && 'base=lmsysorg/sglang:v0.5.16' || format('base={0}', inputs.base_image_ref || 'lmsysorg/sglang:v0.5.16') }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.8.0'
+        default: 'v1.9.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.8.0-sglang-v0.5.16)'
+        description: 'Override image tag (e.g. v1.9.0-sglang-v0.5.16)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+TRTLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc22') }} |
   engine=${{ inputs.trtllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.8.0'
+        default: 'v1.9.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.8.0-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.9.0-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
       source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+vLLM |
   ${{ github.event_name == 'push' && '3-version matrix' || format('base={0}', inputs.base_image_ref || 'vllm/vllm-openai:v0.26.0') }} |
   engine=${{ inputs.vllm_commit || 'latest' }} |
-  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }} |
+  smg=${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }} |
   ${{ github.event_name == 'pull_request' && 'dry-run |' || '' }}
   by @${{ github.actor }}
 
@@ -44,10 +44,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.8.0'
+        default: 'v1.9.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.8.0-vllm-v0.26.0)'
+        description: 'Override image tag (e.g. v1.9.0-vllm-v0.26.0)'
         required: false
         type: string
 
@@ -68,7 +68,7 @@ jobs:
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.8.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.9.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,20 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.10.0", path = "crates/protocols" }
+openai-protocol = { version = "1.11.0", path = "crates/protocols" }
 smg-mm-rdma = { version = "0.1.0", path = "crates/mm_rdma" }
-reasoning-parser = { version = "1.5.0", path = "crates/reasoning_parser" }
-tool-parser = { version = "1.5.0", path = "crates/tool_parser" }
+reasoning-parser = { version = "1.6.0", path = "crates/reasoning_parser" }
+tool-parser = { version = "1.6.0", path = "crates/tool_parser" }
 wfaas = { version = "1.0.5", path = "crates/workflow" }
-llm-tokenizer = { version = "1.5.0", path = "crates/tokenizer" }
+llm-tokenizer = { version = "1.6.0", path = "crates/tokenizer" }
 smg-auth = { version = "1.2.2", path = "crates/auth" }
 smg-mcp = { version = "2.3.2", path = "crates/mcp" }
 kv-index = { version = "1.3.2", path = "crates/kv_index" }
 smg-data-connector = { version = "2.3.3", path = "crates/data_connector", package = "data-connector" }
-llm-multimodal = { version = "1.8.0", path = "crates/multimodal" }
+llm-multimodal = { version = "1.9.0", path = "crates/multimodal" }
 smg-wasm = { version = "1.1.3", path = "crates/wasm", package = "smg-wasm" }
 smg-mesh = { version = "1.4.2", path = "crates/mesh", package = "smg-mesh" }
-smg-grpc-client = { version = "1.9.0", path = "crates/grpc_client" }
+smg-grpc-client = { version = "1.10.0", path = "crates/grpc_client" }
 
 # Shared dependencies
 anyhow = "1.0"

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.8.0"
+version = "1.9.0"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-grpc-client"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 description = "gRPC clients for vLLM, TensorRT-LLM, MLX, TokenSpeed, and SGLang backends"
 license = "Apache-2.0"

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-multimodal"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.10.0"
+version = "1.11.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/crates/reasoning_parser/Cargo.toml
+++ b/crates/reasoning_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasoning-parser"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"

--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-tokenizer"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "LLM tokenizer library with caching and chat template support"
 license = "Apache-2.0"

--- a/crates/tool_parser/Cargo.toml
+++ b/crates/tool_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool-parser"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 description = "Tool/function call parser for LLM model outputs"
 license = "Apache-2.0"

--- a/deploy/helm/smg/Chart.yaml
+++ b/deploy/helm/smg/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: smg
 description: "Shepherd Model Gateway - high-performance inference router for LLM deployments"
 type: application
-version: 1.8.0
-appVersion: "1.8.0"
+version: 1.9.0
+appVersion: "1.9.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/lightseekorg/smg
 sources:

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-servicer"
-version = "0.7.0"
+version = "0.8.0"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, MLX, TokenSpeed, SGLang)"
 requires-python = ">=3.10"
 dependencies = [

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description

### Problem

Version bumps for the v1.9.0 release: 7 workspace crates and the gRPC servicer changed since v1.8.0, and the bindings/helm/docker release surfaces need to sync.

### Solution

`make check-versions` fixes, with one deliberate deviation:

- Minor bumps for changed crates: openai-protocol → 1.11.0, reasoning-parser / tool-parser / llm-tokenizer → 1.6.0, llm-multimodal → 1.9.0, smg-grpc-client → 1.10.0, smg → 1.9.0 (workspace `Cargo.toml` synced).
- Synced to v1.9.0: smg-python, smg-golang, python pyproject, helm chart, sglang/vllm/trtllm docker release workflows.
- **`smg-grpc-servicer` → 0.8.0, not the proposed 0.7.1 patch**: this cycle's servicer port (#1970) drops compatibility with sglang < 0.5.16 (legacy `get_loads` IPC removed upstream, msgspec struct contract). A patch release would flow into `~=0.7.0` pins on older-sglang deployments and fail at import; the minor bump keeps them safe.

Release-note reminder for the v1.9.0 GitHub Release: carry the breaking-change blockquote from #1970 (servicer and SGLang must upgrade together; pip enforces the floor).

## Test Plan

- `make check-versions` re-run: "All versions consistent."

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Updates**
  - Updated the platform release version to 1.9.0 across published packages and deployment metadata.
  - Updated default container build references to use the 1.9.0 release.

- **Component Versioning**
  - Advanced related protocol, tokenizer, parser, multimodal, gateway, and client component versions.
  - Updated the gRPC service package to version 0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->