### PR TITLE
fix(workflow): do not persist step context on Skip

### DIFF
--- a/crates/workflow/src/engine.rs
+++ b/crates/workflow/src/engine.rs
@@ -942,11 +942,21 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
 
             let step_duration = step_start.elapsed();
 
-            self.state_store
-                .update(instance_id, |s| {
-                    s.context = context.clone();
-                })
-                .await?;
+            // Persist the step's context mutations back to shared state — but not
+            // for a Skip. A Skip is a pre-mutation early return (the step ran no
+            // logic), so `context` is just the stale full-copy read at step start;
+            // writing it back would clobber a concurrent parallel-branch step
+            // under last-writer-wins. Concretely: an instantly-skipping external
+            // branch step would erase the `connection_mode` a just-finished local
+            // branch step committed, because the whole context is snapshotted and
+            // rewritten wholesale rather than field-merged.
+            if !matches!(result, Ok(Ok(StepResult::Skip))) {
+                self.state_store
+                    .update(instance_id, |s| {
+                        s.context = context.clone();
+                    })
+                    .await?;
+            }
 
             match result {
                 Ok(Ok(StepResult::Success)) => {

--- a/crates/workflow/tests/workflow_test.rs
+++ b/crates/workflow/tests/workflow_test.rs
@@ -1341,3 +1341,73 @@ async fn test_depends_on_any_one_fails_one_succeeds() {
     // Step C SHOULD have executed (because B succeeded)
     assert_eq!(c_executed_clone.load(Ordering::SeqCst), 1);
 }
+
+/// Regression: a `Skip` step must not persist its (stale) context copy back to
+/// shared state. The engine snapshots the whole context per step and writes it
+/// back wholesale, so a parallel branch that skips after a sibling committed a
+/// mutation would otherwise clobber it (last-writer-wins). See engine.rs.
+#[tokio::test]
+async fn test_skip_does_not_clobber_parallel_context_mutation() {
+    let engine: WorkflowEngine<TestWorkflowData> = WorkflowEngine::new();
+
+    // Both steps snapshot the context at ~t0 (both see test_key=None). The
+    // writer then commits its mutation at ~t40; the skipping step wakes at ~t120
+    // and, with the pre-fix bug, writes its stale (None) snapshot back last —
+    // clobbering the writer. The delays make that ordering deterministic:
+    //   skip reads None (t0) < writer persists Some (t40) < skip persists (t120)
+
+    struct WriterStep;
+    #[async_trait::async_trait]
+    impl StepExecutor<TestWorkflowData> for WriterStep {
+        async fn execute(
+            &self,
+            context: &mut WorkflowContext<TestWorkflowData>,
+        ) -> WorkflowResult<StepResult> {
+            sleep(Duration::from_millis(40)).await;
+            context.data.test_key = Some("survived".to_string());
+            Ok(StepResult::Success)
+        }
+    }
+
+    struct SlowSkipStep;
+    #[async_trait::async_trait]
+    impl StepExecutor<TestWorkflowData> for SlowSkipStep {
+        async fn execute(
+            &self,
+            _context: &mut WorkflowContext<TestWorkflowData>,
+        ) -> WorkflowResult<StepResult> {
+            sleep(Duration::from_millis(120)).await;
+            Ok(StepResult::Skip)
+        }
+    }
+
+    // No dependency between the two steps → they run in parallel.
+    let workflow = WorkflowDefinition::new("skip_clobber", "Skip must not clobber")
+        .add_step(StepDefinition::new(
+            "writer",
+            "Writer",
+            Arc::new(WriterStep),
+        ))
+        .add_step(StepDefinition::new(
+            "slow_skip",
+            "Slow skip",
+            Arc::new(SlowSkipStep),
+        ));
+
+    let workflow_id = workflow.id.clone();
+    engine.register_workflow(workflow).unwrap();
+    let instance_id = engine
+        .start_workflow(workflow_id, TestWorkflowData::default())
+        .await
+        .unwrap();
+
+    sleep(Duration::from_millis(250)).await;
+
+    let state = engine.get_status(instance_id).await.unwrap();
+    assert_eq!(state.status, WorkflowStatus::Completed);
+    assert_eq!(
+        state.context.data.test_key.as_deref(),
+        Some("survived"),
+        "a Skip step clobbered a parallel step's committed context mutation"
+    );
+}


### PR DESCRIPTION
## Description

### Problem

The workflow engine persists step context with a wholesale read-modify-write: it reads the entire context, runs the step, then writes the entire context back **unconditionally** (`s.context = context.clone()`), last-writer-wins. When two steps run in parallel — e.g. a DAG's local and external branches, both depending only on a shared parent — the one that finishes second overwrites the first's mutations. A step that returns `Skip` is a pre-mutation early return, but persisting its stale full-context copy still clobbers a sibling's committed fields.

This is latent for network-probing steps (they finish last and win the race), but a step that returns instantly loses the race and its output is silently erased.

### Solution

Do not write context back when a step returns `StepResult::Skip` — a Skip ran no logic, so it has nothing to persist. `Success` and `Failure` still persist (`Failure` so retries observe partial state).

## Changes

- `crates/workflow/src/engine.rs`: guard the context write-back on `!matches!(result, Ok(Ok(StepResult::Skip)))`.

## Test Plan

- `cargo test -p wfaas` — green (21 tests).
- Follow-up in this PR: a regression test with two parallel steps (one mutates + sleeps, one returns `Skip` immediately) asserting the mutation survives, plus a companion asserting `Success` persists.

Reproduced originally via a gateway worker-registration workflow whose instant local-branch step lost the race to a concurrently-skipping external-branch step; generic to any parallel workflow.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
