### PR TITLE
fix(kimi-k3): treat a sibling closer as the end of an assumed think channel

### DIFF
--- a/crates/reasoning_parser/src/parsers/kimi_k3.rs
+++ b/crates/reasoning_parser/src/parsers/kimi_k3.rs
@@ -102,32 +102,70 @@ impl KimiK3Parser {
 
     /// Locate the end of the think channel in `text`, searching from `from`.
     ///
-    /// Returns `(reasoning_end, content_start)` for whichever comes first: the
-    /// think-close marker (consumed, so content resumes after it) or a sibling
-    /// `response`/`tools` opener (left in place for downstream parsing).
-    /// `None` when neither is present.
+    /// Returns `(reasoning_end, content_start)` for whichever terminator comes
+    /// first. `None` when none is present.
     ///
-    /// A sibling opener has to count as an implicit close because a forced tool
-    /// call can jump straight from the prefilled `<|open|>think<|sep|>` into
-    /// `<|open|>tools<|sep|>`; without it the tools channel would be swallowed
-    /// as reasoning. `message` is excluded — it wraps the whole assistant turn
-    /// and opens *before* the think channel.
-    fn think_channel_end(&self, text: &str, from: usize) -> Option<(usize, usize)> {
+    /// Three kinds of terminator, each with a different span:
+    ///
+    /// - The think-close marker: consumed, so content resumes after it.
+    /// - A sibling `response`/`tools` *opener*: left in place for downstream
+    ///   parsing, so reasoning ends and content starts at the marker. A sibling
+    ///   opener has to count as an implicit close because a forced tool call can
+    ///   jump straight from the prefilled `<|open|>think<|sep|>` into
+    ///   `<|open|>tools<|sep|>`; without it the tools channel would be swallowed
+    ///   as reasoning. `message` is excluded here — it wraps the whole assistant
+    ///   turn and opens *before* the think channel.
+    /// - A sibling `response`/`message` *closer*, but only when `think_observed`
+    ///   is false. See below; the span is `(from, from)`, i.e. no reasoning at
+    ///   all and content covering everything from `from`.
+    ///
+    /// `think_observed` says whether a literal `<|open|>think<|sep|>` was found
+    /// in `text`, as opposed to the channel merely being *assumed* open because
+    /// the caller pre-marked reasoning for a prefilled prompt. Reaching a closer
+    /// for a sibling channel without ever having entered the think channel is a
+    /// contradiction that can only be resolved one way: the model ignored the
+    /// prefilled `<|open|>think<|sep|>` and answered directly, closing the
+    /// channel as `response`/`message`. Everything from `from` is therefore the
+    /// answer, and `strip_content_wrapper` removes the stray closers. When the
+    /// think channel *was* observed, the same closer is just malformed output
+    /// and must not be allowed to retroactively empty the reasoning span.
+    ///
+    /// Note the asymmetry in span: text before a sibling *opener* is reasoning,
+    /// whereas text before a sibling *closer* is the response body.
+    fn think_channel_end(
+        &self,
+        text: &str,
+        from: usize,
+        think_observed: bool,
+    ) -> Option<(usize, usize)> {
         let close = self
             .think_close_re
             .find_at(text, from)
-            .map(|m| (m.start(), m.end()));
-        let sibling = [&self.response_open_re, &self.tools_open_re]
+            .map(|m| (m.start(), (m.start(), m.end())));
+        let sibling_open = [&self.response_open_re, &self.tools_open_re]
             .into_iter()
             .filter_map(|re| re.find_at(text, from).map(|m| m.start()))
             .min()
-            .map(|start| (start, start));
-        // Ties favour `close` (listed first); the markers cannot in fact start
-        // at the same offset, since one begins `<|close|>` and the other `<|open|>`.
-        [close, sibling]
+            .map(|start| (start, (start, start)));
+        let sibling_close = (!think_observed)
+            .then(|| {
+                [&self.response_close_re, &self.message_close_re]
+                    .into_iter()
+                    .filter_map(|re| re.find_at(text, from).map(|m| m.start()))
+                    .min()
+            })
+            .flatten()
+            .map(|start| (start, (from, from)));
+        // Compare on the marker's own position, not on the returned span, so the
+        // `(from, from)` case does not win by virtue of starting at the lowest
+        // possible offset. Ties favour whichever is listed first, preserving the
+        // original preference for `close`; the markers cannot in fact start at
+        // the same offset, since no two of them share a literal prefix.
+        [close, sibling_open, sibling_close]
             .into_iter()
             .flatten()
-            .min_by_key(|&(end, _)| end)
+            .min_by_key(|&(marker_start, _)| marker_start)
+            .map(|(_, span)| span)
     }
 
     /// Return the prefix of accumulated reasoning text that is safe to stream.
@@ -143,10 +181,21 @@ impl KimiK3Parser {
 
         // Sibling openers are held back alongside the think markers: a partial
         // `<|open|>too…` at the tail would otherwise leak into `reasoning_text`
-        // before it completes and ends the channel.
+        // before it completes and ends the channel. Sibling *closers* are held
+        // back for the same reason now that they too can end the channel, and
+        // sharing the `<|close|>` prefix with `THINK_CLOSE` is not enough —
+        // `compute_overlap` matches whole suffixes, so `<|close|>res` would
+        // otherwise leak the `res`.
         let overlap = Self::compute_overlap(
             after_open,
-            &[THINK_OPEN, THINK_CLOSE, RESPONSE_OPEN, TOOLS_OPEN],
+            &[
+                THINK_OPEN,
+                THINK_CLOSE,
+                RESPONSE_OPEN,
+                RESPONSE_CLOSE,
+                MESSAGE_CLOSE,
+                TOOLS_OPEN,
+            ],
         );
         if overlap > 0 {
             &after_open[..after_open.len() - overlap]
@@ -245,7 +294,8 @@ impl ReasoningParser for KimiK3Parser {
             return Ok(ParserResult::normal(self.strip_content_wrapper(text)));
         }
 
-        let Some((reasoning_end, content_start)) = self.think_channel_end(text, reasoning_start)
+        let Some((reasoning_end, content_start)) =
+            self.think_channel_end(text, reasoning_start, m_open.is_some())
         else {
             // Opened but never closed — e.g. output truncated mid-thought.
             // Classify the remainder as reasoning rather than lose it.
@@ -307,13 +357,21 @@ impl ReasoningParser for KimiK3Parser {
         // opener as well as the think-close marker is what lets a forced tools
         // channel reach the content phase instead of streaming as reasoning
         // indefinitely.
-        let r_start = self
-            .think_open_re
-            .find(&self.buffer)
-            .map(|m| m.end())
-            .unwrap_or(0);
+        //
+        // A sibling closer can also end it, but only when the think channel was
+        // assumed rather than observed — see `think_channel_end`. That recovery
+        // is inherently partial while streaming: reasoning deltas for what turns
+        // out to be the answer have already left the building and cannot be
+        // recalled, so the answer is repeated in `reasoning_text`. What the fix
+        // buys here is a correct and complete `normal_text` (a client reading
+        // only `content` sees the whole answer) and a cleared `in_reasoning`,
+        // which is what gates the tool parser. Non-streaming is exact.
+        let think_open = self.think_open_re.find(&self.buffer);
+        let think_observed = think_open.is_some();
+        let r_start = think_open.map(|m| m.end()).unwrap_or(0);
 
-        if let Some((reasoning_end, content_start)) = self.think_channel_end(&self.buffer, r_start)
+        if let Some((reasoning_end, content_start)) =
+            self.think_channel_end(&self.buffer, r_start, think_observed)
         {
             // Transition: reasoning phase ends.
             self.reason_phase_ended = true;
@@ -544,6 +602,85 @@ mod tests {
     }
 
     #[test]
+    fn in_reasoning_answer_closed_as_response_is_content_not_reasoning() {
+        // Regression (observed on 16/700 BEAM answers): the generation prompt
+        // prefills `<|open|>think<|sep|>`, the gateway pre-marks reasoning, and
+        // then the model ignores the think channel and answers straight into it,
+        // closing it as `response`. The completion therefore carries sibling
+        // *closers* and no opener of any kind. Before the fix nothing matched as
+        // a terminator, the whole answer was filed as reasoning, and `content`
+        // came back empty with the wrapper markers still attached.
+        let mut p = KimiK3Parser::new();
+        p.mark_reasoning_started();
+        let input = format!("The answer is 42.{CLOSE}response{SEP}{CLOSE}message{SEP}");
+        let r = p.detect_and_parse_reasoning(&input).unwrap();
+        assert_eq!(r.normal_text, "The answer is 42.");
+        assert_eq!(r.reasoning_text, "");
+        assert!(!p.is_in_reasoning());
+    }
+
+    #[test]
+    fn in_reasoning_answer_closed_as_message_only_is_content() {
+        // Same shape with only the outer `message` closer present.
+        let mut p = KimiK3Parser::new();
+        p.mark_reasoning_started();
+        let input = format!("Paris.{CLOSE}message{SEP}");
+        let r = p.detect_and_parse_reasoning(&input).unwrap();
+        assert_eq!(r.normal_text, "Paris.");
+        assert_eq!(r.reasoning_text, "");
+    }
+
+    #[test]
+    fn observed_think_channel_ignores_a_stray_sibling_closer() {
+        // The contradiction argument only holds when the think channel was
+        // *assumed*. With a real `<|open|>think<|sep|>` in the text, a stray
+        // `<|close|>response<|sep|>` is malformed output, not proof that the
+        // deliberation was really the answer — the reasoning must survive.
+        let mut p = KimiK3Parser::new();
+        let input = format!("{}deliberating{CLOSE}response{SEP}", think_open());
+        let r = p.detect_and_parse_reasoning(&input).unwrap();
+        assert_eq!(
+            r.reasoning_text,
+            format!("deliberating{CLOSE}response{SEP}")
+        );
+        assert_eq!(r.normal_text, "");
+        assert!(p.is_in_reasoning());
+    }
+
+    #[test]
+    fn think_close_wins_over_a_later_sibling_closer() {
+        // A properly closed think channel is terminated by its own marker; the
+        // response closer that follows is just wrapper to strip. This is the
+        // ordering the new closer branch must not disturb.
+        let mut p = KimiK3Parser::new();
+        p.mark_reasoning_started();
+        let input = format!(
+            "step{}{}answer{}{}",
+            think_close(),
+            response_open(),
+            response_close(),
+            message_close()
+        );
+        let r = p.detect_and_parse_reasoning(&input).unwrap();
+        assert_eq!(r.reasoning_text, "step");
+        assert_eq!(r.normal_text, "answer");
+    }
+
+    #[test]
+    fn sibling_opener_before_a_closer_still_splits_at_the_opener() {
+        // Text before a sibling *opener* is reasoning; text before a sibling
+        // *closer* is the answer. When both are present the opener comes first
+        // and must win, or the deliberation would be relabelled as content.
+        let mut p = KimiK3Parser::new();
+        p.mark_reasoning_started();
+        let input =
+            format!("thought{OPEN}response{SEP}answer{CLOSE}response{SEP}{CLOSE}message{SEP}");
+        let r = p.detect_and_parse_reasoning(&input).unwrap();
+        assert_eq!(r.reasoning_text, "thought");
+        assert_eq!(r.normal_text, "answer");
+    }
+
+    #[test]
     fn no_think_channel_is_all_content() {
         let mut p = KimiK3Parser::new();
         let r = p.detect_and_parse_reasoning("just an answer").unwrap();
@@ -614,6 +751,60 @@ mod tests {
             )
         );
         assert!(!p.is_in_reasoning());
+    }
+
+    #[test]
+    fn streaming_answer_closed_as_response_recovers_content() {
+        // Streaming counterpart of
+        // `in_reasoning_answer_closed_as_response_is_content_not_reasoning`.
+        //
+        // The recovery is necessarily partial: by the time the `response` closer
+        // arrives the answer has already been streamed as reasoning deltas and
+        // cannot be recalled, so it appears in both fields. What matters is that
+        // `normal_text` is complete and correct — a client reading only
+        // `content` now gets the whole answer instead of an empty string — and
+        // that `in_reasoning` clears, since it gates the tool parser.
+        let mut p = KimiK3Parser::new();
+        p.mark_reasoning_started();
+        let chunks = [
+            "The answer ",
+            "is 42.",
+            "<|close|>response<|sep|>",
+            "<|close|>message<|sep|>",
+        ];
+
+        let mut reasoning = String::new();
+        let mut normal = String::new();
+        for chunk in chunks {
+            let result = p.parse_reasoning_streaming_incremental(chunk).unwrap();
+            reasoning.push_str(&result.reasoning_text);
+            normal.push_str(&result.normal_text);
+        }
+
+        assert_eq!(normal, "The answer is 42.");
+        assert_eq!(reasoning, "The answer is 42.");
+        assert!(!p.is_in_reasoning());
+    }
+
+    #[test]
+    fn streaming_split_sibling_closer_does_not_leak_into_reasoning() {
+        // A sibling closer now ends the reasoning phase, so a partial one at the
+        // chunk boundary has to be held back like any other terminator. Sharing
+        // the `<|close|>` prefix with the think-close marker is not enough:
+        // `compute_overlap` matches whole suffixes, so without `RESPONSE_CLOSE`
+        // in the holdback set the `res` would be emitted as reasoning.
+        let mut p = KimiK3Parser::new();
+        p.mark_reasoning_started();
+        let partial = p
+            .parse_reasoning_streaming_incremental("The answer<|close|>res")
+            .unwrap();
+        assert_eq!(partial.reasoning_text, "The answer");
+        assert_eq!(partial.normal_text, "");
+        let completed = p
+            .parse_reasoning_streaming_incremental("ponse<|sep|>")
+            .unwrap();
+        assert_eq!(completed.reasoning_text, "");
+        assert_eq!(completed.normal_text, "The answer");
     }
 
     #[test]

--- a/crates/reasoning_parser/src/parsers/kimi_k3.rs
+++ b/crates/reasoning_parser/src/parsers/kimi_k3.rs
@@ -102,36 +102,24 @@ impl KimiK3Parser {
 
     /// Locate the end of the think channel in `text`, searching from `from`.
     ///
-    /// Returns `(reasoning_end, content_start)` for whichever terminator comes
-    /// first. `None` when none is present.
+    /// Returns `(reasoning_end, content_start)` for the earliest terminator, or
+    /// `None` when there is none. Three kinds, each spanning differently:
     ///
-    /// Three kinds of terminator, each with a different span:
+    /// - think-close: consumed, so content resumes after it.
+    /// - sibling `response`/`tools` *opener*: left in place for downstream
+    ///   parsing, since a forced tool call can jump straight from the prefilled
+    ///   `<|open|>think<|sep|>` into `<|open|>tools<|sep|>`. `message` is
+    ///   excluded — it opens *before* the think channel.
+    /// - sibling `response`/`message` *closer*: spans `(from, from)`, all answer
+    ///   and no reasoning, and only when `!think_observed`.
     ///
-    /// - The think-close marker: consumed, so content resumes after it.
-    /// - A sibling `response`/`tools` *opener*: left in place for downstream
-    ///   parsing, so reasoning ends and content starts at the marker. A sibling
-    ///   opener has to count as an implicit close because a forced tool call can
-    ///   jump straight from the prefilled `<|open|>think<|sep|>` into
-    ///   `<|open|>tools<|sep|>`; without it the tools channel would be swallowed
-    ///   as reasoning. `message` is excluded here — it wraps the whole assistant
-    ///   turn and opens *before* the think channel.
-    /// - A sibling `response`/`message` *closer*, but only when `think_observed`
-    ///   is false. See below; the span is `(from, from)`, i.e. no reasoning at
-    ///   all and content covering everything from `from`.
-    ///
-    /// `think_observed` says whether a literal `<|open|>think<|sep|>` was found
-    /// in `text`, as opposed to the channel merely being *assumed* open because
-    /// the caller pre-marked reasoning for a prefilled prompt. Reaching a closer
-    /// for a sibling channel without ever having entered the think channel is a
-    /// contradiction that can only be resolved one way: the model ignored the
-    /// prefilled `<|open|>think<|sep|>` and answered directly, closing the
-    /// channel as `response`/`message`. Everything from `from` is therefore the
-    /// answer, and `strip_content_wrapper` removes the stray closers. When the
-    /// think channel *was* observed, the same closer is just malformed output
-    /// and must not be allowed to retroactively empty the reasoning span.
-    ///
-    /// Note the asymmetry in span: text before a sibling *opener* is reasoning,
-    /// whereas text before a sibling *closer* is the response body.
+    /// `think_observed` says whether `text` holds a literal `<|open|>think<|sep|>`,
+    /// as opposed to the channel being *assumed* open because the caller
+    /// pre-marked reasoning for a prefilled prompt. Only when assumed does a
+    /// sibling closer mean anything: it proves the model ignored the prefill and
+    /// answered directly, so `strip_content_wrapper` clears the stray markers.
+    /// With the channel observed, the same closer is malformed output and must
+    /// not retroactively empty the reasoning span.
     fn think_channel_end(
         &self,
         text: &str,
@@ -156,11 +144,9 @@ impl KimiK3Parser {
             })
             .flatten()
             .map(|start| (start, (from, from)));
-        // Compare on the marker's own position, not on the returned span, so the
-        // `(from, from)` case does not win by virtue of starting at the lowest
-        // possible offset. Ties favour whichever is listed first, preserving the
-        // original preference for `close`; the markers cannot in fact start at
-        // the same offset, since no two of them share a literal prefix.
+        // Keyed on marker position, not on the returned span, or `(from, from)`
+        // would always win. Ties favour `close` (listed first), though no two
+        // markers share a literal prefix so ties cannot arise.
         [close, sibling_open, sibling_close]
             .into_iter()
             .flatten()
@@ -179,13 +165,10 @@ impl KimiK3Parser {
             text
         };
 
-        // Sibling openers are held back alongside the think markers: a partial
-        // `<|open|>too…` at the tail would otherwise leak into `reasoning_text`
-        // before it completes and ends the channel. Sibling *closers* are held
-        // back for the same reason now that they too can end the channel, and
-        // sharing the `<|close|>` prefix with `THINK_CLOSE` is not enough —
-        // `compute_overlap` matches whole suffixes, so `<|close|>res` would
-        // otherwise leak the `res`.
+        // Hold back any tail that could complete into a channel terminator.
+        // Sibling closers need listing individually despite sharing the
+        // `<|close|>` prefix with `THINK_CLOSE`: `compute_overlap` matches whole
+        // suffixes, so `<|close|>res` would otherwise leak the `res`.
         let overlap = Self::compute_overlap(
             after_open,
             &[
@@ -358,14 +341,11 @@ impl ReasoningParser for KimiK3Parser {
         // channel reach the content phase instead of streaming as reasoning
         // indefinitely.
         //
-        // A sibling closer can also end it, but only when the think channel was
-        // assumed rather than observed — see `think_channel_end`. That recovery
-        // is inherently partial while streaming: reasoning deltas for what turns
-        // out to be the answer have already left the building and cannot be
-        // recalled, so the answer is repeated in `reasoning_text`. What the fix
-        // buys here is a correct and complete `normal_text` (a client reading
-        // only `content` sees the whole answer) and a cleared `in_reasoning`,
-        // which is what gates the tool parser. Non-streaming is exact.
+        // A sibling closer can also end it — see `think_channel_end`. Recovery is
+        // partial while streaming, since reasoning deltas for what turns out to be
+        // the answer cannot be recalled and so repeat in `reasoning_text`; what it
+        // buys is a complete `normal_text` and a cleared `in_reasoning`, which
+        // gates the tool parser. Non-streaming is exact.
         let think_open = self.think_open_re.find(&self.buffer);
         let think_observed = think_open.is_some();
         let r_start = think_open.map(|m| m.end()).unwrap_or(0);
@@ -603,13 +583,9 @@ mod tests {
 
     #[test]
     fn in_reasoning_answer_closed_as_response_is_content_not_reasoning() {
-        // Regression (observed on 16/700 BEAM answers): the generation prompt
-        // prefills `<|open|>think<|sep|>`, the gateway pre-marks reasoning, and
-        // then the model ignores the think channel and answers straight into it,
-        // closing it as `response`. The completion therefore carries sibling
-        // *closers* and no opener of any kind. Before the fix nothing matched as
-        // a terminator, the whole answer was filed as reasoning, and `content`
-        // came back empty with the wrapper markers still attached.
+        // Regression (16/700 BEAM answers): reasoning pre-marked for a prefilled
+        // `<|open|>think<|sep|>`, then the model answers straight into it and
+        // closes as `response`, leaving sibling closers and no opener at all.
         let mut p = KimiK3Parser::new();
         p.mark_reasoning_started();
         let input = format!("The answer is 42.{CLOSE}response{SEP}{CLOSE}message{SEP}");
@@ -620,22 +596,9 @@ mod tests {
     }
 
     #[test]
-    fn in_reasoning_answer_closed_as_message_only_is_content() {
-        // Same shape with only the outer `message` closer present.
-        let mut p = KimiK3Parser::new();
-        p.mark_reasoning_started();
-        let input = format!("Paris.{CLOSE}message{SEP}");
-        let r = p.detect_and_parse_reasoning(&input).unwrap();
-        assert_eq!(r.normal_text, "Paris.");
-        assert_eq!(r.reasoning_text, "");
-    }
-
-    #[test]
     fn observed_think_channel_ignores_a_stray_sibling_closer() {
-        // The contradiction argument only holds when the think channel was
-        // *assumed*. With a real `<|open|>think<|sep|>` in the text, a stray
-        // `<|close|>response<|sep|>` is malformed output, not proof that the
-        // deliberation was really the answer — the reasoning must survive.
+        // With a real `<|open|>think<|sep|>` present the closer is malformed
+        // output, not proof the deliberation was the answer: reasoning survives.
         let mut p = KimiK3Parser::new();
         let input = format!("{}deliberating{CLOSE}response{SEP}", think_open());
         let r = p.detect_and_parse_reasoning(&input).unwrap();
@@ -649,9 +612,8 @@ mod tests {
 
     #[test]
     fn think_close_wins_over_a_later_sibling_closer() {
-        // A properly closed think channel is terminated by its own marker; the
-        // response closer that follows is just wrapper to strip. This is the
-        // ordering the new closer branch must not disturb.
+        // Terminators are ranked by marker position; the trailing closers are
+        // just wrapper to strip. The ordering the new branch must not disturb.
         let mut p = KimiK3Parser::new();
         p.mark_reasoning_started();
         let input = format!(
@@ -663,20 +625,6 @@ mod tests {
         );
         let r = p.detect_and_parse_reasoning(&input).unwrap();
         assert_eq!(r.reasoning_text, "step");
-        assert_eq!(r.normal_text, "answer");
-    }
-
-    #[test]
-    fn sibling_opener_before_a_closer_still_splits_at_the_opener() {
-        // Text before a sibling *opener* is reasoning; text before a sibling
-        // *closer* is the answer. When both are present the opener comes first
-        // and must win, or the deliberation would be relabelled as content.
-        let mut p = KimiK3Parser::new();
-        p.mark_reasoning_started();
-        let input =
-            format!("thought{OPEN}response{SEP}answer{CLOSE}response{SEP}{CLOSE}message{SEP}");
-        let r = p.detect_and_parse_reasoning(&input).unwrap();
-        assert_eq!(r.reasoning_text, "thought");
         assert_eq!(r.normal_text, "answer");
     }
 
@@ -755,21 +703,21 @@ mod tests {
 
     #[test]
     fn streaming_answer_closed_as_response_recovers_content() {
-        // Streaming counterpart of
-        // `in_reasoning_answer_closed_as_response_is_content_not_reasoning`.
+        // Streaming counterpart of the regression above, with the closer split
+        // across chunks so the widened holdback set is exercised too: a leaked
+        // `res` would show up in `reasoning`.
         //
-        // The recovery is necessarily partial: by the time the `response` closer
-        // arrives the answer has already been streamed as reasoning deltas and
-        // cannot be recalled, so it appears in both fields. What matters is that
-        // `normal_text` is complete and correct — a client reading only
-        // `content` now gets the whole answer instead of an empty string — and
-        // that `in_reasoning` clears, since it gates the tool parser.
+        // Recovery is partial by construction — the answer was already streamed
+        // as reasoning deltas before the closer arrived, so it appears in both
+        // fields. What matters is a complete `normal_text` and a cleared
+        // `in_reasoning`, which gates the tool parser.
         let mut p = KimiK3Parser::new();
         p.mark_reasoning_started();
         let chunks = [
             "The answer ",
             "is 42.",
-            "<|close|>response<|sep|>",
+            "<|close|>res",
+            "ponse<|sep|>",
             "<|close|>message<|sep|>",
         ];
 
@@ -784,27 +732,6 @@ mod tests {
         assert_eq!(normal, "The answer is 42.");
         assert_eq!(reasoning, "The answer is 42.");
         assert!(!p.is_in_reasoning());
-    }
-
-    #[test]
-    fn streaming_split_sibling_closer_does_not_leak_into_reasoning() {
-        // A sibling closer now ends the reasoning phase, so a partial one at the
-        // chunk boundary has to be held back like any other terminator. Sharing
-        // the `<|close|>` prefix with the think-close marker is not enough:
-        // `compute_overlap` matches whole suffixes, so without `RESPONSE_CLOSE`
-        // in the holdback set the `res` would be emitted as reasoning.
-        let mut p = KimiK3Parser::new();
-        p.mark_reasoning_started();
-        let partial = p
-            .parse_reasoning_streaming_incremental("The answer<|close|>res")
-            .unwrap();
-        assert_eq!(partial.reasoning_text, "The answer");
-        assert_eq!(partial.normal_text, "");
-        let completed = p
-            .parse_reasoning_streaming_incremental("ponse<|sep|>")
-            .unwrap();
-        assert_eq!(completed.reasoning_text, "");
-        assert_eq!(completed.normal_text, "The answer");
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

Found during the **BEAM 1M long-context evaluation**: 16 of 700 answers (2.3%) came back from the gateway with `content` absent and the entire answer — raw XTML wrapper markers included — sitting in `reasoning_content`. Every one had `finish_reason: "stop"`, so nothing looked wrong at the transport level; the answer was simply filed in the wrong field, and a client reading `content` saw nothing.

The failure is **random and long-context specific**. Two hypotheses were tested and refuted before the real trigger was isolated:

| Hypothesis | Result |
|---|---|
| Short, low-deliberation prompts trip it | 0 / 12 reproduced |
| Greedy decoding (`temperature 0`) in a long chat | 0 / 20 reproduced |

It needs **both** a long multi-turn context *and* sampling — it never reproduces deterministically at a fixed prompt, which is why it survived to the eval stage.

**Root cause.** K3's tokenizer is `ThinkingToggle::DefaultOn` (`crates/tokenizer/src/tiktoken.rs:573`), so unless the caller passes `thinking: false`, `should_mark_reasoning_started` (`model_gateway/src/routers/grpc/utils/parsers.rs:20-26`) sets `in_reasoning = true` before a token arrives. That is correct in principle — the generation prompt really does end inside the think channel (`crates/tokenizer/src/encoders/kimi_k3_xtml.rs:285-288`):

```
… <|open|>message role="assistant"<|sep|><|open|>think<|sep|>
```

Since `<|open|>think<|sep|>` is part of the *prompt*, it never appears in the completion. The parser has to take the open channel on faith.

Sampling at `temperature 1.0` in a long chat, K3 sometimes disregards that prefilled channel and answers directly, closing the turn as `response`:

```
Yes — here's a concise summary …  well-being.<|close|>response<|sep|><|close|>message<|sep|>
```

The completion carries **only sibling closers**. `think_channel_end` recognised three terminators, none of them a closer:

| Terminator | Recognised before |
|---|---|
| `<\|close\|>think<\|sep\|>` | yes |
| `<\|open\|>response<\|sep\|>` | yes |
| `<\|open\|>tools<\|sep\|>` | yes |
| `<\|close\|>response<\|sep\|>` | **no** |
| `<\|close\|>message<\|sep\|>` | **no** |

With nothing matched it returned `None`, and the caller's fallback — meant for output truncated mid-thought — filed the remainder as reasoning. The markers survived because `strip_content_wrapper` runs on the content path only, which is also what makes their presence in `reasoning_content` a reliable fingerprint of the bug.

### Solution

Sibling closers now terminate the channel, gated on a new `think_observed` argument: true when a literal `<|open|>think<|sep|>` is in the text, false when the channel was merely *assumed* open because the caller pre-marked reasoning. Only in the assumed case does a closer mean anything — it proves the model ignored the prefill and answered directly. With the channel actually observed, the same closer is malformed output and must not retroactively empty the reasoning span.

The span is asymmetric: text before a sibling *opener* is reasoning, text before a sibling *closer* is the answer. The closer branch therefore returns `(from, from)` and lets `strip_content_wrapper` clean the markers. Candidates are compared on **marker position** rather than on the returned span, or `(from, from)` would always win.

**Known limitation (streaming only).** Streaming recovery is partial by construction: reasoning deltas already sent cannot be recalled, so the answer is repeated in `reasoning_text`. What the fix buys on that path is a complete `normal_text` and a cleared `in_reasoning` (which gates the tool parser). **Non-streaming is exact.**

## Changes

`crates/reasoning_parser/src/parsers/kimi_k3.rs` (1 file, +147/−29):

- `think_channel_end` takes a `think_observed: bool` and gains a third terminator kind — a sibling `response`/`message` **closer**, active only when the think channel was assumed rather than observed, spanning `(from, from)`.
- Terminator selection re-keyed from the returned span to the **marker's own position**, so the `(from, from)` candidate cannot win by starting at the lowest offset. Ties still favour think-close.
- Both call sites pass `think_observed`: `m_open.is_some()` non-streaming, the buffer search result streaming.
- `reasoning_text_ready_to_emit` holdback widened with `RESPONSE_CLOSE` and `MESSAGE_CLOSE`. Sharing the `<|close|>` prefix with `THINK_CLOSE` is not enough — `compute_overlap` matches whole suffixes, so a chunk ending `<|close|>res` would leak the `res` into `reasoning_text`.
- Four unit tests: the non-streaming regression, the `think_observed` guard, terminator precedence, and streaming recovery with the closer split across chunks (which also exercises the widened holdback).

No public API, config, or protocol change.

## Test Plan

Validated end-to-end on 8×B300 against the **exact pre-fix binary that served BEAM**, replaying real BEAM long-context requests. `seed` is forwarded to vLLM, so a `(question, seed)` pair is replayable and the same request can be issued byte-identically against both builds.

| Test | Pre-fix | Fixed |
|---|---|---|
| Controlled A/B, byte-identical request, 2 repeats each | misfiled every time | correct every time |
| 20 questions × 6 seeds = 120 requests @ 206k tokens | **6 / 120 (5.0 %)** | **0 / 120** |
| `cargo test -p reasoning-parser` | — | **98 passed** |

Model output was byte-identical across the A/B (same `completion_tokens`); only the field the answer landed in changed. No regression on the normal path: 106/120 still return both fields, 0 marker leaks, large reasoning traces (38 KB, 57 KB) intact.

**Full method, request and response detail in the [validation comment](https://github.com/lightseekorg/smg/pull/2007#issuecomment-5136977837) below.**

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<details>
<summary>Note on <code>pre-commit run --all-files</code></summary>

It cannot complete in my local environment: the clippy hook builds the whole workspace and `llm-multimodal`'s build script needs `pkg-config` + `opencv4`, which are not installed here. Pre-existing and unrelated to this change. Compensated with `cargo +nightly fmt --all --check`, `cargo test -p reasoning-parser`, and `cargo clippy -p reasoning-parser --all-targets --all-features -- -D warnings`, all clean, locally and in the node's Linux builder image.

</details>
