### PR TITLE
feat(router): ZMQ direct backend connections for same-host engines (#2000)

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -218,11 +218,15 @@ impl Worker for GrpcWorker {
     }
 
     async fn get_backend_client(&self) -> WorkerResult<Option<Arc<BackendClient>>> {
-        // Not used by policies — the FFI layer handles gRPC directly
+        // Not used by policies — the FFI layer handles the backend directly.
         Ok(None)
     }
 
     async fn grpc_health_check(&self) -> WorkerResult<bool> {
+        Ok(self.is_healthy())
+    }
+
+    async fn zmq_health_check(&self) -> WorkerResult<bool> {
         Ok(self.is_healthy())
     }
 

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -23,6 +23,31 @@ from smg.router_args import RouterArgs
 
 logger = logging.getLogger("smg.serve")
 
+# Directory for the per-worker ipc:// sockets when connection_mode == "zmq".
+# SMG derives its data-plane socket paths and the tcp handshake port from the
+# ipc:// worker URL, so the engine and the router only need to agree on this URL.
+_ZMQ_SOCKET_DIR = "/tmp/smg-zmq"
+
+
+def _zmq_ipc_url(port: int) -> str:
+    """Per-worker ipc:// URL. The port keeps it unique across DP-free workers."""
+    return f"ipc://{_ZMQ_SOCKET_DIR}/engine-{port}"
+
+
+def _zmq_handshake_port(ipc_url: str) -> int:
+    """The tcp handshake port SMG derives from an ipc:// URL.
+
+    Mirrors `derive_handshake_port` in model_gateway/src/worker/worker.rs exactly
+    (FNV-1a over the path after `ipc://`, mapped into 20000..=29999) so the engine
+    can be launched with the matching `--data-parallel-rpc-port`.
+    """
+    path = ipc_url[len("ipc://") :] if ipc_url.startswith("ipc://") else ipc_url
+    h = 0xCBF29CE484222325
+    for b in path.encode():
+        h ^= b
+        h = (h * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return 20000 + (h % 10000)
+
 
 # ---------------------------------------------------------------------------
 # WorkerLauncher ABC + backend implementations
@@ -41,14 +66,23 @@ class WorkerLauncher(ABC):
 
     def health_check(self, args: argparse.Namespace, host: str, port: int, timeout: float) -> bool:
         """Return True when the worker at host:port is healthy."""
-        if getattr(args, "connection_mode", "grpc") == "grpc":
+        mode = getattr(args, "connection_mode", "grpc")
+        if mode == "grpc":
             return _grpc_health_check(host, port, timeout)
+        if mode == "zmq":
+            # SMG binds the ZMQ sockets and the engine dials in; there is no
+            # host:port to probe. The router's own health checker gates
+            # readiness, so the launcher just proceeds to start the router.
+            return True
         return _http_health_check(f"http://{host}:{port}/health", timeout)
 
     def worker_url(self, args: argparse.Namespace, host: str, port: int) -> str:
         """Return the URL used by the router to reach this worker."""
-        if getattr(args, "connection_mode", "grpc") == "grpc":
+        mode = getattr(args, "connection_mode", "grpc")
+        if mode == "grpc":
             return f"grpc://{host}:{port}"
+        if mode == "zmq":
+            return _zmq_ipc_url(port)
         return f"http://{host}:{port}"
 
     def _get_tp_size(self, args: argparse.Namespace) -> int:
@@ -163,6 +197,9 @@ class VllmWorkerLauncher(WorkerLauncher):
     def build_command(
         self, args: argparse.Namespace, backend_args: list[str], host: str, port: int
     ) -> list[str]:
+        if getattr(args, "connection_mode", "grpc") == "zmq":
+            return self._build_zmq_command(args, backend_args, port)
+
         vllm_entry_points = (
             "vllm.entrypoints.grpc_server"
             if args.connection_mode == "grpc"
@@ -189,6 +226,48 @@ class VllmWorkerLauncher(WorkerLauncher):
             self._filter_backend_args(backend_args, ["--model", "--host", "--port", "--uds"])
         )
 
+        return cmd
+
+    def _build_zmq_command(
+        self, args: argparse.Namespace, backend_args: list[str], port: int
+    ) -> list[str]:
+        """Launch a headless vLLM EngineCore that dials SMG's ZMQ handshake.
+
+        SMG (the router) binds the tcp handshake + ipc data-plane sockets it
+        derives from the ipc:// worker URL; this engine connects in. Each worker
+        is a standalone engine (`--data-parallel-size 1`); running several is
+        dense data parallelism as N independent ZMQ workers.
+        """
+        rpc_port = _zmq_handshake_port(_zmq_ipc_url(port))
+        cmd = [
+            sys.executable,
+            "-m",
+            "vllm.entrypoints.cli.main",
+            "serve",
+            getattr(args, "model", ""),
+            "--headless",
+            "--data-parallel-size",
+            "1",
+            "--data-parallel-size-local",
+            "1",
+            "--data-parallel-address",
+            "127.0.0.1",
+            "--data-parallel-rpc-port",
+            str(rpc_port),
+        ]
+        cmd.extend(
+            self._filter_backend_args(
+                backend_args,
+                [
+                    "--model",
+                    "--headless",
+                    "--data-parallel-size",
+                    "--data-parallel-size-local",
+                    "--data-parallel-address",
+                    "--data-parallel-rpc-port",
+                ],
+            )
+        )
         return cmd
 
 
@@ -462,7 +541,7 @@ def add_serve_args(parser: argparse.ArgumentParser) -> None:
     group.add_argument(
         "--connection-mode",
         default="grpc",
-        choices=["grpc", "http"],
+        choices=["grpc", "http", "zmq"],
         help="Connection mode for workers (default: grpc). Note: trtllm only support grpc",
     )
     # Router host/port - may be overridden by backend (e.g. sglang)
@@ -540,6 +619,13 @@ def parse_serve_args(
     RouterArgs.add_cli_args(pre_parser, use_router_prefix=True, exclude_host_port=True)
     serve_router_args, backend_args = pre_parser.parse_known_args(argv)
     backend = serve_router_args.backend
+
+    # ZMQ direct-backend is a same-host vLLM EngineCore connection; no other
+    # backend speaks the EngineCore ZMQ protocol.
+    if serve_router_args.connection_mode == "zmq" and backend != "vllm":
+        pre_parser.error(
+            f"connection-mode zmq is only supported for the vllm backend, not {backend}"
+        )
 
     # Pass 2: full parser with backend-specific args; resolve so backend can override
     parser = argparse.ArgumentParser(

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -26,7 +26,10 @@ logger = logging.getLogger("smg.serve")
 # Directory for the per-worker ipc:// sockets when connection_mode == "zmq".
 # SMG derives its data-plane socket paths and the tcp handshake port from the
 # ipc:// worker URL, so the engine and the router only need to agree on this URL.
-_ZMQ_SOCKET_DIR = "/tmp/smg-zmq"
+# Per-user directory for the ZMQ ipc:// sockets. Scoped to the current uid and
+# created 0700 (single-owner) so a shared /tmp cannot leak another user's
+# sockets into this router. Override with SMG_ZMQ_SOCKET_DIR.
+_ZMQ_SOCKET_DIR = os.environ.get("SMG_ZMQ_SOCKET_DIR", f"/tmp/smg-zmq-{os.getuid()}")
 
 
 def _zmq_ipc_url(port: int) -> str:
@@ -47,6 +50,27 @@ def _zmq_handshake_port(ipc_url: str) -> int:
         h ^= b
         h = (h * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
     return 20000 + (h % 10000)
+
+
+def _reject_handshake_port_collisions(ports: list[int]) -> None:
+    """Fail before launch if two workers derive the same ZMQ handshake port.
+
+    The handshake port is an FNV-1a hash of the ipc:// path folded into a
+    10000-wide band, so distinct workers can collide. Two engines dialing the
+    same tcp port would cross their handshakes, so reject it up front with a
+    message naming the colliding URLs instead of failing opaquely at bind time.
+    """
+    seen: dict[int, str] = {}
+    for port in ports:
+        ipc_url = _zmq_ipc_url(port)
+        handshake_port = _zmq_handshake_port(ipc_url)
+        if handshake_port in seen:
+            raise ValueError(
+                f"ZMQ handshake port collision on {handshake_port}: "
+                f"{seen[handshake_port]} and {ipc_url} derive the same port. "
+                "Adjust --worker-base-port so the worker ipc paths differ."
+            )
+        seen[handshake_port] = ipc_url
 
 
 # ---------------------------------------------------------------------------
@@ -124,18 +148,23 @@ class WorkerLauncher(ABC):
     def _filter_backend_args(self, backend_args: list[str], filter_args: list[str]) -> list[str]:
         """Filter out args from backend_args that are already set by the launcher.
 
-        Handles both ``--key value`` and ``--key=value`` syntax.
+        Handles ``--key=value``, ``--key value``, and boolean flags. A filtered
+        key in ``--key value`` form only consumes the following token when it
+        actually looks like a value (not another ``-``-prefixed flag), so a
+        filtered boolean flag does not swallow the argument after it.
         """
         filtered = []
         skip_next = False
-        for arg in backend_args:
+        for i, arg in enumerate(backend_args):
             if skip_next:
                 skip_next = False
                 continue
             key = arg.split("=", 1)[0]
             if key in filter_args:
                 if "=" not in arg:
-                    skip_next = True  # value is the next token
+                    nxt = backend_args[i + 1] if i + 1 < len(backend_args) else None
+                    if nxt is not None and not nxt.startswith("-"):
+                        skip_next = True  # value is the next token
                 continue
             filtered.append(arg)
         return filtered
@@ -542,7 +571,10 @@ def add_serve_args(parser: argparse.ArgumentParser) -> None:
         "--connection-mode",
         default="grpc",
         choices=["grpc", "http", "zmq"],
-        help="Connection mode for workers (default: grpc). Note: trtllm only support grpc",
+        help=(
+            "Connection mode for workers (default: grpc). Note: trtllm only "
+            "supports grpc, and zmq is only supported for the vllm backend"
+        ),
     )
     # Router host/port - may be overridden by backend (e.g. sglang)
     group.add_argument(
@@ -684,6 +716,8 @@ class ServeOrchestrator:
 
     def _launch_workers(self) -> None:
         ports = _find_available_ports(self.args.worker_base_port, self.args.data_parallel_size)
+        if getattr(self.args, "connection_mode", "grpc") == "zmq":
+            _reject_handshake_port_collisions(ports)
         host = self.args.worker_host
         for dp_rank, port in enumerate(ports):
             env = self.launcher.gpu_env(self.args, dp_rank)

--- a/bindings/python/tests/test_serve.py
+++ b/bindings/python/tests/test_serve.py
@@ -26,6 +26,9 @@ from smg.serve import (
     _http_health_check,
     _import_backend_args,
     _is_port_available,
+    _reject_handshake_port_collisions,
+    _zmq_handshake_port,
+    _zmq_ipc_url,
     add_serve_args,
     parse_serve_args,
 )
@@ -618,6 +621,58 @@ class TestFilterBackendArgs:
         launcher = SglangWorkerLauncher()
         backend_args = ["--foo", "bar"]
         assert launcher._filter_backend_args(backend_args, []) == ["--foo", "bar"]
+
+    def test_filtered_boolean_flag_does_not_swallow_next_flag(self):
+        # A filtered boolean flag has no value; the following flag must survive.
+        launcher = SglangWorkerLauncher()
+        backend_args = ["--trust-remote-code", "--tp-size", "2"]
+        result = launcher._filter_backend_args(backend_args, ["--trust-remote-code"])
+        assert result == ["--tp-size", "2"]
+
+    def test_filtered_boolean_flag_at_end_of_args(self):
+        launcher = SglangWorkerLauncher()
+        backend_args = ["--tp-size", "2", "--trust-remote-code"]
+        result = launcher._filter_backend_args(backend_args, ["--trust-remote-code"])
+        assert result == ["--tp-size", "2"]
+
+    def test_filtered_key_value_keeps_following_flag(self):
+        launcher = SglangWorkerLauncher()
+        backend_args = ["--model-path", "/tmp/m", "--trust-remote-code"]
+        result = launcher._filter_backend_args(backend_args, ["--model-path"])
+        assert result == ["--trust-remote-code"]
+
+
+class TestZmqHandshakePort:
+    """Handshake-port derivation must mirror derive_handshake_port in worker.rs."""
+
+    def test_matches_pinned_rust_vectors(self):
+        # These MUST equal derive_handshake_port() in worker.rs for the same path.
+        assert _zmq_handshake_port("ipc:///tmp/smg-zmq/ts0.ipc") == 25152
+        assert _zmq_handshake_port("ipc:///tmp/smg-zmq/ts1.ipc") == 22735
+        assert _zmq_handshake_port("ts0.ipc") == 23912
+
+    def test_always_in_band(self):
+        for port in range(30000, 30050):
+            hp = _zmq_handshake_port(_zmq_ipc_url(port))
+            assert 20000 <= hp <= 29999
+
+    def test_reject_collisions_passes_for_distinct_ports(self):
+        # A normal contiguous port range must not raise.
+        _reject_handshake_port_collisions([30000, 30001, 30002])
+
+    def test_reject_collisions_raises_and_names_urls(self):
+        # Two ports whose ipc paths derive the same handshake port must be
+        # rejected before launch, naming both colliding URLs.
+        base = 30000
+        collider = next(
+            p
+            for p in range(base + 1, base + 20000)
+            if _zmq_handshake_port(_zmq_ipc_url(p)) == _zmq_handshake_port(_zmq_ipc_url(base))
+        )
+        with pytest.raises(ValueError) as exc:
+            _reject_handshake_port_collisions([base, collider])
+        assert _zmq_ipc_url(base) in str(exc.value)
+        assert _zmq_ipc_url(collider) in str(exc.value)
 
 
 class TestSglangWorkerLauncher:

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -424,16 +424,15 @@ mod tests {
 
     const TIMEOUT: Duration = Duration::from_secs(10);
 
-    async fn connect() -> (EngineCoreClient, MockEngine) {
+    /// The returned [`IpcNamespace`] owns the socket tempdir; hold it for the
+    /// test duration so the ipc files outlive the client and are cleaned up.
+    async fn connect() -> (EngineCoreClient, MockEngine, IpcNamespace) {
         let ns = IpcNamespace::new().unwrap();
         let (handshake, input, output) = (
             ns.handshake_endpoint(),
             ns.input_endpoint(),
             ns.output_endpoint(),
         );
-        // Leak the namespace so its tempdir (and the ipc socket files) outlive
-        // the test body.
-        std::mem::forget(ns);
         let (transport, engine) = tokio::join!(
             connect_handshake(
                 &handshake,
@@ -449,7 +448,11 @@ mod tests {
                 default_ready_response()
             ),
         );
-        (EngineCoreClient::new(transport.unwrap()), engine.unwrap())
+        (
+            EngineCoreClient::new(transport.unwrap()),
+            engine.unwrap(),
+            ns,
+        )
     }
 
     fn batch(engine_index: u32, output: EngineCoreOutput) -> Vec<bytes::Bytes> {
@@ -469,7 +472,7 @@ mod tests {
 
     #[tokio::test]
     async fn submit_streams_tokens_until_finish() {
-        let (client, mut engine) = connect().await;
+        let (client, mut engine, _ns) = connect().await;
 
         let request = EngineCoreRequest {
             request_id: "req-1".to_string(),
@@ -520,7 +523,7 @@ mod tests {
 
     #[tokio::test]
     async fn scheduler_stats_surface_as_load_signal() {
-        let (client, mut engine) = connect().await;
+        let (client, mut engine, _ns) = connect().await;
         let mut stream = client
             .submit(EngineCoreRequest {
                 request_id: "r".into(),
@@ -560,7 +563,7 @@ mod tests {
 
     #[tokio::test]
     async fn dropping_stream_sends_abort() {
-        let (client, mut engine) = connect().await;
+        let (client, mut engine, _ns) = connect().await;
         let stream = client
             .submit(EngineCoreRequest {
                 request_id: "req-abort".into(),
@@ -582,7 +585,7 @@ mod tests {
 
     #[tokio::test]
     async fn engine_dead_fails_inflight_requests() {
-        let (client, mut engine) = connect().await;
+        let (client, mut engine, _ns) = connect().await;
         let mut stream = client
             .submit(EngineCoreRequest {
                 request_id: "r".into(),

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -113,12 +113,7 @@ impl VllmEngineClient {
     }
 
     /// Build a single vLLM GenerateRequest from OpenAI ChatCompletionRequest
-    #[expect(
-        clippy::unused_self,
-        reason = "method receiver kept for consistent public API across gRPC backends"
-    )]
     pub fn build_generate_request_from_chat(
-        &self,
         request_id: String,
         body: &ChatCompletionRequest,
         processed_text: String,
@@ -152,12 +147,7 @@ impl VllmEngineClient {
     }
 
     /// Build a basic GenerateRequest from the vLLM spec GenerateRequest
-    #[expect(
-        clippy::unused_self,
-        reason = "method receiver kept for consistent public API across gRPC backends"
-    )]
     pub fn build_plain_generate_request(
-        &self,
         request_id: String,
         body: &GenerateRequest,
         original_text: Option<String>,
@@ -189,12 +179,7 @@ impl VllmEngineClient {
     ///
     /// NOTE: This is used by the Harmony router only. The Regular router uses
     /// responses_to_chat() conversion and goes through the chat pipeline.
-    #[expect(
-        clippy::unused_self,
-        reason = "method receiver kept for consistent public API across gRPC backends"
-    )]
     pub fn build_generate_request_from_responses(
-        &self,
         request_id: String,
         body: &ResponsesRequest,
         processed_text: String,
@@ -405,12 +390,7 @@ impl VllmEngineClient {
     }
 
     /// Build a GenerateRequest from CreateMessageRequest (Anthropic Messages API)
-    #[expect(
-        clippy::unused_self,
-        reason = "method receiver kept for consistent public API across gRPC backends"
-    )]
     pub fn build_generate_request_from_messages(
-        &self,
         request_id: String,
         body: &CreateMessageRequest,
         processed_text: String,
@@ -472,12 +452,7 @@ impl VllmEngineClient {
     }
 
     /// Build a GenerateRequest from CompletionRequest (`/v1/completions`)
-    #[expect(
-        clippy::unused_self,
-        reason = "method receiver kept for consistent public API"
-    )]
     pub fn build_generate_request_from_completion(
-        &self,
         request_id: String,
         body: &CompletionRequest,
         original_text: String,

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -88,7 +88,7 @@ axum-server = { version = "0.8.0", default-features = false, features = ["tls-ru
 ndarray = "0.17"
 memmap2 = "0.9"
 rayon = "1.12"
-rustix = { version = "1", features = ["fs"] }
+rustix = { version = "1", features = ["fs", "process"] }
 tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.7", features = ["trace", "compression-gzip", "cors", "timeout", "limit", "request-id", "util"] }
 serde_json = { version = "1.0", default-features = false, features = ["std", "preserve_order"] }

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -79,6 +79,7 @@ smg-mm-rdma.workspace = true
 smg-wasm = { workspace = true, features = ["storage-hooks"] }
 smg-mesh.workspace = true
 smg-grpc-client.workspace = true
+engine-zmq-client.workspace = true
 
 # External dependencies (not in workspace)
 bincode = "1.3"
@@ -136,6 +137,8 @@ chrono = { version = "0.4", features = ["clock"] }
 toml = "1.1"
 
 [dev-dependencies]
+# Enable the mock engine for the ZMQ client's loopback tests.
+engine-zmq-client = { workspace = true, features = ["mock-engine"] }
 criterion = { version = "0.8", features = ["html_reports"] }
 tower = { version = "0.5", features = ["util"] }
 # Used by PD metrics integration tests to capture metric emission via a

--- a/model_gateway/src/routers/grpc/backend_client.rs
+++ b/model_gateway/src/routers/grpc/backend_client.rs
@@ -1,31 +1,34 @@
 //! Backend client: the polymorphism point over a worker's transport.
 //!
-//! A worker's backend is reached via the [`GrpcClient`] multiplexer (over
-//! SGLang/vLLM/TRT-LLM/MLX/TokenSpeed). `BackendClient` is the seam the
-//! execution pipeline works against so that additional transports (a direct
-//! ZMQ connection to a same-host vLLM EngineCore) can be added as sibling
-//! variants without the pipeline — which operates on [`ProtoStream`] /
-//! [`ProtoGenerateRequest`] — having to change.
-//!
-//! Today it wraps only gRPC; every method delegates to the inner client, so
-//! this is a behavior-neutral seam.
+//! A worker's backend is reached either via gRPC (the [`GrpcClient`] multiplexer
+//! over SGLang/vLLM/TRT-LLM/MLX/TokenSpeed) or via a direct ZMQ connection to a
+//! same-host vLLM EngineCore ([`ZmqEngineClient`]). `BackendClient` keeps those
+//! first-class siblings — `GrpcClient` stays pure gRPC — while the execution
+//! pipeline (which works against [`ProtoStream`]/[`ProtoGenerateRequest`]) is
+//! shared unchanged.
 
 use openai_protocol::{
     chat::ChatCompletionRequest, completion::CompletionRequest, generate::GenerateRequest,
     messages::CreateMessageRequest, worker::WorkerLoadResponse,
 };
-use smg_grpc_client::{common_proto, tokenizer_bundle::StreamBundle, SglangSchedulerClient};
+use smg_grpc_client::{
+    common_proto, tokenizer_bundle::StreamBundle, SglangSchedulerClient, VllmEngineClient,
+};
 
 use crate::routers::grpc::{
     client::{GenerateRequestBuildOptions, GrpcClient, HealthCheckResponse, ModelInfo, ServerInfo},
-    proto_wrapper::{ProtoEmbedComplete, ProtoEmbedRequest, ProtoGenerateRequest, ProtoStream},
+    proto_wrapper::{
+        finish_vllm_request, ProtoEmbedComplete, ProtoEmbedRequest, ProtoGenerateRequest,
+        ProtoStream,
+    },
+    zmq_client::ZmqEngineClient,
 };
 
-/// A worker's backend connection. Currently gRPC-only; a direct-ZMQ variant is
-/// added alongside `Grpc` in a follow-up.
+/// A backend connection: gRPC (any engine) or direct ZMQ (vLLM EngineCore).
 #[derive(Clone)]
 pub enum BackendClient {
     Grpc(GrpcClient),
+    Zmq(ZmqEngineClient),
 }
 
 impl BackendClient {
@@ -33,45 +36,72 @@ impl BackendClient {
     pub fn runtime_type(&self) -> crate::worker::RuntimeType {
         match self {
             Self::Grpc(client) => client.runtime_type(),
+            // ZMQ is the vLLM engine over a different transport.
+            Self::Zmq(_) => crate::worker::RuntimeType::Vllm,
         }
     }
 
-    /// True if this backend speaks the vLLM protocol.
+    /// True if this backend speaks the vLLM protocol (gRPC-vLLM or ZMQ).
     pub fn is_vllm(&self) -> bool {
         match self {
             Self::Grpc(client) => client.is_vllm(),
+            Self::Zmq(_) => true,
+        }
+    }
+
+    /// Local liveness. gRPC has no cheap local flag (it uses a health RPC), so
+    /// this reports `true` for gRPC; ZMQ reflects its connection liveness.
+    pub fn is_alive(&self) -> bool {
+        match self {
+            Self::Grpc(_) => true,
+            Self::Zmq(client) => client.is_alive(),
         }
     }
 
     /// Mutable SGLang client accessor. Only valid for a gRPC-SGLang backend;
     /// callers guard with a runtime/sglang check.
+    #[expect(
+        clippy::panic,
+        reason = "typed accessor: caller guarantees an SGLang gRPC backend"
+    )]
     pub fn as_sglang_mut(&mut self) -> &mut SglangSchedulerClient {
         match self {
             Self::Grpc(client) => client.as_sglang_mut(),
+            Self::Zmq(_) => panic!("Expected SGLang client, got ZMQ backend"),
         }
     }
 
     pub async fn health_check(&self) -> Result<HealthCheckResponse, tonic::Status> {
         match self {
             Self::Grpc(client) => client.health_check().await,
+            Self::Zmq(client) => {
+                let resp = client.health_check();
+                Ok(HealthCheckResponse {
+                    healthy: resp.healthy,
+                    message: resp.message,
+                })
+            }
         }
     }
 
     pub async fn get_model_info(&self) -> Result<ModelInfo, tonic::Status> {
         match self {
             Self::Grpc(client) => client.get_model_info().await,
+            Self::Zmq(client) => Ok(ModelInfo::Vllm(client.get_model_info())),
         }
     }
 
     pub async fn get_server_info(&self) -> Result<ServerInfo, tonic::Status> {
         match self {
             Self::Grpc(client) => client.get_server_info().await,
+            Self::Zmq(client) => Ok(ServerInfo::Vllm(client.get_server_info())),
         }
     }
 
     pub async fn get_loads(&self) -> Result<WorkerLoadResponse, tonic::Status> {
         match self {
             Self::Grpc(client) => client.get_loads().await,
+            Self::Zmq(client) => Ok(client.get_loads()),
         }
     }
 
@@ -81,6 +111,9 @@ impl BackendClient {
     ) -> Result<common_proto::FlushCacheResponse, tonic::Status> {
         match self {
             Self::Grpc(client) => client.flush_cache(timeout_s).await,
+            Self::Zmq(_) => Err(tonic::Status::unimplemented(
+                "FlushCache not supported over ZMQ",
+            )),
         }
     }
 
@@ -90,12 +123,18 @@ impl BackendClient {
     ) -> Result<common_proto::ProfileResponse, tonic::Status> {
         match self {
             Self::Grpc(client) => client.start_profile(req).await,
+            Self::Zmq(_) => Err(tonic::Status::unimplemented(
+                "StartProfile not supported over ZMQ",
+            )),
         }
     }
 
     pub async fn stop_profile(&self) -> Result<common_proto::ProfileResponse, tonic::Status> {
         match self {
             Self::Grpc(client) => client.stop_profile().await,
+            Self::Zmq(_) => Err(tonic::Status::unimplemented(
+                "StopProfile not supported over ZMQ",
+            )),
         }
     }
 
@@ -105,6 +144,9 @@ impl BackendClient {
     ) -> Result<tonic::Streaming<common_proto::KvEventBatch>, tonic::Status> {
         match self {
             Self::Grpc(client) => client.subscribe_kv_events(start_seq).await,
+            Self::Zmq(_) => Err(tonic::Status::unimplemented(
+                "SubscribeKvEvents not supported over ZMQ",
+            )),
         }
     }
 
@@ -113,6 +155,9 @@ impl BackendClient {
     ) -> Result<StreamBundle, Box<dyn std::error::Error + Send + Sync>> {
         match self {
             Self::Grpc(client) => client.get_tokenizer().await,
+            // EngineCore does not serve tokenizer artifacts over ZMQ; the
+            // tokenizer is configured at worker registration instead.
+            Self::Zmq(_) => Err("ZMQ backend does not serve a tokenizer bundle".into()),
         }
     }
 
@@ -122,6 +167,14 @@ impl BackendClient {
     ) -> Result<ProtoStream, tonic::Status> {
         match self {
             Self::Grpc(client) => client.generate(req).await,
+            Self::Zmq(client) => match req {
+                ProtoGenerateRequest::Vllm(boxed_req) => {
+                    Ok(ProtoStream::Zmq(client.generate(*boxed_req).await?))
+                }
+                _ => Err(tonic::Status::internal(
+                    "ZMQ backend expects a vLLM generate request",
+                )),
+            },
         }
     }
 
@@ -131,6 +184,9 @@ impl BackendClient {
     ) -> Result<ProtoEmbedComplete, tonic::Status> {
         match self {
             Self::Grpc(client) => client.embed(req).await,
+            Self::Zmq(_) => Err(tonic::Status::unimplemented(
+                "ZMQ backend does not support embedding yet",
+            )),
         }
     }
 
@@ -145,6 +201,19 @@ impl BackendClient {
         match self {
             Self::Grpc(client) => {
                 client.build_chat_request(request_id, body, processed_text, token_ids, options)
+            }
+            Self::Zmq(_) => {
+                reject_zmq_multimodal(&options)?;
+                finish_vllm_request(None, |mm| {
+                    VllmEngineClient::build_generate_request_from_chat(
+                        request_id,
+                        body,
+                        processed_text,
+                        token_ids,
+                        mm,
+                        options.tool_constraints,
+                    )
+                })
             }
         }
     }
@@ -161,6 +230,19 @@ impl BackendClient {
             Self::Grpc(client) => {
                 client.build_messages_request(request_id, body, processed_text, token_ids, options)
             }
+            Self::Zmq(_) => {
+                reject_zmq_multimodal(&options)?;
+                finish_vllm_request(None, |mm| {
+                    VllmEngineClient::build_generate_request_from_messages(
+                        request_id,
+                        body,
+                        processed_text,
+                        token_ids,
+                        mm,
+                        options.tool_constraints,
+                    )
+                })
+            }
         }
     }
 
@@ -174,6 +256,15 @@ impl BackendClient {
         match self {
             Self::Grpc(client) => {
                 client.build_completion_request(request_id, body, original_text, token_ids)
+            }
+            Self::Zmq(_) => {
+                let req = VllmEngineClient::build_generate_request_from_completion(
+                    request_id,
+                    body,
+                    original_text,
+                    token_ids,
+                )?;
+                Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
             }
         }
     }
@@ -189,6 +280,23 @@ impl BackendClient {
             Self::Grpc(client) => {
                 client.build_generate_request(request_id, body, original_text, token_ids)
             }
+            Self::Zmq(_) => {
+                let req = VllmEngineClient::build_plain_generate_request(
+                    request_id,
+                    body,
+                    original_text,
+                    token_ids,
+                )?;
+                Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
+            }
         }
     }
+}
+
+/// ZMQ text path does not carry multimodal inputs yet.
+fn reject_zmq_multimodal(options: &GenerateRequestBuildOptions) -> Result<(), String> {
+    if options.multimodal_inputs.is_some() {
+        return Err("ZMQ backend does not support multimodal inputs yet".to_string());
+    }
+    Ok(())
 }

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -499,13 +499,13 @@ impl GrpcClient {
                 )?;
                 Ok(ProtoGenerateRequest::Sglang(Box::new(req)))
             }
-            Self::Vllm(client) => {
+            Self::Vllm(_) => {
                 let vllm_mm = options.multimodal_inputs.map(|mm| match mm {
                     MultimodalData::Vllm(data) => data.into_proto(),
                     _ => unreachable!("caller guarantees matching variant"),
                 });
                 finish_vllm_request(vllm_mm, |mm| {
-                    client.build_generate_request_from_chat(
+                    VllmEngineClient::build_generate_request_from_chat(
                         request_id,
                         body,
                         processed_text,
@@ -591,13 +591,13 @@ impl GrpcClient {
                 )?;
                 Ok(ProtoGenerateRequest::Sglang(Box::new(req)))
             }
-            Self::Vllm(client) => {
+            Self::Vllm(_) => {
                 let vllm_mm = options.multimodal_inputs.map(|mm| match mm {
                     MultimodalData::Vllm(data) => data.into_proto(),
                     _ => unreachable!("caller guarantees matching variant"),
                 });
                 finish_vllm_request(vllm_mm, |mm| {
-                    client.build_generate_request_from_messages(
+                    VllmEngineClient::build_generate_request_from_messages(
                         request_id,
                         body,
                         processed_text,
@@ -669,8 +669,8 @@ impl GrpcClient {
                 )?;
                 Ok(ProtoGenerateRequest::Sglang(Box::new(req)))
             }
-            Self::Vllm(client) => {
-                let req = client.build_generate_request_from_completion(
+            Self::Vllm(_) => {
+                let req = VllmEngineClient::build_generate_request_from_completion(
                     request_id,
                     body,
                     original_text,
@@ -725,8 +725,8 @@ impl GrpcClient {
                 )?;
                 Ok(ProtoGenerateRequest::Sglang(Box::new(req)))
             }
-            Self::Vllm(client) => {
-                let req = client.build_plain_generate_request(
+            Self::Vllm(_) => {
+                let req = VllmEngineClient::build_plain_generate_request(
                     request_id,
                     body,
                     original_text,

--- a/model_gateway/src/routers/grpc/common/stages/client_acquisition.rs
+++ b/model_gateway/src/routers/grpc/common/stages/client_acquisition.rs
@@ -73,21 +73,21 @@ async fn get_backend_client_from_worker(
             error!(
                 function = "get_backend_client_from_worker",
                 error = %e,
-                "Failed to get gRPC client from worker"
+                "Failed to get backend client from worker"
             );
             error::internal_error(
                 "get_backend_client_failed",
-                format!("Failed to get gRPC client: {e}"),
+                format!("Failed to get backend client: {e}"),
             )
         })?
         .ok_or_else(|| {
             error!(
                 function = "get_backend_client_from_worker",
-                "Selected worker not configured for gRPC"
+                "Selected worker has no gRPC/ZMQ backend client"
             );
             error::internal_error(
-                "worker_not_configured_for_grpc",
-                "Selected worker is not configured for gRPC",
+                "worker_not_configured_for_backend",
+                "Selected worker is not configured for a gRPC/ZMQ backend",
             )
         })?;
 

--- a/model_gateway/src/routers/grpc/common/stages/encode.rs
+++ b/model_gateway/src/routers/grpc/common/stages/encode.rs
@@ -42,7 +42,7 @@ use crate::{
             },
         },
     },
-    worker::DEFAULT_BOOTSTRAP_PORT,
+    worker::{RuntimeType, DEFAULT_BOOTSTRAP_PORT},
 };
 
 /// No-op unless the request is multimodal and worker selection produced encode
@@ -344,13 +344,19 @@ fn prepare_tokenspeed_items(
         .collect())
 }
 
+/// Display name of the engine runtime behind a client, for diagnostics. Keyed on
+/// the runtime, not the transport: a ZMQ worker is a vLLM engine reached over
+/// `ipc://`, so it reports "vLLM" like any other vLLM worker.
 fn backend_name(client: &BackendClient) -> &'static str {
-    match client {
-        BackendClient::Grpc(GrpcClient::Sglang(_)) => "SGLang",
-        BackendClient::Grpc(GrpcClient::Vllm(_)) => "vLLM",
-        BackendClient::Grpc(GrpcClient::Trtllm(_)) => "TRT-LLM",
-        BackendClient::Grpc(GrpcClient::Mlx(_)) => "MLX",
-        BackendClient::Grpc(GrpcClient::TokenSpeed(_)) => "TokenSpeed",
+    match client.runtime_type() {
+        RuntimeType::Sglang => "SGLang",
+        RuntimeType::Vllm => "vLLM",
+        RuntimeType::Trtllm => "TRT-LLM",
+        RuntimeType::Mlx => "MLX",
+        RuntimeType::TokenSpeed => "TokenSpeed",
+        // A gRPC/ZMQ worker is always a local runtime; External (an upstream
+        // OpenAI-compatible API, HTTP-proxied) and Unspecified never reach here.
+        RuntimeType::External | RuntimeType::Unspecified => "unknown",
     }
 }
 

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -21,7 +21,8 @@ use crate::{
         },
     },
     worker::{
-        ConnectionMode, HashRing, RuntimeType, Worker, WorkerRegistry, WorkerType, UNKNOWN_MODEL_ID,
+        ConnectionModeExt, HashRing, RuntimeType, Worker, WorkerRegistry, WorkerType,
+        UNKNOWN_MODEL_ID,
     },
 };
 
@@ -228,18 +229,21 @@ impl WorkerSelectionStage {
             Some(model_id)
         };
 
-        // Get workers for the specified model, filtered by connection mode
+        // Get workers for the specified model. The gRPC router serves both gRPC
+        // and direct-ZMQ workers, so accept either transport (not HTTP).
         let workers = self.worker_registry.get_workers_filtered(
             model_filter,
             Some(WorkerType::Regular),
-            Some(ConnectionMode::Grpc),
+            None,  // grpc + zmq, filtered below
             None,  // any runtime type
             false, // get all workers, we'll filter by is_available() next
         );
 
         // Use into_iter() to take ownership of Arcs without cloning (avoids atomic inc/dec)
-        let available: Vec<Arc<dyn Worker>> =
-            workers.into_iter().filter(|w| w.is_available()).collect();
+        let available: Vec<Arc<dyn Worker>> = workers
+            .into_iter()
+            .filter(|w| w.connection_mode().uses_grpc_pipeline() && w.is_available())
+            .collect();
 
         if available.is_empty() {
             return None;
@@ -269,7 +273,7 @@ impl WorkerSelectionStage {
         // Record worker selection metric
         Metrics::record_worker_selection(
             metrics_labels::WORKER_REGULAR,
-            metrics_labels::CONNECTION_GRPC,
+            selected.connection_mode().as_metric_label(),
             model_id,
             policy.name(),
         );
@@ -291,11 +295,12 @@ impl WorkerSelectionStage {
             Some(model_id)
         };
 
+        // gRPC + direct-ZMQ workers both ride the gRPC router pipeline.
         let all_workers = self.worker_registry.get_workers_filtered(
             model_filter,
             None,
-            Some(ConnectionMode::Grpc), // Match any gRPC worker
-            None,                       // any runtime type
+            None, // grpc + zmq, filtered below
+            None, // any runtime type
             false,
         );
 
@@ -303,7 +308,7 @@ impl WorkerSelectionStage {
             all_workers
                 .into_iter()
                 .fold((Vec::new(), Vec::new()), |mut acc, w| {
-                    if w.is_available() {
+                    if w.connection_mode().uses_grpc_pipeline() && w.is_available() {
                         match w.metadata().spec.worker_type {
                             WorkerType::Prefill => acc.0.push(w),
                             WorkerType::Decode => acc.1.push(w),
@@ -433,18 +438,19 @@ impl WorkerSelectionStage {
             Some(model_id)
         };
 
+        // gRPC + direct-ZMQ workers both ride the gRPC router pipeline.
         let all_workers = self.worker_registry.get_workers_filtered(
             model_filter,
             None,
-            Some(ConnectionMode::Grpc), // Match any gRPC worker
-            None,                       // any runtime type
+            None, // grpc + zmq, filtered below
+            None, // any runtime type
             false,
         );
 
         let (all_encode, all_prefill, all_decode): (Vec<_>, Vec<_>, Vec<_>) = all_workers
             .into_iter()
             .fold((Vec::new(), Vec::new(), Vec::new()), |mut acc, w| {
-                if w.is_available() {
+                if w.connection_mode().uses_grpc_pipeline() && w.is_available() {
                     match w.metadata().spec.worker_type {
                         WorkerType::Encode => acc.0.push(w),
                         WorkerType::Prefill => acc.1.push(w),

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use axum::response::Response;
-use smg_grpc_client::SglangGenerateRequestOptions;
+use smg_grpc_client::{SglangGenerateRequestOptions, VllmEngineClient};
 use tracing::{debug, error};
 
 use crate::routers::{
@@ -165,12 +165,11 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 };
                 ProtoGenerateRequest::Sglang(Box::new(req))
             }
-            BackendClient::Grpc(GrpcClient::Vllm(vllm_client)) => {
+            BackendClient::Grpc(GrpcClient::Vllm(_)) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());
-                        vllm_client
-                            .build_generate_request_from_chat(
+                        VllmEngineClient::build_generate_request_from_chat(
                                 request_id,
                                 body,
                                 placeholder_processed_text,
@@ -183,8 +182,8 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                                 error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
                             })?
                     }
-                    RequestType::Responses(request) => vllm_client
-                        .build_generate_request_from_responses(
+                    RequestType::Responses(request) => {
+                        VllmEngineClient::build_generate_request_from_responses(
                             request_id,
                             request.as_ref(),
                             placeholder_processed_text,
@@ -194,7 +193,8 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                         .map_err(|e| {
                             error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build vLLM generate request from responses");
                             error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
-                        })?,
+                        })?
+                    }
                     RequestType::Embedding(_) => {
                         return Err(error::bad_request(
                             "harmony_embedding_not_supported",
@@ -343,6 +343,55 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                     }
                 };
                 ProtoGenerateRequest::TokenSpeed(Box::new(req))
+            }
+            BackendClient::Zmq(_) => {
+                // A ZMQ worker is a vLLM engine, so it uses the same vLLM request
+                // builders and supports the same request types (Chat + Responses).
+                let req = match &ctx.input.request_type {
+                    RequestType::Chat(request) => {
+                        let body = modified_request
+                            .as_deref()
+                            .unwrap_or_else(|| request.as_ref());
+                        VllmEngineClient::build_generate_request_from_chat(
+                            request_id,
+                            body,
+                            placeholder_processed_text,
+                            token_ids,
+                            None, // No multimodal in Harmony pipeline
+                            tool_constraints,
+                        )
+                        .map_err(|e| {
+                            error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build ZMQ generate request");
+                            error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
+                        })?
+                    }
+                    RequestType::Responses(request) => {
+                        VllmEngineClient::build_generate_request_from_responses(
+                            request_id,
+                            request.as_ref(),
+                            placeholder_processed_text,
+                            token_ids,
+                            tool_constraints,
+                        )
+                        .map_err(|e| {
+                            error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build ZMQ generate request from responses");
+                            error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
+                        })?
+                    }
+                    RequestType::Embedding(_) => {
+                        return Err(error::bad_request(
+                            "harmony_embedding_not_supported",
+                            "Embedding requests are not supported with Harmony models".to_string(),
+                        ));
+                    }
+                    _ => {
+                        return Err(error::bad_request(
+                            "unsupported_request_type",
+                            "Unsupported request type for Harmony models".to_string(),
+                        ));
+                    }
+                };
+                ProtoGenerateRequest::Vllm(Box::new(req))
             }
         };
 

--- a/model_gateway/src/routers/grpc/mod.rs
+++ b/model_gateway/src/routers/grpc/mod.rs
@@ -16,8 +16,8 @@ pub(crate) mod pipeline;
 pub(crate) mod proto_wrapper;
 pub(crate) mod regular;
 pub(crate) mod router; // Used by routers/factory
-pub mod utils;
-pub mod zmq_client; // ZMQ backend adapter behind the vLLM client surface // Used by routers/http and bindings/golang
+pub mod utils; // Used by routers/http and bindings/golang
+pub mod zmq_client; // ZMQ backend adapter behind the vLLM client surface
 
 // Re-export for convenience
 pub use proto_wrapper::{MultimodalData, TensorBytes};

--- a/model_gateway/src/routers/grpc/mod.rs
+++ b/model_gateway/src/routers/grpc/mod.rs
@@ -5,7 +5,7 @@ use openai_protocol::{chat::ChatCompletionRequest, common::StringOrArray};
 
 use crate::routers::error;
 
-pub mod backend_client; // Used by bindings (Worker trait impl)
+pub mod backend_client; // Polymorphism over gRPC vs ZMQ transports
 pub mod client; // Used by core/
 pub(crate) mod common;
 pub(crate) mod context;
@@ -16,7 +16,8 @@ pub(crate) mod pipeline;
 pub(crate) mod proto_wrapper;
 pub(crate) mod regular;
 pub(crate) mod router; // Used by routers/factory
-pub mod utils; // Used by routers/http and bindings/golang
+pub mod utils;
+pub mod zmq_client; // ZMQ backend adapter behind the vLLM client surface // Used by routers/http and bindings/golang
 
 // Re-export for convenience
 pub use proto_wrapper::{MultimodalData, TensorBytes};

--- a/model_gateway/src/routers/grpc/multimodal/assemble.rs
+++ b/model_gateway/src/routers/grpc/multimodal/assemble.rs
@@ -108,6 +108,7 @@ async fn assemble_multimodal_data_impl(
         BackendClient::Grpc(GrpcClient::Mlx(_)) => {
             anyhow::bail!("MLX does not support multimodal inputs")
         }
+        BackendClient::Zmq(_) => anyhow::bail!("ZMQ backend does not support multimodal inputs"),
     }
 }
 

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -39,7 +39,7 @@ use smg_grpc_client::{
 };
 use smg_mm_rdma::RdmaExporter;
 
-use crate::routers::grpc::multimodal::mm_rdma_exporter;
+use crate::routers::grpc::{multimodal::mm_rdma_exporter, zmq_client::ZmqGenerateStream};
 
 /// Backend-neutral encode->prefill bootstrap info for one multimodal item.
 ///
@@ -1942,6 +1942,9 @@ pub enum ProtoStream {
     Trtllm(TrtllmStream),
     Mlx(MlxStream),
     TokenSpeed(TokenSpeedStream),
+    /// ZMQ backend: a custom stream yielding vLLM-proto responses built from
+    /// EngineCore outputs. Auto-aborts on drop, so `mark_completed` is a no-op.
+    Zmq(ZmqGenerateStream),
 }
 
 impl ProtoStream {
@@ -1968,6 +1971,10 @@ impl ProtoStream {
                 .next()
                 .await
                 .map(|result| result.map(|r| ProtoGenerateResponse::TokenSpeed(Box::new(r)))),
+            Self::Zmq(stream) => stream
+                .next()
+                .await
+                .map(|result| result.map(|r| ProtoGenerateResponse::Vllm(Box::new(r)))),
         }
     }
 
@@ -1979,6 +1986,7 @@ impl ProtoStream {
             Self::Trtllm(stream) => stream.mark_completed(),
             Self::Mlx(stream) => stream.mark_completed(),
             Self::TokenSpeed(stream) => stream.mark_completed(),
+            Self::Zmq(stream) => stream.mark_completed(),
         }
     }
 }

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
@@ -111,6 +111,12 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
                     "TokenSpeed backend does not support embeddings",
                 ));
             }
+            BackendClient::Zmq(_) => {
+                return Err(error::not_implemented(
+                    "unsupported_backend",
+                    "ZMQ backend does not support embeddings yet",
+                ));
+            }
         };
 
         ctx.state.execution_plan = Some(ExecutionPlan::embed(proto_req));

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ZMQ backend adapter (gateway glue): presents the vLLM engine surface (the same
+// proto request/response types as `VllmEngineClient`) but speaks ZMQ directly to
+// a same-host vLLM EngineCore via `engine-zmq-client`, bypassing the gRPC Python
+// servicer.
+//
+// This bridges the gateway's proto request-execution pipeline to the raw ZMQ
+// transport, so it lives with the router (which owns `GrpcClient`/`ProtoStream`),
+// not in `smg-grpc-client` (pure gRPC) or `engine-zmq-client` (pure transport).
+// It consumes the exact `vllm::GenerateRequest` the existing vLLM builders
+// produce and emits `vllm::GenerateResponse` built from `EngineCoreOutput`, so
+// the request-execution stage is reused unchanged.
+
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use engine_zmq_client::{
+    connect_handshake,
+    connector::{EngineCoreClient, EngineCoreStream},
+    protocol::vllm::{
+        output::{EngineCoreFinishReason, EngineCoreOutput, StopReason},
+        request::EngineCoreRequest,
+        sampling::EngineCoreSamplingParams,
+    },
+};
+use futures::StreamExt;
+use openai_protocol::worker::{SchedulerLoadSnapshot, WorkerLoadResponse};
+use smg_grpc_client::vllm_proto as vllm;
+
+/// Direct ZMQ connection to a same-host vLLM EngineCore, presented behind the
+/// vLLM gRPC client surface.
+#[derive(Clone)]
+pub struct ZmqEngineClient {
+    inner: Arc<EngineCoreClient>,
+    /// Model id advertised for metadata (EngineCore does not report it on the
+    /// wire; it is configured at worker registration).
+    model_id: String,
+}
+
+impl ZmqEngineClient {
+    /// Bind the frontend sockets and complete the handshake with the engine(s),
+    /// which must already be running and dialing `handshake_address`.
+    ///
+    /// `input_address`/`output_address` are the `ipc://` data-plane endpoints the
+    /// engines connect to (chosen by SMG). `engine_count` is the number of DP
+    /// ranks to await.
+    pub async fn connect(
+        handshake_address: &str,
+        input_address: &str,
+        output_address: &str,
+        engine_count: usize,
+        model_id: String,
+        timeout: Duration,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let transport = connect_handshake(
+            handshake_address,
+            engine_count,
+            "127.0.0.1",
+            Some(input_address),
+            Some(output_address),
+            timeout,
+        )
+        .await?;
+        Ok(Self {
+            inner: Arc::new(EngineCoreClient::new(transport)),
+            model_id,
+        })
+    }
+
+    /// Submit a generate request and return a stream of vLLM-proto responses.
+    pub async fn generate(
+        &self,
+        req: vllm::GenerateRequest,
+    ) -> Result<ZmqGenerateStream, tonic::Status> {
+        let core_request = translate_request(req).map_err(tonic::Status::invalid_argument)?;
+        let stream = self.inner.submit(core_request).await.map_err(zmq_status)?;
+        Ok(ZmqGenerateStream::new(stream))
+    }
+
+    /// Local liveness: false once the connection observed `ENGINE_CORE_DEAD` or
+    /// a transport failure. No RPC (the raw ZMQ wire has no health RPC).
+    pub fn is_alive(&self) -> bool {
+        self.inner.is_alive()
+    }
+
+    /// Health as an RPC-shaped response, derived from local liveness.
+    pub fn health_check(&self) -> vllm::HealthCheckResponse {
+        let alive = self.inner.is_alive();
+        vllm::HealthCheckResponse {
+            healthy: alive,
+            message: if alive {
+                "ok".to_string()
+            } else {
+                "engine core dead".to_string()
+            },
+        }
+    }
+
+    /// Per-rank load from the piggybacked `scheduler_stats` (SMG's DP routing
+    /// signal), in the same shape as the gRPC `GetLoads` response.
+    pub fn get_loads(&self) -> WorkerLoadResponse {
+        let loads: Vec<SchedulerLoadSnapshot> = self
+            .inner
+            .engines()
+            .iter()
+            .filter_map(|engine| {
+                let dp_rank = engine.engine_id.engine_index()?;
+                let stats = self.inner.scheduler_stats(dp_rank)?;
+                Some(SchedulerLoadSnapshot {
+                    dp_rank: i32::try_from(dp_rank).unwrap_or(i32::MAX),
+                    num_running_reqs: i32::try_from(stats.num_running_reqs).unwrap_or(i32::MAX),
+                    num_waiting_reqs: i32::try_from(stats.num_waiting_reqs).unwrap_or(i32::MAX),
+                    token_usage: stats.kv_cache_usage,
+                    ..Default::default()
+                })
+            })
+            .collect();
+        WorkerLoadResponse {
+            timestamp: String::new(),
+            dp_rank_count: i32::try_from(loads.len()).unwrap_or(i32::MAX),
+            loads,
+        }
+    }
+
+    /// Model info derived from the handshake `EngineCoreReadyResponse` plus the
+    /// configured model id (EngineCore does not report tokenizer/vocab metadata,
+    /// so those come from worker config).
+    pub fn get_model_info(&self) -> vllm::GetModelInfoResponse {
+        let max_context_length = self
+            .inner
+            .engines()
+            .first()
+            .map(|e| e.ready_response.max_model_len)
+            .unwrap_or(0);
+        vllm::GetModelInfoResponse {
+            model_path: self.model_id.clone(),
+            served_model_name: self.model_id.clone(),
+            tokenizer_path: self.model_id.clone(),
+            is_generation: true,
+            max_context_length: u32::try_from(max_context_length).unwrap_or(u32::MAX),
+            ..Default::default()
+        }
+    }
+
+    /// Server info derived from the handshake response.
+    pub fn get_server_info(&self) -> vllm::GetServerInfoResponse {
+        let data_parallel_size = self
+            .inner
+            .engines()
+            .first()
+            .map(|e| e.ready_response.data_parallel_size)
+            .unwrap_or(1);
+        vllm::GetServerInfoResponse {
+            data_parallel_size: i32::try_from(data_parallel_size).unwrap_or(i32::MAX),
+            server_type: "vllm".to_string(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Streaming generate output, mapping each `EngineCoreOutput` to a vLLM-proto
+/// `GenerateResponse` (chunks until the terminal output, then a complete). The
+/// underlying [`EngineCoreStream`] auto-aborts on drop, so no explicit abort or
+/// `mark_completed` is required.
+pub struct ZmqGenerateStream {
+    inner: EngineCoreStream,
+    output_ids: Vec<u32>,
+    completion_tokens: u32,
+    prompt_tokens: u32,
+    cached_tokens: u32,
+}
+
+impl ZmqGenerateStream {
+    fn new(inner: EngineCoreStream) -> Self {
+        Self {
+            inner,
+            output_ids: Vec::new(),
+            completion_tokens: 0,
+            prompt_tokens: 0,
+            cached_tokens: 0,
+        }
+    }
+
+    /// Next vLLM-proto response, or `None` when the stream ends.
+    pub async fn next(&mut self) -> Option<Result<vllm::GenerateResponse, tonic::Status>> {
+        match self.inner.next().await {
+            Some(Ok(output)) => Some(Ok(self.map_output(output))),
+            Some(Err(error)) => Some(Err(zmq_status(error))),
+            None => None,
+        }
+    }
+
+    /// No-op: the ZMQ stream aborts natively on drop, so there is nothing to
+    /// mark. Present for parity with the tonic abort-on-drop streams.
+    #[expect(
+        clippy::unused_self,
+        reason = "receiver kept for API parity with the tonic streams"
+    )]
+    pub fn mark_completed(&mut self) {}
+
+    fn map_output(&mut self, output: EngineCoreOutput) -> vllm::GenerateResponse {
+        if let Some(stats) = &output.prefill_stats {
+            self.prompt_tokens = stats.num_prompt_tokens;
+            self.cached_tokens = stats.num_cached_tokens;
+        }
+        self.completion_tokens += output.new_token_ids.len() as u32;
+        self.output_ids.extend(output.new_token_ids.iter().copied());
+
+        let response = match output.finish_reason {
+            Some(reason) => vllm::generate_response::Response::Complete(vllm::GenerateComplete {
+                output_ids: std::mem::take(&mut self.output_ids),
+                finish_reason: finish_reason_str(reason).to_string(),
+                prompt_tokens: self.prompt_tokens,
+                completion_tokens: self.completion_tokens,
+                cached_tokens: self.cached_tokens,
+                matched_stop: output.stop_reason.map(map_matched_stop),
+                ..Default::default()
+            }),
+            None => vllm::generate_response::Response::Chunk(vllm::GenerateStreamChunk {
+                token_ids: output.new_token_ids,
+                prompt_tokens: self.prompt_tokens,
+                completion_tokens: self.completion_tokens,
+                cached_tokens: self.cached_tokens,
+                ..Default::default()
+            }),
+        };
+        vllm::GenerateResponse {
+            response: Some(response),
+        }
+    }
+}
+
+/// Translate a vLLM-proto generate request into an `EngineCoreRequest`. ZMQ mode
+/// requires pre-tokenized input (SMG tokenizes upstream).
+fn translate_request(req: vllm::GenerateRequest) -> Result<EngineCoreRequest, String> {
+    let prompt_token_ids = match req.input {
+        Some(vllm::generate_request::Input::Tokenized(tokenized)) => Some(tokenized.input_ids),
+        Some(vllm::generate_request::Input::Text(_)) => {
+            return Err("ZMQ mode requires pre-tokenized input (TokenizedInput)".to_string());
+        }
+        None => None,
+    };
+    Ok(EngineCoreRequest {
+        request_id: req.request_id,
+        prompt_token_ids,
+        sampling_params: req.sampling_params.map(translate_sampling),
+        arrival_time: now_secs(),
+        data_parallel_rank: req.data_parallel_rank.map(|rank| rank.max(0) as u32),
+        ..EngineCoreRequest::default()
+    })
+}
+
+fn translate_sampling(sp: vllm::SamplingParams) -> EngineCoreSamplingParams {
+    let logit_bias = if sp.logit_bias.is_empty() {
+        None
+    } else {
+        Some(
+            sp.logit_bias
+                .into_iter()
+                .map(|(token, bias)| (token.max(0) as u32, bias))
+                .collect::<HashMap<_, _>>(),
+        )
+    };
+    EngineCoreSamplingParams {
+        temperature: sp.temperature.unwrap_or(1.0),
+        top_p: sp.top_p,
+        top_k: sp.top_k,
+        min_p: sp.min_p,
+        frequency_penalty: sp.frequency_penalty,
+        presence_penalty: sp.presence_penalty,
+        repetition_penalty: sp.repetition_penalty,
+        max_tokens: sp.max_tokens.unwrap_or(16),
+        min_tokens: sp.min_tokens,
+        stop_token_ids: sp.stop_token_ids,
+        seed: sp.seed.map(i64::from),
+        logprobs: sp.logprobs,
+        prompt_logprobs: sp.prompt_logprobs,
+        logit_bias,
+        ..EngineCoreSamplingParams::default()
+    }
+}
+
+fn map_matched_stop(reason: StopReason) -> vllm::generate_complete::MatchedStop {
+    match reason {
+        StopReason::TokenId(id) => vllm::generate_complete::MatchedStop::MatchedTokenId(id),
+        StopReason::Text(text) => vllm::generate_complete::MatchedStop::MatchedStopStr(text),
+    }
+}
+
+fn finish_reason_str(reason: EngineCoreFinishReason) -> &'static str {
+    match reason {
+        EngineCoreFinishReason::Stop | EngineCoreFinishReason::Repetition => "stop",
+        EngineCoreFinishReason::Length => "length",
+        EngineCoreFinishReason::Abort => "abort",
+        EngineCoreFinishReason::Error => "error",
+    }
+}
+
+fn now_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+fn zmq_status(error: engine_zmq_client::Error) -> tonic::Status {
+    match error {
+        engine_zmq_client::Error::EngineCoreDead => tonic::Status::unavailable(error.to_string()),
+        other => tonic::Status::internal(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use engine_zmq_client::{
+        mock_engine::{connect_to_frontend, default_ready_response, EngineInbound},
+        protocol::vllm::output::{EngineCoreOutputs, RequestBatchOutputs},
+        EngineId,
+    };
+
+    use super::*;
+
+    fn batch(
+        request_id: &str,
+        token: u32,
+        finish: Option<EngineCoreFinishReason>,
+    ) -> EngineCoreOutputs {
+        let finished = finish.map(|_| std::collections::BTreeSet::from([request_id.to_string()]));
+        EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
+            engine_index: 0,
+            outputs: vec![EngineCoreOutput {
+                request_id: request_id.to_string(),
+                new_token_ids: vec![token],
+                finish_reason: finish,
+                ..Default::default()
+            }],
+            finished_requests: finished,
+            ..Default::default()
+        })
+    }
+
+    /// End-to-end over ipc://: the adapter translates a vLLM-proto request to
+    /// EngineCore, and maps the engine's outputs back to vLLM-proto responses.
+    #[tokio::test]
+    async fn generate_e2e_translates_and_streams_vllm_proto() {
+        let dir = tempfile::tempdir().unwrap();
+        let ep = |name: &str| format!("ipc://{}", dir.path().join(name).display());
+        let (handshake, input, output) = (ep("hs.sock"), ep("in.sock"), ep("out.sock"));
+
+        let (client, engine) = tokio::join!(
+            ZmqEngineClient::connect(
+                &handshake,
+                &input,
+                &output,
+                1,
+                "m".to_string(),
+                Duration::from_secs(10)
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let client = client.expect("adapter connect");
+        let engine = engine.expect("mock engine");
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "engine task ends after responding"
+        )]
+        let engine_task = tokio::spawn(async move {
+            let (mut input, mut output) = engine.split();
+            let inbound = input.recv().await.unwrap();
+            let request = match inbound {
+                EngineInbound::Add(request) => request,
+                other => panic!("expected Add, got {other:?}"),
+            };
+            assert_eq!(request.request_id, "r1");
+            assert_eq!(request.prompt_token_ids, Some(vec![1, 2, 3]));
+            assert_eq!(request.sampling_params.as_ref().unwrap().max_tokens, 2);
+            output.send_outputs(&batch("r1", 10, None)).await.unwrap();
+            output
+                .send_outputs(&batch("r1", 11, Some(EngineCoreFinishReason::Length)))
+                .await
+                .unwrap();
+        });
+
+        let req = vllm::GenerateRequest {
+            request_id: "r1".to_string(),
+            input: Some(vllm::generate_request::Input::Tokenized(
+                vllm::TokenizedInput {
+                    original_text: String::new(),
+                    input_ids: vec![1, 2, 3],
+                },
+            )),
+            sampling_params: Some(vllm::SamplingParams {
+                max_tokens: Some(2),
+                ..Default::default()
+            }),
+            stream: true,
+            ..Default::default()
+        };
+        let mut stream = client.generate(req).await.expect("generate");
+
+        let first = stream.next().await.expect("chunk item").expect("chunk ok");
+        match first.response {
+            Some(vllm::generate_response::Response::Chunk(chunk)) => {
+                assert_eq!(chunk.token_ids, vec![10]);
+            }
+            other => panic!("expected chunk, got {other:?}"),
+        }
+        let second = stream
+            .next()
+            .await
+            .expect("complete item")
+            .expect("complete ok");
+        match second.response {
+            Some(vllm::generate_response::Response::Complete(complete)) => {
+                assert_eq!(complete.output_ids, vec![10, 11]);
+                assert_eq!(complete.finish_reason, "length");
+                assert_eq!(complete.completion_tokens, 2);
+            }
+            other => panic!("expected complete, got {other:?}"),
+        }
+        assert!(stream.next().await.is_none());
+
+        engine_task.await.unwrap();
+    }
+
+    #[test]
+    fn finish_reasons_map_to_vllm_strings() {
+        assert_eq!(finish_reason_str(EngineCoreFinishReason::Length), "length");
+        assert_eq!(
+            finish_reason_str(EngineCoreFinishReason::Repetition),
+            "stop"
+        );
+        assert_eq!(finish_reason_str(EngineCoreFinishReason::Abort), "abort");
+    }
+}

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -242,14 +242,20 @@ fn translate_request(req: vllm::GenerateRequest) -> Result<EngineCoreRequest, St
         Some(vllm::generate_request::Input::Text(_)) => {
             return Err("ZMQ mode requires pre-tokenized input (TokenizedInput)".to_string());
         }
-        None => None,
+        None => {
+            return Err("ZMQ mode requires pre-tokenized input; no input provided".to_string());
+        }
     };
+    let data_parallel_rank = req
+        .data_parallel_rank
+        .map(|rank| u32::try_from(rank).map_err(|_| format!("invalid data_parallel_rank: {rank}")))
+        .transpose()?;
     Ok(EngineCoreRequest {
         request_id: req.request_id,
         prompt_token_ids,
         sampling_params: req.sampling_params.map(translate_sampling),
         arrival_time: now_secs(),
-        data_parallel_rank: req.data_parallel_rank.map(|rank| rank.max(0) as u32),
+        data_parallel_rank,
         ..EngineCoreRequest::default()
     })
 }
@@ -261,7 +267,15 @@ fn translate_sampling(sp: vllm::SamplingParams) -> EngineCoreSamplingParams {
         Some(
             sp.logit_bias
                 .into_iter()
-                .map(|(token, bias)| (token.max(0) as u32, bias))
+                .filter_map(|(token, bias)| match u32::try_from(token) {
+                    Ok(t) => Some((t, bias)),
+                    Err(_) => {
+                        // Don't fold negatives onto key 0 (which would silently
+                        // drop all but the last); skip them with a warning.
+                        tracing::warn!("dropping negative logit_bias token id {token}");
+                        None
+                    }
+                })
                 .collect::<HashMap<_, _>>(),
         )
     };

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -160,7 +160,7 @@ impl BasicWorkerBuilder {
         self
     }
 
-    /// Set gRPC client for gRPC workers
+    /// Set the backend client (gRPC or ZMQ) for a local worker.
     pub fn backend_client(mut self, client: BackendClient) -> Self {
         self.backend_client = Some(client);
         self

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -258,16 +258,16 @@ impl BasicWorkerBuilder {
             health_endpoint: self.health_endpoint,
         };
 
-        // Use OnceCell for lock-free gRPC client access after initialization
-        let backend_client = Arc::new(match self.backend_client {
-            Some(client) => {
-                let cell = OnceCell::new();
-                // Pre-set the client if provided (blocking set is fine during construction)
+        // OnceCell for lock-free client access after initialization; ArcSwap so
+        // the ZMQ health probe can evict a dead client (see BasicWorker docs).
+        let backend_client = {
+            let cell = OnceCell::new();
+            if let Some(client) = self.backend_client {
+                // Pre-set the client if provided (set on a fresh cell cannot fail)
                 cell.set(Arc::new(client)).ok();
-                cell
             }
-            None => OnceCell::new(),
-        });
+            Arc::new(ArcSwap::from_pointee(cell))
+        };
 
         // Caller can override the initial status (e.g. when replacing an
         // existing worker, to preserve its prior status). Otherwise:

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -233,7 +233,7 @@ impl BasicWorkerBuilder {
 
     /// Build the BasicWorker instance
     pub fn build(mut self) -> BasicWorker {
-        use std::sync::Arc;
+        use std::sync::{atomic::AtomicBool, Arc};
 
         use tokio::sync::OnceCell;
 
@@ -303,6 +303,7 @@ impl BasicWorkerBuilder {
             )),
             metadata,
             backend_client,
+            zmq_connect_started: Arc::new(AtomicBool::new(false)),
             models_override: Arc::new(ArcSwap::from_pointee(WorkerModels::Wildcard)),
             http_client,
             resilience,

--- a/model_gateway/src/worker/kv_event_monitor.rs
+++ b/model_gateway/src/worker/kv_event_monitor.rs
@@ -103,8 +103,11 @@ impl KvEventMonitor {
         // Normalize model_id to match routing's normalize_model_key — empty → "unknown".
         let model_id = Self::normalize_model_id(worker.model_id());
 
-        if *worker.connection_mode() == ConnectionMode::Http {
-            debug!(worker_url = %url, "HTTP worker, skipping KV event subscription");
+        // Only gRPC workers stream KV events. HTTP proxies don't, and a ZMQ
+        // EngineCore returns `unimplemented` for SubscribeKvEvents — subscribing
+        // there would just be a wasted handshake + round-trip per registration.
+        if *worker.connection_mode() != ConnectionMode::Grpc {
+            debug!(worker_url = %url, mode = %worker.connection_mode(), "non-gRPC worker, skipping KV event subscription");
             return;
         }
 
@@ -377,7 +380,7 @@ impl KvEventMonitor {
         }
 
         loop {
-            let grpc_client = match worker.get_backend_client().await {
+            let backend_client = match worker.get_backend_client().await {
                 Ok(Some(client)) => client,
                 Ok(None) => {
                     // HTTP workers are filtered in on_worker_added, so this should
@@ -386,7 +389,7 @@ impl KvEventMonitor {
                     warn!(
                         worker_url = %worker_url,
                         delay_ms = reconnect_delay_ms,
-                        "Worker has no gRPC client yet, retrying"
+                        "Worker has no backend client yet, retrying"
                     );
                     if sleep_or_shutdown!(
                         Duration::from_millis(reconnect_delay_ms),
@@ -403,7 +406,7 @@ impl KvEventMonitor {
                         worker_url = %worker_url,
                         error = %e,
                         delay_ms = reconnect_delay_ms,
-                        "Failed to get gRPC client, retrying"
+                        "Failed to get backend client, retrying"
                     );
                     if sleep_or_shutdown!(
                         Duration::from_millis(reconnect_delay_ms),
@@ -417,7 +420,7 @@ impl KvEventMonitor {
                 }
             };
 
-            let stream = match grpc_client.subscribe_kv_events(last_seq).await {
+            let stream = match backend_client.subscribe_kv_events(last_seq).await {
                 Ok(stream) => {
                     info!(
                         worker_url = %worker_url,

--- a/model_gateway/src/worker/kv_event_monitor.rs
+++ b/model_gateway/src/worker/kv_event_monitor.rs
@@ -377,7 +377,7 @@ impl KvEventMonitor {
         }
 
         loop {
-            let backend_client = match worker.get_backend_client().await {
+            let grpc_client = match worker.get_backend_client().await {
                 Ok(Some(client)) => client,
                 Ok(None) => {
                     // HTTP workers are filtered in on_worker_added, so this should
@@ -417,7 +417,7 @@ impl KvEventMonitor {
                 }
             };
 
-            let stream = match backend_client.subscribe_kv_events(last_seq).await {
+            let stream = match grpc_client.subscribe_kv_events(last_seq).await {
                 Ok(stream) => {
                     info!(
                         worker_url = %worker_url,

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -955,7 +955,7 @@ impl WorkerManager {
                             WorkerMonitor::fetch_http_load(&client, &worker).await
                         }
                         ConnectionMode::Grpc | ConnectionMode::Zmq => {
-                            WorkerMonitor::fetch_grpc_load(&worker).await
+                            WorkerMonitor::fetch_backend_load(&worker).await
                         }
                     };
                     // `load` is the absolute used-token count. Report it only

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -45,6 +45,7 @@ pub use registry::{WorkerOrigin, WorkerRegistry};
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};
 pub use sampling_defaults::DEFAULT_SAMPLING_PARAMS_LABEL;
 pub use service::WorkerService;
+pub(crate) use worker::ConnectionModeExt;
 pub use worker::{
     AttachedBody, BasicWorker, ConnectionMode, RuntimeType, Worker, WorkerLoadGuard, WorkerType,
     DEFAULT_BOOTSTRAP_PORT, MOONCAKE_CONNECTOR, NIXL_CONNECTOR,

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -610,27 +610,27 @@ impl WorkerMonitor {
         }
     }
 
-    /// Fetch load via the gRPC `GetLoads` RPC. Only supported for SGLang
-    /// backends. Returns `None` on missing client, RPC error, or empty
-    /// `loads` array.
-    pub(crate) async fn fetch_grpc_load(worker: &Arc<dyn Worker>) -> Option<WorkerLoadResponse> {
-        let grpc_client = match worker.get_backend_client().await {
+    /// Fetch load via the backend client's `GetLoads` (gRPC RPC or the ZMQ
+    /// engine's pushed scheduler stats). Returns `None` on missing client,
+    /// error, or empty `loads` array.
+    pub(crate) async fn fetch_backend_load(worker: &Arc<dyn Worker>) -> Option<WorkerLoadResponse> {
+        let backend_client = match worker.get_backend_client().await {
             Ok(Some(client)) => client,
             Ok(None) => {
-                debug!("No gRPC client for worker {}", worker.url());
+                debug!("No backend client for worker {}", worker.url());
                 return None;
             }
             Err(e) => {
-                debug!("Failed to get gRPC client for {}: {e}", worker.url());
+                debug!("Failed to get backend client for {}: {e}", worker.url());
                 return None;
             }
         };
 
-        match grpc_client.get_loads().await {
+        match backend_client.get_loads().await {
             Ok(load) if !load.loads.is_empty() => Some(load),
             Ok(_) => None,
             Err(e) => {
-                debug!("gRPC GetLoads failed for {}: {e}", worker.url());
+                debug!("backend GetLoads failed for {}: {e}", worker.url());
                 None
             }
         }
@@ -834,7 +834,7 @@ async fn group_monitor_loop(
                             WorkerMonitor::fetch_http_load(&client, &worker).await
                         }
                         ConnectionMode::Grpc | ConnectionMode::Zmq => {
-                            WorkerMonitor::fetch_grpc_load(&worker).await
+                            WorkerMonitor::fetch_backend_load(&worker).await
                         }
                     };
                     (worker.url().to_string(), response)

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -614,7 +614,7 @@ impl WorkerMonitor {
     /// backends. Returns `None` on missing client, RPC error, or empty
     /// `loads` array.
     pub(crate) async fn fetch_grpc_load(worker: &Arc<dyn Worker>) -> Option<WorkerLoadResponse> {
-        let backend_client = match worker.get_backend_client().await {
+        let grpc_client = match worker.get_backend_client().await {
             Ok(Some(client)) => client,
             Ok(None) => {
                 debug!("No gRPC client for worker {}", worker.url());
@@ -626,7 +626,7 @@ impl WorkerMonitor {
             }
         };
 
-        match backend_client.get_loads().await {
+        match grpc_client.get_loads().await {
             Ok(load) if !load.loads.is_empty() => Some(load),
             Ok(_) => None,
             Err(e) => {
@@ -833,11 +833,9 @@ async fn group_monitor_loop(
                         ConnectionMode::Http => {
                             WorkerMonitor::fetch_http_load(&client, &worker).await
                         }
-                        ConnectionMode::Grpc => WorkerMonitor::fetch_grpc_load(&worker).await,
-                        // ZMQ load monitoring lands with the backend client; a
-                        // ZMQ worker reports no load until then (never via the
-                        // gRPC load path).
-                        ConnectionMode::Zmq => None,
+                        ConnectionMode::Grpc | ConnectionMode::Zmq => {
+                            WorkerMonitor::fetch_grpc_load(&worker).await
+                        }
                     };
                     (worker.url().to_string(), response)
                 }

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -2,7 +2,7 @@ use std::{
     any::Any,
     fmt,
     sync::{
-        atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -118,6 +118,35 @@ async fn ensure_ipc_socket_dir(base_url: &str) -> WorkerResult<()> {
         }
     }
     Ok(())
+}
+
+/// Bind the SMG-side ZMQ sockets and complete the handshake with the engine.
+/// Shared by the lazy client accessor and the background handshake driver so
+/// both go through the exact same connect path. `base_url` is the `ipc://` URL;
+/// `model_id` is the config-resolved served model (EngineCore reports none).
+async fn connect_zmq_backend(
+    base_url: String,
+    model_id: String,
+) -> WorkerResult<Arc<BackendClient>> {
+    let (handshake, input, output) = zmq_socket_addresses(&base_url)?;
+    ensure_ipc_socket_dir(&base_url).await?;
+    tracing::info!("Binding ZMQ client for worker {base_url} (handshake={handshake})");
+    match ZmqEngineClient::connect(
+        &handshake,
+        &input,
+        &output,
+        1,
+        model_id,
+        ZMQ_CONNECT_TIMEOUT,
+    )
+    .await
+    {
+        Ok(client) => Ok(Arc::new(BackendClient::Zmq(client))),
+        Err(e) => Err(WorkerError::ConnectionFailed {
+            url: base_url,
+            reason: format!("Failed to connect ZMQ engine: {e}"),
+        }),
+    }
 }
 
 /// Default bootstrap port for PD disaggregation (used by SGLang and vLLM Mooncake)
@@ -1045,9 +1074,13 @@ pub struct BasicWorker {
     pub metadata: WorkerMetadata,
     pub runtime: ArcSwap<WorkerRuntime>,
     pub circuit_breaker: ArcSwap<CircuitBreaker>,
-    /// Lazily initialized gRPC client for gRPC workers.
+    /// Lazily initialized backend client (gRPC or ZMQ) for local workers.
     /// Uses OnceCell for lock-free reads after initialization.
     pub backend_client: Arc<OnceCell<Arc<BackendClient>>>,
+    /// Guards the one-shot background ZMQ handshake driver so the health probe
+    /// never cancels a long (model-load) handshake. Self-clears on failure to
+    /// allow a retry. Unused for HTTP/gRPC.
+    pub zmq_connect_started: Arc<AtomicBool>,
     /// Runtime-mutable models override (for lazy discovery).
     /// When not `Wildcard`, overrides metadata.models for routing decisions.
     /// Uses `ArcSwap` for lock-free reads on the hot path (`supports_model`).
@@ -1065,6 +1098,7 @@ impl Clone for BasicWorker {
             runtime: ArcSwap::from(self.runtime.load_full()),
             circuit_breaker: ArcSwap::from(self.circuit_breaker.load_full()),
             backend_client: Arc::clone(&self.backend_client),
+            zmq_connect_started: Arc::clone(&self.zmq_connect_started),
             models_override: Arc::clone(&self.models_override),
             http_client: self.http_client.clone(),
             resilience: self.resilience.clone(),
@@ -1354,38 +1388,14 @@ impl Worker for BasicWorker {
             ConnectionMode::Zmq => {
                 // SMG binds the handshake + data-plane sockets; the
                 // operator-launched engine dials them. The first acquisition
-                // completes the handshake (a liveness signal in itself).
+                // completes the handshake (a liveness signal in itself). The
+                // model id comes from config — EngineCore reports none on the
+                // wire (see create_worker).
+                let base_url = self.metadata.base_url().to_string();
+                let model_id = self.metadata.model_id().to_string();
                 let client = self
                     .backend_client
-                    .get_or_try_init(|| async {
-                        let (handshake, input, output) =
-                            zmq_socket_addresses(self.metadata.base_url())?;
-                        ensure_ipc_socket_dir(self.metadata.base_url()).await?;
-                        // EngineCore does not report a served model name over the
-                        // wire, so the client reports the model resolved from
-                        // config at worker creation (see create_worker).
-                        let model_id = self.metadata.model_id().to_string();
-                        tracing::info!(
-                            "Lazily binding ZMQ client for worker {} (handshake={handshake})",
-                            self.metadata.spec.url
-                        );
-                        match ZmqEngineClient::connect(
-                            &handshake,
-                            &input,
-                            &output,
-                            1,
-                            model_id,
-                            ZMQ_CONNECT_TIMEOUT,
-                        )
-                        .await
-                        {
-                            Ok(client) => Ok(Arc::new(BackendClient::Zmq(client))),
-                            Err(e) => Err(WorkerError::ConnectionFailed {
-                                url: self.metadata.spec.url.clone(),
-                                reason: format!("Failed to connect ZMQ engine: {e}"),
-                            }),
-                        }
-                    })
+                    .get_or_try_init(|| connect_zmq_backend(base_url, model_id))
                     .await?;
                 Ok(Some(Arc::clone(client)))
             }
@@ -1437,32 +1447,38 @@ impl Worker for BasicWorker {
     }
 
     async fn zmq_health_check(&self) -> WorkerResult<bool> {
-        // Acquiring the backend client completes the handshake on the first call
-        // (an implicit liveness check). Bound that by the configured health
-        // timeout — not the much longer handshake window (ZMQ_CONNECT_TIMEOUT) —
-        // so a worker whose engine has not dialed in yet reports not-ready and
-        // frees the probe slot; the next probe retries. Thereafter liveness is
-        // local: the connector marks the client closed on ENGINE_CORE_DEAD or a
-        // transport failure. There is no health RPC on the raw ZMQ wire.
-        let timeout = Duration::from_secs(self.metadata.health_config.timeout_secs);
-        let acquired = match time::timeout(timeout, self.get_backend_client()).await {
-            Ok(result) => result?,
-            Err(_) => {
-                tracing::debug!(
-                    "ZMQ handshake for {} not complete within health timeout",
-                    self.metadata.spec.url
-                );
-                return Ok(false);
-            }
-        };
-        let Some(backend_client) = acquired else {
-            tracing::error!(
-                "Worker {} has connection mode ZMQ but no ZMQ client",
-                self.metadata.spec.url
-            );
-            return Ok(false);
-        };
-        Ok(backend_client.is_alive())
+        // Never drive (or cancel) the handshake from the probe: model load can
+        // take far longer than the health timeout, and cancelling it mid-flight
+        // would rebind the sockets on every probe and never connect. Peek the
+        // cached client instead — if it isn't there yet, kick the handshake off
+        // once in the background and report not-ready until it lands. Thereafter
+        // liveness is local (the connector marks the client closed on
+        // ENGINE_CORE_DEAD or a transport failure); there is no health RPC on
+        // the raw ZMQ wire.
+        if let Some(backend_client) = self.backend_client.get() {
+            return Ok(backend_client.is_alive());
+        }
+        if !self.zmq_connect_started.swap(true, Ordering::SeqCst) {
+            let cell = Arc::clone(&self.backend_client);
+            let started = Arc::clone(&self.zmq_connect_started);
+            let base_url = self.metadata.base_url().to_string();
+            let model_id = self.metadata.model_id().to_string();
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "detached one-shot handshake driver; the OnceCell dedupes with the request path and the guard self-clears on failure to allow a retry"
+            )]
+            // Detached: dropping the handle at scope end leaves the task running.
+            let _handle = tokio::spawn(async move {
+                if cell
+                    .get_or_try_init(|| connect_zmq_backend(base_url, model_id))
+                    .await
+                    .is_err()
+                {
+                    started.store(false, Ordering::SeqCst);
+                }
+            });
+        }
+        Ok(false)
     }
 
     async fn http_health_check(&self) -> WorkerResult<bool> {

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -63,8 +63,10 @@ fn derive_handshake_port(path: &str) -> u16 {
         hash ^= u64::from(*b);
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
-    // `hash % 20000` is always < 20000, so it fits u16 without truncation.
-    20000 + (hash % 20000) as u16
+    // Map into 20000..=29999: below the Linux default ephemeral range
+    // (`net.ipv4.ip_local_port_range` = 32768..60999) so an outbound socket
+    // can't already hold the port. `hash % 10000` always fits u16.
+    20000 + (hash % 10000) as u16
 }
 
 /// Derive the ZMQ socket addresses for a worker from its base URL.
@@ -101,6 +103,19 @@ async fn ensure_ipc_socket_dir(base_url: &str) -> WorkerResult<()> {
                 url: base_url.to_string(),
                 reason: format!("failed to create ipc socket dir for {path}: {e}"),
             })?;
+        // The ipc:// data-plane sockets SMG binds here carry no authentication,
+        // so restrict the directory to the owner (0700). Otherwise any local
+        // user could connect to the EngineCore sockets and read/inject traffic.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+                .await
+                .map_err(|e| WorkerError::ConnectionFailed {
+                    url: base_url.to_string(),
+                    reason: format!("failed to secure ipc socket dir for {path}: {e}"),
+                })?;
+        }
     }
     Ok(())
 }
@@ -157,6 +172,18 @@ fn require_backend_client(
         operation: operation.to_string(),
         reason: "no backend client available".to_string(),
     })
+}
+
+/// EngineCore exposes no admin RPCs over ZMQ, so these ops can never succeed for
+/// a ZMQ worker. Reject them up front rather than dispatching to client
+/// acquisition, which would otherwise drive the (up to 10-minute) lazy handshake
+/// only to return `unimplemented`.
+fn zmq_admin_unsupported(url: &str, operation: &str) -> WorkerError {
+    WorkerError::OperationFailed {
+        url: url.to_string(),
+        operation: operation.to_string(),
+        reason: format!("{operation} is not supported over ZMQ"),
+    }
 }
 
 /// Map a gRPC admin-op outcome (`success` flag plus message) to a
@@ -592,7 +619,8 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                 )
                 .await
             }
-            ConnectionMode::Grpc | ConnectionMode::Zmq => {
+            ConnectionMode::Zmq => Err(zmq_admin_unsupported(self.url(), "flush_cache")),
+            ConnectionMode::Grpc => {
                 let client = require_backend_client(
                     self.url(),
                     "flush_cache",
@@ -628,7 +656,8 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                 )
                 .await
             }
-            ConnectionMode::Grpc | ConnectionMode::Zmq => {
+            ConnectionMode::Zmq => Err(zmq_admin_unsupported(self.url(), "start_profile")),
+            ConnectionMode::Grpc => {
                 let client = require_backend_client(
                     self.url(),
                     "start_profile",
@@ -668,7 +697,8 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                 )
                 .await
             }
-            ConnectionMode::Grpc | ConnectionMode::Zmq => {
+            ConnectionMode::Zmq => Err(zmq_admin_unsupported(self.url(), "stop_profile")),
+            ConnectionMode::Grpc => {
                 let client = require_backend_client(
                     self.url(),
                     "stop_profile",
@@ -1408,10 +1438,24 @@ impl Worker for BasicWorker {
 
     async fn zmq_health_check(&self) -> WorkerResult<bool> {
         // Acquiring the backend client completes the handshake on the first call
-        // (an implicit liveness check). Thereafter liveness is local: the
-        // connector marks the client closed on ENGINE_CORE_DEAD or a transport
-        // failure. There is no health RPC to make over the raw ZMQ wire.
-        let Some(backend_client) = self.get_backend_client().await? else {
+        // (an implicit liveness check). Bound that by the configured health
+        // timeout — not the much longer handshake window (ZMQ_CONNECT_TIMEOUT) —
+        // so a worker whose engine has not dialed in yet reports not-ready and
+        // frees the probe slot; the next probe retries. Thereafter liveness is
+        // local: the connector marks the client closed on ENGINE_CORE_DEAD or a
+        // transport failure. There is no health RPC on the raw ZMQ wire.
+        let timeout = Duration::from_secs(self.metadata.health_config.timeout_secs);
+        let acquired = match time::timeout(timeout, self.get_backend_client()).await {
+            Ok(result) => result?,
+            Err(_) => {
+                tracing::debug!(
+                    "ZMQ handshake for {} not complete within health timeout",
+                    self.metadata.spec.url
+                );
+                return Ok(false);
+            }
+        };
+        let Some(backend_client) = acquired else {
             tracing::error!(
                 "Worker {} has connection mode ZMQ but no ZMQ client",
                 self.metadata.spec.url

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -56,7 +56,7 @@ const ZMQ_HANDSHAKE_HOST: &str = "127.0.0.1";
 /// `--data-parallel-rpc-port`); making the port a pure function of the worker
 /// URL lets the operator compute the same `--data-parallel-rpc-port` without a
 /// side channel. FNV-1a keeps it stable across processes and builds. Mapped
-/// into 20000..=39999 to avoid well-known and typical ephemeral ranges.
+/// into 20000..=29999 to avoid well-known and typical ephemeral ranges.
 fn derive_handshake_port(path: &str) -> u16 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for b in path.as_bytes() {
@@ -94,27 +94,61 @@ fn zmq_socket_addresses(base_url: &str) -> WorkerResult<(String, String, String)
 /// Create the parent directory for a worker's `ipc://` sockets. Kept off the
 /// address computation (which is pure) and async so it doesn't block a runtime
 /// thread.
+///
+/// The ipc:// data-plane sockets SMG binds here carry no authentication, so the
+/// directory must be owner-controlled: when this call creates it, it is created
+/// 0700 (mode applied at mkdir time — no chmod window); when it already exists,
+/// its permissions are left untouched (never chmod a shared dir like `/tmp`)
+/// and it is rejected unless it is a real directory owned by the current user.
 async fn ensure_ipc_socket_dir(base_url: &str) -> WorkerResult<()> {
     let path = base_url.strip_prefix("ipc://").unwrap_or(base_url);
-    if let Some(parent) = std::path::Path::new(path).parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| WorkerError::ConnectionFailed {
-                url: base_url.to_string(),
-                reason: format!("failed to create ipc socket dir for {path}: {e}"),
-            })?;
-        // The ipc:// data-plane sockets SMG binds here carry no authentication,
-        // so restrict the directory to the owner (0700). Otherwise any local
-        // user could connect to the EngineCore sockets and read/inject traffic.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            tokio::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+    let Some(parent) = std::path::Path::new(path).parent() else {
+        return Ok(());
+    };
+    let fail = |reason: String| WorkerError::ConnectionFailed {
+        url: base_url.to_string(),
+        reason,
+    };
+    // symlink_metadata: a symlinked parent must not redirect the checks (or the
+    // sockets) into a directory we did not verify.
+    let meta = match tokio::fs::symlink_metadata(parent).await {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let mut builder = tokio::fs::DirBuilder::new();
+            builder.recursive(true);
+            #[cfg(unix)]
+            builder.mode(0o700);
+            builder
+                .create(parent)
                 .await
-                .map_err(|e| WorkerError::ConnectionFailed {
-                    url: base_url.to_string(),
-                    reason: format!("failed to secure ipc socket dir for {path}: {e}"),
-                })?;
+                .map_err(|e| fail(format!("failed to create ipc socket dir for {path}: {e}")))?;
+            tokio::fs::symlink_metadata(parent)
+                .await
+                .map_err(|e| fail(format!("failed to stat ipc socket dir for {path}: {e}")))?
+        }
+        Err(e) => {
+            return Err(fail(format!(
+                "failed to stat ipc socket dir for {path}: {e}"
+            )))
+        }
+    };
+    if !meta.is_dir() {
+        return Err(fail(format!(
+            "ipc socket dir {} exists but is not a directory",
+            parent.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let uid = rustix::process::geteuid().as_raw();
+        if meta.uid() != uid {
+            return Err(fail(format!(
+                "ipc socket dir {} is owned by uid {} (expected {uid}); refusing to bind \
+                 unauthenticated ZMQ sockets in a directory owned by another user",
+                parent.display(),
+                meta.uid()
+            )));
         }
     }
     Ok(())
@@ -1075,8 +1109,11 @@ pub struct BasicWorker {
     pub runtime: ArcSwap<WorkerRuntime>,
     pub circuit_breaker: ArcSwap<CircuitBreaker>,
     /// Lazily initialized backend client (gRPC or ZMQ) for local workers.
-    /// Uses OnceCell for lock-free reads after initialization.
-    pub backend_client: Arc<OnceCell<Arc<BackendClient>>>,
+    /// The inner `OnceCell` keeps reads lock-free after initialization and
+    /// dedupes concurrent connects; the outer `ArcSwap` lets the ZMQ health
+    /// probe evict a dead client by swapping in a fresh cell (gRPC never
+    /// swaps — a failed gRPC worker is removed and re-added instead).
+    pub backend_client: Arc<ArcSwap<OnceCell<Arc<BackendClient>>>>,
     /// Guards the one-shot background ZMQ handshake driver so the health probe
     /// never cancels a long (model-load) handshake. Self-clears on failure to
     /// allow a retry. Unused for HTTP/gRPC.
@@ -1350,8 +1387,8 @@ impl Worker for BasicWorker {
             ConnectionMode::Grpc => {
                 // OnceCell provides lock-free reads after initialization.
                 // get_or_try_init only acquires internal lock on first call.
-                let client = self
-                    .backend_client
+                let cell = self.backend_client.load_full();
+                let client = cell
                     .get_or_try_init(|| async {
                         let runtime_str = self.metadata.spec.runtime_type.to_string();
                         tracing::info!(
@@ -1393,8 +1430,8 @@ impl Worker for BasicWorker {
                 // wire (see create_worker).
                 let base_url = self.metadata.base_url().to_string();
                 let model_id = self.metadata.model_id().to_string();
-                let client = self
-                    .backend_client
+                let cell = self.backend_client.load_full();
+                let client = cell
                     .get_or_try_init(|| connect_zmq_backend(base_url, model_id))
                     .await?;
                 Ok(Some(Arc::clone(client)))
@@ -1403,10 +1440,11 @@ impl Worker for BasicWorker {
     }
 
     async fn reset_grpc_client(&self) -> WorkerResult<()> {
-        // OnceCell doesn't support resetting. This is intentional for lock-free performance.
-        // If a connection fails, the worker should be removed and re-added.
+        // Intentional no-op: a failed gRPC worker is removed and re-added rather
+        // than reconnected in place. (The ZMQ path differs: its health probe
+        // evicts a dead client and reconnects — see zmq_health_check.)
         tracing::debug!(
-            "reset_grpc_client called for {} (no-op with OnceCell)",
+            "reset_grpc_client called for {} (no-op for gRPC workers)",
             self.metadata.spec.url
         );
         Ok(())
@@ -1455,25 +1493,46 @@ impl Worker for BasicWorker {
         // liveness is local (the connector marks the client closed on
         // ENGINE_CORE_DEAD or a transport failure); there is no health RPC on
         // the raw ZMQ wire.
-        if let Some(backend_client) = self.backend_client.get() {
-            return Ok(backend_client.is_alive());
+        let cell = self.backend_client.load_full();
+        if let Some(backend_client) = cell.get() {
+            if backend_client.is_alive() {
+                return Ok(true);
+            }
+            // The engine behind this client died, and a ZMQ client cannot
+            // reconnect in place (liveness is latched). Evict the dead client
+            // and reset the handshake guard so the next probe re-runs
+            // connect_zmq_backend, rebinding the sockets for a replacement
+            // engine to dial into. Eviction cannot race an in-flight connect:
+            // a cell only becomes non-empty once its connect finished, and
+            // compare_and_swap keeps a lagging probe from clobbering a fresh
+            // cell another probe already swapped in.
+            tracing::warn!(
+                "ZMQ engine for {} is no longer alive; evicting the dead client and rebinding on a later probe",
+                self.metadata.spec.url
+            );
+            self.backend_client
+                .compare_and_swap(&cell, Arc::new(OnceCell::new()));
+            self.zmq_connect_started.store(false, Ordering::SeqCst);
+            return Ok(false);
         }
         if !self.zmq_connect_started.swap(true, Ordering::SeqCst) {
-            let cell = Arc::clone(&self.backend_client);
             let started = Arc::clone(&self.zmq_connect_started);
             let base_url = self.metadata.base_url().to_string();
             let model_id = self.metadata.model_id().to_string();
+            let url = self.metadata.spec.url.clone();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "detached one-shot handshake driver; the OnceCell dedupes with the request path and the guard self-clears on failure to allow a retry"
             )]
             // Detached: dropping the handle at scope end leaves the task running.
             let _handle = tokio::spawn(async move {
-                if cell
+                if let Err(e) = cell
                     .get_or_try_init(|| connect_zmq_backend(base_url, model_id))
                     .await
-                    .is_err()
                 {
+                    tracing::warn!(
+                        "ZMQ backend handshake failed for {url}: {e}; will retry on the next health probe"
+                    );
                     started.store(false, Ordering::SeqCst);
                 }
             });
@@ -2591,5 +2650,158 @@ mod tests {
         assert!(worker.supports_model("text-embedding-3-small"));
         assert!(!worker.supports_model("non-existent-model"));
         assert!(worker.has_models_discovered());
+    }
+
+    /// Pinned FNV-1a vectors. serve.py's `_zmq_handshake_port` derives the same
+    /// value from the same `ipc://` path so the launcher can pass a matching
+    /// `--data-parallel-rpc-port` without a side channel — if this changes, that
+    /// mirror must change in lockstep or the engine and router pick different
+    /// handshake ports and never connect.
+    #[test]
+    fn derive_handshake_port_matches_pinned_vectors() {
+        assert_eq!(derive_handshake_port("/tmp/smg-zmq/ts0.ipc"), 25152);
+        assert_eq!(derive_handshake_port("/tmp/smg-zmq/ts1.ipc"), 22735);
+        assert_eq!(derive_handshake_port("ts0.ipc"), 23912);
+        // Range invariant: every path maps into 20000..=29999.
+        for p in ["", "a", "/x/y/z.ipc", "very/long/path/with/segments.sock"] {
+            let port = derive_handshake_port(p);
+            assert!(
+                (20000..=29999).contains(&port),
+                "port {port} out of band for {p:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn zmq_socket_addresses_split_handshake_tcp_from_ipc_data_plane() {
+        let (handshake, input, output) =
+            zmq_socket_addresses("ipc:///tmp/smg-zmq/ts0.ipc").unwrap();
+        assert_eq!(handshake, "tcp://127.0.0.1:25152");
+        assert_eq!(input, "ipc:///tmp/smg-zmq/ts0.ipc-in.sock");
+        assert_eq!(output, "ipc:///tmp/smg-zmq/ts0.ipc-out.sock");
+        // A non-ipc base URL has no data-plane topology and must be rejected.
+        assert!(zmq_socket_addresses("tcp://127.0.0.1:5000").is_err());
+    }
+
+    #[tokio::test]
+    async fn ensure_ipc_socket_dir_creates_a_private_owner_only_dir() {
+        let base = tempfile::tempdir().unwrap();
+        let dir = base.path().join("sockets");
+        let url = format!("ipc://{}/x.ipc", dir.display());
+        ensure_ipc_socket_dir(&url).await.unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "created socket dir must be 0700");
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ensure_ipc_socket_dir_leaves_an_existing_owned_dir_untouched() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        let url = format!("ipc://{}/x.ipc", dir.path().display());
+        ensure_ipc_socket_dir(&url).await.unwrap();
+        let mode = std::fs::metadata(dir.path()).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "an existing dir must not be chmod'd");
+    }
+
+    #[tokio::test]
+    async fn ensure_ipc_socket_dir_rejects_a_non_directory_parent() {
+        let base = tempfile::tempdir().unwrap();
+        let file = base.path().join("not-a-dir");
+        std::fs::write(&file, b"x").unwrap();
+        let url = format!("ipc://{}/x.ipc", file.display());
+        assert!(ensure_ipc_socket_dir(&url).await.is_err());
+    }
+
+    /// A ZMQ client whose engine dies must be evicted by the health probe (the
+    /// connection can't reconnect in place — liveness is latched), and the
+    /// handshake guard reset so a later probe rebinds the sockets for a
+    /// replacement engine. A live client stays cached across probes.
+    #[tokio::test]
+    async fn zmq_health_check_evicts_a_dead_client_and_resets_the_guard() {
+        use engine_zmq_client::{
+            mock_engine::{connect_to_frontend, default_ready_response},
+            EngineId, ENGINE_CORE_DEAD_SENTINEL,
+        };
+
+        let base = tempfile::tempdir().unwrap();
+        let ep = |name: &str| format!("ipc://{}", base.path().join(name).display());
+        let (handshake, input, output) = (ep("hs.sock"), ep("in.sock"), ep("out.sock"));
+
+        let (client, engine) = tokio::join!(
+            ZmqEngineClient::connect(
+                &handshake,
+                &input,
+                &output,
+                1,
+                "m".to_string(),
+                Duration::from_secs(10)
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let client = client.expect("adapter connect");
+        let mut engine = engine.expect("mock engine");
+
+        let worker = BasicWorkerBuilder::new(ep("ts0.ipc"))
+            .connection_mode(ConnectionMode::Zmq)
+            .health_config(no_health_check())
+            .build();
+
+        // Inject a completed connect and mark the one-shot guard as set.
+        let cell = worker.backend_client.load_full();
+        cell.set(Arc::new(BackendClient::Zmq(client)))
+            .ok()
+            .expect("cell empty");
+        worker.zmq_connect_started.store(true, Ordering::SeqCst);
+
+        // A live client stays cached and reports healthy.
+        assert!(worker.zmq_health_check().await.unwrap());
+        assert!(worker.backend_client.load().get().is_some());
+
+        // Kill the engine and wait for the dispatcher to latch the client closed.
+        engine
+            .send_output(vec![bytes::Bytes::from_static(ENGINE_CORE_DEAD_SENTINEL)])
+            .await
+            .unwrap();
+        let observed_dead = time::timeout(Duration::from_secs(5), async {
+            loop {
+                let alive = worker
+                    .backend_client
+                    .load()
+                    .get()
+                    .map(|c| c.is_alive())
+                    .unwrap_or(false);
+                if !alive {
+                    break;
+                }
+                time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(
+            observed_dead.is_ok(),
+            "client never observed ENGINE_CORE_DEAD"
+        );
+
+        // The next probe evicts the dead client and resets the guard so a later
+        // probe re-runs the handshake for a replacement engine.
+        assert!(!worker.zmq_health_check().await.unwrap());
+        assert!(
+            worker.backend_client.load().get().is_none(),
+            "dead client must be evicted from the cell"
+        );
+        assert!(
+            !worker.zmq_connect_started.load(Ordering::SeqCst),
+            "handshake guard must reset to allow a reconnect"
+        );
     }
 }

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -26,7 +26,7 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
         common::header_utils::extract_routing_key,
-        grpc::{backend_client::BackendClient, client::GrpcClient},
+        grpc::{backend_client::BackendClient, client::GrpcClient, zmq_client::ZmqEngineClient},
     },
 };
 
@@ -41,6 +41,69 @@ const FLUSH_HTTP_TIMEOUT: Duration = Duration::from_secs(45);
 /// a long time while the backend serializes large traces. Matches the
 /// gRPC client's profile deadline.
 const PROFILE_HTTP_TIMEOUT: Duration = Duration::from_secs(630);
+
+/// Time to wait for a ZMQ engine to complete the startup handshake. Generous:
+/// the engine loads the model and profiles KV cache between INIT and READY.
+const ZMQ_CONNECT_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Loopback host for the TCP handshake. ZMQ direct connections are same-host
+/// only, so the handshake never leaves loopback.
+const ZMQ_HANDSHAKE_HOST: &str = "127.0.0.1";
+
+/// Derive a deterministic TCP handshake port from the ipc data-plane path.
+///
+/// vLLM's headless engine dials a *TCP* handshake (`--data-parallel-address` +
+/// `--data-parallel-rpc-port`); making the port a pure function of the worker
+/// URL lets the operator compute the same `--data-parallel-rpc-port` without a
+/// side channel. FNV-1a keeps it stable across processes and builds. Mapped
+/// into 20000..=39999 to avoid well-known and typical ephemeral ranges.
+fn derive_handshake_port(path: &str) -> u16 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in path.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    // `hash % 20000` is always < 20000, so it fits u16 without truncation.
+    20000 + (hash % 20000) as u16
+}
+
+/// Derive the ZMQ socket addresses for a worker from its base URL.
+///
+/// Mirrors vLLM's headless topology: the **handshake is TCP** (the engine dials
+/// it, so it matches `vllm serve --headless --data-parallel-rpc-port`), while
+/// the **data plane is `ipc://`** for the same-host fast path (SMG chooses these
+/// and hands them to the engine during the handshake INIT). The operator gives a
+/// single `ipc://<path>` base; SMG binds the ipc input/output at
+/// `<path>-in.sock` / `-out.sock` and derives the TCP handshake port from the
+/// path. Returns `(handshake, input, output)`.
+fn zmq_socket_addresses(base_url: &str) -> WorkerResult<(String, String, String)> {
+    let path = base_url
+        .strip_prefix("ipc://")
+        .ok_or_else(|| WorkerError::ConnectionFailed {
+            url: base_url.to_string(),
+            reason: "ZMQ worker URL must be ipc://<path>".to_string(),
+        })?;
+    let handshake = format!("tcp://{ZMQ_HANDSHAKE_HOST}:{}", derive_handshake_port(path));
+    let input = format!("ipc://{path}-in.sock");
+    let output = format!("ipc://{path}-out.sock");
+    Ok((handshake, input, output))
+}
+
+/// Create the parent directory for a worker's `ipc://` sockets. Kept off the
+/// address computation (which is pure) and async so it doesn't block a runtime
+/// thread.
+async fn ensure_ipc_socket_dir(base_url: &str) -> WorkerResult<()> {
+    let path = base_url.strip_prefix("ipc://").unwrap_or(base_url);
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| WorkerError::ConnectionFailed {
+                url: base_url.to_string(),
+                reason: format!("failed to create ipc socket dir for {path}: {e}"),
+            })?;
+    }
+    Ok(())
+}
 
 /// Default bootstrap port for PD disaggregation (used by SGLang and vLLM Mooncake)
 pub const DEFAULT_BOOTSTRAP_PORT: u16 = 8998;
@@ -94,17 +157,6 @@ fn require_backend_client(
         operation: operation.to_string(),
         reason: "no backend client available".to_string(),
     })
-}
-
-/// Error for an admin op invoked on a ZMQ worker. ZMQ backend operations are
-/// wired in a follow-up; until then a ZMQ worker is recognized but its admin
-/// surface is unavailable (it never routes through the gRPC client).
-fn zmq_admin_unsupported(url: &str, operation: &str) -> WorkerError {
-    WorkerError::OperationFailed {
-        url: url.to_string(),
-        operation: operation.to_string(),
-        reason: "admin operations are not yet supported for ZMQ workers".to_string(),
-    }
 }
 
 /// Map a gRPC admin-op outcome (`success` flag plus message) to a
@@ -508,10 +560,14 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
 
     /// Reset the gRPC client connection (for reconnection scenarios)
     /// No-op for HTTP workers
-    async fn reset_backend_client(&self) -> WorkerResult<()> {
+    async fn reset_grpc_client(&self) -> WorkerResult<()> {
         Ok(())
     }
     async fn grpc_health_check(&self) -> WorkerResult<bool>;
+    /// Liveness check for a ZMQ worker. Unlike gRPC there is no health RPC on
+    /// the raw wire: liveness is local (handshake completed and the engine has
+    /// not signalled `ENGINE_CORE_DEAD`).
+    async fn zmq_health_check(&self) -> WorkerResult<bool>;
     async fn http_health_check(&self) -> WorkerResult<bool>;
 
     // ── Admin operations ────────────────────────────────────────────
@@ -536,7 +592,7 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                 )
                 .await
             }
-            ConnectionMode::Grpc => {
+            ConnectionMode::Grpc | ConnectionMode::Zmq => {
                 let client = require_backend_client(
                     self.url(),
                     "flush_cache",
@@ -549,7 +605,6 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                     result.map(|r| (r.success, r.message)),
                 )
             }
-            ConnectionMode::Zmq => Err(zmq_admin_unsupported(self.url(), "flush_cache")),
         }
     }
 
@@ -573,7 +628,7 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                 )
                 .await
             }
-            ConnectionMode::Grpc => {
+            ConnectionMode::Grpc | ConnectionMode::Zmq => {
                 let client = require_backend_client(
                     self.url(),
                     "start_profile",
@@ -595,7 +650,6 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                     result.map(|r| (r.success, r.message)),
                 )
             }
-            ConnectionMode::Zmq => Err(zmq_admin_unsupported(self.url(), "start_profile")),
         }
     }
 
@@ -614,7 +668,7 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                 )
                 .await
             }
-            ConnectionMode::Grpc => {
+            ConnectionMode::Grpc | ConnectionMode::Zmq => {
                 let client = require_backend_client(
                     self.url(),
                     "stop_profile",
@@ -627,7 +681,6 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                     result.map(|r| (r.success, r.message)),
                 )
             }
-            ConnectionMode::Zmq => Err(zmq_admin_unsupported(self.url(), "stop_profile")),
         }
     }
 }
@@ -997,7 +1050,7 @@ impl fmt::Debug for BasicWorker {
             .field("status", &runtime.status())
             .field("revision", &runtime.revision())
             .field("circuit_breaker_state", &self.circuit_breaker_state())
-            .field("backend_client", &"<OnceCell>")
+            .field("grpc_client", &"<OnceCell>")
             .finish()
     }
 }
@@ -1078,9 +1131,7 @@ impl Worker for BasicWorker {
         let probe_ok = match &self.metadata.spec.connection_mode {
             ConnectionMode::Http => self.http_health_check().await?,
             ConnectionMode::Grpc => self.grpc_health_check().await?,
-            // ZMQ liveness lands with the backend client; until then a ZMQ
-            // worker is recognized but never becomes ready (not routable).
-            ConnectionMode::Zmq => false,
+            ConnectionMode::Zmq => self.zmq_health_check().await?,
         };
 
         if probe_ok {
@@ -1231,10 +1282,7 @@ impl Worker for BasicWorker {
 
     async fn get_backend_client(&self) -> WorkerResult<Option<Arc<BackendClient>>> {
         match self.metadata.spec.connection_mode {
-            // Neither HTTP nor ZMQ has a gRPC client. A ZMQ worker's backend
-            // client is a separate type wired in a follow-up; it is never a
-            // gRPC client.
-            ConnectionMode::Http | ConnectionMode::Zmq => Ok(None),
+            ConnectionMode::Http => Ok(None),
             ConnectionMode::Grpc => {
                 // OnceCell provides lock-free reads after initialization.
                 // get_or_try_init only acquires internal lock on first call.
@@ -1273,14 +1321,52 @@ impl Worker for BasicWorker {
                     .await?;
                 Ok(Some(Arc::clone(client)))
             }
+            ConnectionMode::Zmq => {
+                // SMG binds the handshake + data-plane sockets; the
+                // operator-launched engine dials them. The first acquisition
+                // completes the handshake (a liveness signal in itself).
+                let client = self
+                    .backend_client
+                    .get_or_try_init(|| async {
+                        let (handshake, input, output) =
+                            zmq_socket_addresses(self.metadata.base_url())?;
+                        ensure_ipc_socket_dir(self.metadata.base_url()).await?;
+                        // EngineCore does not report a served model name over the
+                        // wire, so the client reports the model resolved from
+                        // config at worker creation (see create_worker).
+                        let model_id = self.metadata.model_id().to_string();
+                        tracing::info!(
+                            "Lazily binding ZMQ client for worker {} (handshake={handshake})",
+                            self.metadata.spec.url
+                        );
+                        match ZmqEngineClient::connect(
+                            &handshake,
+                            &input,
+                            &output,
+                            1,
+                            model_id,
+                            ZMQ_CONNECT_TIMEOUT,
+                        )
+                        .await
+                        {
+                            Ok(client) => Ok(Arc::new(BackendClient::Zmq(client))),
+                            Err(e) => Err(WorkerError::ConnectionFailed {
+                                url: self.metadata.spec.url.clone(),
+                                reason: format!("Failed to connect ZMQ engine: {e}"),
+                            }),
+                        }
+                    })
+                    .await?;
+                Ok(Some(Arc::clone(client)))
+            }
         }
     }
 
-    async fn reset_backend_client(&self) -> WorkerResult<()> {
+    async fn reset_grpc_client(&self) -> WorkerResult<()> {
         // OnceCell doesn't support resetting. This is intentional for lock-free performance.
         // If a connection fails, the worker should be removed and re-added.
         tracing::debug!(
-            "reset_backend_client called for {} (no-op with OnceCell)",
+            "reset_grpc_client called for {} (no-op with OnceCell)",
             self.metadata.spec.url
         );
         Ok(())
@@ -1318,6 +1404,21 @@ impl Worker for BasicWorker {
                 Ok(false)
             }
         }
+    }
+
+    async fn zmq_health_check(&self) -> WorkerResult<bool> {
+        // Acquiring the backend client completes the handshake on the first call
+        // (an implicit liveness check). Thereafter liveness is local: the
+        // connector marks the client closed on ENGINE_CORE_DEAD or a transport
+        // failure. There is no health RPC to make over the raw ZMQ wire.
+        let Some(backend_client) = self.get_backend_client().await? else {
+            tracing::error!(
+                "Worker {} has connection mode ZMQ but no ZMQ client",
+                self.metadata.spec.url
+            );
+            return Ok(false);
+        };
+        Ok(backend_client.is_alive())
     }
 
     async fn http_health_check(&self) -> WorkerResult<bool> {

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -147,6 +147,18 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
                 .dp_info
                 .as_ref()
                 .ok_or_else(|| WorkflowError::ContextValueNotFound("dp_info".to_string()))?;
+            // A ZMQ worker binds a single EngineCore connection (engine_count=1);
+            // DP>1 needs the coordinator + wave protocol (not yet implemented), so
+            // fail loudly rather than silently under-connecting.
+            if *connection_mode == ConnectionMode::Zmq && dp_info.dp_size > 1 {
+                return Err(WorkflowError::StepFailed {
+                    step_id: StepId::new("create_worker"),
+                    message: format!(
+                        "ZMQ worker {} cannot run data-parallel (dp_size={}); DP>1 over ZMQ is not yet supported",
+                        config.url, dp_info.dp_size
+                    ),
+                });
+            }
             (0..dp_info.dp_size)
                 .map(|r| Some((r, dp_info.dp_size)))
                 .collect()

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -147,18 +147,7 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
                 .dp_info
                 .as_ref()
                 .ok_or_else(|| WorkflowError::ContextValueNotFound("dp_info".to_string()))?;
-            // A ZMQ worker binds a single EngineCore connection (engine_count=1);
-            // DP>1 needs the coordinator + wave protocol (not yet implemented), so
-            // fail loudly rather than silently under-connecting.
-            if *connection_mode == ConnectionMode::Zmq && dp_info.dp_size > 1 {
-                return Err(WorkflowError::StepFailed {
-                    step_id: StepId::new("create_worker"),
-                    message: format!(
-                        "ZMQ worker {} cannot run data-parallel (dp_size={}); DP>1 over ZMQ is not yet supported",
-                        config.url, dp_info.dp_size
-                    ),
-                });
-            }
+            validate_zmq_dp(*connection_mode, dp_info.dp_size, &config.url)?;
             (0..dp_info.dp_size)
                 .map(|r| Some((r, dp_info.dp_size)))
                 .collect()
@@ -376,6 +365,29 @@ fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
     }
 }
 
+/// Reject a data-parallel worker the ZMQ path cannot serve.
+///
+/// A ZMQ worker binds a single EngineCore connection (engine_count=1); DP>1
+/// needs the coordinator + wave protocol (not yet implemented), so fail loudly
+/// rather than silently under-connecting. Only ZMQ with `dp_size > 1` is
+/// rejected; gRPC/HTTP data parallelism and single-engine ZMQ are fine.
+fn validate_zmq_dp(
+    connection_mode: ConnectionMode,
+    dp_size: usize,
+    url: &str,
+) -> Result<(), WorkflowError> {
+    if connection_mode == ConnectionMode::Zmq && dp_size > 1 {
+        return Err(WorkflowError::StepFailed {
+            step_id: StepId::new("create_worker"),
+            message: format!(
+                "ZMQ worker {url} cannot run data-parallel (dp_size={dp_size}); \
+                 DP>1 over ZMQ is not yet supported"
+            ),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -479,6 +491,33 @@ mod tests {
         let card = build_model_card("GLM-5.2", &spec, &HashMap::new(), &aliases);
 
         assert!(card.aliases.is_empty());
+    }
+
+    #[test]
+    fn zmq_data_parallel_is_rejected_as_a_create_worker_failure() {
+        // dp_size > 1 over ZMQ is the only rejected combination, and it must
+        // surface as a create_worker StepFailed.
+        let err = validate_zmq_dp(ConnectionMode::Zmq, 2, "ipc:///tmp/smg-zmq/ts0.ipc")
+            .expect_err("dp_size > 1 over ZMQ must be rejected");
+        match err {
+            WorkflowError::StepFailed { step_id, message } => {
+                assert_eq!(step_id, StepId::new("create_worker"));
+                assert!(message.contains("dp_size=2"), "message was: {message}");
+            }
+            other => panic!("expected StepFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_engine_zmq_and_data_parallel_grpc_are_accepted() {
+        // Single-engine ZMQ is the supported ZMQ shape; gRPC/HTTP data
+        // parallelism is untouched by the ZMQ guard.
+        validate_zmq_dp(ConnectionMode::Zmq, 1, "ipc:///tmp/smg-zmq/ts0.ipc")
+            .expect("single-engine ZMQ must be accepted");
+        validate_zmq_dp(ConnectionMode::Grpc, 4, "grpc://worker:8080")
+            .expect("gRPC data parallelism must be accepted");
+        validate_zmq_dp(ConnectionMode::Http, 4, "http://worker:8080")
+            .expect("HTTP data parallelism must be accepted");
     }
 
     #[test]

--- a/model_gateway/src/workflow/steps/local/ensure_harmony_encoding.rs
+++ b/model_gateway/src/workflow/steps/local/ensure_harmony_encoding.rs
@@ -12,7 +12,6 @@ use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, Wo
 
 use crate::{
     routers::grpc::harmony::{try_harmony_encoding, HarmonyDetector},
-    worker::ConnectionMode,
     workflow::data::{WorkerKind, WorkerWorkflowData},
 };
 
@@ -28,8 +27,13 @@ impl StepExecutor<WorkerWorkflowData> for EnsureHarmonyEncodingStep {
             return Ok(StepResult::Skip);
         }
 
-        // Only the gRPC pipeline serves Harmony natively; HTTP proxies to the backend.
-        if context.data.connection_mode != Some(ConnectionMode::Grpc) {
+        // Only the gRPC-router pipeline (gRPC + ZMQ) serves Harmony natively;
+        // HTTP proxies to the backend, which owns the encoding.
+        if !context
+            .data
+            .connection_mode
+            .is_some_and(|mode| mode.uses_grpc_pipeline())
+        {
             return Ok(StepResult::Skip);
         }
 

--- a/model_gateway/src/workflow/tokenizer_registration.rs
+++ b/model_gateway/src/workflow/tokenizer_registration.rs
@@ -314,7 +314,7 @@ async fn fetch_tokenizer_from_worker(
             runtime
         );
 
-        let grpc_client = match worker.get_backend_client().await {
+        let backend_client = match worker.get_backend_client().await {
             Ok(Some(client)) => client,
             Ok(None) => {
                 failures.push(format!(
@@ -332,7 +332,7 @@ async fn fetch_tokenizer_from_worker(
             }
         };
 
-        let bundle = match grpc_client.get_tokenizer().await {
+        let bundle = match backend_client.get_tokenizer().await {
             Ok(bundle) => bundle,
             Err(e) => {
                 let is_unimplemented = e

--- a/model_gateway/src/workflow/tokenizer_registration.rs
+++ b/model_gateway/src/workflow/tokenizer_registration.rs
@@ -314,7 +314,7 @@ async fn fetch_tokenizer_from_worker(
             runtime
         );
 
-        let backend_client = match worker.get_backend_client().await {
+        let grpc_client = match worker.get_backend_client().await {
             Ok(Some(client)) => client,
             Ok(None) => {
                 failures.push(format!(
@@ -332,7 +332,7 @@ async fn fetch_tokenizer_from_worker(
             }
         };
 
-        let bundle = match backend_client.get_tokenizer().await {
+        let bundle = match grpc_client.get_tokenizer().await {
             Ok(bundle) => bundle,
             Err(e) => {
                 let is_unimplemented = e


### PR DESCRIPTION
## Description

### Problem

Final step of #2000: make a same-host ZMQ worker fully **routable** so SMG talks directly to a vLLM EngineCore over ZMQ, bypassing the gRPC Python servicer (one process, one serialization round-trip, and a context switch per message removed).

Builds on the two foundations already in main:
- #2018 — `ConnectionMode::Zmq` (a ZMQ worker is recognized/classified, but not yet routable)
- #2019 — the `BackendClient` seam

### Solution

Add `BackendClient::Zmq(ZmqEngineClient)` alongside `Grpc` and wire the worker's real ZMQ client, so the existing gRPC-router pipeline routes ZMQ workers unchanged.

## Changes

- `BackendClient::Zmq(ZmqEngineClient)` + a `ProtoStream::Zmq` variant (yields vLLM responses); the pipeline (`ProtoStream`/`ProtoGenerateRequest`) is otherwise untouched.
- `routers/grpc/zmq_client.rs`: `ZmqEngineClient` adapter (proto ⇄ EngineCore) over the `engine-zmq-client` crate — connect / generate / loads / model-info / health / is_alive.
- Worker: `get_backend_client` builds the real ZMQ client (tcp handshake + ipc data plane derived from the `ipc://` URL); local-liveness `zmq_health_check`; load monitoring via the backend client.
- Worker selection includes ZMQ via `ConnectionMode::uses_grpc_pipeline()`; harmony/embedding/assemble stages gain ZMQ arms (Chat + Responses).
- vLLM request builders made associated so both gRPC and ZMQ reuse them.

## Test Plan

- **End-to-end against real vLLM 0.26.0** (Qwen3-0.6B) on GB300 via stock `vllm serve --headless --data-parallel-rpc-port <derived>` — real generation + correct token accounting.
- Also validated against the mock worker.
- `cargo check` on `llm-multimodal` + `bindings/python` + `bindings/golang`; `clippy -p smg --all-targets -- -D warnings` clean; nightly fmt clean; `smg` lib 1348 pass (lone failure is the pre-existing `distinct_ids…interner` parallel-test flake, passes in isolation).

Completes the #2000 stack: #2018 (connection mode) → #2019 (backend client) → this (ZMQ routing).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
