### PR TITLE
feat(engine-zmq-client): vLLM EngineCore ZMQ client crate + mock-worker mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/mm_rdma", "crates/wasm", "crates/mesh", "crates/grpc_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "crates/mock_worker"]
+members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/mm_rdma", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/engine_zmq_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "crates/mock_worker"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -18,6 +18,7 @@ llm-multimodal = { version = "1.9.0", path = "crates/multimodal" }
 smg-wasm = { version = "1.1.3", path = "crates/wasm", package = "smg-wasm" }
 smg-mesh = { version = "1.4.2", path = "crates/mesh", package = "smg-mesh" }
 smg-grpc-client = { version = "1.10.0", path = "crates/grpc_client" }
+engine-zmq-client = { version = "0.1.0", path = "crates/engine_zmq_client" }
 
 # Shared dependencies
 anyhow = "1.0"
@@ -31,6 +32,15 @@ axum = { version = "0.8.9" }
 blake3 = "1.8"
 lz4_flex = "0.14"
 bytemuck = { version = "1.25" }
+byteorder = "1.5.0"
+bytes = "1.12.0"
+half = { version = "2.7.1", features = ["bytemuck"] }
+rmp-serde = "1.3.1"
+rmpv = { version = "1.3.1", features = ["with-serde"] }
+serde_default = "0.2.0"
+serde_repr = "0.1.20"
+serde_tuple = "1.1.3"
+zeromq = { version = "0.6.0", default-features = false, features = ["tokio-runtime", "all-transport"] }
 chrono = { version = "0.4" }
 dashmap = "6.2.1"
 http = "1.4.2"

--- a/crates/engine_zmq_client/Cargo.toml
+++ b/crates/engine_zmq_client/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "engine-zmq-client"
+version = "0.1.0"
+edition = "2021"
+description = "Engine-agnostic ZMQ transport + per-engine protocol modules for same-host SMG backend connections"
+license = "Apache-2.0"
+repository = "https://github.com/lightseekorg/smg"
+
+# The vLLM EngineCore protocol module is a clean-room port of vLLM's Apache-2.0
+# `vllm-engine-core-client` crate (vllm-project/vllm, rust/src/engine-core-client).
+# It is a protocol reference, not a dependency — see #2001.
+
+[features]
+# Expose the engine-side ZMQ driver (`mock_engine`) so out-of-crate consumers
+# (mock-worker) can run a mock vLLM EngineCore. Always compiled under `cfg(test)`
+# for the crate's own loopback tests.
+mock-engine = []
+
+[dependencies]
+# Wire codec: msgpack + positional-tuple serde + zero-copy tensor aux-frames.
+rmp-serde.workspace = true
+rmpv.workspace = true
+serde.workspace = true
+serde_default.workspace = true
+serde_json.workspace = true
+serde_repr.workspace = true
+serde_tuple.workspace = true
+serde_with.workspace = true
+bytemuck.workspace = true
+byteorder.workspace = true
+bytes.workspace = true
+half.workspace = true
+
+# Transport + async runtime.
+zeromq.workspace = true
+tokio = { workspace = true, features = ["rt", "sync", "time", "net", "macros"] }
+tokio-util.workspace = true
+futures.workspace = true
+parking_lot.workspace = true
+
+# Errors + logging.
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+[lints]
+workspace = true

--- a/crates/engine_zmq_client/examples/live_probe.rs
+++ b/crates/engine_zmq_client/examples/live_probe.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Live wire-validation probe: play the SMG frontend against a real headless
+// vLLM EngineCore over ZMQ. Binds the handshake/input/output sockets, drives the
+// handshake, submits one tokenized generate request, and prints the streamed
+// token ids.
+//
+// Usage:
+//   live_probe <handshake_addr> <input_ipc> <output_ipc> [tok1 tok2 ...]
+//
+// Then launch the engine so it dials <handshake_addr>:
+//   vllm serve <model> --headless --data-parallel-size 1 \
+//     --data-parallel-size-local 1 \
+//     --data-parallel-address 127.0.0.1 --data-parallel-rpc-port <port> \
+//     --enforce-eager
+
+use std::time::Duration;
+
+use engine_zmq_client::{
+    connect_handshake,
+    protocol::vllm::{request::EngineCoreRequest, sampling::EngineCoreSamplingParams},
+    EngineCoreClient,
+};
+use futures::StreamExt;
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let handshake = args
+        .next()
+        .expect("arg1: handshake address (tcp://host:port)");
+    let input = args.next().expect("arg2: input ipc:// address");
+    let output = args.next().expect("arg3: output ipc:// address");
+    let tokens: Vec<u32> = args.filter_map(|a| a.parse().ok()).collect();
+    let prompt_token_ids = if tokens.is_empty() {
+        vec![1, 2, 3, 4]
+    } else {
+        tokens
+    };
+
+    // Model load + KV profiling happen between INIT and READY, so allow a long
+    // handshake window.
+    let timeout = Duration::from_secs(600);
+
+    eprintln!("[probe] binding sockets; waiting for engine to connect on {handshake}");
+    let transport = connect_handshake(
+        &handshake,
+        1,
+        "127.0.0.1",
+        Some(&input),
+        Some(&output),
+        timeout,
+    )
+    .await
+    .expect("handshake with engine");
+
+    let engine = &transport.engines[0];
+    eprintln!(
+        "[probe] engine registered: vllm_version={} max_model_len={} num_gpu_blocks={} block_size={} dtype={} engine_index={:?}",
+        engine.ready_response.vllm_version,
+        engine.ready_response.max_model_len,
+        engine.ready_response.num_gpu_blocks,
+        engine.ready_response.block_size,
+        engine.ready_response.dtype.as_str(),
+        engine.engine_id.engine_index(),
+    );
+
+    let client = EngineCoreClient::new(transport);
+
+    let request = EngineCoreRequest {
+        request_id: "probe-1".to_string(),
+        prompt_token_ids: Some(prompt_token_ids.clone()),
+        sampling_params: Some(EngineCoreSamplingParams {
+            temperature: 0.0,
+            max_tokens: 32,
+            ..EngineCoreSamplingParams::for_test()
+        }),
+        ..EngineCoreRequest::default()
+    };
+    eprintln!("[probe] submitting request with prompt_token_ids={prompt_token_ids:?}");
+
+    let mut stream = client.submit(request).await.expect("submit");
+    let mut all_tokens = Vec::new();
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(output) => {
+                all_tokens.extend(output.new_token_ids.iter().copied());
+                eprintln!(
+                    "[probe] +{:?} finish={:?}",
+                    output.new_token_ids, output.finish_reason
+                );
+                if output.finished() {
+                    eprintln!(
+                        "[probe] DONE finish={:?} total_tokens={} ids={:?}",
+                        output.finish_reason,
+                        all_tokens.len(),
+                        all_tokens
+                    );
+                    break;
+                }
+            }
+            Err(error) => {
+                eprintln!("[probe] ERROR: {error}");
+                std::process::exit(1);
+            }
+        }
+    }
+    eprintln!("[probe] success: streamed {} tokens", all_tokens.len());
+}

--- a/crates/engine_zmq_client/examples/live_probe.rs
+++ b/crates/engine_zmq_client/examples/live_probe.rs
@@ -14,6 +14,16 @@
 //     --data-parallel-address 127.0.0.1 --data-parallel-rpc-port <port> \
 //     --enforce-eager
 
+// This is a dev-only CLI probe, not library code: printing to stderr, `expect`
+// on argument/handshake errors, and `process::exit` on failure are all
+// appropriate here and intentionally exempt from the workspace restriction lints.
+#![expect(
+    clippy::print_stderr,
+    clippy::expect_used,
+    clippy::disallowed_methods,
+    reason = "dev-only live-validation CLI example"
+)]
+
 use std::time::Duration;
 
 use engine_zmq_client::{

--- a/crates/engine_zmq_client/src/codec/dtype.rs
+++ b/crates/engine_zmq_client/src/codec/dtype.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/dtype.rs and protocol/logprobs/array.rs.
+
+use std::io::Cursor;
+
+use byteorder::{BigEndian, LittleEndian, NativeEndian, ReadBytesExt};
+
+use crate::error::{Error, Result};
+
+/// Effective model dtype reported by the engine after config resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ModelDtype {
+    #[serde(rename = "float16")]
+    Float16,
+    #[serde(rename = "bfloat16")]
+    BFloat16,
+    #[serde(rename = "float32")]
+    Float32,
+}
+
+impl ModelDtype {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Float16 => "float16",
+            Self::BFloat16 => "bfloat16",
+            Self::Float32 => "float32",
+        }
+    }
+}
+
+/// The scalar element type of a wire ndarray, parsed from its numpy dtype string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarType {
+    I32,
+    I64,
+    F32,
+}
+
+impl ScalarType {
+    /// Size in bytes of one element.
+    pub fn element_size(self) -> usize {
+        match self {
+            Self::I32 | Self::F32 => 4,
+            Self::I64 => 8,
+        }
+    }
+}
+
+/// Byte order encoded by the numpy dtype prefix (`<`, `>`, `=`, `|`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Endianness {
+    Little,
+    Big,
+    Native,
+}
+
+/// Parse a numpy dtype string (e.g. `"<i4"`, `"float32"`) into a scalar type
+/// and byte order.
+pub fn parse_dtype(dtype: &str, field: &str) -> Result<(ScalarType, Endianness)> {
+    let (endianness, body) = match dtype.as_bytes().first().copied() {
+        Some(b'<') => (Endianness::Little, &dtype[1..]),
+        Some(b'>') => (Endianness::Big, &dtype[1..]),
+        Some(b'=') | Some(b'|') => (Endianness::Native, &dtype[1..]),
+        _ => (Endianness::Native, dtype),
+    };
+
+    let scalar = match body {
+        "i4" | "int32" => ScalarType::I32,
+        "i8" | "int64" => ScalarType::I64,
+        "f4" | "float32" => ScalarType::F32,
+        _ => {
+            return Err(decode_error(
+                field,
+                &format!("unsupported dtype string {dtype:?}"),
+            ))
+        }
+    };
+    Ok((scalar, endianness))
+}
+
+/// Decode a little/big/native-endian buffer into a `Vec<i32>`.
+pub fn decode_i32_vec(bytes: &[u8], endianness: Endianness, field: &str) -> Result<Vec<i32>> {
+    if !bytes.len().is_multiple_of(4) {
+        return Err(decode_error(
+            field,
+            &format!("byte length {} is not divisible by 4", bytes.len()),
+        ));
+    }
+    let mut cursor = Cursor::new(bytes);
+    let mut values = Vec::with_capacity(bytes.len() / 4);
+    while (cursor.position() as usize) < bytes.len() {
+        let value = match endianness {
+            Endianness::Little => cursor.read_i32::<LittleEndian>(),
+            Endianness::Big => cursor.read_i32::<BigEndian>(),
+            Endianness::Native => cursor.read_i32::<NativeEndian>(),
+        }
+        .map_err(|error| decode_error(field, &format!("failed to read i32 payload: {error}")))?;
+        values.push(value);
+    }
+    Ok(values)
+}
+
+/// Decode a little/big/native-endian buffer into a `Vec<i64>`.
+pub fn decode_i64_vec(bytes: &[u8], endianness: Endianness, field: &str) -> Result<Vec<i64>> {
+    if !bytes.len().is_multiple_of(8) {
+        return Err(decode_error(
+            field,
+            &format!("byte length {} is not divisible by 8", bytes.len()),
+        ));
+    }
+    let mut cursor = Cursor::new(bytes);
+    let mut values = Vec::with_capacity(bytes.len() / 8);
+    while (cursor.position() as usize) < bytes.len() {
+        let value = match endianness {
+            Endianness::Little => cursor.read_i64::<LittleEndian>(),
+            Endianness::Big => cursor.read_i64::<BigEndian>(),
+            Endianness::Native => cursor.read_i64::<NativeEndian>(),
+        }
+        .map_err(|error| decode_error(field, &format!("failed to read i64 payload: {error}")))?;
+        values.push(value);
+    }
+    Ok(values)
+}
+
+/// Decode a little/big/native-endian buffer into a `Vec<f32>`.
+pub fn decode_f32_vec(bytes: &[u8], endianness: Endianness, field: &str) -> Result<Vec<f32>> {
+    if !bytes.len().is_multiple_of(4) {
+        return Err(decode_error(
+            field,
+            &format!("byte length {} is not divisible by 4", bytes.len()),
+        ));
+    }
+    let mut cursor = Cursor::new(bytes);
+    let mut values = Vec::with_capacity(bytes.len() / 4);
+    while (cursor.position() as usize) < bytes.len() {
+        let value = match endianness {
+            Endianness::Little => cursor.read_f32::<LittleEndian>(),
+            Endianness::Big => cursor.read_f32::<BigEndian>(),
+            Endianness::Native => cursor.read_f32::<NativeEndian>(),
+        }
+        .map_err(|error| decode_error(field, &format!("failed to read f32 payload: {error}")))?;
+        values.push(value);
+    }
+    Ok(values)
+}
+
+/// Convert a signed token id / rank into `u32`, rejecting negatives and overflow.
+pub fn convert_to_u32<I>(value: I, field: &str) -> Result<u32>
+where
+    I: TryInto<u32> + std::fmt::Display + Copy,
+{
+    value.try_into().map_err(|_| {
+        decode_error(
+            field,
+            &format!("expected non-negative value that fits in u32, got {value}"),
+        )
+    })
+}
+
+/// Build an [`Error::ExtValueDecode`] scoped to a field name.
+pub fn decode_error(field: &str, reason: &str) -> Error {
+    Error::ExtValueDecode {
+        message: format!("{field}: {reason}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serde_uses_protocol_dtype_strings() {
+        assert_eq!(
+            serde_json::to_value(ModelDtype::Float16).unwrap(),
+            serde_json::json!("float16")
+        );
+        assert_eq!(
+            serde_json::from_value::<ModelDtype>(serde_json::json!("bfloat16")).unwrap(),
+            ModelDtype::BFloat16
+        );
+        assert_eq!(ModelDtype::Float32.as_str(), "float32");
+    }
+
+    #[test]
+    fn parse_dtype_handles_endianness_and_aliases() {
+        assert_eq!(
+            parse_dtype("<i4", "f").unwrap(),
+            (ScalarType::I32, Endianness::Little)
+        );
+        assert_eq!(
+            parse_dtype(">i8", "f").unwrap(),
+            (ScalarType::I64, Endianness::Big)
+        );
+        assert_eq!(
+            parse_dtype("=f4", "f").unwrap(),
+            (ScalarType::F32, Endianness::Native)
+        );
+        assert_eq!(
+            parse_dtype("float32", "f").unwrap(),
+            (ScalarType::F32, Endianness::Native)
+        );
+        assert!(parse_dtype("<c8", "f").is_err());
+    }
+
+    #[test]
+    fn decoders_respect_endianness() {
+        let le = 1_i32.to_le_bytes();
+        assert_eq!(
+            decode_i32_vec(&le, Endianness::Little, "f").unwrap(),
+            vec![1]
+        );
+        let be = 1_i32.to_be_bytes();
+        assert_eq!(decode_i32_vec(&be, Endianness::Big, "f").unwrap(), vec![1]);
+        assert!(decode_i32_vec(&[0, 1, 2], Endianness::Little, "f").is_err());
+
+        let f = 2.5_f32.to_le_bytes();
+        assert_eq!(
+            decode_f32_vec(&f, Endianness::Little, "f").unwrap(),
+            vec![2.5]
+        );
+        let big = 7_i64.to_be_bytes();
+        assert_eq!(decode_i64_vec(&big, Endianness::Big, "f").unwrap(), vec![7]);
+    }
+
+    #[test]
+    fn convert_to_u32_rejects_negative() {
+        assert_eq!(convert_to_u32(5_i32, "f").unwrap(), 5);
+        assert!(convert_to_u32(-1_i32, "f").is_err());
+    }
+}

--- a/crates/engine_zmq_client/src/codec/mod.rs
+++ b/crates/engine_zmq_client/src/codec/mod.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/mod.rs.
+
+//! Engine-agnostic wire primitives: msgpack (de)serialization, numpy dtype
+//! handling, and the zero-copy tensor aux-frame codec.
+
+use std::{any::type_name, io::Cursor};
+
+use rmpv::Value;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+pub mod dtype;
+pub mod tensor;
+
+/// Dynamic msgpack value used for schema positions that are preserved but not
+/// yet strongly typed.
+pub type OpaqueValue = Value;
+
+/// Encode a Rust value into msgpack using named fields (map encoding for
+/// structs; positional arrays come from `serde_tuple`-derived types).
+pub fn encode_msgpack<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: Serialize + std::fmt::Debug,
+{
+    rmp_serde::to_vec_named(value).map_err(|error| Error::Encode {
+        target_type: type_name::<T>(),
+        message: format!("failed to encode value `{value:?}`: {error}"),
+    })
+}
+
+/// Decode a msgpack payload into a strongly typed value, attaching a dynamic
+/// value preview to decode failures for diagnostics.
+pub fn decode_msgpack<T>(bytes: &[u8]) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    fn decode_value_preview(bytes: &[u8]) -> String {
+        match decode_value(bytes) {
+            Ok(value) => format!("{value}"),
+            Err(error) => format!("<value decode failed: {error}>"),
+        }
+    }
+
+    rmp_serde::from_slice(bytes).map_err(|error| Error::Decode {
+        target_type: type_name::<T>(),
+        message: format!("{error}; value fallback: {}", decode_value_preview(bytes)),
+    })
+}
+
+/// Decode a msgpack payload into a dynamic value for diagnostics and tests.
+pub fn decode_value(bytes: &[u8]) -> Result<Value> {
+    Ok(rmpv::decode::read_value(&mut Cursor::new(bytes))?)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn decode_msgpack_includes_type_name_and_value_fallback() {
+        let payload = rmp_serde::to_vec_named(&BTreeMap::from([("status", "READY")])).unwrap();
+        let error = decode_msgpack::<u64>(&payload).unwrap_err();
+        let rendered = error.to_string();
+        assert!(rendered.contains("u64"), "missing type name: {rendered}");
+        assert!(
+            rendered.contains("READY"),
+            "missing value fallback: {rendered}"
+        );
+    }
+
+    #[test]
+    fn roundtrip_named_map_struct() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Cfg {
+            status: String,
+            headless: bool,
+        }
+        let cfg = Cfg {
+            status: "HELLO".into(),
+            headless: true,
+        };
+        let bytes = encode_msgpack(&cfg).unwrap();
+        assert_eq!(decode_msgpack::<Cfg>(&bytes).unwrap(), cfg);
+    }
+}

--- a/crates/engine_zmq_client/src/codec/tensor.rs
+++ b/crates/engine_zmq_client/src/codec/tensor.rs
@@ -1,0 +1,505 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/tensor.rs and protocol/logprobs/array.rs.
+//
+// Mirrors Python `vllm/v1/serial_utils.py` `encode_ndarray`/`encode_tensor`.
+
+use bytemuck::{cast_slice, Pod};
+use bytes::Bytes;
+use half::{bf16, f16};
+use rmpv::Value;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+use super::dtype::{
+    convert_to_u32, decode_error, decode_f32_vec, decode_i32_vec, decode_i64_vec, parse_dtype,
+    Endianness, ScalarType,
+};
+use crate::error::Result;
+
+/// Tensors and ndarrays are encoded with this msgpack extension type in Python.
+/// See `vllm/v1/serial_utils.py` `CUSTOM_TYPE_RAW_VIEW`.
+const CUSTOM_TYPE_RAW_VIEW: i8 = 3;
+
+/// Total number of elements implied by `shape`, or `None` on overflow.
+pub fn checked_numel(shape: &[usize]) -> Option<usize> {
+    shape
+        .iter()
+        .try_fold(1usize, |acc, dim| acc.checked_mul(*dim))
+}
+
+#[derive(Serialize)]
+#[serde(rename = "_ExtStruct")]
+struct MsgpackExtRef<'a>((i8, ByteSlice<'a>));
+
+struct ByteSlice<'a>(&'a [u8]);
+
+struct PodVec<T: Pod>(Vec<T>);
+
+impl<T: Pod> AsRef<[u8]> for PodVec<T> {
+    fn as_ref(&self) -> &[u8] {
+        cast_slice(&self.0)
+    }
+}
+
+fn bytes_from_pod_vec<T>(data: Vec<T>) -> Bytes
+where
+    T: Pod + Send + 'static,
+{
+    Bytes::from_owner(PodVec(data))
+}
+
+impl Serialize for ByteSlice<'_> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bytes(self.0)
+    }
+}
+
+/// Python ndarray/tensor wire tuple encoded as `(dtype, shape, data)`.
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct WireNdArray {
+    pub dtype: String,
+    pub shape: Vec<usize>,
+    pub data: WireArrayData,
+}
+
+impl WireNdArray {
+    /// float32 tensor/ndarray backed by native-endian raw-view bytes (no copy).
+    pub fn from_f32(shape: Vec<usize>, data: Vec<f32>) -> std::result::Result<Self, String> {
+        validate_element_count(&shape, data.len())?;
+        Ok(Self::from_raw_bytes(
+            "float32",
+            shape,
+            bytes_from_pod_vec(data),
+        ))
+    }
+
+    /// float16 tensor/ndarray backed by native-endian raw-view bytes (no copy).
+    pub fn from_f16(shape: Vec<usize>, data: Vec<f16>) -> std::result::Result<Self, String> {
+        validate_element_count(&shape, data.len())?;
+        Ok(Self::from_raw_bytes(
+            "float16",
+            shape,
+            bytes_from_pod_vec(data),
+        ))
+    }
+
+    /// bfloat16 tensor/ndarray backed by native-endian raw-view bytes (no copy).
+    pub fn from_bf16(shape: Vec<usize>, data: Vec<bf16>) -> std::result::Result<Self, String> {
+        validate_element_count(&shape, data.len())?;
+        Ok(Self::from_raw_bytes(
+            "bfloat16",
+            shape,
+            bytes_from_pod_vec(data),
+        ))
+    }
+
+    /// int64 tensor/ndarray backed by native-endian raw-view bytes (no copy).
+    pub fn from_i64(shape: Vec<usize>, data: Vec<i64>) -> std::result::Result<Self, String> {
+        validate_element_count(&shape, data.len())?;
+        Ok(Self::from_raw_bytes(
+            "int64",
+            shape,
+            bytes_from_pod_vec(data),
+        ))
+    }
+
+    /// uint32 tensor/ndarray backed by native-endian raw-view bytes (no copy).
+    pub fn from_u32(shape: Vec<usize>, data: Vec<u32>) -> std::result::Result<Self, String> {
+        validate_element_count(&shape, data.len())?;
+        Ok(Self::from_raw_bytes(
+            "uint32",
+            shape,
+            bytes_from_pod_vec(data),
+        ))
+    }
+
+    /// bool tensor/ndarray: one byte per element (`torch.bool` storage), not a
+    /// packed bitmap. `false -> 0`, `true -> 1`.
+    pub fn from_bool(shape: Vec<usize>, data: Vec<bool>) -> std::result::Result<Self, String> {
+        validate_element_count(&shape, data.len())?;
+        Ok(Self {
+            dtype: "bool".to_string(),
+            shape,
+            data: WireArrayData::RawView(Bytes::from(
+                data.into_iter().map(u8::from).collect::<Vec<_>>(),
+            )),
+        })
+    }
+
+    /// Build from already-encoded raw-view bytes matching `dtype`/`shape`.
+    pub fn from_raw(dtype: impl Into<String>, shape: Vec<usize>, data: Vec<u8>) -> Self {
+        Self::from_raw_bytes(dtype, shape, Bytes::from(data))
+    }
+
+    /// Build from an owned immutable raw-view buffer.
+    pub fn from_raw_bytes(dtype: impl Into<String>, shape: Vec<usize>, data: Bytes) -> Self {
+        Self {
+            dtype: dtype.into(),
+            shape,
+            data: WireArrayData::RawView(data),
+        }
+    }
+
+    // NOTE: send-side aux-frame extraction (moving large inline tensors into
+    // ordered aux frames) is added with the typed multimodal module — text
+    // requests carry no tensors. The receive-side resolution below is used now
+    // (logprobs arrays may arrive as aux frames).
+}
+
+/// Validate that the shape product matches the data length.
+fn validate_element_count(shape: &[usize], len: usize) -> std::result::Result<(), String> {
+    let expected = checked_numel(shape)
+        .ok_or_else(|| format!("tensor shape product overflows usize: {shape:?}"))?;
+    if expected == len {
+        Ok(())
+    } else {
+        Err(format!(
+            "tensor data length {len} does not match shape {shape:?} product {expected}"
+        ))
+    }
+}
+
+/// Same wire shape as [`WireNdArray`]; multimodal payloads use it for tensors.
+pub type WireTensor = WireNdArray;
+
+/// Array/tensor payload inside [`WireNdArray`]: either an inline raw-view ext or
+/// a one-based index into the multipart aux-frame list.
+#[derive(Debug, Clone, PartialEq)]
+pub enum WireArrayData {
+    /// Index of the aux frame holding this array's raw bytes (one-based).
+    AuxIndex(usize),
+    /// Inline raw bytes of this array/tensor.
+    RawView(Bytes),
+}
+
+impl WireArrayData {
+    /// Consume into the inline raw view, if present.
+    pub fn into_raw_view(self) -> Option<Bytes> {
+        match self {
+            Self::RawView(bytes) => Some(bytes),
+            Self::AuxIndex(_) => None,
+        }
+    }
+
+    /// Borrow the inline raw view, if present.
+    pub fn as_raw_view(&self) -> Option<&Bytes> {
+        match self {
+            Self::RawView(bytes) => Some(bytes),
+            Self::AuxIndex(_) => None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for WireArrayData {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        match value {
+            Value::Ext(tag, bytes) if tag == CUSTOM_TYPE_RAW_VIEW => {
+                Ok(Self::RawView(Bytes::from(bytes)))
+            }
+            Value::Ext(tag, _) => Err(serde::de::Error::custom(format!(
+                "unsupported extension type code {tag}"
+            ))),
+            Value::Integer(index) => index
+                .as_u64()
+                .map(|index| Self::AuxIndex(index as usize))
+                .ok_or_else(|| {
+                    serde::de::Error::custom("aux frame index must be a non-negative integer")
+                }),
+            other => Err(serde::de::Error::custom(format!(
+                "expected raw-view ext or aux frame index, got {other:?}"
+            ))),
+        }
+    }
+}
+
+impl Serialize for WireArrayData {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::AuxIndex(index) => serializer.serialize_u64(*index as u64),
+            Self::RawView(bytes) => {
+                MsgpackExtRef((CUSTOM_TYPE_RAW_VIEW, ByteSlice(bytes))).serialize(serializer)
+            }
+        }
+    }
+}
+
+/// A decoded rank-2 array with its dimensions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecodedArray2<T> {
+    pub rows: usize,
+    pub cols: usize,
+    pub data: Vec<T>,
+}
+
+/// Resolve an array payload to raw bytes, following an aux-frame index into
+/// `frames` (frame 0 is the primary msgpack, so indices are one-based).
+pub fn resolve_array_bytes<Frame>(
+    value: WireArrayData,
+    field: &str,
+    frames: &[Frame],
+) -> Result<Bytes>
+where
+    Frame: AsRef<[u8]>,
+{
+    match value {
+        WireArrayData::RawView(bytes) => Ok(bytes),
+        WireArrayData::AuxIndex(index) => {
+            let frame = frames.get(index).ok_or_else(|| {
+                decode_error(
+                    field,
+                    &format!(
+                        "aux frame index {index} out of range for {} frames",
+                        frames.len()
+                    ),
+                )
+            })?;
+            Ok(Bytes::copy_from_slice(frame.as_ref()))
+        }
+    }
+}
+
+/// Validate that `byte_len` matches the shape product times the scalar size.
+pub fn validate_byte_length(
+    shape: &[usize],
+    byte_len: usize,
+    field: &str,
+    scalar: ScalarType,
+) -> Result<()> {
+    let element_count = checked_numel(shape)
+        .ok_or_else(|| decode_error(field, "shape element count overflowed usize"))?;
+    let expected = element_count
+        .checked_mul(scalar.element_size())
+        .ok_or_else(|| decode_error(field, "byte length overflowed usize"))?;
+    if expected != byte_len {
+        return Err(decode_error(
+            field,
+            &format!("byte length mismatch: expected {expected}, got {byte_len}"),
+        ));
+    }
+    Ok(())
+}
+
+fn decode_array_metadata<Frame>(
+    value: WireNdArray,
+    field: &str,
+    frames: &[Frame],
+    expected_scalars: &[ScalarType],
+) -> Result<(Vec<usize>, Bytes, ScalarType, Endianness)>
+where
+    Frame: AsRef<[u8]>,
+{
+    let WireNdArray { dtype, shape, data } = value;
+    let (scalar, endianness) = parse_dtype(&dtype, field)?;
+    if !expected_scalars.contains(&scalar) {
+        return Err(decode_error(
+            field,
+            &format!("expected dtype in {expected_scalars:?}, got {dtype}"),
+        ));
+    }
+    let bytes = resolve_array_bytes(data, field, frames)?;
+    validate_byte_length(shape.as_slice(), bytes.len(), field, scalar)?;
+    Ok((shape, bytes, scalar, endianness))
+}
+
+/// Decode a rank-2 integer array (i32/i64) to `u32` rows.
+pub fn decode_array2_u32<Frame>(
+    value: WireNdArray,
+    field: &str,
+    frames: &[Frame],
+) -> Result<DecodedArray2<u32>>
+where
+    Frame: AsRef<[u8]>,
+{
+    let (shape, bytes, scalar, endianness) =
+        decode_array_metadata(value, field, frames, &[ScalarType::I32, ScalarType::I64])?;
+    if shape.len() != 2 {
+        return Err(decode_error(
+            field,
+            &format!("expected rank-2 array, got rank {}", shape.len()),
+        ));
+    }
+    let data = decode_int_as_u32(&bytes, scalar, endianness, field)?;
+    Ok(DecodedArray2 {
+        rows: shape[0],
+        cols: shape[1],
+        data,
+    })
+}
+
+/// Decode a rank-1 integer array (i32/i64) to a `Vec<u32>`.
+pub fn decode_array1_u32<Frame>(
+    value: WireNdArray,
+    field: &str,
+    frames: &[Frame],
+) -> Result<Vec<u32>>
+where
+    Frame: AsRef<[u8]>,
+{
+    let (shape, bytes, scalar, endianness) =
+        decode_array_metadata(value, field, frames, &[ScalarType::I32, ScalarType::I64])?;
+    if shape.len() != 1 {
+        return Err(decode_error(
+            field,
+            &format!("expected rank-1 array, got rank {}", shape.len()),
+        ));
+    }
+    decode_int_as_u32(&bytes, scalar, endianness, field)
+}
+
+/// Decode a rank-2 float32 array.
+pub fn decode_array2_f32<Frame>(
+    value: WireNdArray,
+    field: &str,
+    frames: &[Frame],
+) -> Result<DecodedArray2<f32>>
+where
+    Frame: AsRef<[u8]>,
+{
+    let (shape, bytes, _, endianness) =
+        decode_array_metadata(value, field, frames, &[ScalarType::F32])?;
+    if shape.len() != 2 {
+        return Err(decode_error(
+            field,
+            &format!("expected rank-2 array, got rank {}", shape.len()),
+        ));
+    }
+    let data = decode_f32_vec(&bytes, endianness, field)?;
+    Ok(DecodedArray2 {
+        rows: shape[0],
+        cols: shape[1],
+        data,
+    })
+}
+
+fn decode_int_as_u32(
+    bytes: &[u8],
+    scalar: ScalarType,
+    endianness: Endianness,
+    field: &str,
+) -> Result<Vec<u32>> {
+    match scalar {
+        ScalarType::I32 => decode_i32_vec(bytes, endianness, field)?
+            .into_iter()
+            .map(|value| convert_to_u32(value, field))
+            .collect(),
+        ScalarType::I64 => decode_i64_vec(bytes, endianness, field)?
+            .into_iter()
+            .map(|value| convert_to_u32(value, field))
+            .collect(),
+        ScalarType::F32 => Err(decode_error(field, "expected integer dtype, got f32")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_view_serializes_as_msgpack_ext() {
+        let bytes = vec![1, 2, 3, 4];
+        let encoded =
+            rmp_serde::to_vec_named(&WireArrayData::RawView(bytes.clone().into())).expect("encode");
+        let expected = rmp_serde::to_vec_named(&Value::Ext(CUSTOM_TYPE_RAW_VIEW, bytes.clone()))
+            .expect("encode expected");
+        assert_eq!(encoded, expected);
+        assert_eq!(
+            rmpv::decode::read_value(&mut std::io::Cursor::new(encoded)).expect("decode"),
+            Value::Ext(CUSTOM_TYPE_RAW_VIEW, bytes)
+        );
+    }
+
+    #[test]
+    fn constructors_build_raw_view_tensors_without_copy() {
+        let f32_data = vec![1.0, 2.5];
+        let f32_data_ptr = f32_data.as_ptr().cast::<u8>();
+        let f32_tensor = WireNdArray::from_f32(vec![2], f32_data).unwrap();
+        assert_eq!(f32_tensor.dtype, "float32");
+        assert_eq!(f32_tensor.shape, vec![2]);
+        let f32_raw_view = f32_tensor.data.into_raw_view().expect("raw view");
+        // Zero-copy: the raw view aliases the original allocation.
+        assert_eq!(f32_raw_view.as_ptr(), f32_data_ptr);
+        assert_eq!(
+            f32_raw_view,
+            [1.0_f32, 2.5]
+                .into_iter()
+                .flat_map(f32::to_ne_bytes)
+                .collect::<Vec<_>>()
+        );
+
+        let i64_tensor = WireNdArray::from_i64(vec![1], vec![-7]).unwrap();
+        assert_eq!(i64_tensor.dtype, "int64");
+        assert_eq!(
+            i64_tensor.data.into_raw_view().expect("raw view").as_ref(),
+            (-7_i64).to_ne_bytes().as_ref()
+        );
+
+        let bool_tensor = WireNdArray::from_bool(vec![2], vec![false, true]).unwrap();
+        assert_eq!(
+            bool_tensor.data.into_raw_view().expect("raw view"),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn constructors_validate_shape_product() {
+        let err = WireNdArray::from_f32(vec![2, 2], vec![1.0, 2.0]).unwrap_err();
+        assert!(err.contains("does not match shape"));
+    }
+
+    #[test]
+    fn decode_array_roundtrips_through_aux_frame() {
+        // Encode a rank-1 i32 array as an aux frame, then decode it back.
+        let arr = WireNdArray::from_raw_bytes(
+            "<i4",
+            vec![3],
+            Bytes::from(
+                [10_i32, 20, 30]
+                    .into_iter()
+                    .flat_map(i32::to_le_bytes)
+                    .collect::<Vec<_>>(),
+            ),
+        );
+        // frame 0 = primary (unused here), frame 1 = the array bytes.
+        let raw = arr.data.as_raw_view().expect("raw").clone();
+        let framed = vec![Bytes::new(), raw];
+        let via_aux = WireNdArray {
+            dtype: "<i4".into(),
+            shape: vec![3],
+            data: WireArrayData::AuxIndex(1),
+        };
+        assert_eq!(
+            decode_array1_u32(via_aux, "ids", &framed).unwrap(),
+            vec![10, 20, 30]
+        );
+    }
+
+    #[test]
+    fn decode_array2_f32_checks_rank_and_length() {
+        let bytes = Bytes::from(
+            [1.0_f32, 2.0, 3.0, 4.0]
+                .into_iter()
+                .flat_map(f32::to_le_bytes)
+                .collect::<Vec<_>>(),
+        );
+        let arr = WireNdArray {
+            dtype: "<f4".into(),
+            shape: vec![2, 2],
+            data: WireArrayData::RawView(bytes),
+        };
+        let decoded = decode_array2_f32(arr, "lp", &[Bytes::new()]).unwrap();
+        assert_eq!((decoded.rows, decoded.cols), (2, 2));
+        assert_eq!(decoded.data, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+}

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -1,0 +1,590 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// The connector: the frontend-side request/response layer over a
+// [`ConnectedTransport`]. Adapted from the Apache-2.0 reference
+// `vllm-engine-core-client` (vllm-project/vllm) client, scoped to SMG's needs:
+//
+// - No client-side DP load balancing. SMG routing picks the rank and stamps
+//   `data_parallel_rank`; the connector consumes the piggybacked per-rank
+//   `scheduler_stats` as the load signal.
+// - No DP coordinator / wave protocol yet (single shared transport, DP=1).
+// - No utility RPC (deferred).
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use futures::Stream;
+use parking_lot::Mutex;
+use tokio::{sync::mpsc, task::JoinHandle};
+use tracing::{trace, warn};
+use zeromq::RouterSendHalf;
+
+use crate::{
+    codec::encode_msgpack,
+    error::{Error, Result},
+    protocol::vllm::{
+        output::{EngineCoreOutput, EngineCoreOutputs},
+        request::{EngineCoreRequest, EngineCoreRequestType},
+        stats::SchedulerStats,
+    },
+    transport::{run_output_loop, send_message, ConnectedEngine, ConnectedTransport, EngineId},
+};
+
+type OutputSender = mpsc::UnboundedSender<Result<EngineCoreOutput>>;
+type OutputReceiver = mpsc::UnboundedReceiver<Result<EngineCoreOutput>>;
+
+/// Routes engine outputs to per-request streams and tracks in-flight requests.
+/// Keyed by `request_id`; the value is that request's output channel sender.
+#[derive(Default)]
+struct RequestRegistry {
+    closed: bool,
+    requests: HashMap<String, OutputSender>,
+}
+
+impl RequestRegistry {
+    /// Register a new request, returning the receiver for its output stream.
+    fn register(&mut self, request_id: String) -> Result<OutputReceiver> {
+        if self.closed {
+            return Err(Error::ClientClosed {
+                message: "client is shutting down".to_string(),
+            });
+        }
+        if self.requests.contains_key(&request_id) {
+            return Err(Error::DuplicateRequestId { request_id });
+        }
+        let (sender, receiver) = mpsc::unbounded_channel();
+        self.requests.insert(request_id, sender);
+        Ok(receiver)
+    }
+
+    /// Deliver one output to its request stream; drop the entry when terminal.
+    fn route(&mut self, output: EngineCoreOutput) {
+        let request_id = output.request_id.clone();
+        let Some(sender) = self.requests.get(&request_id) else {
+            trace!(%request_id, "output for unknown/finished request; dropping");
+            return;
+        };
+        let finished = output.finished();
+        if sender.send(Ok(output)).is_err() || finished {
+            // Receiver gone (stream dropped) or request finished — stop tracking.
+            self.requests.remove(&request_id);
+        }
+    }
+
+    /// Remove finished/aborted request ids reported out-of-band by the engine.
+    fn remove_all<'a>(&mut self, request_ids: impl IntoIterator<Item = &'a String>) {
+        for request_id in request_ids {
+            self.requests.remove(request_id);
+        }
+    }
+
+    /// Fail every in-flight request with a shared error and close the registry.
+    fn fail_all(&mut self, error: Arc<Error>) {
+        self.closed = true;
+        for (_, sender) in self.requests.drain() {
+            let _ = sender.send(Err(Error::Shared(error.clone())));
+        }
+    }
+}
+
+struct ClientInner {
+    /// Shared input ROUTER send half (serialized across concurrent submits).
+    input_send: tokio::sync::Mutex<RouterSendHalf>,
+    engines: Vec<ConnectedEngine>,
+    registry: Mutex<RequestRegistry>,
+    /// Latest per-rank scheduler load, keyed by engine index. SMG's DP load signal.
+    load: Mutex<HashMap<u32, SchedulerStats>>,
+    /// Auto-abort channel fed by dropped streams.
+    abort_tx: mpsc::UnboundedSender<(EngineId, String)>,
+    client_index: u32,
+}
+
+impl ClientInner {
+    /// Pick the engine for a request: by `data_parallel_rank` if set, else the
+    /// sole engine. SMG routing is authoritative for rank selection. The rank is
+    /// matched against the engine's ZMQ index (Python `EngineCoreProc`'s 2-byte
+    /// identity), which is version-independent — unlike the `data_parallel_rank`
+    /// field, which not every vLLM version sends in `EngineCoreReadyResponse`.
+    fn select_engine(&self, data_parallel_rank: Option<u32>) -> Result<EngineId> {
+        match data_parallel_rank {
+            Some(rank) => self
+                .engines
+                .iter()
+                .find(|engine| engine.engine_id.engine_index() == Some(rank))
+                .map(|engine| engine.engine_id.clone())
+                .ok_or(Error::InvalidDataParallelRank {
+                    rank,
+                    num_engines: self.engines.len() as u32,
+                }),
+            None => self
+                .engines
+                .first()
+                .map(|engine| engine.engine_id.clone())
+                .ok_or(Error::ClientClosed {
+                    message: "no engines connected".to_string(),
+                }),
+        }
+    }
+
+    /// Send an encoded request frame to one engine over the shared input socket.
+    async fn send_to_engine(
+        &self,
+        engine_id: &EngineId,
+        request_type: EngineCoreRequestType,
+        payload: Vec<u8>,
+        aux_frames: Vec<bytes::Bytes>,
+    ) -> Result<()> {
+        let mut input_send = self.input_send.lock().await;
+        send_message(
+            &mut input_send,
+            engine_id,
+            request_type.to_frame(),
+            payload.into(),
+            aux_frames,
+        )
+        .await
+    }
+
+    /// Send an Abort for one request id to its engine.
+    async fn abort(&self, engine_id: &EngineId, request_id: &str) -> Result<()> {
+        let payload = encode_msgpack(&[request_id.to_string()])?;
+        self.send_to_engine(engine_id, EngineCoreRequestType::Abort, payload, Vec::new())
+            .await
+    }
+}
+
+/// Direct ZMQ connection to a same-host vLLM EngineCore (one or more DP ranks
+/// behind one shared transport).
+pub struct EngineCoreClient {
+    inner: Arc<ClientInner>,
+    tasks: Vec<JoinHandle<()>>,
+    next_client_seq: AtomicU64,
+}
+
+impl EngineCoreClient {
+    /// Build a client over a connected transport, spawning the output loop and
+    /// dispatcher. Background tasks are aborted when the client is dropped.
+    pub fn new(transport: ConnectedTransport) -> Self {
+        let ConnectedTransport {
+            engines,
+            input_send,
+            output_socket,
+            ..
+        } = transport;
+
+        let (abort_tx, abort_rx) = mpsc::unbounded_channel();
+        let inner = Arc::new(ClientInner {
+            input_send: tokio::sync::Mutex::new(input_send),
+            engines,
+            registry: Mutex::new(RequestRegistry::default()),
+            load: Mutex::new(HashMap::new()),
+            abort_tx,
+            client_index: 0,
+        });
+
+        // Transport output loop: decode raw frames -> EngineCoreOutputs channel.
+        let (out_tx, out_rx) = mpsc::channel(256);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "background tasks are aborted on client drop"
+        )]
+        let output_task = tokio::spawn(run_output_loop(output_socket, out_tx));
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "background tasks are aborted on client drop"
+        )]
+        let dispatch_task = tokio::spawn(run_dispatcher(out_rx, abort_rx, inner.clone()));
+
+        Self {
+            inner,
+            tasks: vec![output_task, dispatch_task],
+            next_client_seq: AtomicU64::new(0),
+        }
+    }
+
+    /// The engines connected on this transport.
+    pub fn engines(&self) -> &[ConnectedEngine] {
+        &self.inner.engines
+    }
+
+    /// Whether the connection is still live. Becomes false once the dispatcher
+    /// observes `ENGINE_CORE_DEAD`, a transport failure, or the output stream
+    /// closing. No RPC — this is a local liveness flag.
+    pub fn is_alive(&self) -> bool {
+        !self.inner.registry.lock().closed
+    }
+
+    /// The latest scheduler load for one engine index (DP routing signal), if
+    /// any batch has been seen from it yet.
+    pub fn scheduler_stats(&self, engine_index: u32) -> Option<SchedulerStats> {
+        self.inner.load.lock().get(&engine_index).cloned()
+    }
+
+    /// Submit a request and return a stream of its outputs. The request is
+    /// routed by `data_parallel_rank` (SMG-pinned) or to the sole engine.
+    /// Dropping the returned stream before it finishes aborts the request.
+    pub async fn submit(&self, mut request: EngineCoreRequest) -> Result<EngineCoreStream> {
+        request.validate()?;
+        let engine_id = self.inner.select_engine(request.data_parallel_rank)?;
+
+        request.client_index = self.inner.client_index;
+        // Stamp a per-client monotonic arrival tiebreaker; wall-clock arrival is
+        // set by SMG upstream. current_wave stays 0 (no coordinator in scope).
+        let _seq = self.next_client_seq.fetch_add(1, Ordering::Relaxed);
+
+        let request_id = request.request_id.clone();
+        let receiver = self.inner.registry.lock().register(request_id.clone())?;
+
+        let payload = encode_msgpack(&request)?;
+        // Text path carries no aux tensor frames.
+        if let Err(error) = self
+            .inner
+            .send_to_engine(&engine_id, EngineCoreRequestType::Add, payload, Vec::new())
+            .await
+        {
+            // Roll back the registry entry so a failed send doesn't leak it.
+            self.inner.registry.lock().remove_all([&request_id]);
+            return Err(error);
+        }
+
+        Ok(EngineCoreStream {
+            request_id,
+            engine_id,
+            receiver,
+            abort_tx: self.inner.abort_tx.clone(),
+            finished: false,
+        })
+    }
+
+    /// Explicitly abort an in-flight request.
+    pub async fn abort(&self, engine_id: &EngineId, request_id: &str) -> Result<()> {
+        self.inner
+            .registry
+            .lock()
+            .remove_all([&request_id.to_string()]);
+        self.inner.abort(engine_id, request_id).await
+    }
+}
+
+impl Drop for EngineCoreClient {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+/// Route decoded outputs to per-request streams and forward auto-abort requests
+/// to their engines. Runs until the output channel closes or the engine dies.
+async fn run_dispatcher(
+    mut out_rx: mpsc::Receiver<Result<EngineCoreOutputs>>,
+    mut abort_rx: mpsc::UnboundedReceiver<(EngineId, String)>,
+    inner: Arc<ClientInner>,
+) {
+    loop {
+        tokio::select! {
+            output = out_rx.recv() => {
+                match output {
+                    Some(Ok(EngineCoreOutputs::RequestBatch(batch))) => {
+                        if let Some(stats) = batch.scheduler_stats {
+                            inner.load.lock().insert(batch.engine_index, *stats);
+                        }
+                        let mut registry = inner.registry.lock();
+                        for output in batch.outputs {
+                            registry.route(output);
+                        }
+                        if let Some(finished) = &batch.finished_requests {
+                            registry.remove_all(finished);
+                        }
+                    }
+                    // DP control / utility outputs are out of scope for now.
+                    Some(Ok(_)) => {}
+                    Some(Err(error)) => {
+                        if matches!(error, Error::EngineCoreDead | Error::Transport(_)) {
+                            warn!(%error, "engine transport failed; failing all in-flight requests");
+                            inner.registry.lock().fail_all(Arc::new(error));
+                            return;
+                        }
+                        // A per-message decode error is non-fatal; keep going.
+                        warn!(%error, "ignoring undecodable engine output");
+                    }
+                    None => break,
+                }
+            }
+            abort = abort_rx.recv() => {
+                if let Some((engine_id, request_id)) = abort {
+                    inner.registry.lock().remove_all([&request_id]);
+                    if let Err(error) = inner.abort(&engine_id, &request_id).await {
+                        warn!(%error, %request_id, "failed to send abort");
+                    }
+                }
+            }
+        }
+    }
+    inner
+        .registry
+        .lock()
+        .fail_all(Arc::new(Error::ClientClosed {
+            message: "engine output stream ended".to_string(),
+        }));
+}
+
+/// Stream of outputs for one submitted request. Dropping it before the terminal
+/// output aborts the request on the engine.
+pub struct EngineCoreStream {
+    request_id: String,
+    engine_id: EngineId,
+    receiver: OutputReceiver,
+    abort_tx: mpsc::UnboundedSender<(EngineId, String)>,
+    finished: bool,
+}
+
+impl EngineCoreStream {
+    /// The request id this stream tracks.
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+}
+
+impl Stream for EngineCoreStream {
+    type Item = Result<EngineCoreOutput>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::task::Poll;
+        if self.finished {
+            return Poll::Ready(None);
+        }
+        match self.receiver.poll_recv(cx) {
+            Poll::Ready(Some(Ok(output))) => {
+                if output.finished() {
+                    self.finished = true;
+                }
+                Poll::Ready(Some(Ok(output)))
+            }
+            Poll::Ready(Some(Err(error))) => {
+                self.finished = true;
+                Poll::Ready(Some(Err(error)))
+            }
+            Poll::Ready(None) => {
+                self.finished = true;
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for EngineCoreStream {
+    fn drop(&mut self) {
+        if !self.finished {
+            // Best-effort auto-abort; the dispatcher sends the Abort frame.
+            let _ = self
+                .abort_tx
+                .send((self.engine_id.clone(), self.request_id.clone()));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::StreamExt;
+
+    use super::*;
+    use crate::{
+        codec::{decode_msgpack, encode_msgpack},
+        mock_engine::{connect_to_frontend, default_ready_response, IpcNamespace, MockEngine},
+        protocol::vllm::output::{
+            EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, RequestBatchOutputs,
+        },
+        transport::{connect_handshake, ENGINE_CORE_DEAD_SENTINEL},
+    };
+
+    const TIMEOUT: Duration = Duration::from_secs(10);
+
+    async fn connect() -> (EngineCoreClient, MockEngine) {
+        let ns = IpcNamespace::new().unwrap();
+        let (handshake, input, output) = (
+            ns.handshake_endpoint(),
+            ns.input_endpoint(),
+            ns.output_endpoint(),
+        );
+        // Leak the namespace so its tempdir (and the ipc socket files) outlive
+        // the test body.
+        std::mem::forget(ns);
+        let (transport, engine) = tokio::join!(
+            connect_handshake(
+                &handshake,
+                1,
+                "127.0.0.1",
+                Some(&input),
+                Some(&output),
+                TIMEOUT
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        (EngineCoreClient::new(transport.unwrap()), engine.unwrap())
+    }
+
+    fn batch(engine_index: u32, output: EngineCoreOutput) -> Vec<bytes::Bytes> {
+        let finished = output.finish_reason.map(|_| {
+            let mut set = std::collections::BTreeSet::new();
+            set.insert(output.request_id.clone());
+            set
+        });
+        let outputs = EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
+            engine_index,
+            outputs: vec![output],
+            finished_requests: finished,
+            ..RequestBatchOutputs::default()
+        });
+        vec![bytes::Bytes::from(encode_msgpack(&outputs).unwrap())]
+    }
+
+    #[tokio::test]
+    async fn submit_streams_tokens_until_finish() {
+        let (client, mut engine) = connect().await;
+
+        let request = EngineCoreRequest {
+            request_id: "req-1".to_string(),
+            prompt_token_ids: Some(vec![1, 2, 3]),
+            ..EngineCoreRequest::default()
+        };
+        let mut stream = client.submit(request).await.unwrap();
+
+        // Engine receives the Add and streams two chunks then a terminal output.
+        let frames = engine.recv_request().await.unwrap();
+        assert_eq!(frames[0].as_ref(), b"\x00");
+        let received: EngineCoreRequest = decode_msgpack(frames[1].as_ref()).unwrap();
+        assert_eq!(received.request_id, "req-1");
+
+        engine
+            .send_output(batch(
+                0,
+                EngineCoreOutput {
+                    request_id: "req-1".into(),
+                    new_token_ids: vec![10],
+                    ..Default::default()
+                },
+            ))
+            .await
+            .unwrap();
+        engine
+            .send_output(batch(
+                0,
+                EngineCoreOutput {
+                    request_id: "req-1".into(),
+                    new_token_ids: vec![11],
+                    finish_reason: Some(EngineCoreFinishReason::Stop),
+                    ..Default::default()
+                },
+            ))
+            .await
+            .unwrap();
+
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.new_token_ids, vec![10]);
+        assert!(!first.finished());
+        let second = stream.next().await.unwrap().unwrap();
+        assert_eq!(second.new_token_ids, vec![11]);
+        assert!(second.finished());
+        // Terminal output ends the stream.
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn scheduler_stats_surface_as_load_signal() {
+        let (client, mut engine) = connect().await;
+        let mut stream = client
+            .submit(EngineCoreRequest {
+                request_id: "r".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        engine.recv_request().await.unwrap();
+
+        let outputs = EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
+            engine_index: 0,
+            outputs: vec![EngineCoreOutput {
+                request_id: "r".into(),
+                new_token_ids: vec![7],
+                finish_reason: Some(EngineCoreFinishReason::Stop),
+                ..Default::default()
+            }],
+            scheduler_stats: Some(Box::new(SchedulerStats {
+                num_running_reqs: 3,
+                num_waiting_reqs: 5,
+                ..Default::default()
+            })),
+            finished_requests: Some(std::collections::BTreeSet::from(["r".to_string()])),
+            ..Default::default()
+        });
+        engine
+            .send_output(vec![bytes::Bytes::from(encode_msgpack(&outputs).unwrap())])
+            .await
+            .unwrap();
+
+        // Drain the stream so the batch is processed.
+        while stream.next().await.is_some() {}
+        let stats = client.scheduler_stats(0).expect("load recorded");
+        assert_eq!(stats.num_running_reqs, 3);
+        assert_eq!(stats.num_waiting_reqs, 5);
+    }
+
+    #[tokio::test]
+    async fn dropping_stream_sends_abort() {
+        let (client, mut engine) = connect().await;
+        let stream = client
+            .submit(EngineCoreRequest {
+                request_id: "req-abort".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        // Consume the Add frame.
+        let add = engine.recv_request().await.unwrap();
+        assert_eq!(add[0].as_ref(), b"\x00");
+
+        drop(stream); // not finished -> auto-abort
+
+        let abort = engine.recv_request().await.unwrap();
+        assert_eq!(abort[0].as_ref(), b"\x01"); // Abort
+        let ids: Vec<String> = decode_msgpack(abort[1].as_ref()).unwrap();
+        assert_eq!(ids, vec!["req-abort".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn engine_dead_fails_inflight_requests() {
+        let (client, mut engine) = connect().await;
+        let mut stream = client
+            .submit(EngineCoreRequest {
+                request_id: "r".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        engine.recv_request().await.unwrap();
+
+        engine
+            .send_output(vec![bytes::Bytes::from_static(ENGINE_CORE_DEAD_SENTINEL)])
+            .await
+            .unwrap();
+
+        let result = stream.next().await.expect("an error item");
+        assert!(matches!(result, Err(Error::Shared(_))));
+    }
+}

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -10,13 +10,7 @@
 // - No DP coordinator / wave protocol yet (single shared transport, DP=1).
 // - No utility RPC (deferred).
 
-use std::{
-    collections::HashMap,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use futures::Stream;
 use parking_lot::Mutex;
@@ -163,7 +157,6 @@ impl ClientInner {
 pub struct EngineCoreClient {
     inner: Arc<ClientInner>,
     tasks: Vec<JoinHandle<()>>,
-    next_client_seq: AtomicU64,
 }
 
 impl EngineCoreClient {
@@ -203,7 +196,6 @@ impl EngineCoreClient {
         Self {
             inner,
             tasks: vec![output_task, dispatch_task],
-            next_client_seq: AtomicU64::new(0),
         }
     }
 
@@ -233,9 +225,7 @@ impl EngineCoreClient {
         let engine_id = self.inner.select_engine(request.data_parallel_rank)?;
 
         request.client_index = self.inner.client_index;
-        // Stamp a per-client monotonic arrival tiebreaker; wall-clock arrival is
-        // set by SMG upstream. current_wave stays 0 (no coordinator in scope).
-        let _seq = self.next_client_seq.fetch_add(1, Ordering::Relaxed);
+        // current_wave stays 0 (no DP coordinator in scope for the text path).
 
         let request_id = request.request_id.clone();
         let receiver = self.inner.registry.lock().register(request_id.clone())?;
@@ -281,6 +271,14 @@ impl Drop for EngineCoreClient {
 
 /// Route decoded outputs to per-request streams and forward auto-abort requests
 /// to their engines. Runs until the output channel closes or the engine dies.
+/// If the engine emits no output for this long while requests are in flight, the
+/// dispatcher treats it as dead. A hard engine death (SIGKILL/OOM) sends no
+/// `ENGINE_CORE_DEAD` sentinel, and a bound PULL socket never errors when its
+/// PUSH peer vanishes — so silence is the only available death signal. Generous
+/// so a slow first token never trips it, while still bounding an otherwise
+/// infinite hang.
+const ENGINE_SILENCE_DEATH_TIMEOUT: Duration = Duration::from_secs(300);
+
 async fn run_dispatcher(
     mut out_rx: mpsc::Receiver<Result<EngineCoreOutputs>>,
     mut abort_rx: mpsc::UnboundedReceiver<(EngineId, String)>,
@@ -323,6 +321,21 @@ async fn run_dispatcher(
                         warn!(%error, %request_id, "failed to send abort");
                     }
                 }
+            }
+            // Positive-liveness watchdog. select! rebuilds this sleep every
+            // iteration, so any output or abort resets it; it only fires after a
+            // full window of pure silence.
+            () = tokio::time::sleep(ENGINE_SILENCE_DEATH_TIMEOUT) => {
+                let mut registry = inner.registry.lock();
+                if !registry.requests.is_empty() {
+                    warn!(
+                        "no engine output for {ENGINE_SILENCE_DEATH_TIMEOUT:?} with in-flight \
+                         requests; treating engine as dead"
+                    );
+                    registry.fail_all(Arc::new(Error::EngineCoreDead));
+                    return;
+                }
+                // Idle with nothing in flight: silence is expected, keep waiting.
             }
         }
     }

--- a/crates/engine_zmq_client/src/error.rs
+++ b/crates/engine_zmq_client/src/error.rs
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Error variants for the vLLM EngineCore protocol are adapted from the
+// Apache-2.0 reference `vllm-engine-core-client` (vllm-project/vllm,
+// rust/src/engine-core-client/src/error.rs). See crate root for provenance.
+
+use std::{sync::Arc, time::Duration};
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Public error type for the engine ZMQ client.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("messagepack encode failed for {target_type}: {message}")]
+    Encode {
+        target_type: &'static str,
+        message: String,
+    },
+    #[error("messagepack decode failed for {target_type}: {message}")]
+    Decode {
+        target_type: &'static str,
+        message: String,
+    },
+    #[error("messagepack value decode failed")]
+    ValueDecode(#[from] rmpv::decode::Error),
+    #[error("messagepack ext value decode failed: {message}")]
+    ExtValueDecode { message: String },
+    #[error("io error")]
+    Io(#[from] std::io::Error),
+    #[error("transport error")]
+    Transport(#[from] zeromq::ZmqError),
+    #[error("ZMQ runtime task failed")]
+    ZmqRuntimeTask(#[from] tokio::task::JoinError),
+    #[error("engine core reported fatal failure")]
+    EngineCoreDead,
+    #[error("startup handshake timed out while waiting for {stage} after {timeout:?}")]
+    HandshakeTimeout {
+        stage: &'static str,
+        timeout: Duration,
+    },
+    #[error("engine input registration timed out after {timeout:?}")]
+    InputRegistrationTimeout { timeout: Duration },
+    #[error("unexpected engine id in startup handshake: expected {expected:?}, got {actual:?}")]
+    UnexpectedHandshakeIdentity { expected: Vec<u8>, actual: Vec<u8> },
+    #[error("unexpected startup handshake message: {message}")]
+    UnexpectedHandshakeMessage { message: String },
+    #[error("unsupported auxiliary frame(s): expected {expected} frame(s), got {frame_count}")]
+    UnsupportedAuxFrames { expected: usize, frame_count: usize },
+    #[error("unsupported field `{field}` in {context}")]
+    UnsupportedField {
+        context: &'static str,
+        field: &'static str,
+    },
+    #[error("request `{request_id}` is already in flight")]
+    DuplicateRequestId { request_id: String },
+    #[error("data parallel rank {rank} is out of range for {num_engines} engine(s)")]
+    InvalidDataParallelRank { rank: u32, num_engines: u32 },
+    #[error("request output stream for `{request_id}` closed unexpectedly")]
+    RequestStreamClosed { request_id: String },
+    #[error("engine-core output dispatcher closed: {message}")]
+    DispatcherClosed { message: String },
+    #[error("engine ZMQ client is closed: {message}")]
+    ClientClosed { message: String },
+
+    /// Allows cloning the same error across multiple request streams.
+    #[error(transparent)]
+    Shared(Arc<Self>),
+}
+
+impl Error {
+    /// Construct an [`Error::Encode`] for `T`.
+    pub fn encode<T>(err: impl std::fmt::Display) -> Self {
+        Self::Encode {
+            target_type: std::any::type_name::<T>(),
+            message: err.to_string(),
+        }
+    }
+
+    /// Construct an [`Error::Decode`] for `T`.
+    pub fn decode<T>(err: impl std::fmt::Display) -> Self {
+        Self::Decode {
+            target_type: std::any::type_name::<T>(),
+            message: err.to_string(),
+        }
+    }
+}

--- a/crates/engine_zmq_client/src/lib.rs
+++ b/crates/engine_zmq_client/src/lib.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Engine-agnostic ZMQ transport + per-engine protocol modules for same-host
+//! SMG backend connections.
+//!
+//! When SMG and an inference engine share a host, the gRPC path
+//! (gateway → gRPC → Python servicer → ZMQ → scheduler) collapses to a direct
+//! ZMQ connection over `ipc://`, dropping a process, a serialization
+//! round-trip, and a context switch per message. This crate owns that wire.
+//!
+//! # Layout
+//!
+//! - [`codec`] — engine-agnostic wire primitives: msgpack positional-tuple
+//!   serde, numpy dtype handling, and the zero-copy tensor aux-frame codec.
+//! - `protocol` — per-engine protocol modules (vLLM EngineCore first).
+//! - `transport` — the ZMQ socket topology (SMG binds; engines connect in).
+//! - `connector` — request submission, streaming output, and DP wave handling.
+//!
+//! # Provenance
+//!
+//! The vLLM EngineCore protocol module is a clean-room port of vLLM's
+//! Apache-2.0 `vllm-engine-core-client` crate
+//! (vllm-project/vllm, `rust/src/engine-core-client`). vLLM's client is the
+//! reference for the protocol layer, not a dependency — see issue #2001.
+
+pub mod codec;
+pub mod connector;
+mod error;
+pub mod protocol;
+pub mod transport;
+
+/// Engine-side ZMQ driver for a mock vLLM EngineCore. Compiled for the crate's
+/// own loopback tests and, behind the `mock-engine` feature, for out-of-crate
+/// consumers such as `mock-worker`.
+#[cfg(any(test, feature = "mock-engine"))]
+pub mod mock_engine;
+
+pub use connector::{EngineCoreClient, EngineCoreStream};
+pub use error::{Error, Result};
+pub use transport::{
+    connect_handshake, run_output_loop, send_message, ConnectedEngine, ConnectedTransport,
+    EngineId, ENGINE_CORE_DEAD_SENTINEL,
+};

--- a/crates/engine_zmq_client/src/mock_engine.rs
+++ b/crates/engine_zmq_client/src/mock_engine.rs
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Test-only mock engine, adapted from the Apache-2.0 reference
+// `vllm-engine-core-client` (vllm-project/vllm): mock_engine.rs + test_utils.rs.
+//
+// Plays the Python `EngineCoreProc` role over ZMQ so the transport and
+// connector can be loopback-tested without a GPU: a DEALER completes the
+// HELLO/INIT/READY handshake, a DEALER registers on the input socket and
+// receives requests, and a PUSH sends outputs back.
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use tokio::time::{sleep, timeout};
+use zeromq::{
+    prelude::{Socket, SocketRecv, SocketSend},
+    util::PeerIdentity,
+    DealerSocket, PushSocket, SocketOptions, ZmqMessage,
+};
+
+use crate::{
+    codec::{decode_msgpack, dtype::ModelDtype, encode_msgpack},
+    protocol::vllm::{
+        handshake::{EngineCoreReadyResponse, HandshakeInitMessage, ReadyMessage},
+        output::EngineCoreOutputs,
+        request::{EngineCoreRequest, EngineCoreRequestType},
+    },
+    transport::EngineId,
+    Error, Result,
+};
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Per-test IPC endpoint namespace backed by a unique temporary directory, so
+/// concurrent tests never collide on socket paths.
+#[cfg(test)]
+pub struct IpcNamespace {
+    dir: tempfile::TempDir,
+}
+
+#[cfg(test)]
+impl IpcNamespace {
+    pub fn new() -> std::io::Result<Self> {
+        Ok(Self {
+            dir: tempfile::TempDir::new()?,
+        })
+    }
+
+    fn endpoint(&self, name: impl AsRef<std::path::Path>) -> String {
+        format!("ipc://{}", self.dir.path().join(name).to_string_lossy())
+    }
+
+    pub fn handshake_endpoint(&self) -> String {
+        self.endpoint("handshake.sock")
+    }
+
+    pub fn input_endpoint(&self) -> String {
+        self.endpoint("input.sock")
+    }
+
+    pub fn output_endpoint(&self) -> String {
+        self.endpoint("output.sock")
+    }
+}
+
+/// A default post-init ready response for mock engines.
+pub fn default_ready_response() -> EngineCoreReadyResponse {
+    EngineCoreReadyResponse {
+        max_model_len: 1024 * 1024,
+        num_gpu_blocks: 0,
+        block_size: 16,
+        dp_stats_address: None,
+        dtype: ModelDtype::Float32,
+        vllm_version: "test-vllm-version".to_string(),
+        world_size: 1,
+        data_parallel_size: 1,
+        tensor_parallel_size: 1,
+        pipeline_parallel_size: 1,
+        decode_context_parallel_size: 1,
+        data_parallel_rank: 0,
+        max_num_seqs: 256,
+        max_num_batched_tokens: 8192,
+        instance_id: "test-instance".to_string(),
+        kv_cache_size_tokens: None,
+        kv_cache_max_concurrency: None,
+        kv_events_config: None,
+    }
+}
+
+/// A typed request received by a mock engine from the frontend.
+#[derive(Debug)]
+pub enum EngineInbound {
+    /// An add-request (`EngineCoreRequestType::Add`). Boxed to keep the enum small.
+    Add(Box<EngineCoreRequest>),
+    /// An abort for the given request ids (`EngineCoreRequestType::Abort`).
+    Abort(Vec<String>),
+    /// Any other request type byte (StartDpWave / Utility), unhandled here.
+    Other(u8),
+}
+
+/// The request-receiving half of a mock engine (frontend -> engine).
+pub struct MockEngineInput {
+    socket: DealerSocket,
+}
+
+impl MockEngineInput {
+    /// Receive one request's raw frames (`[request_type, payload, aux..]`); the
+    /// DEALER identity is already stripped.
+    pub async fn recv_frames(&mut self) -> Result<Vec<Bytes>> {
+        Ok(self.socket.recv().await?.into_vec())
+    }
+
+    /// Receive and classify the next request.
+    pub async fn recv(&mut self) -> Result<EngineInbound> {
+        let frames = self.recv_frames().await?;
+        let Some((type_frame, payload)) = frames.first().zip(frames.get(1)) else {
+            return Err(Error::UnexpectedHandshakeMessage {
+                message: format!("expected >=2 request frames, got {}", frames.len()),
+            });
+        };
+        match EngineCoreRequestType::from_frame(type_frame) {
+            Some(EngineCoreRequestType::Add) => {
+                Ok(EngineInbound::Add(Box::new(decode_msgpack(payload)?)))
+            }
+            Some(EngineCoreRequestType::Abort) => {
+                Ok(EngineInbound::Abort(decode_msgpack(payload)?))
+            }
+            Some(other) => Ok(EngineInbound::Other(other as u8)),
+            None => Err(Error::UnexpectedHandshakeMessage {
+                message: format!("unknown request type frame {:?}", type_frame.as_ref()),
+            }),
+        }
+    }
+}
+
+/// The output-sending half of a mock engine (engine -> frontend).
+pub struct MockEngineOutput {
+    socket: PushSocket,
+}
+
+impl MockEngineOutput {
+    /// Push a raw multi-frame output message (frame 0 plus any aux frames).
+    pub async fn send_frames(&mut self, frames: Vec<Bytes>) -> Result<()> {
+        let mut iter = frames.into_iter();
+        let Some(first) = iter.next() else {
+            return Err(Error::UnexpectedHandshakeMessage {
+                message: "mock engine output needs at least one frame".to_string(),
+            });
+        };
+        let mut message = ZmqMessage::from(first);
+        for frame in iter {
+            message.push_back(frame);
+        }
+        self.socket.send(message).await?;
+        Ok(())
+    }
+
+    /// Encode and push one [`EngineCoreOutputs`] message (text path: single frame).
+    pub async fn send_outputs(&mut self, outputs: &EngineCoreOutputs) -> Result<()> {
+        self.send_frames(vec![Bytes::from(encode_msgpack(outputs)?)])
+            .await
+    }
+}
+
+/// One mock engine's frontend-facing sockets after a completed handshake.
+pub struct MockEngine {
+    /// The INIT message the frontend sent during handshake.
+    pub init: HandshakeInitMessage,
+    input: MockEngineInput,
+    output: MockEngineOutput,
+}
+
+impl MockEngine {
+    /// Split into independently-owned request and output halves (for concurrent
+    /// recv/send, e.g. a request loop plus an output writer task).
+    pub fn split(self) -> (MockEngineInput, MockEngineOutput) {
+        (self.input, self.output)
+    }
+
+    /// Receive one request's raw frames. Convenience for sequential test drivers.
+    pub async fn recv_request(&mut self) -> Result<Vec<Bytes>> {
+        self.input.recv_frames().await
+    }
+
+    /// Push a raw multi-frame output. Convenience for sequential test drivers.
+    pub async fn send_output(&mut self, frames: Vec<Bytes>) -> Result<()> {
+        self.output.send_frames(frames).await
+    }
+}
+
+fn ready_message(status: &str) -> ReadyMessage {
+    ReadyMessage {
+        status: Some(status.to_string()),
+        local: Some(true),
+        headless: Some(true),
+        parallel_config_hash: None,
+    }
+}
+
+fn peer_identity(engine_id: &EngineId) -> Result<PeerIdentity> {
+    PeerIdentity::try_from(engine_id.clone()).map_err(|error| Error::UnexpectedHandshakeMessage {
+        message: format!(
+            "invalid mock engine identity {:?}: {error}",
+            engine_id.to_vec()
+        ),
+    })
+}
+
+/// Wait for a ZMQ endpoint to become connectable before dialing it.
+async fn wait_for_endpoint(endpoint: &str) -> Result<()> {
+    let Some(socket_path) = endpoint.strip_prefix("ipc://") else {
+        return Ok(());
+    };
+    timeout(CONNECT_TIMEOUT, async {
+        while tokio::net::UnixStream::connect(socket_path).await.is_err() {
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .map_err(|_| Error::HandshakeTimeout {
+        stage: "mock engine IPC endpoint",
+        timeout: CONNECT_TIMEOUT,
+    })
+}
+
+/// Connect a mock engine to a frontend-owned handshake endpoint: HELLO → INIT →
+/// READY, then register on the input socket with `ready_response` and open the
+/// output PUSH socket.
+pub async fn connect_to_frontend(
+    handshake_address: &str,
+    engine_id: impl Into<EngineId>,
+    ready_response: EngineCoreReadyResponse,
+) -> Result<MockEngine> {
+    let engine_id = engine_id.into();
+    let identity = peer_identity(&engine_id)?;
+
+    wait_for_endpoint(handshake_address).await?;
+    let mut handshake_options = SocketOptions::default();
+    handshake_options.peer_identity(identity.clone());
+    let mut handshake = DealerSocket::with_options(handshake_options);
+    handshake.connect(handshake_address).await?;
+
+    // HELLO -> (INIT) -> READY.
+    handshake
+        .send(ZmqMessage::from(encode_msgpack(&ready_message("HELLO"))?))
+        .await?;
+    let init_frames = handshake.recv().await?.into_vec();
+    let [init_frame] = init_frames.as_slice() else {
+        return Err(Error::UnexpectedHandshakeMessage {
+            message: format!("expected one INIT frame, got {}", init_frames.len()),
+        });
+    };
+    let init: HandshakeInitMessage = decode_msgpack(init_frame.as_ref())?;
+    handshake
+        .send(ZmqMessage::from(encode_msgpack(&ready_message("READY"))?))
+        .await?;
+
+    let [input_address] = init.addresses.inputs.as_slice() else {
+        return Err(Error::UnexpectedHandshakeMessage {
+            message: format!(
+                "expected one input address, got {}",
+                init.addresses.inputs.len()
+            ),
+        });
+    };
+    let [output_address] = init.addresses.outputs.as_slice() else {
+        return Err(Error::UnexpectedHandshakeMessage {
+            message: format!(
+                "expected one output address, got {}",
+                init.addresses.outputs.len()
+            ),
+        });
+    };
+
+    // Register on the input socket: [ready_response] with the engine identity.
+    wait_for_endpoint(input_address).await?;
+    let mut input_options = SocketOptions::default();
+    input_options.peer_identity(identity);
+    let mut input = DealerSocket::with_options(input_options);
+    input.connect(input_address).await?;
+    input
+        .send(ZmqMessage::from(encode_msgpack(&ready_response)?))
+        .await?;
+
+    wait_for_endpoint(output_address).await?;
+    let mut output = PushSocket::new();
+    output.connect(output_address).await?;
+
+    Ok(MockEngine {
+        init,
+        input: MockEngineInput { socket: input },
+        output: MockEngineOutput { socket: output },
+    })
+}

--- a/crates/engine_zmq_client/src/protocol/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-engine wire protocol modules. vLLM's EngineCore protocol is first; the
+//! sglang-family msgpack protocol (issues #2003/#2006) will live alongside it.
+
+pub mod vllm;

--- a/crates/engine_zmq_client/src/protocol/vllm/handshake.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/handshake.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/handshake.rs.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::codec::{dtype::ModelDtype, OpaqueValue};
+
+/// Decoded engine startup-handshake payload sent on the handshake socket
+/// (`{"status": "HELLO"|"READY", ...}`). Mirrors Python `EngineCoreProc`
+/// handshake construction in `vllm/v1/engine/core.py`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReadyMessage {
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub local: Option<bool>,
+    #[serde(default)]
+    pub headless: Option<bool>,
+    #[serde(default)]
+    pub parallel_config_hash: Option<String>,
+}
+
+/// KV-event publisher configuration reported by EngineCore.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KvEventsConfig {
+    pub enable_kv_cache_events: bool,
+    pub publisher: String,
+    pub endpoint: String,
+    pub replay_endpoint: Option<String>,
+    pub buffer_steps: u32,
+    pub hwm: u32,
+    pub max_queue_size: u32,
+    pub topic: String,
+}
+
+/// Post-initialization configuration sent by each engine on the input socket
+/// registration message, after the handshake completes.
+///
+/// Values may differ from the original config (e.g. `max_model_len` after KV
+/// cache auto-fitting, `num_gpu_blocks` after profiling), so the frontend must
+/// read them rather than assume the CLI values. Mirrors Python
+/// `EngineCoreReadyResponse` in `vllm/v1/engine/__init__.py`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EngineCoreReadyResponse {
+    /// Engine-reported maximum model context length (auto-fitted after KV cache
+    /// profiling; may differ from the original config value).
+    pub max_model_len: u64,
+    /// Number of GPU blocks available for KV cache on this engine.
+    pub num_gpu_blocks: u64,
+    /// KV cache block size (tokens per block).
+    pub block_size: u64,
+    /// DP coordinator stats publish address, if applicable.
+    pub dp_stats_address: Option<String>,
+    /// Effective model dtype after Python vLLM resolves `--dtype`.
+    pub dtype: ModelDtype,
+    /// Python vLLM version reported by the engine process (compatibility gate).
+    pub vllm_version: String,
+    /// World size (TP * PP) from the parallel config.
+    pub world_size: u64,
+    /// Data parallelism size from the parallel config.
+    pub data_parallel_size: u64,
+    // The fields below vary by vLLM version (present on dev/HEAD, absent on the
+    // 0.26.0 release). They are `#[serde(default)]` so one struct decodes across
+    // versions — the `vllm_version` field above identifies which engine we hit.
+    /// Tensor-parallel size of this engine.
+    #[serde(default)]
+    pub tensor_parallel_size: u32,
+    /// Pipeline-parallel size of this engine.
+    #[serde(default)]
+    pub pipeline_parallel_size: u32,
+    /// Decode-context-parallel size of this engine.
+    #[serde(default)]
+    pub decode_context_parallel_size: u32,
+    /// This engine's data-parallel rank. Not sent by all versions; prefer the
+    /// engine's ZMQ index for routing (see the connector).
+    #[serde(default)]
+    pub data_parallel_rank: u32,
+    /// Scheduler cap on concurrently running sequences.
+    #[serde(default)]
+    pub max_num_seqs: u64,
+    /// Scheduler cap on batched tokens per step.
+    #[serde(default)]
+    pub max_num_batched_tokens: u64,
+    /// Unique identifier for this server instance.
+    #[serde(default)]
+    pub instance_id: String,
+    /// Total KV cache capacity in tokens, if reported.
+    #[serde(default)]
+    pub kv_cache_size_tokens: Option<u64>,
+    /// Maximum achievable request concurrency given the KV cache, if reported.
+    #[serde(default)]
+    pub kv_cache_max_concurrency: Option<f64>,
+    /// KV-event publisher configuration, if configured.
+    #[serde(default)]
+    pub kv_events_config: Option<KvEventsConfig>,
+}
+
+/// Frontend-owned ZMQ addresses sent to the engine during handshake init.
+/// Mirrors Python `EngineZmqAddresses` in `vllm/v1/engine/utils.py`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeAddresses {
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+    pub coordinator_input: Option<String>,
+    pub coordinator_output: Option<String>,
+    pub frontend_stats_publish_address: Option<String>,
+}
+
+/// Startup handshake payload sent from the frontend to initialize an engine
+/// after receiving `HELLO`. Mirrors Python `EngineHandshakeMetadata`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeInitMessage {
+    pub addresses: HandshakeAddresses,
+    pub parallel_config: BTreeMap<String, OpaqueValue>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::{decode_msgpack, encode_msgpack};
+
+    #[test]
+    fn ready_message_roundtrips_hello() {
+        let msg = ReadyMessage {
+            status: Some("HELLO".to_string()),
+            local: Some(true),
+            headless: Some(false),
+            parallel_config_hash: None,
+        };
+        let bytes = encode_msgpack(&msg).unwrap();
+        let decoded: ReadyMessage = decode_msgpack(&bytes).unwrap();
+        assert_eq!(decoded.status.as_deref(), Some("HELLO"));
+        assert_eq!(decoded.local, Some(true));
+        assert_eq!(decoded.headless, Some(false));
+    }
+
+    #[test]
+    fn ready_response_reads_vllm_version_and_dtype() {
+        // A named-field msgpack map (not a positional tuple), like Python sends.
+        let json = serde_json::json!({
+            "max_model_len": 4096u64,
+            "num_gpu_blocks": 1000u64,
+            "block_size": 16u64,
+            "dp_stats_address": serde_json::Value::Null,
+            "dtype": "bfloat16",
+            "vllm_version": "0.22.0",
+            "world_size": 1u64,
+            "data_parallel_size": 1u64,
+            "tensor_parallel_size": 1u32,
+            "pipeline_parallel_size": 1u32,
+            "decode_context_parallel_size": 1u32,
+            "data_parallel_rank": 0u32,
+            "max_num_seqs": 256u64,
+            "max_num_batched_tokens": 8192u64,
+            "instance_id": "inst-1",
+            "kv_cache_size_tokens": serde_json::Value::Null,
+            "kv_cache_max_concurrency": serde_json::Value::Null,
+        });
+        let resp: EngineCoreReadyResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.vllm_version, "0.22.0");
+        assert_eq!(resp.dtype, ModelDtype::BFloat16);
+        assert_eq!(resp.data_parallel_rank, 0);
+        // Optional trailing field defaults when omitted.
+        assert!(resp.kv_events_config.is_none());
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/vllm/logprobs.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/logprobs.rs
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/logprobs.rs + protocol/logprobs/wire.rs.
+// The numpy-array decoders live in `crate::codec::tensor`.
+
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+use crate::{
+    codec::tensor::{
+        decode_array1_u32, decode_array2_f32, decode_array2_u32, WireArrayData, WireNdArray,
+    },
+    error::{Error, Result},
+};
+
+/// One token candidate and its logprob metadata for a single sequence position.
+///
+/// The first entry in a [`PositionLogprobs`] is always the sampled/selected
+/// token; remaining entries follow the engine's returned top-k candidate order.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TokenLogprob {
+    pub token_id: u32,
+    pub logprob: f32,
+    /// The sampled/selected token uses its actual vocab rank; remaining entries
+    /// use 1-based top-k ranks matching the engine's candidate order.
+    pub rank: u32,
+}
+
+/// Logprob payload for one sequence position (semantic, post-decode form).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PositionLogprobs {
+    pub entries: Vec<TokenLogprob>,
+}
+
+impl PositionLogprobs {
+    /// Group one decoded logprobs row into per-position form, attaching the
+    /// sampled/selected token's actual vocab rank to entry 0.
+    fn from_decoded_row(token_ids: &[u32], logprobs: &[f32], sampled_rank: u32) -> Result<Self> {
+        if token_ids.len() != logprobs.len() {
+            return Err(Error::ExtValueDecode {
+                message: format!(
+                    "logprobs row length mismatch: token_ids={}, logprobs={}",
+                    token_ids.len(),
+                    logprobs.len()
+                ),
+            });
+        }
+        if sampled_rank == 0 {
+            return Err(Error::ExtValueDecode {
+                message: "token_ranks must be >= 1 for decoded engine-core logprobs".to_string(),
+            });
+        }
+
+        let mut entries = Vec::with_capacity(token_ids.len());
+        for (index, (&token_id, &logprob)) in token_ids.iter().zip(logprobs.iter()).enumerate() {
+            let rank = if index == 0 {
+                sampled_rank
+            } else {
+                index as u32
+            };
+            entries.push(TokenLogprob {
+                token_id,
+                logprob,
+                rank,
+            });
+        }
+        Ok(Self { entries })
+    }
+}
+
+/// Decoded per-request logprobs payload for one engine-core output: one
+/// [`PositionLogprobs`] per scored position.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Logprobs {
+    pub positions: Vec<PositionLogprobs>,
+}
+
+impl Logprobs {
+    pub fn len(&self) -> usize {
+        self.positions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.positions.is_empty()
+    }
+}
+
+/// Python wire representation of `LogprobsLists`/`LogprobsTensors` before
+/// aux-frame references and raw-view payloads are resolved. Mirrors Python
+/// `vllm/v1/outputs.py`.
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct WireLogprobs {
+    /// Wire array with shape `[num_positions, max_num_logprobs + 1]`.
+    pub logprob_token_ids: WireNdArray,
+    /// Wire array with shape `[num_positions, max_num_logprobs + 1]`.
+    pub logprobs: WireNdArray,
+    /// Wire array with shape `[num_positions]`. Python names it
+    /// `sampled_token_ranks` (sample logprobs) / `selected_token_ranks` (prompt
+    /// logprobs); one neutral field here since both share the wire shape.
+    pub token_ranks: WireNdArray,
+    /// Preserved only for wire compatibility with batch-level Python tensors.
+    /// Scheduler-sliced per-request outputs emit `None`; any other value is
+    /// rejected by the semantic decoder.
+    #[serde(default)]
+    pub cu_num_generated_tokens: Option<Vec<usize>>,
+}
+
+impl WireLogprobs {
+    /// Convert semantic per-position logprobs into the Python wire tuple shape.
+    /// Exists mainly so tests can inject semantic logprobs without hand-building
+    /// ndarray raw-view tuples.
+    fn from_direct(value: &Logprobs) -> std::result::Result<Self, String> {
+        let rows = value.positions.len();
+        let cols = value
+            .positions
+            .first()
+            .map(|position| position.entries.len())
+            .unwrap_or(0);
+
+        let mut token_ids = Vec::with_capacity(rows.saturating_mul(cols).saturating_mul(8));
+        let mut logprobs = Vec::with_capacity(rows.saturating_mul(cols).saturating_mul(4));
+        let mut token_ranks = Vec::with_capacity(rows.saturating_mul(8));
+
+        for (row_index, position) in value.positions.iter().enumerate() {
+            if position.entries.len() != cols {
+                return Err(format!(
+                    "logprobs row {row_index} length mismatch: expected {cols}, got {}",
+                    position.entries.len()
+                ));
+            }
+            let Some((sampled, _)) = position.entries.split_first() else {
+                return Err(format!("logprobs row {row_index} is empty"));
+            };
+
+            token_ranks.extend_from_slice(&(sampled.rank as i64).to_le_bytes());
+            for entry in &position.entries {
+                token_ids.extend_from_slice(&(entry.token_id as i64).to_le_bytes());
+                logprobs.extend_from_slice(&entry.logprob.to_le_bytes());
+            }
+        }
+
+        Ok(Self {
+            logprob_token_ids: WireNdArray {
+                dtype: "<i8".to_string(),
+                shape: vec![rows, cols],
+                data: WireArrayData::RawView(token_ids.into()),
+            },
+            logprobs: WireNdArray {
+                dtype: "<f4".to_string(),
+                shape: vec![rows, cols],
+                data: WireArrayData::RawView(logprobs.into()),
+            },
+            token_ranks: WireNdArray {
+                dtype: "<i8".to_string(),
+                shape: vec![rows],
+                data: WireArrayData::RawView(token_ranks.into()),
+            },
+            cu_num_generated_tokens: None,
+        })
+    }
+
+    /// Resolve wire-format logprobs into semantic [`Logprobs`] by decoding the
+    /// three arrays (via aux frames as needed) and grouping each row.
+    fn resolve<Frame>(self, frames: &[Frame], field_prefix: &str) -> Result<Logprobs>
+    where
+        Frame: AsRef<[u8]>,
+    {
+        if let Some(indices) = self.cu_num_generated_tokens {
+            return Err(Error::ExtValueDecode {
+                message: format!(
+                    "{field_prefix}.cu_num_generated_tokens: expected None for per-request \
+                     engine-core logprobs payload, got {indices:?}"
+                ),
+            });
+        }
+
+        let token_ids = decode_array2_u32(
+            self.logprob_token_ids,
+            &format!("{field_prefix}.logprob_token_ids"),
+            frames,
+        )?;
+        let logprobs =
+            decode_array2_f32(self.logprobs, &format!("{field_prefix}.logprobs"), frames)?;
+        let token_ranks = decode_array1_u32(
+            self.token_ranks,
+            &format!("{field_prefix}.token_ranks"),
+            frames,
+        )?;
+
+        if token_ids.rows != logprobs.rows || token_ids.cols != logprobs.cols {
+            return Err(Error::ExtValueDecode {
+                message: format!(
+                    "{field_prefix}: row shape mismatch between token ids ({}, {}) and logprobs ({}, {})",
+                    token_ids.rows, token_ids.cols, logprobs.rows, logprobs.cols
+                ),
+            });
+        }
+        if token_ids.rows != token_ranks.len() {
+            return Err(Error::ExtValueDecode {
+                message: format!(
+                    "{field_prefix}: token_ranks length {} does not match row count {}",
+                    token_ranks.len(),
+                    token_ids.rows
+                ),
+            });
+        }
+
+        // Empty position lists may be encoded as either [0, 0] or [0, k + 1].
+        if token_ids.rows == 0 {
+            return Ok(Logprobs {
+                positions: Vec::new(),
+            });
+        }
+        if token_ids.cols == 0 {
+            return Err(Error::ExtValueDecode {
+                message: format!(
+                    "{field_prefix}: zero-column logprobs payload with {} rows",
+                    token_ids.rows
+                ),
+            });
+        }
+
+        let mut positions = Vec::with_capacity(token_ids.rows);
+        for ((token_ids_row, logprobs_row), sampled_rank) in token_ids
+            .data
+            .chunks(token_ids.cols)
+            .zip(logprobs.data.chunks(logprobs.cols))
+            .zip(token_ranks)
+        {
+            positions.push(PositionLogprobs::from_decoded_row(
+                token_ids_row,
+                logprobs_row,
+                sampled_rank,
+            )?);
+        }
+
+        Ok(Logprobs { positions })
+    }
+}
+
+/// Output field wrapper deserialized from the Python wire shape, then resolved
+/// into [`Logprobs`] before the decoded message is returned to callers.
+#[derive(Clone, PartialEq, Debug)]
+pub enum MaybeWireLogprobs {
+    /// Still in wire format; needs [`MaybeWireLogprobs::resolve`]. Internal use
+    /// only during deserialization.
+    Wire(Box<WireLogprobs>),
+    /// The decoded logprobs value.
+    Direct(Logprobs),
+}
+
+impl MaybeWireLogprobs {
+    /// The decoded logprobs, if already resolved.
+    pub fn as_direct(&self) -> Option<&Logprobs> {
+        match self {
+            Self::Direct(value) => Some(value),
+            Self::Wire(_) => None,
+        }
+    }
+
+    /// Resolve the wire representation into decoded logprobs, looking up aux
+    /// frames and decoding raw views as needed.
+    pub(crate) fn resolve<Frame>(self, frames: &[Frame], field_prefix: &str) -> Result<Self>
+    where
+        Frame: AsRef<[u8]>,
+    {
+        match self {
+            Self::Direct(value) => Ok(Self::Direct(value)),
+            Self::Wire(value) => value.resolve(frames, field_prefix).map(Self::Direct),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MaybeWireLogprobs {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // On the wire it is always the wire form.
+        WireLogprobs::deserialize(deserializer).map(|v| Self::Wire(Box::new(v)))
+    }
+}
+
+impl Serialize for MaybeWireLogprobs {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Test-only: we never actually serialize into aux frames on the send path.
+        match self {
+            Self::Wire(value) => value.serialize(serializer),
+            Self::Direct(value) => WireLogprobs::from_direct(value)
+                .map_err(serde::ser::Error::custom)?
+                .serialize(serializer),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+
+    fn direct(positions: Vec<Vec<(u32, f32, u32)>>) -> Logprobs {
+        Logprobs {
+            positions: positions
+                .into_iter()
+                .map(|entries| PositionLogprobs {
+                    entries: entries
+                        .into_iter()
+                        .map(|(token_id, logprob, rank)| TokenLogprob {
+                            token_id,
+                            logprob,
+                            rank,
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn logprobs_roundtrip_from_direct_through_wire_resolve() {
+        // Two positions, top-2 each: entry 0 is the sampled token with its true
+        // vocab rank; entry 1 is a top-k alternative (synthetic rank 1).
+        let original = direct(vec![
+            vec![(10, -0.1, 5), (11, -1.2, 1)],
+            vec![(20, -0.3, 2), (21, -2.5, 1)],
+        ]);
+        let wire = WireLogprobs::from_direct(&original).unwrap();
+        // Inline raw views, so no aux frames are needed to resolve.
+        let resolved = wire.resolve(&[Bytes::new()], "lp").unwrap();
+        assert_eq!(resolved, original);
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved.positions[0].entries[0].rank, 5);
+        assert_eq!(resolved.positions[0].entries[1].rank, 1);
+    }
+
+    #[test]
+    fn resolve_rejects_nonnull_cu_num_generated_tokens() {
+        let mut wire = WireLogprobs::from_direct(&direct(vec![vec![(1, -0.5, 1)]])).unwrap();
+        wire.cu_num_generated_tokens = Some(vec![1]);
+        assert!(wire.resolve(&[Bytes::new()], "lp").is_err());
+    }
+
+    #[test]
+    fn resolve_rejects_zero_sampled_rank() {
+        let wire = WireLogprobs::from_direct(&direct(vec![vec![(1, -0.5, 0)]])).unwrap();
+        assert!(wire.resolve(&[Bytes::new()], "lp").is_err());
+    }
+
+    #[test]
+    fn maybe_wire_logprobs_deserializes_as_wire_then_resolves() {
+        let bytes = rmp_serde::to_vec_named(
+            &WireLogprobs::from_direct(&direct(vec![vec![(7, -0.2, 3)]])).unwrap(),
+        )
+        .unwrap();
+        let maybe: MaybeWireLogprobs = rmp_serde::from_slice(&bytes).unwrap();
+        assert!(maybe.as_direct().is_none()); // still wire
+        let resolved = maybe.resolve(&[Bytes::new()], "lp").unwrap();
+        assert_eq!(
+            resolved.as_direct().unwrap().positions[0].entries[0].token_id,
+            7
+        );
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/vllm/lora.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/lora.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/lora.rs.
+
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+use crate::codec::OpaqueValue;
+
+/// Request for a LoRA adapter. Mirrors Python `vllm.lora.request.LoRARequest`,
+/// a msgspec `array_like=True` struct — keep the field order aligned with Python.
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct LoraRequest {
+    pub lora_name: String,
+    pub lora_int_id: u64,
+    pub lora_path: String,
+    #[serde(default)]
+    pub base_model_name: Option<String>,
+    #[serde(default)]
+    pub tensorizer_config_dict: Option<OpaqueValue>,
+    #[serde(default)]
+    pub load_inplace: bool,
+    #[serde(default)]
+    pub is_3d_lora_weight: bool,
+}
+
+impl LoraRequest {
+    pub fn new(
+        lora_name: String,
+        lora_int_id: u64,
+        lora_path: String,
+        load_inplace: bool,
+        is_3d_lora_weight: bool,
+    ) -> Self {
+        Self {
+            lora_name,
+            lora_int_id,
+            lora_path,
+            base_model_name: None,
+            tensorizer_config_dict: None,
+            load_inplace,
+            is_3d_lora_weight,
+        }
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/vllm/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/mod.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! vLLM EngineCore wire protocol.
+//!
+//! Clean-room port of vLLM's Apache-2.0 `vllm-engine-core-client`
+//! (vllm-project/vllm, `rust/src/engine-core-client/src/protocol`). Struct
+//! shapes, field order, and `array_like` positional-tuple encoding are the wire
+//! contract with Python `EngineCoreProc` — do not reorder fields.
+//!
+//! Text generation is typed fully. Multimodal features, structured outputs
+//! (guided decoding), and pooling params are carried as [`crate::codec::OpaqueValue`]
+//! for now — they serialize as `nil` on the text path and get strongly typed in
+//! the multimodal phase.
+
+pub mod handshake;
+pub mod logprobs;
+pub mod lora;
+pub mod output;
+pub mod request;
+pub mod sampling;
+pub mod stats;

--- a/crates/engine_zmq_client/src/protocol/vllm/output.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/output.rs
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/output.rs.
+//
+// `utility_output` is carried as OpaqueValue (typed utility RPC deferred); the
+// semantic classification into RequestBatch / Utility / DpControl is preserved.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_default::DefaultFromSerde;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+use crate::{
+    codec::{decode_msgpack, OpaqueValue},
+    error::{Error, Result},
+    protocol::vllm::{
+        logprobs::MaybeWireLogprobs,
+        stats::{PrefillStats, SchedulerStats},
+    },
+};
+
+/// The stop reason associated with a finished output. Python models this as
+/// `stop_reason: int | str | None`; narrowed here into a tagged enum.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum StopReason {
+    TokenId(u32),
+    Text(String),
+}
+
+/// Reason a request finished. Mirrors Python `FinishReason` (integer-encoded).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum EngineCoreFinishReason {
+    /// A stop string was emitted.
+    Stop = 0,
+    /// `max_tokens` or `max_model_len` was reached.
+    Length = 1,
+    /// The request was aborted by the client.
+    Abort = 2,
+    /// A retryable request-level internal error occurred.
+    Error = 3,
+    /// A repetitive token pattern was detected.
+    Repetition = 4,
+}
+
+/// Event types emitted by engine-core for one request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum EngineCoreEventType {
+    Queued = 1,
+    Scheduled = 2,
+    Preempted = 3,
+}
+
+/// A timestamped engine-core event associated with one request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EngineCoreEvent {
+    pub r#type: EngineCoreEventType,
+    pub timestamp: f64,
+}
+
+/// Engine-core output for a single request. Mirrors Python `EngineCoreOutput`
+/// (`array_like` — field order is the wire contract).
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple, DefaultFromSerde)]
+pub struct EngineCoreOutput {
+    pub request_id: String,
+    pub new_token_ids: Vec<u32>,
+    /// Decoded sample logprobs for the newly generated positions.
+    #[serde(default)]
+    pub new_logprobs: Option<MaybeWireLogprobs>,
+    /// Decoded prompt logprobs for the scored prompt positions.
+    #[serde(default)]
+    pub new_prompt_logprobs_tensors: Option<MaybeWireLogprobs>,
+    #[serde(default)]
+    pub pooling_output: Option<OpaqueValue>,
+    #[serde(default)]
+    pub finish_reason: Option<EngineCoreFinishReason>,
+    #[serde(default)]
+    pub stop_reason: Option<StopReason>,
+    #[serde(default)]
+    pub events: Option<Vec<EngineCoreEvent>>,
+    #[serde(default)]
+    pub kv_transfer_params: Option<serde_json::Value>,
+    #[serde(default)]
+    pub ec_transfer_params: Option<serde_json::Value>,
+    #[serde(default)]
+    pub trace_headers: Option<OpaqueValue>,
+    /// Breakdown of the scheduled prefill computation, set on the first output
+    /// of a newly scheduled prefill and elided for subsequent decode outputs.
+    #[serde(default)]
+    pub prefill_stats: Option<PrefillStats>,
+    #[serde(default)]
+    pub routed_experts: Option<OpaqueValue>,
+    /// Number of NaNs seen in logits. Values above zero indicate corruption.
+    #[serde(default)]
+    pub num_nans_in_logits: u32,
+}
+
+impl EngineCoreOutput {
+    /// Whether this output is terminal for the request.
+    pub fn finished(&self) -> bool {
+        self.finish_reason.is_some()
+    }
+
+    /// Resolve wire-format logprobs in-place using the aux frames.
+    fn resolve_in_place<Frame>(&mut self, frames: &[Frame]) -> Result<()>
+    where
+        Frame: AsRef<[u8]>,
+    {
+        self.new_logprobs = self
+            .new_logprobs
+            .take()
+            .map(|value| value.resolve(frames, "new_logprobs"))
+            .transpose()?;
+        self.new_prompt_logprobs_tensors = self
+            .new_prompt_logprobs_tensors
+            .take()
+            .map(|value| value.resolve(frames, "new_prompt_logprobs_tensors"))
+            .transpose()?;
+        Ok(())
+    }
+}
+
+/// Raw Python/msgpack engine-core output envelope. Mirrors Python
+/// `EngineCoreOutputs` (`array_like`).
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple, DefaultFromSerde)]
+struct WireEngineCoreOutputs {
+    #[serde(default)]
+    engine_index: u32,
+    /// Outputs grouped for this client in the current engine tick.
+    #[serde(default)]
+    outputs: Vec<EngineCoreOutput>,
+    #[serde(default)]
+    scheduler_stats: Option<Box<SchedulerStats>>,
+    #[serde(default)]
+    timestamp: f64,
+    /// Utility RPC result (untyped for now).
+    #[serde(default)]
+    utility_output: Option<OpaqueValue>,
+    #[serde(default)]
+    finished_requests: Option<BTreeSet<String>>,
+    /// In DP mode, signals that the current wave finished and engines are paused.
+    #[serde(default)]
+    wave_complete: Option<u32>,
+    /// In DP mode, signals that a request arrived for an old wave and the next
+    /// wave needs to start in other engines.
+    #[serde(default)]
+    start_wave: Option<u32>,
+}
+
+/// Data-parallel control notifications multiplexed through `EngineCoreOutputs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DpControlMessage {
+    WaveComplete(u32),
+    StartWave(u32),
+}
+
+/// A batch of per-request outputs plus the piggybacked scheduler stats.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct RequestBatchOutputs {
+    pub engine_index: u32,
+    pub outputs: Vec<EngineCoreOutput>,
+    pub scheduler_stats: Option<Box<SchedulerStats>>,
+    pub timestamp: f64,
+    pub finished_requests: Option<BTreeSet<String>>,
+}
+
+/// A utility RPC result (untyped payload for now).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct UtilityCallOutput {
+    pub engine_index: u32,
+    pub timestamp: f64,
+    pub output: Option<OpaqueValue>,
+}
+
+/// A DP wave-control notification.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DpControlOutput {
+    pub engine_index: u32,
+    pub timestamp: f64,
+    pub control: DpControlMessage,
+}
+
+/// Semantic engine-core output families. Python uses one product-shaped wire
+/// struct; the Rust protocol exposes the finite semantic families while keeping
+/// the same msgpack shape.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EngineCoreOutputs {
+    RequestBatch(RequestBatchOutputs),
+    Utility(UtilityCallOutput),
+    DpControl(DpControlOutput),
+}
+
+impl EngineCoreOutputs {
+    /// The request batch, if this is a `RequestBatch` variant.
+    pub fn as_request_batch(&self) -> Option<&RequestBatchOutputs> {
+        match self {
+            Self::RequestBatch(batch) => Some(batch),
+            _ => None,
+        }
+    }
+
+    /// Consume into the request batch, if this is a `RequestBatch` variant.
+    pub fn into_request_batch(self) -> Option<RequestBatchOutputs> {
+        match self {
+            Self::RequestBatch(batch) => Some(batch),
+            _ => None,
+        }
+    }
+
+    /// Resolve wire-format fields in-place using the aux frames.
+    fn resolve_in_place<Frame>(&mut self, frames: &[Frame]) -> Result<()>
+    where
+        Frame: AsRef<[u8]>,
+    {
+        if let Self::RequestBatch(batch) = self {
+            for output in &mut batch.outputs {
+                output.resolve_in_place(frames)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl From<RequestBatchOutputs> for EngineCoreOutputs {
+    fn from(outputs: RequestBatchOutputs) -> Self {
+        Self::RequestBatch(outputs)
+    }
+}
+
+impl From<UtilityCallOutput> for EngineCoreOutputs {
+    fn from(output: UtilityCallOutput) -> Self {
+        Self::Utility(output)
+    }
+}
+
+impl From<DpControlOutput> for EngineCoreOutputs {
+    fn from(output: DpControlOutput) -> Self {
+        Self::DpControl(output)
+    }
+}
+
+/// Classify the raw wire message into the semantic Rust enum.
+impl TryFrom<WireEngineCoreOutputs> for EngineCoreOutputs {
+    type Error = Error;
+
+    fn try_from(value: WireEngineCoreOutputs) -> Result<Self> {
+        let has_request_payload = !value.outputs.is_empty()
+            || value.scheduler_stats.is_some()
+            || value.finished_requests.is_some();
+
+        match (
+            has_request_payload,
+            &value.utility_output,
+            &value.wave_complete,
+            &value.start_wave,
+        ) {
+            (true, None, None, None) => Ok(RequestBatchOutputs {
+                engine_index: value.engine_index,
+                outputs: value.outputs,
+                scheduler_stats: value.scheduler_stats,
+                timestamp: value.timestamp,
+                finished_requests: value.finished_requests,
+            }
+            .into()),
+            (false, Some(_), None, None) => Ok(UtilityCallOutput {
+                engine_index: value.engine_index,
+                timestamp: value.timestamp,
+                output: value.utility_output,
+            }
+            .into()),
+            (false, None, Some(wave), None) => Ok(DpControlOutput {
+                engine_index: value.engine_index,
+                timestamp: value.timestamp,
+                control: DpControlMessage::WaveComplete(*wave),
+            }
+            .into()),
+            (false, None, None, Some(wave)) => Ok(DpControlOutput {
+                engine_index: value.engine_index,
+                timestamp: value.timestamp,
+                control: DpControlMessage::StartWave(*wave),
+            }
+            .into()),
+            _ => Err(Error::Decode {
+                target_type: "EngineCoreOutputs",
+                message: "invalid wire shape".to_string(),
+            }),
+        }
+    }
+}
+
+impl From<EngineCoreOutputs> for WireEngineCoreOutputs {
+    fn from(value: EngineCoreOutputs) -> Self {
+        match value {
+            EngineCoreOutputs::RequestBatch(batch) => Self {
+                engine_index: batch.engine_index,
+                outputs: batch.outputs,
+                scheduler_stats: batch.scheduler_stats,
+                timestamp: batch.timestamp,
+                finished_requests: batch.finished_requests,
+                ..Default::default()
+            },
+            EngineCoreOutputs::Utility(utility) => Self {
+                engine_index: utility.engine_index,
+                timestamp: utility.timestamp,
+                utility_output: utility.output,
+                ..Default::default()
+            },
+            EngineCoreOutputs::DpControl(control) => {
+                let (wave_complete, start_wave) = match control.control {
+                    DpControlMessage::WaveComplete(wave) => (Some(wave), None),
+                    DpControlMessage::StartWave(wave) => (None, Some(wave)),
+                };
+                Self {
+                    engine_index: control.engine_index,
+                    timestamp: control.timestamp,
+                    wave_complete,
+                    start_wave,
+                    ..Default::default()
+                }
+            }
+        }
+    }
+}
+
+impl Serialize for EngineCoreOutputs {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        WireEngineCoreOutputs::from(self.clone()).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for EngineCoreOutputs {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        WireEngineCoreOutputs::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Decode one ordinary or multipart engine-core output message into the typed
+/// public protocol shape. Frame 0 is the primary msgpack; `frames[1..]` are the
+/// ordered aux tensor frames.
+pub fn decode_engine_core_outputs<Frame>(frames: &[Frame]) -> Result<EngineCoreOutputs>
+where
+    Frame: AsRef<[u8]>,
+{
+    let first_frame = frames.first().ok_or_else(|| Error::ExtValueDecode {
+        message: "missing output frame".to_string(),
+    })?;
+
+    let mut outputs: EngineCoreOutputs = decode_msgpack(first_frame.as_ref())?;
+    outputs.resolve_in_place(frames)?;
+    Ok(outputs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::{decode_msgpack, encode_msgpack};
+
+    #[test]
+    fn engine_core_outputs_roundtrip_finished_fields() {
+        let outputs = WireEngineCoreOutputs {
+            outputs: vec![EngineCoreOutput {
+                request_id: "req-1".to_string(),
+                new_token_ids: vec![42],
+                finish_reason: Some(EngineCoreFinishReason::Length),
+                stop_reason: Some(StopReason::Text("stop".to_string())),
+                ..Default::default()
+            }],
+            finished_requests: Some(BTreeSet::from(["req-1".to_string()])),
+            ..Default::default()
+        };
+
+        let encoded = encode_msgpack(&outputs).unwrap();
+        let decoded: WireEngineCoreOutputs = decode_msgpack(&encoded).unwrap();
+
+        assert_eq!(decoded.outputs.len(), 1);
+        assert_eq!(
+            decoded.outputs[0].finish_reason,
+            Some(EngineCoreFinishReason::Length)
+        );
+        assert_eq!(
+            decoded.outputs[0].stop_reason,
+            Some(StopReason::Text("stop".to_string()))
+        );
+        assert_eq!(
+            decoded.finished_requests,
+            Some(BTreeSet::from(["req-1".to_string()]))
+        );
+    }
+
+    #[test]
+    fn classify_request_batch() {
+        let wire = WireEngineCoreOutputs {
+            outputs: vec![EngineCoreOutput {
+                request_id: "req-1".to_string(),
+                new_token_ids: vec![7],
+                ..Default::default()
+            }],
+            finished_requests: Some(BTreeSet::from(["req-1".to_string()])),
+            ..Default::default()
+        };
+        let classified = EngineCoreOutputs::try_from(wire).unwrap();
+        let batch = classified.as_request_batch().expect("request batch");
+        assert_eq!(batch.outputs[0].new_token_ids, vec![7]);
+        assert_eq!(
+            batch.finished_requests,
+            Some(BTreeSet::from(["req-1".to_string()]))
+        );
+    }
+
+    #[test]
+    fn classify_utility() {
+        let wire = WireEngineCoreOutputs {
+            utility_output: Some(rmpv::Value::from(42u32)),
+            ..Default::default()
+        };
+        let classified = EngineCoreOutputs::try_from(wire).unwrap();
+        assert!(matches!(classified, EngineCoreOutputs::Utility(_)));
+    }
+
+    #[test]
+    fn classify_dp_control_start_wave() {
+        let wire = WireEngineCoreOutputs {
+            start_wave: Some(3),
+            ..Default::default()
+        };
+        let classified = EngineCoreOutputs::try_from(wire).unwrap();
+        assert_eq!(
+            classified,
+            EngineCoreOutputs::DpControl(DpControlOutput {
+                engine_index: 0,
+                timestamp: 0.0,
+                control: DpControlMessage::StartWave(3),
+            })
+        );
+    }
+
+    #[test]
+    fn classify_rejects_mixed_shape() {
+        let wire = WireEngineCoreOutputs {
+            outputs: vec![EngineCoreOutput {
+                request_id: "req-1".to_string(),
+                new_token_ids: vec![7],
+                ..Default::default()
+            }],
+            utility_output: Some(rmpv::Value::from(1u32)),
+            ..Default::default()
+        };
+        let error = EngineCoreOutputs::try_from(wire).unwrap_err();
+        assert!(error.to_string().contains("invalid wire shape"), "{error}");
+    }
+
+    #[test]
+    fn decode_engine_core_outputs_from_single_frame() {
+        let wire = WireEngineCoreOutputs {
+            outputs: vec![EngineCoreOutput {
+                request_id: "req-1".to_string(),
+                new_token_ids: vec![1, 2, 3],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let bytes = encode_msgpack(&wire).unwrap();
+        let decoded = decode_engine_core_outputs(&[bytes]).unwrap();
+        assert_eq!(
+            decoded.as_request_batch().unwrap().outputs[0].new_token_ids,
+            vec![1, 2, 3]
+        );
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/vllm/request.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/request.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/request.rs.
+//
+// `mm_features` is carried as OpaqueValue for now (typed in the multimodal
+// phase); on the text path it is `nil` and carries no aux-frame tensors.
+
+use std::collections::{BTreeMap, HashMap};
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use serde_default::DefaultFromSerde;
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+use crate::{
+    codec::OpaqueValue,
+    protocol::vllm::{lora, sampling::EngineCoreSamplingParams},
+    Error, Result,
+};
+
+/// Request types are single-byte protocol constants sent as a raw ZMQ frame
+/// (no encoding step). Mirrors Python `EngineCoreRequestType`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum EngineCoreRequestType {
+    Add = 0,
+    Abort = 1,
+    StartDpWave = 2,
+    Utility = 3,
+}
+
+impl EngineCoreRequestType {
+    /// Decode the single-byte request-type frame. `None` for unrecognized values.
+    pub fn from_frame(frame: &[u8]) -> Option<Self> {
+        let [value] = frame else {
+            return None;
+        };
+        match value {
+            0 => Some(Self::Add),
+            1 => Some(Self::Abort),
+            2 => Some(Self::StartDpWave),
+            3 => Some(Self::Utility),
+            _ => None,
+        }
+    }
+
+    /// Encode as the single-byte frame used on the engine input socket.
+    pub fn to_frame(self) -> Bytes {
+        Bytes::from_static(match self {
+            Self::Add => b"\x00",
+            Self::Abort => b"\x01",
+            Self::StartDpWave => b"\x02",
+            Self::Utility => b"\x03",
+        })
+    }
+}
+
+/// Extra kwargs consumed by engine-side reasoning parsers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ReasoningParserKwargs {
+    /// Effective kwargs visible to the chat template for this request.
+    pub chat_template_kwargs: HashMap<String, serde_json::Value>,
+}
+
+/// Engine-core add-request payload sent from frontend to engine.
+///
+/// This is a msgspec `array_like=True` struct: it serializes as a positional
+/// msgpack array of exactly 20 elements. **Field order is the wire contract** —
+/// do not reorder. Mirrors Python `EngineCoreRequest`.
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple, DefaultFromSerde)]
+pub struct EngineCoreRequest {
+    pub request_id: String,
+    pub prompt_token_ids: Option<Vec<u32>>,
+    /// Multimodal features (untyped for now; `nil` on the text path).
+    pub mm_features: Option<OpaqueValue>,
+    pub sampling_params: Option<EngineCoreSamplingParams>,
+    /// Pooling parameters, preserved in the schema but not yet strongly typed.
+    pub pooling_params: Option<OpaqueValue>,
+    pub arrival_time: f64,
+    #[serde(default)]
+    pub lora_request: Option<lora::LoraRequest>,
+    #[serde(default)]
+    pub cache_salt: Option<String>,
+    #[serde(default)]
+    pub data_parallel_rank: Option<u32>,
+    /// Unsupported in this client: Python uses a custom tensor/aux-frame path.
+    #[serde(default)]
+    pub prompt_embeds: Option<OpaqueValue>,
+    /// Per-position mask for mixed-mode inputs. `Some(true)` = real token id;
+    /// `Some(false)` = position uses a pre-computed `prompt_embeds` entry;
+    /// `None` for pure-tokens and pure-embeds requests.
+    #[serde(default)]
+    pub prompt_is_token_ids: Option<Vec<bool>>,
+    /// Client index, so outputs return to the same client when the frontend
+    /// scales out.
+    #[serde(default)]
+    pub client_index: u32,
+    /// In DP mode, the wave this request is expected to belong to.
+    #[serde(default)]
+    pub current_wave: u32,
+    #[serde(default)]
+    pub priority: i32,
+    #[serde(default)]
+    pub trace_headers: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    pub resumable: bool,
+    /// Original user-provided request ID, used for output reporting and aborts.
+    #[serde(default)]
+    pub external_req_id: Option<String>,
+    #[serde(default)]
+    pub reasoning_ended: Option<bool>,
+    /// Reasoning-parser kwargs forwarded to the structured-output backend.
+    #[serde(default)]
+    pub reasoning_parser_kwargs: Option<ReasoningParserKwargs>,
+    /// If `true`, add to the waiting queue and immediately abort, so
+    /// connector-side cleanup runs via the standard `request_finished` hook.
+    #[serde(default)]
+    pub abort_immediately: bool,
+}
+
+impl EngineCoreRequest {
+    /// Validate fields intentionally not supported in this client.
+    pub fn validate(&self) -> Result<()> {
+        if self.prompt_embeds.is_some() {
+            return Err(Error::UnsupportedField {
+                context: "EngineCoreRequest",
+                field: "prompt_embeds",
+            });
+        }
+        Ok(())
+    }
+
+    // NOTE: send-side aux-frame extraction (walking `mm_features` for large
+    // tensors) is added with the typed multimodal module. Text requests carry
+    // no tensors, so the transport send path appends no aux frames for now.
+}
+
+#[cfg(test)]
+mod tests {
+    use rmpv::Value;
+
+    use super::*;
+    use crate::codec::{decode_value, encode_msgpack};
+
+    #[test]
+    fn request_type_frames_roundtrip() {
+        for ty in [
+            EngineCoreRequestType::Add,
+            EngineCoreRequestType::Abort,
+            EngineCoreRequestType::StartDpWave,
+            EngineCoreRequestType::Utility,
+        ] {
+            assert_eq!(EngineCoreRequestType::from_frame(&ty.to_frame()), Some(ty));
+        }
+        assert_eq!(EngineCoreRequestType::Add.to_frame().as_ref(), b"\x00");
+        assert_eq!(EngineCoreRequestType::from_frame(b"\x09"), None);
+        assert_eq!(EngineCoreRequestType::from_frame(b""), None);
+    }
+
+    #[test]
+    fn engine_core_request_serializes_as_full_array() {
+        let request = EngineCoreRequest {
+            request_id: "req-1".to_string(),
+            prompt_token_ids: Some(vec![1, 2, 3]),
+            sampling_params: Some(EngineCoreSamplingParams {
+                max_tokens: 8,
+                ..EngineCoreSamplingParams::for_test()
+            }),
+            arrival_time: 1234.5,
+            client_index: 7,
+            ..EngineCoreRequest::default()
+        };
+
+        let encoded = encode_msgpack(&request).unwrap();
+        let value = decode_value(&encoded).unwrap();
+        let array = match value {
+            Value::Array(array) => array,
+            other => panic!("expected array, got {other:?}"),
+        };
+
+        // 20-element positional tuple; spot-check the wire positions.
+        assert_eq!(array.len(), 20);
+        assert_eq!(array[0], Value::from("req-1"));
+        assert_eq!(array[2], Value::Nil); // mm_features
+        assert_eq!(array[4], Value::Nil); // pooling_params
+        assert_eq!(array[10], Value::Nil); // prompt_is_token_ids
+        assert_eq!(array[11], Value::from(7)); // client_index
+    }
+
+    #[test]
+    fn validate_rejects_prompt_embeds() {
+        let request = EngineCoreRequest {
+            prompt_embeds: Some(Value::from(1)),
+            ..EngineCoreRequest::default()
+        };
+        assert!(request.validate().is_err());
+        assert!(EngineCoreRequest::default().validate().is_ok());
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/vllm/sampling.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/sampling.rs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/sampling.rs.
+//
+// `structured_outputs` (guided decoding) is carried as OpaqueValue for now; it
+// serializes as `nil` when absent and gets strongly typed in a later phase.
+
+use std::collections::{BTreeSet, HashMap};
+
+use serde::{Deserialize, Serialize};
+use serde_default::DefaultFromSerde;
+
+use crate::codec::OpaqueValue;
+
+fn default_top_p() -> f32 {
+    1.0
+}
+
+fn default_repetition_penalty() -> f32 {
+    1.0
+}
+
+fn default_temperature() -> f32 {
+    1.0
+}
+
+fn default_max_tokens() -> u32 {
+    16
+}
+
+/// Parameters for detecting repetitive N-gram patterns in output tokens.
+/// Mirrors Python `RepetitionDetectionParams`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RepetitionDetectionParams {
+    /// Maximum N-gram size to check. 0 disables detection.
+    pub max_pattern_size: u32,
+    /// Minimum N-gram size to check. Defaults to 1 when zero.
+    #[serde(default)]
+    pub min_pattern_size: u32,
+    /// Minimum number of repetitions to trigger detection (must be >= 2).
+    pub min_count: u32,
+}
+
+impl RepetitionDetectionParams {
+    /// `true` when effectively disabled (`max_pattern_size == 0`).
+    pub fn is_disabled(&self) -> bool {
+        self.max_pattern_size == 0
+    }
+}
+
+/// Engine-core-facing sampling parameters for text generation.
+///
+/// The normalized southbound subset the frontend sends to Python engine-core.
+/// User-facing semantics (`stop` strings, `n`, `ignore_eos`, output aggregation)
+/// are handled by higher layers before values reach this DTO. Python's
+/// `SamplingParams` is `omit_defaults=True`, so msgpack drops default-valued
+/// keys; the whole struct defaults, with per-field fns for the non-zero defaults.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, DefaultFromSerde)]
+#[serde(default)]
+pub struct EngineCoreSamplingParams {
+    /// Controls randomness. Lower is more deterministic; zero means greedy.
+    #[serde(default = "default_temperature")]
+    pub temperature: f32,
+    /// Cumulative probability threshold for nucleus sampling.
+    #[serde(default = "default_top_p")]
+    pub top_p: f32,
+    /// Maximum number of top tokens to consider. `0` means all tokens.
+    pub top_k: u32,
+    /// Random seed used by the sampler when present.
+    pub seed: Option<i64>,
+    /// Maximum number of tokens to generate per output sequence.
+    #[serde(default = "default_max_tokens")]
+    pub max_tokens: u32,
+    /// Minimum number of tokens to generate before EOS or stop-token handling.
+    pub min_tokens: u32,
+    /// Maximum reasoning ("thinking") tokens before the reasoning section is
+    /// force-closed. `None` means unlimited (the user-facing `-1` sentinel is
+    /// normalized to `None` upstream). Enforced engine-side when a reasoning
+    /// parser is configured.
+    pub thinking_token_budget: Option<u64>,
+    /// Log probabilities per generated token. `None` disables; `-1` requests the
+    /// full vocabulary.
+    pub logprobs: Option<i32>,
+    /// Log probabilities per prompt token. `None` disables; `-1` requests the
+    /// full vocabulary.
+    pub prompt_logprobs: Option<i32>,
+    /// Minimum probability threshold for token sampling.
+    pub min_p: f32,
+    /// Frequency penalty applied by the sampler.
+    pub frequency_penalty: f32,
+    /// Presence penalty applied by the sampler.
+    pub presence_penalty: f32,
+    /// Repetition penalty applied by the sampler.
+    #[serde(default = "default_repetition_penalty")]
+    pub repetition_penalty: f32,
+    /// Repetitive N-gram detection params. `None` disables detection.
+    pub repetition_detection: Option<RepetitionDetectionParams>,
+    /// Token IDs that stop generation.
+    pub stop_token_ids: Vec<u32>,
+    /// Primary EOS token ID used by engine-core's dedicated EOS stop path.
+    /// Mirrors Python's internal `_eos_token_id`, derived from tokenizer/model
+    /// metadata by the frontend rather than supplied by end users.
+    #[serde(rename = "_eos_token_id")]
+    pub eos_token_id: Option<u32>,
+    /// Complete stop-token set used by engine-core for `min_tokens` masking.
+    /// Mirrors Python's internal `_all_stop_token_ids`.
+    #[serde(rename = "_all_stop_token_ids")]
+    pub all_stop_token_ids: BTreeSet<u32>,
+    /// Logit biases to apply during sampling; keys are token IDs.
+    pub logit_bias: Option<HashMap<u32, f32>>,
+    /// Restrict output to these token IDs only.
+    pub allowed_token_ids: Option<Vec<u32>>,
+    /// Tokenized bad words to avoid during generation.
+    #[serde(rename = "_bad_words_token_ids")]
+    pub bad_words_token_ids: Option<Vec<Vec<u32>>>,
+    /// Structured outputs (guided decoding). Carried untyped for now; `nil` on
+    /// the text path.
+    pub structured_outputs: Option<OpaqueValue>,
+    /// Specific token IDs for which log probabilities should be returned at each
+    /// position, in addition to the sampled/scored token.
+    pub logprob_token_ids: Option<Vec<u32>>,
+    /// If `Some(true)`, skip reading from the prefix cache (newly computed blocks
+    /// may still populate it). `None` defers to engine-core defaults.
+    pub skip_reading_prefix_cache: Option<bool>,
+    /// Additional request parameters for custom extensions (`vllm_xargs`).
+    pub extra_args: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl EngineCoreSamplingParams {
+    /// Default sampling params for testing purposes only.
+    pub fn for_test() -> Self {
+        Self {
+            temperature: 1.0,
+            top_p: 1.0,
+            top_k: 0,
+            seed: None,
+            max_tokens: 65536,
+            min_tokens: 0,
+            thinking_token_budget: None,
+            logprobs: None,
+            prompt_logprobs: None,
+            min_p: 0.0,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
+            repetition_penalty: 1.0,
+            repetition_detection: None,
+            stop_token_ids: Vec::new(),
+            eos_token_id: None,
+            all_stop_token_ids: BTreeSet::new(),
+            logit_bias: None,
+            allowed_token_ids: None,
+            bad_words_token_ids: None,
+            structured_outputs: None,
+            logprob_token_ids: None,
+            skip_reading_prefix_cache: None,
+            extra_args: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmpv::Value;
+
+    use crate::{codec::decode_msgpack, protocol::vllm::request::EngineCoreRequest};
+
+    /// A real `sampling_params` is a sparse `omit_defaults` map; absent fields
+    /// must fall back to defaults.
+    #[test]
+    fn decodes_sampling_params_with_omitted_defaults() {
+        let sampling_params = Value::Map(vec![
+            (
+                Value::from("stop_token_ids"),
+                Value::Array(vec![Value::from(151643u32)]),
+            ),
+            (Value::from("skip_reading_prefix_cache"), Value::from(false)),
+        ]);
+        let request = Value::Array(vec![
+            Value::from("req-omit-defaults"),
+            Value::Array(vec![
+                Value::from(1u32),
+                Value::from(2u32),
+                Value::from(3u32),
+            ]),
+            Value::Nil,
+            sampling_params,
+            Value::Nil,
+            Value::from(1.0f64),
+        ]);
+
+        let mut bytes = Vec::new();
+        rmpv::encode::write_value(&mut bytes, &request).unwrap();
+
+        let decoded: EngineCoreRequest = decode_msgpack(&bytes)
+            .expect("a real omit_defaults request must decode (regression: missing field)");
+
+        assert_eq!(decoded.request_id, "req-omit-defaults");
+        let sampling = decoded.sampling_params.expect("sampling params present");
+
+        assert_eq!(sampling.stop_token_ids, vec![151643]);
+        assert_eq!(sampling.skip_reading_prefix_cache, Some(false));
+
+        // Omitted fields -> Python defaults.
+        assert_eq!(sampling.temperature, 1.0);
+        assert_eq!(sampling.top_p, 1.0);
+        assert_eq!(sampling.top_k, 0);
+        assert_eq!(sampling.seed, None);
+        assert_eq!(sampling.max_tokens, 16);
+        assert_eq!(sampling.min_tokens, 0);
+        assert_eq!(sampling.min_p, 0.0);
+        assert_eq!(sampling.repetition_penalty, 1.0);
+        assert_eq!(sampling.logprobs, None);
+        assert_eq!(sampling.eos_token_id, None);
+        assert!(sampling.all_stop_token_ids.is_empty());
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/vllm/stats.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/stats.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/stats.rs.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::codec::OpaqueValue;
+
+/// Base cache hit statistics. Mirrors Python `BaseCacheStats`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct BaseCacheStats {
+    pub reset: bool,
+    pub requests: u64,
+    pub queries: u64,
+    pub hits: u64,
+}
+
+/// Prefix cache hit statistics. Mirrors Python `PrefixCacheStats`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PrefixCacheStats {
+    #[serde(flatten)]
+    pub base: BaseCacheStats,
+    pub preempted_requests: u64,
+    pub preempted_queries: u64,
+    pub preempted_hits: u64,
+}
+
+/// Single KV cache block eviction sample. Mirrors Python `KvCacheEvictionEvent`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct KvCacheEvictionEvent {
+    pub lifetime_seconds: f64,
+    pub idle_seconds: f64,
+    pub reuse_gaps_seconds: Vec<f64>,
+}
+
+/// Per-step speculative-decoding stats. Mirrors Python `SpecDecodingStats`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SpecDecodingStats {
+    pub num_spec_tokens: u64,
+    pub num_drafts: u64,
+    pub num_draft_tokens: u64,
+    pub num_accepted_tokens: u64,
+    pub num_accepted_tokens_per_pos: Vec<u64>,
+}
+
+/// Breakdown of a scheduled prefill computation.
+///
+/// Python models this as a plain `@dataclass`, so msgspec serializes it as a
+/// map (named fields), not the array-like form used by `EngineCoreOutput`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrefillStats {
+    #[serde(default)]
+    pub num_prompt_tokens: u32,
+    #[serde(default)]
+    pub num_computed_tokens: u32,
+    #[serde(default)]
+    pub num_cached_tokens: u32,
+    #[serde(default)]
+    pub num_local_cached_tokens: u32,
+    #[serde(default)]
+    pub num_external_cached_tokens: u32,
+    #[serde(default)]
+    pub num_cache_creation_tokens: u32,
+}
+
+/// Debug stats for the metrics calculation. Mirrors Python `DebugPerfStats`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct DebugPerfStats {
+    pub calc_duration: f64,
+    pub num_prefill_requests: u64,
+    pub num_decode_requests: u64,
+    pub context_breakdown: Option<BTreeMap<String, u64>>,
+    pub num_flops_per_gpu_breakdown: Option<BTreeMap<String, u64>>,
+    pub num_read_bytes_per_gpu_breakdown: Option<BTreeMap<String, u64>>,
+    pub num_write_bytes_per_gpu_breakdown: Option<BTreeMap<String, u64>>,
+}
+
+/// Estimated MFU/performance stats. Mirrors Python `PerfStats`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PerfStats {
+    pub num_flops_per_gpu: u64,
+    pub num_read_bytes_per_gpu: u64,
+    pub num_write_bytes_per_gpu: u64,
+    pub debug_stats: Option<DebugPerfStats>,
+}
+
+/// CUDA graph runtime stats. Mirrors Python `CudagraphStats`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CudagraphStats {
+    pub num_unpadded_tokens: u64,
+    pub num_padded_tokens: u64,
+    pub num_paddings: u64,
+    pub runtime_mode: String,
+}
+
+/// Scheduler stats piggybacked on every output batch. Mirrors Python
+/// `SchedulerStats`.
+///
+/// `num_running_reqs` / `num_waiting_reqs` are SMG's per-rank DP load signal —
+/// fresher than any polled `GetLoads`, and the reason the connector consumes
+/// these instead of the reference's client-side load balancer.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SchedulerStats {
+    /// Number of requests in model execution batches.
+    pub num_running_reqs: u64,
+    /// Length of the "waiting" request queue.
+    pub num_waiting_reqs: u64,
+    /// Length of the "skipped waiting" queue.
+    #[serde(default)]
+    pub num_skipped_waiting_reqs: u64,
+    /// Internal DP load-balancing step counter.
+    pub step_counter: u64,
+    /// Internal DP load-balancing wave number.
+    pub current_wave: u64,
+    /// KV-cache usage. `1.0` means 100% usage.
+    pub kv_cache_usage: f64,
+    /// Local prefix cache statistics.
+    pub prefix_cache_stats: PrefixCacheStats,
+    /// External connector prefix cache statistics, when configured.
+    pub connector_prefix_cache_stats: Option<PrefixCacheStats>,
+    /// Sampled KV cache eviction events for residency metrics.
+    pub kv_cache_eviction_events: Vec<KvCacheEvictionEvent>,
+    /// Speculative decoding scheduler stats, when enabled.
+    pub spec_decoding_stats: Option<SpecDecodingStats>,
+    /// Connector-specific KV transfer stats, kept opaque for now.
+    pub kv_connector_stats: Option<BTreeMap<String, OpaqueValue>>,
+    /// CUDA graph runtime stats when graph metrics are enabled.
+    pub cudagraph_stats: Option<CudagraphStats>,
+    /// Estimated MFU/performance stats, when enabled.
+    pub perf_stats: Option<PerfStats>,
+}

--- a/crates/engine_zmq_client/src/transport.rs
+++ b/crates/engine_zmq_client/src/transport.rs
@@ -1,0 +1,653 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Ported from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): transport.rs.
+//
+// The frontend (SMG) BINDS all sockets; engines CONNECT in. Scoped to a single
+// shared transport with no DP coordinator (coordinator lands with DP>1). The
+// reference's `expect`/`panic`/`hex`/`thiserror-ext`/`enum-as-inner` are
+// replaced with std/error-handled equivalents to satisfy `clippy -D warnings`.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+    ops::Deref,
+    time::Duration,
+};
+
+use bytes::Bytes;
+use tokio::{sync::mpsc, time::timeout};
+use tracing::{debug, error, info, trace, warn};
+use zeromq::{
+    prelude::{Socket, SocketRecv, SocketSend},
+    util::PeerIdentity,
+    PullSocket, RouterSendHalf, RouterSocket, ZmqError, ZmqMessage,
+};
+
+use crate::{
+    codec::{decode_msgpack, encode_msgpack},
+    error::{Error, Result},
+    protocol::vllm::{
+        handshake::{
+            EngineCoreReadyResponse, HandshakeAddresses, HandshakeInitMessage, ReadyMessage,
+        },
+        output::{decode_engine_core_outputs, EngineCoreOutputs},
+    },
+};
+
+/// Single-frame sentinel Python `EngineCoreProc` emits on the output socket when
+/// the engine dies.
+pub const ENGINE_CORE_DEAD_SENTINEL: &[u8] = b"ENGINE_CORE_DEAD";
+
+/// Opaque routing identity of one engine on the frontend transport.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EngineId(Bytes);
+
+impl Debug for EngineId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EngineId(")?;
+        for byte in &self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl EngineId {
+    /// The engine id as a ZMQ frame.
+    pub fn to_frame(&self) -> Bytes {
+        self.0.clone()
+    }
+
+    /// Consume into the underlying ZMQ frame.
+    pub fn into_frame(self) -> Bytes {
+        self.0
+    }
+
+    /// Parse the Python-compatible engine index (two-byte little-endian ROUTER
+    /// identity used by `EngineCoreProc`), or `None` if not two bytes.
+    pub fn engine_index(&self) -> Option<u32> {
+        if self.len() != 2 {
+            return None;
+        }
+        Some(u16::from_le_bytes([self[0], self[1]]) as u32)
+    }
+
+    /// Construct an engine id from the Python-compatible engine index encoding.
+    pub fn from_engine_index(value: u32) -> Self {
+        Self(Bytes::copy_from_slice(&(value as u16).to_le_bytes()))
+    }
+}
+
+impl Deref for EngineId {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl From<Vec<u8>> for EngineId {
+    fn from(value: Vec<u8>) -> Self {
+        Self(Bytes::from(value))
+    }
+}
+
+impl<const N: usize> From<&[u8; N]> for EngineId {
+    fn from(value: &[u8; N]) -> Self {
+        Self(Bytes::copy_from_slice(value))
+    }
+}
+
+impl TryFrom<EngineId> for PeerIdentity {
+    type Error = ZmqError;
+
+    fn try_from(value: EngineId) -> std::result::Result<Self, Self::Error> {
+        PeerIdentity::try_from(value.into_frame())
+    }
+}
+
+/// Per-engine handshake result collected while bootstrapping one shared
+/// transport.
+#[derive(Clone, Debug)]
+pub struct ConnectedEngine {
+    /// The identity of the connected engine.
+    pub engine_id: EngineId,
+    /// Post-init configuration received on the input socket registration.
+    pub ready_response: EngineCoreReadyResponse,
+}
+
+/// The connected shared transport plus all registered engines after a
+/// successful startup handshake.
+pub struct ConnectedTransport {
+    /// Local address of the shared input socket engines connect to for requests.
+    pub input_address: String,
+    /// Local address of the shared output socket engines connect to for outputs.
+    pub output_address: String,
+    /// All engines connected through the startup handshake.
+    pub engines: Vec<ConnectedEngine>,
+    /// The sending half of the shared input ROUTER socket.
+    pub input_send: RouterSendHalf,
+    /// The shared output PULL socket for receiving all engines' responses.
+    pub output_socket: PullSocket,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum EngineStartupState {
+    HelloReceived,
+    ReadyReceived,
+}
+
+impl EngineStartupState {
+    fn is_ready_received(&self) -> bool {
+        matches!(self, Self::ReadyReceived)
+    }
+}
+
+fn unexpected_handshake(message: impl Into<String>) -> Error {
+    Error::UnexpectedHandshakeMessage {
+        message: message.into(),
+    }
+}
+
+/// Connect to one or more engines through the startup handshake protocol,
+/// returning the shared data-plane transport plus the registered engines.
+///
+/// The frontend binds the shared input/output sockets first, then the handshake
+/// socket, drives HELLO -> INIT -> READY per engine, and finally waits for each
+/// engine to register (its `EngineCoreReadyResponse`) on the input socket.
+pub async fn connect_handshake(
+    handshake_address: &str,
+    engine_count: usize,
+    local_host: &str,
+    local_input_address: Option<&str>,
+    local_output_address: Option<&str>,
+    ready_timeout: Duration,
+) -> Result<ConnectedTransport> {
+    if engine_count == 0 {
+        return Err(unexpected_handshake("expected engine_count >= 1"));
+    }
+
+    info!(
+        engine_count,
+        handshake_address, "waiting for engines to connect"
+    );
+
+    // 1. Bind shared input/output sockets first so every engine receives the
+    //    same data-plane addresses during handshake.
+    let (input_address, mut input_socket, output_address, output_socket) =
+        bind_local_sockets(local_host, local_input_address, local_output_address).await?;
+    info!(%input_address, %output_address, "bound local transport sockets");
+
+    // 2. Bind the shared handshake socket. All engines connect here with their
+    //    own identities; startup order does not matter.
+    let mut handshake_socket = RouterSocket::new();
+    handshake_socket.bind(handshake_address).await?;
+
+    let mut engines: BTreeMap<EngineId, EngineStartupState> = BTreeMap::new();
+
+    // 3. Receive HELLO from every engine and send a matching INIT.
+    while engines.len() < engine_count {
+        let message = timeout(ready_timeout, handshake_socket.recv())
+            .await
+            .map_err(|_| Error::HandshakeTimeout {
+                stage: "HELLO",
+                timeout: ready_timeout,
+            })??;
+        let (engine_id, handshake_message) = decode_handshake_message(message)?;
+        match handshake_message.status.as_deref() {
+            Some("HELLO") => {
+                if engines.contains_key(&engine_id) {
+                    return Err(unexpected_handshake(format!(
+                        "duplicate engine id {engine_id:?} during startup handshake"
+                    )));
+                }
+                debug!(?engine_id, "received HELLO from engine");
+                send_init_message(
+                    &mut handshake_socket,
+                    &engine_id,
+                    &input_address,
+                    &output_address,
+                )
+                .await?;
+                engines.insert(engine_id, EngineStartupState::HelloReceived);
+            }
+            Some("READY") => {
+                // READY may overlap the HELLO phase.
+                match engines.get_mut(&engine_id) {
+                    Some(state) if !state.is_ready_received() => {
+                        *state = EngineStartupState::ReadyReceived;
+                    }
+                    _ => {
+                        return Err(unexpected_handshake(format!(
+                            "READY for unexpected or duplicate engine id {engine_id:?}"
+                        )));
+                    }
+                }
+            }
+            other => {
+                return Err(unexpected_handshake(format!(
+                    "unexpected handshake status {other:?}"
+                )))
+            }
+        }
+    }
+
+    // 4. Every engine may now send READY (no coordinator gate in this scope).
+    while engines.values().any(|state| !state.is_ready_received()) {
+        let message = timeout(ready_timeout, handshake_socket.recv())
+            .await
+            .map_err(|_| Error::HandshakeTimeout {
+                stage: "READY",
+                timeout: ready_timeout,
+            })??;
+        let (engine_id, handshake_message) = decode_handshake_message(message)?;
+        match handshake_message.status.as_deref() {
+            Some("READY") => match engines.get_mut(&engine_id) {
+                Some(state) if !state.is_ready_received() => {
+                    debug!(?engine_id, "received READY from engine");
+                    *state = EngineStartupState::ReadyReceived;
+                }
+                _ => {
+                    return Err(unexpected_handshake(format!(
+                        "READY for unexpected or duplicate engine id {engine_id:?}"
+                    )));
+                }
+            },
+            Some("HELLO") => {
+                return Err(unexpected_handshake(format!(
+                    "duplicate HELLO for engine id {engine_id:?} after INIT phase"
+                )));
+            }
+            other => {
+                return Err(unexpected_handshake(format!(
+                    "unexpected handshake status {other:?}"
+                )))
+            }
+        }
+    }
+
+    // 5. Wait for every engine to register on the shared input socket.
+    let engines =
+        wait_for_input_registrations(&mut input_socket, engines.into_keys(), ready_timeout).await?;
+    info!(engine_count = engines.len(), "engines connected");
+
+    let (input_send, _) = input_socket.split();
+
+    Ok(ConnectedTransport {
+        input_address,
+        output_address,
+        engines,
+        input_send,
+        output_socket,
+    })
+}
+
+/// Bind the shared input (ROUTER) and output (PULL) sockets. `ipc://` is
+/// supported via explicit addresses; otherwise an ephemeral `tcp://host:0` is used.
+async fn bind_local_sockets(
+    local_host: &str,
+    local_input_address: Option<&str>,
+    local_output_address: Option<&str>,
+) -> Result<(String, RouterSocket, String, PullSocket)> {
+    let mut input_socket = RouterSocket::new();
+    let input_bind = local_input_address
+        .map(str::to_owned)
+        .unwrap_or_else(|| format!("tcp://{local_host}:0"));
+    let input_address = input_socket.bind(&input_bind).await?.to_string();
+
+    let mut output_socket = PullSocket::new();
+    let output_bind = local_output_address
+        .map(str::to_owned)
+        .unwrap_or_else(|| format!("tcp://{local_host}:0"));
+    let output_address = output_socket.bind(&output_bind).await?.to_string();
+
+    Ok((input_address, input_socket, output_address, output_socket))
+}
+
+/// Decode a 2-frame handshake message `[engine_id, ready-payload]`.
+fn decode_handshake_message(message: ZmqMessage) -> Result<(EngineId, ReadyMessage)> {
+    let frames = message.into_vec();
+    let [id_frame, payload] = frames.as_slice() else {
+        return Err(unexpected_handshake(format!(
+            "expected 2 frames, got {}",
+            frames.len()
+        )));
+    };
+    let engine_id = EngineId(id_frame.clone());
+    let handshake_message: ReadyMessage = decode_msgpack(payload)?;
+    Ok((engine_id, handshake_message))
+}
+
+/// Send an INIT message giving the engine the frontend's data-plane addresses.
+async fn send_init_message(
+    handshake_socket: &mut RouterSocket,
+    engine_id: &EngineId,
+    input_address: &str,
+    output_address: &str,
+) -> Result<()> {
+    let init_message = HandshakeInitMessage {
+        addresses: HandshakeAddresses {
+            inputs: vec![input_address.to_string()],
+            outputs: vec![output_address.to_string()],
+            coordinator_input: None,
+            coordinator_output: None,
+            frontend_stats_publish_address: None,
+        },
+        parallel_config: BTreeMap::new(),
+    };
+    let payload = encode_msgpack(&init_message)?;
+
+    let mut message = ZmqMessage::from(engine_id.to_frame());
+    message.push_back(Bytes::from(payload));
+    handshake_socket.send(message).await?;
+    debug!(?engine_id, "sent INIT to engine");
+    Ok(())
+}
+
+/// Wait for each engine to connect to the shared input socket and register with
+/// `[identity, EngineCoreReadyResponse]`.
+async fn wait_for_input_registrations(
+    input_socket: &mut RouterSocket,
+    expected_engines: impl IntoIterator<Item = EngineId>,
+    ready_timeout: Duration,
+) -> Result<Vec<ConnectedEngine>> {
+    let expected_engines = expected_engines.into_iter().collect::<Vec<_>>();
+    let mut pending = expected_engines.iter().cloned().collect::<BTreeSet<_>>();
+    let mut ready_responses = BTreeMap::new();
+
+    while !pending.is_empty() {
+        let registration = timeout(ready_timeout, input_socket.recv())
+            .await
+            .map_err(|_| Error::InputRegistrationTimeout {
+                timeout: ready_timeout,
+            })??;
+
+        let frames = registration.into_vec();
+        let [id_frame, payload] = frames.as_slice() else {
+            return Err(unexpected_handshake(format!(
+                "expected 2 frames for engine input registration, got {}",
+                frames.len()
+            )));
+        };
+        let engine_id = EngineId(id_frame.clone());
+        if !pending.remove(&engine_id) {
+            return Err(unexpected_handshake(format!(
+                "input registration for unexpected engine id {engine_id:?}"
+            )));
+        }
+        if payload.is_empty() {
+            return Err(unexpected_handshake(format!(
+                "empty EngineCoreReadyResponse from engine id {engine_id:?}"
+            )));
+        }
+        let ready_response: EngineCoreReadyResponse = decode_msgpack(payload)?;
+        debug!(?engine_id, "received input registration from engine");
+        ready_responses.insert(engine_id, ready_response);
+    }
+
+    expected_engines
+        .into_iter()
+        .map(|engine_id| {
+            let ready_response = ready_responses.remove(&engine_id).ok_or_else(|| {
+                unexpected_handshake(format!(
+                    "missing ready response for engine id {engine_id:?}"
+                ))
+            })?;
+            Ok(ConnectedEngine {
+                engine_id,
+                ready_response,
+            })
+        })
+        .collect()
+}
+
+/// Send an encoded request to one engine over the shared input ROUTER socket.
+/// Frames: `[engine_id, request_type, payload, aux..]`.
+pub async fn send_message(
+    input_send: &mut RouterSendHalf,
+    engine_id: &EngineId,
+    request_type: Bytes,
+    payload: Bytes,
+    aux_frames: Vec<Bytes>,
+) -> Result<()> {
+    let mut message = ZmqMessage::from(engine_id.to_frame());
+    message.push_back(request_type);
+    message.push_back(payload);
+    for frame in aux_frames {
+        message.push_back(frame);
+    }
+    trace!(
+        ?engine_id,
+        frame_count = message.len(),
+        "sending ZMQ message"
+    );
+    input_send.send(message).await?;
+    Ok(())
+}
+
+/// Receive engine outputs from the shared PULL socket, decode them, and forward
+/// them on `tx`. Terminates on the `ENGINE_CORE_DEAD` sentinel, a transport
+/// error, or when the receiver is dropped. Decode errors are forwarded but do
+/// not stop the loop.
+pub async fn run_output_loop(
+    mut output_socket: PullSocket,
+    tx: mpsc::Sender<Result<EngineCoreOutputs>>,
+) {
+    loop {
+        let message = match output_socket.recv().await {
+            Ok(message) => message,
+            Err(error) => {
+                error!(%error, "failed to receive output message");
+                let _ = tx.send(Err(Error::Transport(error))).await;
+                return;
+            }
+        };
+
+        let frames = message.into_vec();
+        let Some(frame) = frames.first() else {
+            warn!("received empty output message; skipping");
+            continue;
+        };
+        if frame.as_ref() == ENGINE_CORE_DEAD_SENTINEL {
+            warn!("received ENGINE_CORE_DEAD sentinel from engine");
+            let _ = tx.send(Err(Error::EngineCoreDead)).await;
+            return;
+        }
+
+        let decoded = match decode_engine_core_outputs(&frames) {
+            Ok(decoded) => Ok(decoded),
+            Err(error) => {
+                // Keep the loop running so a single bad message doesn't drop the
+                // engine connection.
+                warn!(%error, "failed to decode output message");
+                Err(error)
+            }
+        };
+
+        if tx.send(decoded).await.is_err() {
+            warn!("output loop receiver dropped; shutting down output loop");
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        codec::encode_msgpack,
+        mock_engine::{connect_to_frontend, default_ready_response, IpcNamespace},
+        protocol::vllm::{
+            output::{
+                EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, RequestBatchOutputs,
+            },
+            request::{EngineCoreRequest, EngineCoreRequestType},
+        },
+    };
+
+    const TIMEOUT: Duration = Duration::from_secs(10);
+
+    #[tokio::test]
+    async fn bind_local_sockets_supports_ipc() {
+        let ns = IpcNamespace::new().unwrap();
+        let (input_address, _in, output_address, _out) = bind_local_sockets(
+            "127.0.0.1",
+            Some(&ns.input_endpoint()),
+            Some(&ns.output_endpoint()),
+        )
+        .await
+        .unwrap();
+        assert!(input_address.starts_with("ipc://"));
+        assert!(output_address.starts_with("ipc://"));
+    }
+
+    #[tokio::test]
+    async fn handshake_then_request_and_output_roundtrip() {
+        let ns = IpcNamespace::new().unwrap();
+        let (handshake, input, output) = (
+            ns.handshake_endpoint(),
+            ns.input_endpoint(),
+            ns.output_endpoint(),
+        );
+
+        // Frontend binds + drives handshake; mock engine (index 0) connects in.
+        let (transport, engine) = tokio::join!(
+            connect_handshake(
+                &handshake,
+                1,
+                "127.0.0.1",
+                Some(&input),
+                Some(&output),
+                TIMEOUT
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let transport = transport.expect("frontend handshake");
+        let mut engine = engine.expect("mock engine connect");
+
+        // Registration surfaced the engine + its post-init config.
+        assert_eq!(transport.engines.len(), 1);
+        assert_eq!(
+            transport.engines[0].engine_id,
+            EngineId::from_engine_index(0)
+        );
+        assert_eq!(
+            transport.engines[0].ready_response.vllm_version,
+            "test-vllm-version"
+        );
+
+        let ConnectedTransport {
+            mut input_send,
+            output_socket,
+            engines,
+            ..
+        } = transport;
+        let engine_id = engines[0].engine_id.clone();
+
+        // Send an Add request; the engine receives [request_type, payload].
+        let request = EngineCoreRequest {
+            request_id: "req-1".to_string(),
+            prompt_token_ids: Some(vec![1, 2, 3]),
+            ..EngineCoreRequest::default()
+        };
+        let payload = encode_msgpack(&request).unwrap();
+        send_message(
+            &mut input_send,
+            &engine_id,
+            EngineCoreRequestType::Add.to_frame(),
+            Bytes::from(payload),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+
+        let request_frames = engine.recv_request().await.unwrap();
+        assert_eq!(request_frames[0].as_ref(), b"\x00"); // Add
+        let received: EngineCoreRequest = decode_msgpack(request_frames[1].as_ref()).unwrap();
+        assert_eq!(received.request_id, "req-1");
+        assert_eq!(received.prompt_token_ids, Some(vec![1, 2, 3]));
+
+        // Engine pushes a terminal output; the output loop decodes + forwards it.
+        let (out_tx, mut out_rx) = mpsc::channel(4);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test output loop torn down when the test ends"
+        )]
+        let _output_loop = tokio::spawn(run_output_loop(output_socket, out_tx));
+
+        let outputs = EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
+            engine_index: 0,
+            outputs: vec![EngineCoreOutput {
+                request_id: "req-1".to_string(),
+                new_token_ids: vec![100, 101],
+                finish_reason: Some(EngineCoreFinishReason::Stop),
+                ..EngineCoreOutput::default()
+            }],
+            finished_requests: Some(BTreeSet::from(["req-1".to_string()])),
+            ..RequestBatchOutputs::default()
+        });
+        engine
+            .send_output(vec![Bytes::from(encode_msgpack(&outputs).unwrap())])
+            .await
+            .unwrap();
+
+        let received = out_rx
+            .recv()
+            .await
+            .expect("output delivered")
+            .expect("decoded ok");
+        let batch = received.as_request_batch().expect("request batch");
+        assert_eq!(batch.outputs[0].new_token_ids, vec![100, 101]);
+        assert_eq!(
+            batch.outputs[0].finish_reason,
+            Some(EngineCoreFinishReason::Stop)
+        );
+    }
+
+    #[tokio::test]
+    async fn dead_sentinel_surfaces_engine_core_dead() {
+        let ns = IpcNamespace::new().unwrap();
+        let (handshake, input, output) = (
+            ns.handshake_endpoint(),
+            ns.input_endpoint(),
+            ns.output_endpoint(),
+        );
+
+        let (transport, engine) = tokio::join!(
+            connect_handshake(
+                &handshake,
+                1,
+                "127.0.0.1",
+                Some(&input),
+                Some(&output),
+                TIMEOUT
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let transport = transport.expect("frontend handshake");
+        let mut engine = engine.expect("mock engine connect");
+
+        let (out_tx, mut out_rx) = mpsc::channel(4);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test output loop torn down when the test ends"
+        )]
+        let _output_loop = tokio::spawn(run_output_loop(transport.output_socket, out_tx));
+
+        engine
+            .send_output(vec![Bytes::from_static(ENGINE_CORE_DEAD_SENTINEL)])
+            .await
+            .unwrap();
+        let received = out_rx.recv().await.expect("sentinel delivered");
+        assert!(matches!(received, Err(Error::EngineCoreDead)));
+    }
+}

--- a/crates/mock_worker/Cargo.toml
+++ b/crates/mock_worker/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 smg-grpc-client.workspace = true
+engine-zmq-client = { workspace = true, features = ["mock-engine"] }
 tokio = { workspace = true, features = ["full"] }
 tonic.workspace = true
 axum.workspace = true
@@ -18,3 +19,6 @@ serde_json.workspace = true
 futures.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mock_worker/src/config.rs
+++ b/crates/mock_worker/src/config.rs
@@ -17,6 +17,13 @@ pub struct Config {
     pub grpc_base_port: u16,
     /// Number of gRPC workers to start.
     pub grpc_count: u16,
+    /// Frontend handshake `ipc://` address ZMQ mock engines connect to (they
+    /// dial the SMG/test frontend, which binds the sockets).
+    pub zmq_handshake: Option<String>,
+    /// Number of ZMQ mock EngineCore ranks to start (each a DP rank).
+    pub zmq_count: u16,
+    /// Engine index of the first ZMQ rank; ranks use `[start, start+count)`.
+    pub zmq_start_index: u32,
     /// Model id advertised by every worker (one model, many replicas).
     pub model_id: String,
     /// Tokenizer path advertised by gRPC workers (for gateway autoload).
@@ -42,6 +49,9 @@ impl Config {
             http_count: 0,
             grpc_base_port: 0,
             grpc_count: 0,
+            zmq_handshake: None,
+            zmq_count: 0,
+            zmq_start_index: 0,
             model_id: "mock-model".to_string(),
             tokenizer_path: String::new(),
             gen_delay: Duration::from_millis(0),
@@ -58,6 +68,11 @@ impl Config {
                 "--http-count" => cfg.http_count = parse(value(&mut args, &flag)?, &flag)?,
                 "--grpc-base-port" => cfg.grpc_base_port = parse(value(&mut args, &flag)?, &flag)?,
                 "--grpc-count" => cfg.grpc_count = parse(value(&mut args, &flag)?, &flag)?,
+                "--zmq-handshake" => cfg.zmq_handshake = Some(value(&mut args, &flag)?),
+                "--zmq-count" => cfg.zmq_count = parse(value(&mut args, &flag)?, &flag)?,
+                "--zmq-start-index" => {
+                    cfg.zmq_start_index = parse(value(&mut args, &flag)?, &flag)?
+                }
                 "--model" => cfg.model_id = value(&mut args, &flag)?,
                 "--tokenizer" => cfg.tokenizer_path = value(&mut args, &flag)?,
                 "--gen-ms" => {
@@ -102,14 +117,17 @@ impl Config {
         // `--output-tokens` doubles as the realistic engine's default output
         // length when a request omits `max_tokens`.
         cfg.engine.max_new_default = cfg.output_tokens;
-        if cfg.http_count == 0 && cfg.grpc_count == 0 {
+        if cfg.http_count == 0 && cfg.grpc_count == 0 && cfg.zmq_count == 0 {
             return Err(format!(
-                "nothing to do: pass --http-count and/or --grpc-count\n\n{}",
+                "nothing to do: pass --http-count, --grpc-count, and/or --zmq-count\n\n{}",
                 usage()
             ));
         }
         if cfg.grpc_count > 0 && cfg.grpc_base_port == 0 {
             return Err("--grpc-base-port is required when --grpc-count > 0".to_string());
+        }
+        if cfg.zmq_count > 0 && cfg.zmq_handshake.is_none() {
+            return Err("--zmq-handshake <ipc://…> is required when --zmq-count > 0".to_string());
         }
         Ok(cfg)
     }
@@ -133,6 +151,9 @@ fn usage() -> String {
        --http-count <n>         number of HTTP workers (default 0)\n\
        --grpc-base-port <port>  first gRPC port (required if --grpc-count > 0)\n\
        --grpc-count <n>         number of gRPC workers (default 0)\n\
+       --zmq-handshake <addr>   frontend ipc:// handshake addr (required if --zmq-count > 0)\n\
+       --zmq-count <n>          number of ZMQ mock EngineCore ranks (default 0)\n\
+       --zmq-start-index <n>    engine index of the first ZMQ rank (default 0)\n\
        --model <id>             advertised model id (default mock-model)\n\
        --tokenizer <path>       tokenizer path for gRPC autoload (default = model)\n\
        --gen-ms <ms>            canned per-request latency (default 0)\n\

--- a/crates/mock_worker/src/main.rs
+++ b/crates/mock_worker/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod engine;
 mod grpc;
 mod http;
+mod zmq;
 
 use std::{process::ExitCode, sync::Arc};
 
@@ -55,6 +56,12 @@ async fn main() -> ExitCode {
             break;
         };
         workers.spawn(grpc::serve(cfg.clone(), cfg.host.clone(), port));
+    }
+    if let Some(handshake) = cfg.zmq_handshake.clone() {
+        for i in 0..cfg.zmq_count {
+            let engine_index = cfg.zmq_start_index + i as u32;
+            workers.spawn(zmq::serve(cfg.clone(), handshake.clone(), engine_index));
+        }
     }
 
     tracing::info!("started {} mock workers; ctrl-c to stop", workers.len());

--- a/crates/mock_worker/src/zmq.rs
+++ b/crates/mock_worker/src/zmq.rs
@@ -1,0 +1,348 @@
+//! Mock ZMQ EngineCore worker: plays the vLLM `EngineCoreProc` role over ZMQ so
+//! SMG's `engine-zmq-client` connector can be exercised without a GPU. Unlike
+//! the HTTP/gRPC workers (which bind and are dialed by the gateway), a ZMQ mock
+//! engine *dials* the frontend's `ipc://` handshake address, then registers,
+//! receives `EngineCoreRequest`s, and pushes `EngineCoreOutputs` — driven by the
+//! same continuous-batching [`Engine`] simulator the other protocols use.
+
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+    time::Duration,
+};
+
+use engine_zmq_client::{
+    mock_engine::{connect_to_frontend, default_ready_response, EngineInbound},
+    protocol::vllm::{
+        output::{
+            EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, RequestBatchOutputs,
+        },
+        stats::SchedulerStats,
+    },
+    EngineId,
+};
+use tokio::{sync::mpsc, task::AbortHandle};
+
+use crate::{
+    config::Config,
+    engine::{Engine, GenEvent, LoadSnapshot, NewRequest},
+};
+
+/// Run one mock ZMQ EngineCore rank: connect to `handshake_address`, then serve
+/// requests until the frontend disconnects.
+pub async fn serve(cfg: Arc<Config>, handshake_address: String, engine_index: u32) {
+    let mut ready = default_ready_response();
+    ready.data_parallel_rank = engine_index;
+    ready.instance_id = format!("mock-zmq-{engine_index}");
+
+    let mock = match connect_to_frontend(
+        &handshake_address,
+        EngineId::from_engine_index(engine_index),
+        ready,
+    )
+    .await
+    {
+        Ok(mock) => mock,
+        Err(error) => {
+            tracing::error!("zmq engine {engine_index} handshake failed: {error}");
+            return;
+        }
+    };
+    tracing::info!("zmq mock engine {engine_index} connected to {handshake_address}");
+
+    let (mut input, output) = mock.split();
+    let engine = cfg.realistic.then(|| Engine::spawn(cfg.engine.clone()));
+
+    // A single writer owns the output PUSH socket; per-request forwarders funnel
+    // their outputs here so concurrent requests serialize onto the one socket.
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<EngineCoreOutputs>();
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "writer self-terminates when the output channel closes"
+    )]
+    let _writer = tokio::spawn(async move {
+        let mut output = output;
+        while let Some(outputs) = out_rx.recv().await {
+            if let Err(error) = output.send_outputs(&outputs).await {
+                tracing::warn!("zmq engine output send failed: {error}");
+                break;
+            }
+        }
+    });
+
+    let mut inflight: HashMap<String, AbortHandle> = HashMap::new();
+    loop {
+        match input.recv().await {
+            Ok(EngineInbound::Add(request)) => {
+                let request_id = request.request_id.clone();
+                let prompt = request.prompt_token_ids.clone().unwrap_or_default();
+                // Honor the request's max_tokens; fall back to the worker default.
+                let max_new = request
+                    .sampling_params
+                    .as_ref()
+                    .map(|params| params.max_tokens)
+                    .filter(|&max| max > 0)
+                    .unwrap_or(cfg.output_tokens);
+
+                let (gen_tx, gen_rx) = mpsc::unbounded_channel::<GenEvent>();
+                match &engine {
+                    Some(engine) => engine.submit(NewRequest {
+                        request_id: request_id.clone(),
+                        prompt_token_ids: prompt,
+                        max_new,
+                        events: gen_tx,
+                    }),
+                    None => {
+                        let delay = cfg.gen_delay;
+                        #[expect(
+                            clippy::disallowed_methods,
+                            reason = "canned producer self-terminates after Done"
+                        )]
+                        let _canned = tokio::spawn(canned_generate(gen_tx, max_new, delay));
+                    }
+                }
+
+                #[expect(
+                    clippy::disallowed_methods,
+                    reason = "forwarder self-terminates on Done or abort"
+                )]
+                let forwarder = tokio::spawn(forward_request(
+                    request_id.clone(),
+                    engine_index,
+                    gen_rx,
+                    out_tx.clone(),
+                    engine.clone(),
+                ));
+                inflight.insert(request_id, forwarder.abort_handle());
+            }
+            Ok(EngineInbound::Abort(request_ids)) => {
+                for request_id in request_ids {
+                    if let Some(handle) = inflight.remove(&request_id) {
+                        handle.abort();
+                    }
+                    // Push a terminal Abort output so the frontend stream ends.
+                    let _ = out_tx.send(terminal_batch(
+                        engine_index,
+                        request_id,
+                        EngineCoreFinishReason::Abort,
+                    ));
+                }
+            }
+            Ok(EngineInbound::Other(byte)) => {
+                tracing::debug!("zmq engine {engine_index} ignoring request type {byte}");
+            }
+            Err(error) => {
+                tracing::info!("zmq engine {engine_index} input closed: {error}");
+                break;
+            }
+        }
+    }
+}
+
+/// Forward one request's generation events to the output funnel as
+/// `EngineCoreOutputs`, attaching the engine's load snapshot as `scheduler_stats`.
+async fn forward_request(
+    request_id: String,
+    engine_index: u32,
+    mut gen_rx: mpsc::UnboundedReceiver<GenEvent>,
+    out_tx: mpsc::UnboundedSender<EngineCoreOutputs>,
+    engine: Option<Engine>,
+) {
+    while let Some(event) = gen_rx.recv().await {
+        let load = engine
+            .as_ref()
+            .map(|engine| to_scheduler_stats(&engine.load()));
+        match event {
+            GenEvent::Token { token_id, .. } => {
+                let batch =
+                    token_batch(engine_index, request_id.clone(), vec![token_id], None, load);
+                if out_tx.send(batch).is_err() {
+                    return;
+                }
+            }
+            GenEvent::Done { finish_reason, .. } => {
+                let batch = token_batch(
+                    engine_index,
+                    request_id,
+                    Vec::new(),
+                    Some(map_finish(finish_reason)),
+                    load,
+                );
+                let _ = out_tx.send(batch);
+                return;
+            }
+        }
+    }
+    // Channel closed without Done (the request was aborted); nothing to send.
+}
+
+/// Canned generator for non-realistic mode: emit `output_tokens` synthetic
+/// tokens then a terminal Done.
+async fn canned_generate(
+    gen_tx: mpsc::UnboundedSender<GenEvent>,
+    output_tokens: u32,
+    gen_delay: Duration,
+) {
+    for i in 0..output_tokens {
+        if !gen_delay.is_zero() {
+            tokio::time::sleep(gen_delay).await;
+        }
+        let event = GenEvent::Token {
+            token_id: 100 + i,
+            prompt_tokens: 1,
+            cached_tokens: 0,
+        };
+        if gen_tx.send(event).is_err() {
+            return;
+        }
+    }
+    let _ = gen_tx.send(GenEvent::Done {
+        finish_reason: "stop",
+        prompt_tokens: 1,
+        completion_tokens: output_tokens,
+        cached_tokens: 0,
+    });
+}
+
+/// Build a single-request output batch.
+fn token_batch(
+    engine_index: u32,
+    request_id: String,
+    new_token_ids: Vec<u32>,
+    finish_reason: Option<EngineCoreFinishReason>,
+    scheduler_stats: Option<SchedulerStats>,
+) -> EngineCoreOutputs {
+    let finished_requests = finish_reason.map(|_| BTreeSet::from([request_id.clone()]));
+    EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
+        engine_index,
+        outputs: vec![EngineCoreOutput {
+            request_id,
+            new_token_ids,
+            finish_reason,
+            ..Default::default()
+        }],
+        scheduler_stats: scheduler_stats.map(Box::new),
+        finished_requests,
+        ..Default::default()
+    })
+}
+
+/// A terminal batch carrying only a finish reason (for aborts).
+fn terminal_batch(
+    engine_index: u32,
+    request_id: String,
+    finish_reason: EngineCoreFinishReason,
+) -> EngineCoreOutputs {
+    token_batch(
+        engine_index,
+        request_id,
+        Vec::new(),
+        Some(finish_reason),
+        None,
+    )
+}
+
+/// Map the simulator's load snapshot onto the piggybacked scheduler stats SMG
+/// uses as its DP routing signal.
+fn to_scheduler_stats(snapshot: &LoadSnapshot) -> SchedulerStats {
+    SchedulerStats {
+        num_running_reqs: snapshot.num_running_reqs.max(0) as u64,
+        num_waiting_reqs: snapshot.num_waiting_reqs.max(0) as u64,
+        kv_cache_usage: snapshot.token_usage,
+        ..Default::default()
+    }
+}
+
+fn map_finish(reason: &str) -> EngineCoreFinishReason {
+    match reason {
+        "length" => EngineCoreFinishReason::Length,
+        "abort" => EngineCoreFinishReason::Abort,
+        _ => EngineCoreFinishReason::Stop,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use engine_zmq_client::{
+        connect_handshake, protocol::vllm::request::EngineCoreRequest, EngineCoreClient,
+    };
+    use futures::StreamExt;
+
+    use super::*;
+    use crate::engine::EngineParams;
+
+    fn test_config() -> Config {
+        Config {
+            host: "127.0.0.1".to_string(),
+            http_base_port: 0,
+            http_count: 0,
+            grpc_base_port: 0,
+            grpc_count: 0,
+            zmq_handshake: None,
+            zmq_count: 0,
+            zmq_start_index: 0,
+            model_id: "mock-model".to_string(),
+            tokenizer_path: "mock-model".to_string(),
+            gen_delay: Duration::ZERO,
+            output_tokens: 4,
+            realistic: false,
+            engine: EngineParams::default(),
+        }
+    }
+
+    /// End-to-end over ipc://: the engine-zmq-client connector (frontend) drives
+    /// a full generate against this mock ZMQ engine.
+    #[tokio::test]
+    async fn end_to_end_generate_over_ipc() {
+        let dir = tempfile::tempdir().unwrap();
+        let endpoint = |name: &str| format!("ipc://{}", dir.path().join(name).display());
+        let (handshake, input, output) = (
+            endpoint("hs.sock"),
+            endpoint("in.sock"),
+            endpoint("out.sock"),
+        );
+
+        let cfg = Arc::new(test_config());
+        // Engine dials the frontend; it waits for the handshake endpoint to bind.
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "serve loops until the test drops its handles"
+        )]
+        let _engine = tokio::spawn(serve(cfg, handshake.clone(), 0));
+
+        let transport = connect_handshake(
+            &handshake,
+            1,
+            "127.0.0.1",
+            Some(&input),
+            Some(&output),
+            Duration::from_secs(10),
+        )
+        .await
+        .expect("frontend handshake");
+        let client = EngineCoreClient::new(transport);
+        assert_eq!(client.engines()[0].ready_response.data_parallel_rank, 0);
+
+        let mut stream = client
+            .submit(EngineCoreRequest {
+                request_id: "t1".to_string(),
+                prompt_token_ids: Some(vec![1, 2, 3]),
+                ..Default::default()
+            })
+            .await
+            .expect("submit");
+
+        let mut tokens = Vec::new();
+        let mut finished = false;
+        while let Some(item) = stream.next().await {
+            let output = item.expect("output ok");
+            tokens.extend(output.new_token_ids.clone());
+            if output.finished() {
+                finished = true;
+                break;
+            }
+        }
+        assert!(finished, "stream should reach a terminal output");
+        assert_eq!(tokens.len(), 4, "canned mode emits output_tokens tokens");
+    }
+}


### PR DESCRIPTION
## Description

### Problem

When SMG and a vLLM engine share a host, requests take the long path: gateway → gRPC → Python servicer/AsyncLLM → ZMQ → scheduler. That is an extra process, a serialization round-trip, and a context switch per message, all avoidable when the engine's native EngineCore ZMQ interface is right there on the same box. Before SMG can speak that interface, it needs a Rust implementation of vLLM's EngineCore ZMQ wire protocol (issue #2000, #2002).

### Solution

Add a standalone `engine-zmq-client` crate: a clean-room port of vLLM's Apache-2.0 EngineCore ZMQ protocol (protocol reference, not a dependency — #2001). This PR is the transport/protocol layer only; it does not touch `model_gateway`, so it compiles and tests on its own.

## Changes

- **`crates/engine_zmq_client`** (new):
  - `codec` — msgpack positional-tuple request/output serde, numpy dtype handling, zero-copy tensor aux-frame codec.
  - `protocol/vllm` — handshake (`HELLO`→`INIT`→`READY`, version-tolerant `EngineCoreReadyResponse`), request/sampling/lora/output/logprobs/stats tuples; text path typed, multimodal/structured-output carried opaque.
  - `transport` — frontend binds handshake(ROUTER)/input(ROUTER)/output(PULL); engines connect in (2-byte LE engine_index identity); `ENGINE_CORE_DEAD` sentinel.
  - `connector` — `submit`→streaming `EngineCoreStream`, `abort`, per-engine scheduler-stats load, auto-abort on drop, fail-all on engine death.
  - `mock_engine` — engine-side driver behind the `mock-engine` feature.
- **`crates/mock_worker`** — ZMQ mode (`--zmq-*`) driving the mock engine, for GPU-free routing/policy A/B.
- **`Cargo.toml`** — add the crate to the workspace + its shared deps (zeromq, rmp-serde, serde_tuple, …).

## Test Plan

- `cargo test -p engine-zmq-client --features mock-engine` — green (34 tests, incl. full frontend↔mock-engine loopback generate over `ipc://`).
- `cargo test -p mock-worker` — green (7 tests).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- The protocol was separately validated end-to-end against real vLLM 0.26.0 (see the gateway integration PR).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
