### PR TITLE
fix(router): configure model aliases for service discovery

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -486,6 +486,7 @@ struct Router {
     encode_policy: Option<PolicyType>,
     multimodal_tensor_transport: Option<String>,
     multimodal_shm_min_bytes: Option<usize>,
+    model_aliases: HashMap<String, String>,
 }
 
 impl Router {
@@ -795,6 +796,7 @@ impl Router {
             .maybe_model_path(self.model_path.as_ref())
             .maybe_tokenizer_path(self.tokenizer_path.as_ref())
             .maybe_chat_template(self.chat_template.as_ref())
+            .model_aliases(self.model_aliases.clone())
             .maybe_oracle(oracle)
             .maybe_postgres(postgres_config)
             .maybe_redis(redis_config)
@@ -953,6 +955,7 @@ impl Router {
         encode_policy = None,
         multimodal_tensor_transport = None,
         multimodal_shm_min_bytes = None,
+        model_aliases = HashMap::new(),
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1079,6 +1082,7 @@ impl Router {
         encode_policy: Option<PolicyType>,
         multimodal_tensor_transport: Option<String>,
         multimodal_shm_min_bytes: Option<usize>,
+        model_aliases: HashMap<String, String>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1219,6 +1223,7 @@ impl Router {
             encode_policy,
             multimodal_tensor_transport,
             multimodal_shm_min_bytes,
+            model_aliases,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -93,6 +93,7 @@ class RouterArgs:
     router_selector: dict[str, str] = dataclasses.field(default_factory=dict)
     bootstrap_port_annotation: str = "sglang.ai/bootstrap-port"
     model_id_from: str | None = None
+    model_aliases: dict[str, str] = dataclasses.field(default_factory=dict)
     # Prometheus configuration
     prometheus_port: int | None = None
     prometheus_host: str | None = None
@@ -678,6 +679,17 @@ class RouterArgs:
                 "Override each worker's model ID from pod metadata."
                 " Accepted values: 'namespace', 'label:<key>', 'annotation:<key>'."
                 " The backend-discovered model name becomes an alias."
+            ),
+        )
+        k8s_group.add_argument(
+            f"--{prefix}model-alias",
+            type=str,
+            action="append",
+            default=[],
+            help=(
+                "Accept an extra client-facing model name for a served model."
+                " Format: <alias>=<canonical>. Repeat for multiple aliases."
+                " Matching is case-sensitive."
             ),
         )
         # Prometheus configuration
@@ -1323,6 +1335,9 @@ class RouterArgs:
         args_dict["storage_context_headers"] = cls._parse_selector(
             cli_args_dict.get(f"{prefix}storage_context_headers", None)
         )
+        args_dict["model_aliases"] = cls._parse_model_aliases(
+            cli_args_dict.get(f"{prefix}model_alias", [])
+        )
 
         # Mooncake-specific annotation
         args_dict["bootstrap_port_annotation"] = "sglang.ai/bootstrap-port"
@@ -1378,6 +1393,34 @@ class RouterArgs:
                 key, value = item.split("=", 1)
                 selector[key] = value
         return selector
+
+    @staticmethod
+    def _parse_model_aliases(alias_list):
+        if not alias_list:
+            return {}
+
+        aliases = {}
+        for item in alias_list:
+            if "=" not in item:
+                raise ValueError(
+                    f"Invalid model alias '{item}'. Expected format: <alias>=<canonical>"
+                )
+            alias, canonical = item.split("=", 1)
+            if not alias or not canonical:
+                raise ValueError(
+                    f"Invalid model alias '{item}'. Alias and canonical model ID must be non-empty"
+                )
+            if alias == canonical:
+                raise ValueError(
+                    f"Invalid model alias '{item}'. Alias must differ from the canonical model ID"
+                )
+            previous = aliases.get(alias)
+            if previous is not None and previous != canonical:
+                raise ValueError(
+                    f"Invalid model alias '{alias}'. It maps to both '{previous}' and '{canonical}'"
+                )
+            aliases[alias] = canonical
+        return aliases
 
     @staticmethod
     def _parse_prefill_urls(prefill_list):

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -93,7 +93,6 @@ class RouterArgs:
     router_selector: dict[str, str] = dataclasses.field(default_factory=dict)
     bootstrap_port_annotation: str = "sglang.ai/bootstrap-port"
     model_id_from: str | None = None
-    model_aliases: dict[str, str] = dataclasses.field(default_factory=dict)
     # Prometheus configuration
     prometheus_port: int | None = None
     prometheus_host: str | None = None
@@ -201,6 +200,8 @@ class RouterArgs:
     mesh_advertise_host: str | None = None
     mesh_port: int = 39527
     mesh_peer_urls: list[str] = dataclasses.field(default_factory=list)
+    # Append new fields here to preserve positional callers.
+    model_aliases: dict[str, str] = dataclasses.field(default_factory=dict)
 
     @staticmethod
     def add_cli_args(

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -5,6 +5,7 @@ These tests focus on testing the argument parsing logic in isolation,
 without starting actual router instances.
 """
 
+import argparse
 from types import SimpleNamespace
 
 import pytest
@@ -72,6 +73,30 @@ class TestRouterArgs:
         # Test multiple equals signs (should use first one)
         result = RouterArgs._parse_selector(["app=worker=extra"])
         assert result == {"app": "worker=extra"}
+
+    def test_parse_model_aliases(self):
+        result = RouterArgs._parse_model_aliases(
+            ["GLM-5.2-Coding=GLM-5.2", "glm-5.2=GLM-5.2"]
+        )
+
+        assert result == {
+            "GLM-5.2-Coding": "GLM-5.2",
+            "glm-5.2": "GLM-5.2",
+        }
+
+    @pytest.mark.parametrize(
+        "entries",
+        [
+            ["missing-separator"],
+            ["=GLM-5.2"],
+            ["GLM-5.2-Coding="],
+            ["GLM-5.2=GLM-5.2"],
+            ["shared=model-a", "shared=model-b"],
+        ],
+    )
+    def test_parse_model_aliases_rejects_invalid_entries(self, entries):
+        with pytest.raises(ValueError):
+            RouterArgs._parse_model_aliases(entries)
 
     def test_parse_prefill_urls_valid(self):
         """Test parsing valid prefill URL arguments."""
@@ -664,6 +689,32 @@ class TestParseRouterArgs:
             assert router_args.selector == {"app": "worker", "env": "prod"}
             assert router_args.service_discovery_port == 8080
             assert router_args.service_discovery_namespace == "default"
+
+    def test_parse_repeated_model_alias_args(self):
+        router_args = parse_router_args(
+            [
+                "--model-alias",
+                "GLM-5.2-Coding=GLM-5.2",
+                "--model-alias",
+                "glm-5.2=GLM-5.2",
+            ]
+        )
+
+        assert router_args.model_aliases == {
+            "GLM-5.2-Coding": "GLM-5.2",
+            "glm-5.2": "GLM-5.2",
+        }
+
+    def test_parse_prefixed_model_alias_args(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args(
+            ["--router-model-alias", "GLM-5.2-Coding=GLM-5.2"]
+        )
+
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+
+        assert router_args.model_aliases == {"GLM-5.2-Coding": "GLM-5.2"}
 
     def test_parse_retry_and_circuit_breaker_args(self):
         """Test parsing retry and circuit breaker arguments."""

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -75,9 +75,7 @@ class TestRouterArgs:
         assert result == {"app": "worker=extra"}
 
     def test_parse_model_aliases(self):
-        result = RouterArgs._parse_model_aliases(
-            ["GLM-5.2-Coding=GLM-5.2", "glm-5.2=GLM-5.2"]
-        )
+        result = RouterArgs._parse_model_aliases(["GLM-5.2-Coding=GLM-5.2", "glm-5.2=GLM-5.2"])
 
         assert result == {
             "GLM-5.2-Coding": "GLM-5.2",
@@ -708,9 +706,7 @@ class TestParseRouterArgs:
     def test_parse_prefixed_model_alias_args(self):
         parser = argparse.ArgumentParser()
         RouterArgs.add_cli_args(parser, use_router_prefix=True)
-        namespace = parser.parse_args(
-            ["--router-model-alias", "GLM-5.2-Coding=GLM-5.2"]
-        )
+        namespace = parser.parse_args(["--router-model-alias", "GLM-5.2-Coding=GLM-5.2"])
 
         router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -245,7 +245,9 @@ Note: Enabling service discovery automatically enables IGW mode.
 
 | Option | Description |
 |--------|-------------|
-| `--model-alias` | Accept an extra client-facing model name for a served model (format: `<alias>=<canonical>`, repeatable). Applied to every locally registered worker whose model ID equals the canonical side, including workers registered by Kubernetes service discovery. Matching is case-sensitive. Aliased requests are routed to the canonical model and answered with the canonical model ID; `/v1/models` lists canonical IDs only. |
+| `--model-alias` | Accept an extra client-facing model name for a served model (format: `<alias>=<canonical>`, repeatable). Applied after worker metadata discovery to every local worker whose model ID equals the canonical side. Matching is case-sensitive. Aliased requests are sent to the canonical model; backend responses are passed through unchanged. `/v1/models` lists canonical IDs only. |
+
+Aliases do not participate in Kubernetes Pod selection or model discovery. A discovered worker's canonical model ID continues to come from the backend `served_model_name`; aliases only add names that resolve to that canonical ID after registration.
 
 Example:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -241,6 +241,21 @@ Note: Enabling service discovery automatically enables IGW mode.
 |--------|-------------|
 | `--model-id-from` | Override each worker's `model_id` from pod metadata. Accepted values: `namespace`, `label:<key>`, or `annotation:<key>`. |
 
+### Model Aliases
+
+| Option | Description |
+|--------|-------------|
+| `--model-alias` | Accept an extra client-facing model name for a served model (format: `<alias>=<canonical>`, repeatable). Applied to every locally registered worker whose model ID equals the canonical side, including workers registered by Kubernetes service discovery. Matching is case-sensitive. Aliased requests are routed to the canonical model and answered with the canonical model ID; `/v1/models` lists canonical IDs only. |
+
+Example:
+
+```bash
+smg launch \
+  --service-discovery ... \
+  --model-alias GLM-5.2-Coding=GLM-5.2 \
+  --model-alias glm-5.2=GLM-5.2
+```
+
 ---
 
 ## Tokenizer Configuration

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -472,6 +472,12 @@ impl RouterConfigBuilder {
         self
     }
 
+    /// Alias → canonical model ID map applied to locally created workers.
+    pub fn model_aliases(mut self, aliases: HashMap<String, String>) -> Self {
+        self.config.model_aliases = aliases;
+        self
+    }
+
     pub fn disable_tokenizer_autoload(mut self, disable: bool) -> Self {
         self.config.disable_tokenizer_autoload = disable;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -122,6 +122,14 @@ pub struct RouterConfig {
     /// Overrides model_path tokenizer if provided
     pub tokenizer_path: Option<String>,
     pub chat_template: Option<String>,
+    /// Alias → canonical model ID map. At worker creation, every alias whose
+    /// canonical ID equals the worker's model ID is added to that model's
+    /// `ModelCard.aliases`. This is the configuration entry for deployments
+    /// whose workers are registered automatically (startup URLs or Kubernetes
+    /// service discovery), where no caller supplies a `ModelCard` by hand.
+    /// Lookup stays case-sensitive; entries name exact client-sent strings.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub model_aliases: HashMap<String, String>,
     /// Disable automatic tokenizer loading at startup and worker registration
     #[serde(default)]
     pub disable_tokenizer_autoload: bool,
@@ -822,6 +830,7 @@ impl Default for RouterConfig {
             tokenizer_path: None,
             chat_template: None,
             disable_tokenizer_autoload: false,
+            model_aliases: HashMap::new(),
             history_backend: default_history_backend(),
             oracle: None,
             postgres: None,

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -83,6 +83,7 @@ impl ConfigValidator {
         Self::validate_storage_context_headers(config)?;
         Self::validate_tenant_resolution(config)?;
         Self::validate_tenant_api_keys(config)?;
+        Self::validate_model_aliases(config)?;
         if let Some(discovery) = &config.discovery {
             Self::validate_discovery(discovery, &config.mode)?;
         }
@@ -114,6 +115,27 @@ impl ConfigValidator {
         }
 
         Self::validate_tokenizer_cache(&config.tokenizer_cache)?;
+
+        Ok(())
+    }
+
+    fn validate_model_aliases(config: &RouterConfig) -> ConfigResult<()> {
+        for (alias, canonical) in &config.model_aliases {
+            if alias.is_empty() || canonical.is_empty() {
+                return Err(ConfigError::InvalidValue {
+                    field: "model_aliases".to_string(),
+                    value: format!("{alias}={canonical}"),
+                    reason: "Alias and canonical model ID must be non-empty".to_string(),
+                });
+            }
+            if alias == canonical {
+                return Err(ConfigError::InvalidValue {
+                    field: "model_aliases".to_string(),
+                    value: alias.clone(),
+                    reason: "Alias must differ from the canonical model ID".to_string(),
+                });
+            }
+        }
 
         Ok(())
     }
@@ -1104,6 +1126,29 @@ mod tests {
         );
 
         assert!(ConfigValidator::validate(&config).is_ok());
+    }
+
+    #[test]
+    fn test_validate_model_aliases() {
+        let mut config = regular_mode_config();
+        config.model_aliases = std::collections::HashMap::from([
+            ("GLM-5.2-Coding".to_string(), "GLM-5.2".to_string()),
+            ("glm-5.2".to_string(), "GLM-5.2".to_string()),
+        ]);
+        assert!(ConfigValidator::validate(&config).is_ok());
+
+        for (alias, canonical) in [
+            ("", "GLM-5.2"),
+            ("GLM-5.2-Coding", ""),
+            ("GLM-5.2", "GLM-5.2"),
+        ] {
+            config.model_aliases =
+                std::collections::HashMap::from([(alias.to_string(), canonical.to_string())]);
+            assert!(matches!(
+                ConfigValidator::validate(&config),
+                Err(ConfigError::InvalidValue { ref field, .. }) if field == "model_aliases"
+            ));
+        }
     }
 
     fn regular_mode_config() -> RouterConfig {

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -373,6 +373,14 @@ struct CliArgs {
     #[arg(long, help_heading = "Service Discovery (Kubernetes)", value_parser = parse_model_id_from)]
     model_id_from: Option<String>,
 
+    /// Accept an extra client-facing model name for a served model
+    /// (format: alias=canonical, repeatable). Applied to every locally
+    /// registered worker whose model ID equals the canonical side,
+    /// including workers registered by Kubernetes service discovery.
+    /// Matching is case-sensitive.
+    #[arg(long = "model-alias", action = ArgAction::Append, value_parser = parse_model_alias, help_heading = "Routing Policy")]
+    model_alias: Vec<String>,
+
     // ==================== Logging ====================
     /// Directory to store log files
     #[arg(long, help_heading = "Logging")]
@@ -834,6 +842,26 @@ enum OracleConnectSource {
 /// Validate `--model-id-from` value at CLI parse time.
 fn parse_model_id_from(s: &str) -> Result<String, String> {
     ModelIdSource::parse(s)?;
+    Ok(s.to_string())
+}
+
+/// Validate `--model-alias` value at CLI parse time (format: alias=canonical).
+fn parse_model_alias(s: &str) -> Result<String, String> {
+    let Some((alias, canonical)) = s.split_once('=') else {
+        return Err(format!(
+            "Invalid model-alias value '{s}'. Expected: <alias>=<canonical>"
+        ));
+    };
+    if alias.is_empty() || canonical.is_empty() {
+        return Err(format!(
+            "Invalid model-alias value '{s}'. Alias and canonical model ID must be non-empty"
+        ));
+    }
+    if alias == canonical {
+        return Err(format!(
+            "Invalid model-alias value '{s}'. Alias must differ from the canonical model ID"
+        ));
+    }
     Ok(s.to_string())
 }
 
@@ -1387,6 +1415,29 @@ impl CliArgs {
             _ => (None, None, None),
         };
 
+        // clap validated each entry's shape; here we only reject the same
+        // alias naming two different canonical models, which would make the
+        // routing outcome depend on argument order.
+        let mut model_aliases: HashMap<String, String> = HashMap::new();
+        for entry in &self.model_alias {
+            let Some((alias, canonical)) = entry.split_once('=') else {
+                return Err(ConfigError::InvalidValue {
+                    field: "model_alias".to_string(),
+                    value: entry.clone(),
+                    reason: "Expected: <alias>=<canonical>".to_string(),
+                });
+            };
+            if let Some(previous) = model_aliases.insert(alias.to_string(), canonical.to_string()) {
+                if previous != canonical {
+                    return Err(ConfigError::InvalidValue {
+                        field: "model_alias".to_string(),
+                        value: alias.to_string(),
+                        reason: format!("Alias maps to both '{previous}' and '{canonical}'"),
+                    });
+                }
+            }
+        }
+
         let builder = RouterConfig::builder()
             .mode(mode)
             .policy(policy)
@@ -1464,6 +1515,7 @@ impl CliArgs {
             .maybe_model_path(self.model_path.as_ref())
             .maybe_tokenizer_path(self.tokenizer_path.as_ref())
             .maybe_chat_template(self.chat_template.as_ref())
+            .model_aliases(model_aliases)
             .maybe_oracle(oracle)
             .maybe_postgres(postgres)
             .maybe_redis(redis)

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -378,7 +378,7 @@ struct CliArgs {
     /// registered worker whose model ID equals the canonical side,
     /// including workers registered by Kubernetes service discovery.
     /// Matching is case-sensitive.
-    #[arg(long = "model-alias", action = ArgAction::Append, value_parser = parse_model_alias, help_heading = "Routing Policy")]
+    #[arg(long = "model-alias", action = ArgAction::Append, value_parser = parse_model_alias, help_heading = "Service Discovery (Kubernetes)")]
     model_alias: Vec<String>,
 
     // ==================== Logging ====================
@@ -1912,5 +1912,16 @@ mod tests {
 
         let server_config = cli.to_server_config(router_config).unwrap();
         assert_eq!(server_config.runtime_worker_threads, None);
+    }
+
+    #[test]
+    fn conflicting_model_aliases_are_rejected() {
+        let cli = cli_args_from(&["--model-alias", "x=a", "--model-alias", "x=b"]);
+
+        assert!(matches!(
+            cli.to_router_config(vec![], vec![]),
+            Err(ConfigError::InvalidValue { field, reason, .. })
+                if field == "model_alias" && reason == "Alias maps to both 'a' and 'b'"
+        ));
     }
 }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -74,6 +74,41 @@ pub struct Router {
     webrtc_stun_server: Option<String>,
 }
 
+trait RealtimeRestRequest: serde::Serialize + Clone {
+    fn model(&self) -> Option<&str>;
+    fn set_model(&mut self, model: String);
+}
+
+impl RealtimeRestRequest for RealtimeSessionCreateRequest {
+    fn model(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+
+    fn set_model(&mut self, model: String) {
+        self.model = Some(model);
+    }
+}
+
+impl RealtimeRestRequest for RealtimeClientSecretCreateRequest {
+    fn model(&self) -> Option<&str> {
+        self.session.model.as_deref()
+    }
+
+    fn set_model(&mut self, model: String) {
+        self.session.model = Some(model);
+    }
+}
+
+impl RealtimeRestRequest for RealtimeTranscriptionSessionCreateRequest {
+    fn model(&self) -> Option<&str> {
+        self.model.as_deref()
+    }
+
+    fn set_model(&mut self, model: String) {
+        self.model = Some(model);
+    }
+}
+
 impl std::fmt::Debug for Router {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Router")
@@ -235,6 +270,47 @@ impl Router {
                 ..Default::default()
             })
             .await
+    }
+
+    async fn route_realtime_rest<T: RealtimeRestRequest + Sync>(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &T,
+        endpoint: &'static str,
+        endpoint_label: &'static str,
+    ) -> Response {
+        let requested_model = body.model().unwrap_or_default();
+        let canonical_model = self.worker_registry.resolve_model_alias(requested_model);
+        let model = canonical_model.as_deref().unwrap_or(requested_model);
+        let worker = self.select_realtime_worker(model, headers).await;
+
+        if let Some(canonical_model) = canonical_model.as_deref() {
+            let mut body = body.clone();
+            body.set_model(canonical_model.to_string());
+            forward_realtime_rest(
+                RealtimeLabels::HTTP,
+                &self.client,
+                worker,
+                headers,
+                &body,
+                model,
+                endpoint,
+                endpoint_label,
+            )
+            .await
+        } else {
+            forward_realtime_rest(
+                RealtimeLabels::HTTP,
+                &self.client,
+                worker,
+                headers,
+                body,
+                model,
+                endpoint,
+                endpoint_label,
+            )
+            .await
+        }
     }
 
     pub async fn route_typed_request<T: GenerationRequest + serde::Serialize + Clone>(
@@ -1340,15 +1416,9 @@ impl RouterTrait for Router {
         headers: Option<&HeaderMap>,
         body: &RealtimeSessionCreateRequest,
     ) -> Response {
-        let model = body.model.as_deref().unwrap_or_default();
-        let worker = self.select_realtime_worker(model, headers).await;
-        forward_realtime_rest(
-            RealtimeLabels::HTTP,
-            &self.client,
-            worker,
+        self.route_realtime_rest(
             headers,
             body,
-            model,
             "/v1/realtime/sessions",
             metrics_labels::ENDPOINT_REALTIME_SESSIONS,
         )
@@ -1360,15 +1430,9 @@ impl RouterTrait for Router {
         headers: Option<&HeaderMap>,
         body: &RealtimeClientSecretCreateRequest,
     ) -> Response {
-        let model = body.session.model.as_deref().unwrap_or_default();
-        let worker = self.select_realtime_worker(model, headers).await;
-        forward_realtime_rest(
-            RealtimeLabels::HTTP,
-            &self.client,
-            worker,
+        self.route_realtime_rest(
             headers,
             body,
-            model,
             "/v1/realtime/client_secrets",
             metrics_labels::ENDPOINT_REALTIME_CLIENT_SECRETS,
         )
@@ -1380,15 +1444,9 @@ impl RouterTrait for Router {
         headers: Option<&HeaderMap>,
         body: &RealtimeTranscriptionSessionCreateRequest,
     ) -> Response {
-        let model = body.model.as_deref().unwrap_or_default();
-        let worker = self.select_realtime_worker(model, headers).await;
-        forward_realtime_rest(
-            RealtimeLabels::HTTP,
-            &self.client,
-            worker,
+        self.route_realtime_rest(
             headers,
             body,
-            model,
             "/v1/realtime/transcription_sessions",
             metrics_labels::ENDPOINT_REALTIME_TRANSCRIPTION,
         )

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -73,7 +73,12 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
             .or_else(|| labels.get("model_path").cloned())
             .unwrap_or_else(|| UNKNOWN_MODEL_ID.to_string());
 
-        let model_card = build_model_card(&model_id, config, &labels);
+        let model_card = build_model_card(
+            &model_id,
+            config,
+            &labels,
+            &app_context.router_config.model_aliases,
+        );
 
         let runtime_type = match context.data.detected_runtime_type.as_deref() {
             Some(s) => s.parse::<RuntimeType>().unwrap_or(config.runtime_type),
@@ -200,6 +205,7 @@ fn build_model_card(
     model_id: &str,
     config: &WorkerSpec,
     labels: &HashMap<String, String>,
+    model_aliases: &HashMap<String, String>,
 ) -> ModelCard {
     let user_provided = config.models.find(model_id).is_some();
     let mut card = config
@@ -280,6 +286,18 @@ fn build_model_card(
         card.model_type |= ModelType::VISION;
     }
 
+    // Router-level alias map (`--model-alias alias=canonical`): attach every
+    // alias that names this canonical model. This is the only alias entry
+    // point for automatically registered workers (startup URLs, Kubernetes
+    // service discovery) — the backend reports a single served model name, so
+    // it can never declare aliases itself. A user-provided card keeps its own
+    // aliases; duplicates are skipped so re-registration stays idempotent.
+    for (alias, canonical) in model_aliases {
+        if canonical == &card.id && alias != &card.id && !card.aliases.contains(alias) {
+            card.aliases.push(alias.clone());
+        }
+    }
+
     card
 }
 
@@ -350,5 +368,63 @@ mod tests {
             normalize_url("localhost:30001", ConnectionMode::Grpc),
             "grpc://localhost:30001"
         );
+    }
+
+    fn alias_map(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(alias, canonical)| (alias.to_string(), canonical.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn model_alias_map_attaches_matching_aliases_to_discovered_card() {
+        // The service-discovery path supplies no user card, so the card is
+        // built from the discovered model ID alone; the router-level alias
+        // map is the only way it can gain aliases.
+        let spec = WorkerSpec::new("http://worker:8080");
+        let aliases = alias_map(&[
+            ("GLM-5.2-Coding", "GLM-5.2"),
+            ("other-alias", "other-model"),
+        ]);
+
+        let card = build_model_card("GLM-5.2", &spec, &HashMap::new(), &aliases);
+
+        assert_eq!(card.id, "GLM-5.2");
+        assert_eq!(card.aliases, vec!["GLM-5.2-Coding".to_string()]);
+    }
+
+    #[test]
+    fn model_alias_map_is_case_sensitive_and_skips_self_reference() {
+        let spec = WorkerSpec::new("http://worker:8080");
+        // Wrong-case canonical must not match; an alias equal to the model ID
+        // must not be attached (it would shadow the canonical entry).
+        let aliases = alias_map(&[("glm-5.2-coding", "glm-5.2"), ("GLM-5.2", "GLM-5.2")]);
+
+        let card = build_model_card("GLM-5.2", &spec, &HashMap::new(), &aliases);
+
+        assert!(card.aliases.is_empty());
+    }
+
+    #[test]
+    fn model_alias_map_does_not_duplicate_user_provided_alias() {
+        // POST /workers can already carry aliases in the spec; the router map
+        // must merge, not duplicate, so repeated registration stays stable.
+        let mut spec = WorkerSpec::new("http://worker:8080");
+        let card_with_alias = ModelCard::new("GLM-5.2").with_alias("GLM-5.2-Coding");
+        spec.models = vec![card_with_alias].into();
+        let aliases = alias_map(&[("GLM-5.2-Coding", "GLM-5.2"), ("glm-5.2", "GLM-5.2")]);
+
+        let card = build_model_card("GLM-5.2", &spec, &HashMap::new(), &aliases);
+
+        assert_eq!(
+            card.aliases
+                .iter()
+                .filter(|a| *a == "GLM-5.2-Coding")
+                .count(),
+            1
+        );
+        assert!(card.aliases.contains(&"glm-5.2".to_string()));
+        assert_eq!(card.aliases.len(), 2);
     }
 }

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -63,18 +63,10 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
         let kv_role = labels.remove("kv_role");
         let kv_engine_id = labels.remove("kv_engine_id").filter(|s| !s.is_empty());
 
-        // Determine model_id: config.models > discovered labels > UNKNOWN_MODEL_ID
-        let model_id = config
-            .models
-            .primary()
-            .map(|m| m.id.clone())
-            .or_else(|| labels.get("served_model_name").cloned())
-            .or_else(|| labels.get("model_id").cloned())
-            .or_else(|| labels.get("model_path").cloned())
-            .unwrap_or_else(|| UNKNOWN_MODEL_ID.to_string());
+        let model_id = resolve_model_id(config, &labels);
 
         let model_card = build_model_card(
-            &model_id,
+            model_id,
             config,
             &labels,
             &app_context.router_config.model_aliases,
@@ -199,6 +191,22 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         false
     }
+}
+
+/// Resolve the canonical model ID before aliases are applied.
+///
+/// Kubernetes service discovery creates a spec without model cards, so its
+/// canonical ID comes from the backend's `served_model_name`. Router aliases
+/// are deliberately absent from this function and cannot change discovery.
+fn resolve_model_id<'a>(config: &'a WorkerSpec, labels: &'a HashMap<String, String>) -> &'a str {
+    config
+        .models
+        .primary()
+        .map(|model| model.id.as_str())
+        .or_else(|| labels.get("served_model_name").map(String::as_str))
+        .or_else(|| labels.get("model_id").map(String::as_str))
+        .or_else(|| labels.get("model_path").map(String::as_str))
+        .unwrap_or(UNKNOWN_MODEL_ID)
 }
 
 fn build_model_card(
@@ -337,6 +345,7 @@ fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::worker::WorkerRegistry;
 
     #[test]
     fn normalize_url_preserves_existing_schemes() {
@@ -392,6 +401,38 @@ mod tests {
 
         assert_eq!(card.id, "GLM-5.2");
         assert_eq!(card.aliases, vec!["GLM-5.2-Coding".to_string()]);
+    }
+
+    #[test]
+    fn service_discovery_keeps_served_model_name_canonical() {
+        // Service discovery supplies an empty model list. Metadata discovery
+        // supplies the backend's served_model_name.
+        let spec = WorkerSpec::new("http://worker:8080");
+        let labels = HashMap::from([
+            ("served_model_name".to_string(), "GLM-5.2".to_string()),
+            ("model_id".to_string(), "GLM-5.2-Coding".to_string()),
+            ("model_path".to_string(), "unrelated-alias".to_string()),
+        ]);
+        let aliases = alias_map(&[
+            ("GLM-5.2-Coding", "GLM-5.2"),
+            ("unrelated-alias", "other-model"),
+        ]);
+
+        let model_id = resolve_model_id(&spec, &labels);
+        let card = build_model_card(model_id, &spec, &labels, &aliases);
+        let worker: Arc<dyn Worker> =
+            Arc::new(BasicWorkerBuilder::new(&spec.url).model(card).build());
+        let registry = WorkerRegistry::new();
+        registry.register(worker.clone()).unwrap();
+
+        assert_eq!(worker.model_id(), "GLM-5.2");
+        assert_eq!(registry.get_by_model("GLM-5.2").len(), 1);
+        assert_eq!(registry.get_by_model("GLM-5.2-Coding").len(), 1);
+        assert_eq!(
+            registry.resolve_model_alias("GLM-5.2-Coding").as_deref(),
+            Some("GLM-5.2")
+        );
+        assert!(registry.get_by_model("unrelated-alias").is_empty());
     }
 
     #[test]

--- a/model_gateway/tests/common/mock_worker.rs
+++ b/model_gateway/tests/common/mock_worker.rs
@@ -328,6 +328,12 @@ impl MockWorker {
                 post(audio_transcriptions_handler),
             )
             .route("/v1/responses", post(responses_handler))
+            .route("/v1/realtime/sessions", post(realtime_rest_handler))
+            .route("/v1/realtime/client_secrets", post(realtime_rest_handler))
+            .route(
+                "/v1/realtime/transcription_sessions",
+                post(realtime_rest_handler),
+            )
             .route("/v1/responses/{response_id}", get(responses_get_handler))
             .route(
                 "/v1/responses/{response_id}/cancel",
@@ -759,6 +765,20 @@ async fn chat_completions_handler(
         }))
         .into_response()
     }
+}
+
+async fn realtime_rest_handler(
+    State(config): State<Arc<RwLock<MockWorkerConfig>>>,
+    Json(payload): Json<serde_json::Value>,
+) -> Response {
+    let config = config.read().await;
+    record_request(config.port, &payload);
+
+    if should_fail(&config) {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    Json(json!({"status": "ok"})).into_response()
 }
 
 async fn messages_handler(

--- a/model_gateway/tests/routing/model_alias_test.rs
+++ b/model_gateway/tests/routing/model_alias_test.rs
@@ -41,6 +41,8 @@ mod model_alias_tests {
         let worker = registry.get(&worker_id).unwrap();
         let mut spec = worker.metadata().spec.as_ref().clone();
         spec.models = vec![ModelCard::new(CANONICAL_MODEL).with_alias(MODEL_ALIAS)].into();
+        spec.labels
+            .insert("realtime".to_string(), "true".to_string());
         let replacement = BasicWorkerBuilder::from_spec(spec)
             .health_config(worker.metadata().health_config.clone())
             .health_endpoint(&worker.metadata().health_endpoint)
@@ -204,6 +206,51 @@ mod model_alias_tests {
             CANONICAL_MODEL,
             "the multipart form must carry the canonical model ID"
         );
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_realtime_rest_routes_forward_the_canonical_model() {
+        let recorder = RequestRecorder::new();
+        set_request_recorder(WORKER_PORT + 5, Arc::clone(&recorder));
+
+        let ctx = AppTestContext::new(vec![TestWorkerConfig::healthy(WORKER_PORT + 5)]).await;
+        let app = ctx.create_app();
+        declare_alias(&ctx, &format!("http://127.0.0.1:{}", WORKER_PORT + 5));
+
+        for (endpoint, payload) in [
+            (
+                "/v1/realtime/sessions",
+                json!({"type": "realtime", "model": MODEL_ALIAS}),
+            ),
+            (
+                "/v1/realtime/client_secrets",
+                json!({
+                    "session": {"type": "realtime", "model": MODEL_ALIAS}
+                }),
+            ),
+            (
+                "/v1/realtime/transcription_sessions",
+                json!({"type": "transcription", "model": MODEL_ALIAS}),
+            ),
+        ] {
+            let request = Request::builder()
+                .method("POST")
+                .uri(endpoint)
+                .header(CONTENT_TYPE, "application/json")
+                .header("Authorization", "Bearer test-key")
+                .body(Body::from(payload.to_string()))
+                .unwrap();
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "endpoint {endpoint}");
+        }
+
+        let forwarded = recorder.bodies();
+        assert_eq!(forwarded.len(), 3);
+        assert_eq!(forwarded[0]["model"], CANONICAL_MODEL);
+        assert_eq!(forwarded[1]["session"]["model"], CANONICAL_MODEL);
+        assert_eq!(forwarded[2]["model"], CANONICAL_MODEL);
 
         ctx.shutdown().await;
     }


### PR DESCRIPTION
## Description

### Problem

Kubernetes-discovered workers register their canonical backend model ID. Clients that use a configured alias cannot route to those workers.

### Solution

Add repeatable `--model-alias <alias>=<canonical>` configuration. Keep the discovered `served_model_name` canonical and attach matching aliases to the worker model card. Pass the configuration through the Python launcher and PyO3 binding.

## Changes

- Parse and validate model alias mappings in the Rust and Python CLIs.
- Apply configured aliases to discovered workers without changing their canonical model ID.
- Preserve existing positional `RouterArgs` callers by appending the new field.
- Document the service-discovery configuration.

## Test Plan

Final validation on the exact PR head is pending.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for mapping client-facing model aliases to canonical model IDs.
  - Added repeatable `--model-alias <alias>=<canonical>` support in CLI and Python interfaces.
  - Alias resolution routes requests to canonical models while backend responses remain unchanged.
  - Model discovery/worker metadata now merges router aliases for discovered workers without duplicating existing entries.

- **Bug Fixes**
  - Added validation for malformed, empty, conflicting, or self-referencing aliases.

- **Documentation**
  - Documented model-alias behavior (case sensitivity, model listing, and examples).

- **Tests**
  - Expanded argument parsing and alias validation test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->