### PR TITLE
fix(scheduler): retain worker capacity tracking

### DIFF
--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -25,6 +25,7 @@ use super::{
     slots::SlotPool,
     Class, ClassRuntimeConfig, SchedulerSettings,
 };
+use crate::worker::WorkerCapacity;
 
 /// Max time to wait, after firing a preemption cancel, for the victim's slot
 /// to free before falling back to enqueue.
@@ -479,6 +480,25 @@ impl PriorityScheduler {
     /// on the scheduler fires `release_notify`, which lets the
     /// dispatcher observe the failed upgrade and exit.
     pub fn spawn_dispatcher(self: &Arc<Self>, capacity_watch: watch::Receiver<u16>) {
+        self.spawn_dispatcher_inner(capacity_watch, None);
+    }
+
+    /// Spawn the dispatcher while retaining the capacity tracker that owns
+    /// the watch sender. The dispatcher is the tracker consumer, so its task
+    /// owns the tracker for exactly as long as dynamic capacity is needed.
+    pub(crate) fn spawn_dispatcher_retaining_capacity(
+        self: &Arc<Self>,
+        capacity_watch: watch::Receiver<u16>,
+        worker_capacity: Arc<WorkerCapacity>,
+    ) {
+        self.spawn_dispatcher_inner(capacity_watch, Some(worker_capacity));
+    }
+
+    fn spawn_dispatcher_inner(
+        self: &Arc<Self>,
+        capacity_watch: watch::Receiver<u16>,
+        capacity_owner: Option<Arc<WorkerCapacity>>,
+    ) {
         let weak = Arc::downgrade(self);
         let notify = Arc::clone(&self.release_notify);
         // Periodic tick so the starvation override can fire even when no
@@ -495,6 +515,9 @@ impl PriorityScheduler {
             reason = "dispatcher loop holds only a Weak<Self> and exits when the scheduler is dropped (Drop fires release_notify)"
         )]
         tokio::spawn(async move {
+            // Keep the sender and its worker-event task alive until this
+            // dispatcher exits. Existing receiver-only callers pass None.
+            let capacity_owner = capacity_owner;
             // `Option<watch::Receiver>` so we can drop the receiver once the
             // upstream sender is closed. A bare `Receiver` whose sender is
             // gone makes `changed()` resolve `Err` immediately on every
@@ -504,6 +527,9 @@ impl PriorityScheduler {
             let mut tick = tokio::time::interval(tick_period);
             tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
+                // This read keeps an optional tracker owned by the task for
+                // every iteration, without extending Scheduler's lifetime.
+                let _ = capacity_owner.as_ref();
                 let new_capacity = match capacity_watch.as_mut() {
                     Some(rx) => tokio::select! {
                         () = notify.notified() => None,

--- a/model_gateway/src/middleware/scheduler/state.rs
+++ b/model_gateway/src/middleware/scheduler/state.rs
@@ -101,9 +101,13 @@ impl AdmissionMode {
         )
         .map_err(|e| e.to_string())?;
 
-        let scheduler = PriorityScheduler::new(&settings, worker_capacity.current())
+        // Subscribe before reading the initial value. If capacity changes
+        // while the scheduler is being built, the receiver records that
+        // change and the dispatcher applies it instead of missing it.
+        let capacity_watch = worker_capacity.watch();
+        let scheduler = PriorityScheduler::new(&settings, *capacity_watch.borrow())
             .map_err(|e| e.to_string())?;
-        scheduler.spawn_dispatcher(worker_capacity.watch());
+        scheduler.spawn_dispatcher_retaining_capacity(capacity_watch, worker_capacity);
         scheduler.spawn_sampler(SAMPLER_INTERVAL);
 
         let resolver: Arc<dyn TenantPolicyResolver> =
@@ -132,4 +136,69 @@ fn load_yaml(path: Option<&str>) -> Result<Option<super::PrioritySchedulerYaml>,
     let contents = std::fs::read_to_string(path).map_err(|e| format!("reading {path}: {e}"))?;
     let parsed = serde_yaml::from_str(&contents).map_err(|e| format!("parsing {path}: {e}"))?;
     Ok(Some(parsed))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, time::Instant};
+
+    use smg_auth::RequestId;
+    use tokio::time::{sleep, Duration};
+
+    use super::*;
+    use crate::worker::BasicWorkerBuilder;
+
+    #[tokio::test]
+    async fn priority_mode_applies_capacity_changes_after_startup() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let config = RouterConfig {
+            max_concurrent_requests: 256,
+            priority_scheduler_enabled: true,
+            ..RouterConfig::default()
+        };
+        let AdmissionMode::Priority(state) =
+            AdmissionMode::try_build_priority(&config, Arc::clone(&registry), None).unwrap()
+        else {
+            panic!("priority scheduler should start");
+        };
+
+        let mut labels = HashMap::new();
+        labels.insert("max_running_requests".to_string(), "1".to_string());
+        let worker = Arc::new(
+            BasicWorkerBuilder::new("http://capacity-test:8000")
+                .labels(labels)
+                .status(openai_protocol::worker::WorkerStatus::Ready)
+                .build(),
+        );
+        registry.register(worker).expect("worker should register");
+
+        // The dispatcher must retain the tracker and apply its update. Once
+        // capacity drops to one, a second System request cannot acquire a
+        // slot while the first is still in flight.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut attempt = 0;
+        loop {
+            let first = state.scheduler.acquire_inflight(
+                Class::System,
+                RequestId(format!("capacity-first-{attempt}")),
+            );
+            let second = state.scheduler.acquire_inflight(
+                Class::System,
+                RequestId(format!("capacity-second-{attempt}")),
+            );
+            let updated = first.is_some() && second.is_none();
+            drop(second);
+            drop(first);
+
+            if updated {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "scheduler did not apply the worker capacity update"
+            );
+            attempt += 1;
+            sleep(Duration::from_millis(10)).await;
+        }
+    }
 }

--- a/model_gateway/src/middleware/scheduler/state.rs
+++ b/model_gateway/src/middleware/scheduler/state.rs
@@ -90,6 +90,11 @@ impl AdmissionMode {
             ..CapacityTrackerSettings::default()
         };
         let worker_capacity = WorkerCapacity::spawn(registry, cap_settings);
+        // Keep a receiver alive as soon as the tracker exists. Tokio's
+        // `watch::Sender::send` does not retain a value when no receiver is
+        // subscribed, so parsing the scheduler configuration must not create
+        // a gap where the first fleet update is lost.
+        let capacity_watch = worker_capacity.watch();
 
         let default_max_class = Class::parse_header(&rc.priority_scheduler_default_max_class);
         let yaml = load_yaml(rc.priority_scheduler_config.as_deref())?;
@@ -101,11 +106,10 @@ impl AdmissionMode {
         )
         .map_err(|e| e.to_string())?;
 
-        // Subscribe before reading the initial value. If capacity changes
-        // while the scheduler is being built, the receiver records that
-        // change and the dispatcher applies it instead of missing it.
-        let capacity_watch = worker_capacity.watch();
-        let scheduler = PriorityScheduler::new(&settings, *capacity_watch.borrow())
+        // The atomic value covers any update that won the race before the
+        // receiver subscribed; subsequent updates remain queued for the
+        // dispatcher through `capacity_watch`.
+        let scheduler = PriorityScheduler::new(&settings, worker_capacity.current())
             .map_err(|e| e.to_string())?;
         scheduler.spawn_dispatcher_retaining_capacity(capacity_watch, worker_capacity);
         scheduler.spawn_sampler(SAMPLER_INTERVAL);


### PR DESCRIPTION
## Description

### Problem

`WorkerCapacity` is constructed only while priority admission starts. Its event task keeps a weak reference, so its watch sender is dropped at the end of setup. The priority dispatcher then stops receiving worker-fleet capacity changes and can keep the bootstrap capacity after workers scale or become unhealthy.

### Solution

The dispatcher now owns the capacity tracker for its own lifetime. It subscribes before reading the initial value, so an update during setup is retained and applied. The scheduler still owns no tracker reference, so dropping the scheduler stops the dispatcher and releases the tracker.

## Changes

- Retain `WorkerCapacity` in the priority dispatcher task.
- Subscribe to capacity updates before constructing the scheduler snapshot.
- Add a regression test: after a ready worker with capacity one is registered, a second system admission is rejected while the first is active.

## Test Plan

- Passed cargo nightly format check.
- Passed targeted scheduler regression test with protoc 35.1 available: 1 passed.
- Passed `cargo clippy -p smg --lib -- -D warnings`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo clippy -p smg --lib -- -D warnings` passes
- [x] Targeted regression test passes
- [ ] Documentation updated: behavior already documented; this restores it
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved priority scheduling to apply worker-capacity updates reliably after startup.
  * Prevented capacity changes occurring during scheduler initialization from being missed.
  * Ensured concurrency limits reflect updated capacity while the scheduler is running.
* **Tests**
  * Added a Tokio test covering post-startup priority admission behavior under constrained capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->