### PR TITLE
chore(nightly): pin DeepSeek-V4-Flash legs to the 0731 checkpoint

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -147,7 +147,7 @@ jobs:
               # Concurrent TP=4 per arm (0-3 + 4-7).
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
-               "model": "deepseek-ai/DeepSeek-V4-Flash", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-FC",
+               "model": "deepseek-ai/DeepSeek-V4-Flash-0731", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-0731-FC",
                "vllm_tool": "deepseek_v4", "vllm_reason": "deepseek_v4",
                "smg_tool": "deepseek_v4",
                "smg_reason": "deepseek_v31",  # TODO(confirm): no deepseek_v4 SMG reasoning parser yet

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -163,7 +163,7 @@ jobs:
               # Concurrent TP=4 per arm (0-3 + 4-7); num_tasks-capped.
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
-               "model": "deepseek-ai/DeepSeek-V4-Flash",
+               "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
                "vllm_tool": "deepseek_v4", "vllm_reason": "deepseek_v4",
                "smg_tool": "deepseek_v4", "smg_reason": "deepseek_v31",
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -64,7 +64,7 @@ Key env knobs for `launch_arm.sh`: `BFCL_GPU` (CUDA_VISIBLE_DEVICES, e.g. `0,1`)
 |---|---|---|---|---|
 | Qwen3.6-27B (`qwen3.6`) | `4-gpu-h100` | 2 | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
 | gpt-oss-120b (`gpt-oss`) | `4-gpu-h100` | 2 | `openai` / — | _(none — SMG auto-routes harmony)_ / — |
-| DeepSeek-V4-Flash (`deepseek-v4`) | `blackwell` | 4 | `deepseek_v4` / `deepseek_v4` (+`--tokenizer-mode deepseek_v4 --trust-remote-code`) | `deepseek_v4` / `deepseek_v31`† |
+| DeepSeek-V4-Flash-0731 (`deepseek-v4`) | `blackwell` | 4 | `deepseek_v4` / `deepseek_v4` (+`--tokenizer-mode deepseek_v4 --trust-remote-code`) | `deepseek_v4` / `deepseek_v31`† |
 | MiniMax-M2.7 (`minimax-m2.7`) | `blackwell` | 4 | `minimax_m2` / `minimax_m2` (+`--trust-remote-code`) | `minimax_m2` / `minimax` |
 | Kimi-K2.6 int4 (`kimi-k2.6`) | `blackwell` | 4 | `kimi_k2` / `kimi_k2` (+`--trust-remote-code`) | `kimik2` / `kimi_k25`† |
 
@@ -89,7 +89,7 @@ The nightly (`.github/workflows/nightly-bfcl.yml`) runs the A/B as a GitHub Acti
 matrix — one leg per model, `fail-fast: false`, each on its own runner:
 
 - `4-gpu-h100` — Qwen3.6-27B and gpt-oss-120b, TP=2 per arm (GPUs 0,1 + 2,3).
-- `blackwell` (B200) — DeepSeek-V4-Flash, MiniMax-M2.7, Kimi-K2.6 int4, TP=4 per arm
+- `blackwell` (B200) — DeepSeek-V4-Flash-0731, MiniMax-M2.7, Kimi-K2.6 int4, TP=4 per arm
   (GPUs 0-3 + 4-7).
 
 All legs use `max_model_len` **32768**: the `multi_turn` categories emit ~18k-token
@@ -107,7 +107,7 @@ Each leg sets `arm_mode`:
   saved score files. Flip a leg's `arm_mode` to enable it.
 
 Per the A/B's premise, model size is irrelevant — a smaller same-family checkpoint
-exercises the identical parser — so the matrix uses DeepSeek-V4-Flash and int4
+exercises the identical parser — so the matrix uses DeepSeek-V4-Flash-0731 and int4
 Kimi-K2.6 to validate the `deepseek_v4` / `kimi_k2` parsers without the full weights.
 
 `workflow_dispatch` can target one leg via the `only` input and override

--- a/scripts/tau2/README.md
+++ b/scripts/tau2/README.md
@@ -97,7 +97,7 @@ dominated by model-load time, serialized by a host lock, so a PR run is not fast
 |---|---|---|---|---|
 | qwen3.6 | Qwen/Qwen3.6-27B | 4-gpu-h100 (2) | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
 | gpt-oss | openai/gpt-oss-120b | 4-gpu-h100 (2) | `openai` / — | — / — (harmony auto) |
-| deepseek-v4 | deepseek-ai/DeepSeek-V4-Flash | blackwell (4) | `deepseek_v4` / `deepseek_v4` | `deepseek_v4` / `deepseek_v31` |
+| deepseek-v4 | deepseek-ai/DeepSeek-V4-Flash-0731 | blackwell (4) | `deepseek_v4` / `deepseek_v4` | `deepseek_v4` / `deepseek_v31` |
 | minimax-m2.7 | MiniMaxAI/MiniMax-M2.7 | blackwell (4) | `minimax_m2` / `minimax_m2` | `minimax_m2` / `minimax` |
 | kimi-k2.6 | moonshotai/Kimi-K2.6 | blackwell (4) | `kimi_k2` / `kimi_k2` | `kimik2` / `kimi_k25` |
 | glm-5.2 | zai-org/GLM-5.2-FP8 | blackwell (8, seq) | `glm47` / `glm45` | `glm47_moe` / `glm45` |


### PR DESCRIPTION
## Description

### Problem

The `deepseek-v4` legs of the nightly BFCL and tau2 A/B matrices point at the
undated `deepseek-ai/DeepSeek-V4-Flash` repo. We want the matrix to exercise the
`0731` checkpoint.

### Solution

Point both nightly legs at `deepseek-ai/DeepSeek-V4-Flash-0731` and update the two
matrix tables that document them.

No parser or factory changes are needed:

- **Tool-call routing** — `crates/tool_parser/src/factory.rs:403` maps the glob
  `deepseek-ai/DeepSeek-V4*` to the `deepseek_v4` parser, which the suffixed id
  still matches. (It does *not* fall through to the `deepseek-*` → `pythonic`
  catch-all on the following line.)
- **BFCL handler** — `bfcl_model` is registered at runtime by
  `scripts/bfcl/register_bfcl_model.py`, which synthesizes `<model-id>-FC` against
  `OpenAICompletionsHandler`, so `deepseek-ai/DeepSeek-V4-Flash-0731-FC` needs no
  upstream `bfcl-eval` entry.

The leg keeps its existing `deepseek_v4` / `deepseek_v31` parser pairing, `--kv-cache-dtype fp8 --block-size 256` flags, TP=4 concurrent arm layout, and `2400s` startup timeout.

## Changes

- `.github/workflows/nightly-bfcl.yml` — `model` and `bfcl_model` on the `deepseek-v4` leg.
- `.github/workflows/nightly-tau2.yml` — `model` on the `deepseek-v4` leg.
- `scripts/bfcl/README.md`, `scripts/tau2/README.md` — matrix tables and prose naming the leg's checkpoint.

Deliberately left alone, since they record results actually measured against the
old checkpoint rather than live config: the benchmark tables in
`docs/blog/pytorch-fast-and-correct.md` and the dated plan/spec under
`docs/superpowers/`. The HuggingFace URLs in `crates/tool_parser/src/parsers/deepseek_dsml.rs`
and `crates/tokenizer/src/encoders/deepseek_v4.rs` also still point at the base repo,
which is where the encoding reference lives.

## Test Plan

Config-only change; no Rust or Python source touched.

- `pre-commit run --files <the four changed files>` — all hooks pass (`check yaml`, `codespell`, whitespace).
- Both workflows still parse: `python3 -c "import yaml; yaml.safe_load(open(f))"` on each.
- Verified no `DeepSeek-V4-Flash` occurrence without the `-0731` suffix remains under `.github/` or `scripts/`.

**Requires the new checkpoint to be pre-staged on the Blackwell runner.** The leg
sets `model_cache: /raid/models` and the matrix comment notes models are staged on
NVMe at `/raid/models/<id>`; the first nightly will fail at load if
`deepseek-ai/DeepSeek-V4-Flash-0731` is not present there.

Recommend a `workflow_dispatch` with `only=deepseek-v4` on both nightlies to confirm
the leg launches, parses, and scores before the first scheduled run.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changed)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly BFCL and Tau2 evaluations to use the `DeepSeek-V4-Flash-0731` model checkpoint.
  * Aligned the BFCL function-calling handler and parser configuration with the updated model identifier.

* **Documentation**
  * Updated evaluation matrix and validation guidance to reference the new DeepSeek model version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->