### PR TITLE
feat(grpc): wire tenant token rate limiting into gRPC router

### DIFF
--- a/crates/mock_worker/Cargo.toml
+++ b/crates/mock_worker/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 publish = false
 description = "Multi-port mock HTTP/gRPC inference worker for SMG gateway scale testing"
 
+[lib]
+name = "mock_worker"
+path = "src/lib.rs"
+
 [[bin]]
 name = "mock-worker"
 path = "src/main.rs"

--- a/crates/mock_worker/src/lib.rs
+++ b/crates/mock_worker/src/lib.rs
@@ -1,0 +1,8 @@
+//! Library surface for `mock-worker`'s HTTP/gRPC simulators, so both the
+//! standalone binary and in-process integration tests can drive them.
+
+pub mod config;
+pub mod engine;
+pub mod grpc;
+pub mod http;
+pub mod zmq;

--- a/crates/mock_worker/src/main.rs
+++ b/crates/mock_worker/src/main.rs
@@ -6,15 +6,9 @@
 //! TokenSpeed scheduler service (the gateway tokenizes and speaks token ids).
 //! All responses are canned — there is no real model.
 
-mod config;
-mod engine;
-mod grpc;
-mod http;
-mod zmq;
-
 use std::{process::ExitCode, sync::Arc};
 
-use crate::config::Config;
+use mock_worker::{config::Config, grpc, http, zmq};
 
 #[tokio::main]
 async fn main() -> ExitCode {

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -145,6 +145,7 @@ smg = { path = ".", features = ["test-util"] }
 # Enable the mock engine for the ZMQ client's loopback tests.
 engine-zmq-client = { workspace = true, features = ["mock-engine"] }
 criterion = { version = "0.8", features = ["html_reports"] }
+mock-worker = { path = "../crates/mock_worker" }
 tower = { version = "0.5", features = ["util"] }
 # Used by PD metrics integration tests to capture metric emission via a
 # thread-local Prometheus recorder (same versions as the runtime deps above).

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -185,6 +185,15 @@ impl AppContextBuilder {
         self
     }
 
+    /// Set an already-built tenant rate limiter directly, bypassing
+    /// `maybe_rate_limit_manager`'s config-loading. For callers (test
+    /// harnesses) that build `AppContext` piecemeal rather than through
+    /// `from_config` and so can't reach that private, config-driven setter.
+    pub fn rate_limit_manager(mut self, rate_limit_manager: Option<Arc<RateLimitManager>>) -> Self {
+        self.rate_limit_manager = rate_limit_manager;
+        self
+    }
+
     /// Build the tenant rate limiter from config. `Ok(None)` (feature
     /// disabled) is a valid, non-fatal outcome. `Err` (enabled but the
     /// policy YAML failed to load/parse/validate) fails startup — an

--- a/model_gateway/src/rate_limit/rejection.rs
+++ b/model_gateway/src/rate_limit/rejection.rs
@@ -11,13 +11,18 @@ use crate::routers::error;
 pub const RATE_LIMIT_ERROR_CODE: &str = "tenant_rate_limit_exceeded";
 
 /// `retry_after_secs` of `0` omits the `Retry-After` header (nothing to
-/// wait for is a caller bug, not a real rejection state).
+/// wait for is a caller bug, not a real rejection state). `u64::MAX` is
+/// `ScopeBucket::dry_run`'s "this request exceeds the scope's total
+/// capacity and can never be admitted, no matter how long the caller
+/// waits" sentinel -- surfacing that literally would tell the client to
+/// wait about 584 billion years, so it's omitted the same way; the error
+/// body still explains why.
 pub fn rejection_response(retry_after_secs: u64) -> Response {
     let mut response = error::too_many_requests(
         RATE_LIMIT_ERROR_CODE,
         "Tenant rate limit exceeded for this request",
     );
-    if retry_after_secs > 0 {
+    if retry_after_secs > 0 && retry_after_secs != u64::MAX {
         if let Ok(value) = HeaderValue::from_str(&retry_after_secs.to_string()) {
             response.headers_mut().insert(RETRY_AFTER, value);
         }
@@ -48,6 +53,13 @@ mod tests {
     #[test]
     fn zero_retry_after_omits_header() {
         let response = rejection_response(0);
+        assert!(response.headers().get(RETRY_AFTER).is_none());
+    }
+
+    #[test]
+    fn impossible_retry_after_sentinel_omits_header() {
+        let response = rejection_response(u64::MAX);
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
         assert!(response.headers().get(RETRY_AFTER).is_none());
     }
 }

--- a/model_gateway/src/routers/grpc/common/response_formatting.rs
+++ b/model_gateway/src/routers/grpc/common/response_formatting.rs
@@ -12,11 +12,14 @@ use crate::routers::grpc::proto_wrapper::{ProtoGenerateComplete, ProtoGenerateSt
 
 /// Build usage information from collected gRPC responses
 ///
-/// Sums completion_tokens across all responses, since each is a distinct
-/// generation. `prompt_tokens` takes the max instead: chat/generate requests
-/// have exactly one prompt shared by every `n>1` choice, and each response
-/// reports that same full prompt length, so summing would charge it once per
-/// choice instead of once per request (Completion's own batched usage
+/// Sums completion_tokens (and reasoning_tokens, each choice's own
+/// independent reasoning trace) across all responses, since each is a
+/// distinct generation. `prompt_tokens` and `cached_tokens` take the max
+/// instead: chat/generate requests have exactly one prompt shared by every
+/// `n>1` choice -- cached_tokens is a property of that same prompt (how much
+/// of it hit the KV cache), not of the individual completion -- and each
+/// response reports that same full length, so summing would charge it once
+/// per choice instead of once per request (Completion's own batched usage
 /// computation already does this correctly per-prompt; mirrored here).
 pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
     let total_prompt_tokens: u32 = responses
@@ -25,7 +28,11 @@ pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
         .max()
         .unwrap_or(0);
     let total_completion_tokens: u32 = responses.iter().map(|r| r.completion_tokens()).sum();
-    let total_cached_tokens: u32 = responses.iter().map(|r| r.cached_tokens()).sum();
+    let total_cached_tokens: u32 = responses
+        .iter()
+        .map(|r| r.cached_tokens())
+        .max()
+        .unwrap_or(0);
     let total_reasoning_tokens: u32 = responses.iter().map(|r| r.reasoning_tokens()).sum();
 
     Usage::from_counts(total_prompt_tokens, total_completion_tokens)
@@ -83,9 +90,14 @@ mod tests {
 
     use super::*;
 
-    fn complete(prompt_tokens: u32, completion_tokens: u32) -> ProtoGenerateComplete {
+    fn complete(
+        prompt_tokens: u32,
+        cached_tokens: u32,
+        completion_tokens: u32,
+    ) -> ProtoGenerateComplete {
         ProtoGenerateComplete::TokenSpeed(tokenspeed::GenerateComplete {
             prompt_tokens,
+            cached_tokens,
             completion_tokens,
             ..Default::default()
         })
@@ -93,12 +105,17 @@ mod tests {
 
     #[test]
     fn build_usage_charges_the_shared_prompt_once_for_n_greater_than_1() {
-        let responses = vec![complete(10, 4), complete(10, 6)];
+        let responses = vec![complete(10, 8, 4), complete(10, 8, 6)];
         let usage = build_usage(&responses);
 
         assert_eq!(
             usage.prompt_tokens, 10,
             "n>1 choices share one prompt -- must not be multiplied per choice"
+        );
+        assert_eq!(
+            usage.prompt_tokens_details.as_ref().map(|d| d.cached_tokens),
+            Some(8),
+            "cached_tokens is a property of the shared prompt too -- must not be multiplied per choice"
         );
         assert_eq!(
             usage.completion_tokens, 10,

--- a/model_gateway/src/routers/grpc/common/response_formatting.rs
+++ b/model_gateway/src/routers/grpc/common/response_formatting.rs
@@ -12,10 +12,18 @@ use crate::routers::grpc::proto_wrapper::{ProtoGenerateComplete, ProtoGenerateSt
 
 /// Build usage information from collected gRPC responses
 ///
-/// Sums prompt_tokens and completion_tokens across all responses.
-/// Typically used with n>1 parameter where multiple completions are generated.
+/// Sums completion_tokens across all responses, since each is a distinct
+/// generation. `prompt_tokens` takes the max instead: chat/generate requests
+/// have exactly one prompt shared by every `n>1` choice, and each response
+/// reports that same full prompt length, so summing would charge it once per
+/// choice instead of once per request (Completion's own batched usage
+/// computation already does this correctly per-prompt; mirrored here).
 pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
-    let total_prompt_tokens: u32 = responses.iter().map(|r| r.prompt_tokens()).sum();
+    let total_prompt_tokens: u32 = responses
+        .iter()
+        .map(|r| r.prompt_tokens())
+        .max()
+        .unwrap_or(0);
     let total_completion_tokens: u32 = responses.iter().map(|r| r.completion_tokens()).sum();
     let total_cached_tokens: u32 = responses.iter().map(|r| r.cached_tokens()).sum();
     let total_reasoning_tokens: u32 = responses.iter().map(|r| r.reasoning_tokens()).sum();
@@ -66,5 +74,35 @@ impl CompletionTokenTracker {
     /// Get total completion tokens across all indices
     pub fn total(&self) -> u32 {
         self.tokens.values().sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use smg_grpc_client::tokenspeed_proto as tokenspeed;
+
+    use super::*;
+
+    fn complete(prompt_tokens: u32, completion_tokens: u32) -> ProtoGenerateComplete {
+        ProtoGenerateComplete::TokenSpeed(tokenspeed::GenerateComplete {
+            prompt_tokens,
+            completion_tokens,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn build_usage_charges_the_shared_prompt_once_for_n_greater_than_1() {
+        let responses = vec![complete(10, 4), complete(10, 6)];
+        let usage = build_usage(&responses);
+
+        assert_eq!(
+            usage.prompt_tokens, 10,
+            "n>1 choices share one prompt -- must not be multiplied per choice"
+        );
+        assert_eq!(
+            usage.completion_tokens, 10,
+            "each choice generates its own completion -- must be summed"
+        );
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -13,13 +13,14 @@ use tracing::{debug, warn};
 
 use crate::{
     middleware::{RequestId, TenantRequestMeta},
+    rate_limit::{ReservationAttachment, SharedReservationHandle},
     routers::grpc::{
-        context::{RequestType, WorkerSelection},
+        context::{LoadGuards, RequestType, WorkerSelection},
         proto_wrapper::ProtoGenerateRequest,
     },
     worker::{
-        sampling_defaults::SamplingDefaults, RuntimeType, Worker, DEFAULT_BOOTSTRAP_PORT,
-        DEFAULT_SAMPLING_PARAMS_LABEL,
+        sampling_defaults::SamplingDefaults, AttachedBody, RuntimeType, Worker,
+        DEFAULT_BOOTSTRAP_PORT, DEFAULT_SAMPLING_PARAMS_LABEL,
     },
 };
 
@@ -78,6 +79,28 @@ impl SamplingDefaultsMask {
 
     fn any(self) -> bool {
         self.temperature || self.top_p || self.top_k || self.min_p || self.repetition_penalty
+    }
+}
+
+/// Attach load guards and/or a rate-limit reservation to a streaming
+/// response body so each survives (and, for the reservation, resolves via
+/// `ReservationAttachment`'s `Drop`) exactly as long as the body does,
+/// regardless of how the client disconnects. A no-op returning `response`
+/// unchanged when both are `None`.
+pub(crate) fn attach_response_guards(
+    response: axum::response::Response,
+    guards: Option<LoadGuards>,
+    reservation: Option<Arc<SharedReservationHandle>>,
+) -> axum::response::Response {
+    match (guards, reservation) {
+        (Some(guards), Some(handle)) => {
+            AttachedBody::wrap_response(response, (guards, ReservationAttachment::new(handle)))
+        }
+        (Some(guards), None) => AttachedBody::wrap_response(response, guards),
+        (None, Some(handle)) => {
+            AttachedBody::wrap_response(response, ReservationAttachment::new(handle))
+        }
+        (None, None) => response,
     }
 }
 

--- a/model_gateway/src/routers/grpc/common/stages/mod.rs
+++ b/model_gateway/src/routers/grpc/common/stages/mod.rs
@@ -43,6 +43,7 @@ mod client_acquisition;
 mod dispatch_metadata;
 pub(crate) mod encode;
 pub(crate) mod helpers;
+mod rate_limit;
 mod request_execution;
 mod worker_selection;
 
@@ -50,5 +51,6 @@ mod worker_selection;
 pub(crate) use client_acquisition::ClientAcquisitionStage;
 pub(crate) use dispatch_metadata::DispatchMetadataStage;
 pub(crate) use encode::EncodeStage;
+pub(crate) use rate_limit::{RateLimitCell, RateLimitOutcome, RateLimitReserveStage};
 pub(crate) use request_execution::RequestExecutionStage;
 pub(crate) use worker_selection::{WorkerSelectionMode, WorkerSelectionStage};

--- a/model_gateway/src/routers/grpc/common/stages/rate_limit.rs
+++ b/model_gateway/src/routers/grpc/common/stages/rate_limit.rs
@@ -8,7 +8,10 @@
 //! reach this stage reserves (or is denied) and caches the outcome; every
 //! later attempt sees the cached outcome and skips straight through.
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use async_trait::async_trait;
 use axum::response::Response;
@@ -18,7 +21,8 @@ use tracing::error;
 use super::PipelineStage;
 use crate::{
     rate_limit::{
-        rejection_response, RateLimitManager, Reservation, ReserveRequest, SharedReservationHandle,
+        rejection_response, RateLimitManager, Reservation, ReservationAttachment, ReserveRequest,
+        SharedReservationHandle,
     },
     routers::{error, grpc::context::RequestContext},
 };
@@ -36,19 +40,71 @@ pub(crate) enum RateLimitOutcome {
 /// across an `.await`, and `RetryExecutor` runs attempts strictly
 /// sequentially, so there's no real contention -- this is just correct
 /// check-then-act bookkeeping, not a concurrency primitive.
-pub(crate) struct RateLimitCell(Mutex<Option<RateLimitOutcome>>);
+///
+/// `Drop` is the safety net for a reservation that never gets the chance to
+/// resolve through any of the normal paths -- e.g. the priority scheduler
+/// preempting the route future (dropping it) before a response of any kind
+/// (streaming or not) is ever produced. Non-streaming success (settled
+/// inline) and the router's post-retry-loop close-if-unsettled both resolve
+/// the handle *before* this cell would otherwise drop, so `Drop`'s own
+/// `abandon_if_open` is a safe no-op there (CAS-guarded, first resolution
+/// wins). Streaming success is the one case that needs an explicit opt-out
+/// (`handed_off`): resolution there is intentionally deferred to whenever
+/// the response body's `ReservationAttachment` drops, which happens *after*
+/// this cell would otherwise drop (`route_*_impl` returns the initial SSE
+/// response long before the stream finishes) -- without the flag, `Drop`
+/// would race that deferred resolution and always win, permanently
+/// abandoning the reservation before real usage is ever settled.
+pub(crate) struct RateLimitCell {
+    outcome: Mutex<Option<RateLimitOutcome>>,
+    handed_off: AtomicBool,
+}
 
 impl RateLimitCell {
     pub(crate) fn new() -> Self {
-        Self(Mutex::new(None))
+        Self {
+            outcome: Mutex::new(None),
+            handed_off: AtomicBool::new(false),
+        }
     }
 
     pub(crate) fn peek(&self) -> Option<RateLimitOutcome> {
-        self.0.lock().clone()
+        self.outcome.lock().clone()
     }
 
     fn set(&self, outcome: RateLimitOutcome) {
-        *self.0.lock() = Some(outcome);
+        *self.outcome.lock() = Some(outcome);
+    }
+
+    /// For a streaming response about to attach a `ReservationAttachment`:
+    /// extract the admitted handle (if any), and mark this cell as having
+    /// handed off resolution responsibility so `Drop` doesn't race the
+    /// attachment's own, correctly-timed resolution. No-op (returns `None`)
+    /// if nothing was ever reserved or the request was denied.
+    pub(crate) fn take_for_streaming_handoff(&self) -> Option<Arc<SharedReservationHandle>> {
+        match self.peek() {
+            Some(RateLimitOutcome::Admitted(handle)) => {
+                self.handed_off.store(true, Ordering::Release);
+                Some(handle)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl Drop for RateLimitCell {
+    fn drop(&mut self) {
+        if self.handed_off.load(Ordering::Acquire) {
+            return;
+        }
+        if let Some(RateLimitOutcome::Admitted(handle)) = self.outcome.get_mut().take() {
+            // `SharedReservationHandle::abandon_if_open` is private to the
+            // rate_limit module; going through the public `ReservationAttachment`
+            // RAII wrapper (construct then immediately drop) triggers the
+            // same CAS-guarded abandon without needing to widen that
+            // visibility.
+            drop(ReservationAttachment::new(handle));
+        }
     }
 }
 
@@ -106,7 +162,7 @@ impl PipelineStage for RateLimitReserveStage {
                     request_charge_id: tenant_meta.request_charge_id,
                     tenant_key: tenant_meta.tenant_key.clone(),
                     model_id: Some(ctx.input.model_id.clone()),
-                    estimated_input_tokens: prep.token_ids().len() as u32,
+                    estimated_input_tokens: prep.total_input_token_count() as u32,
                 };
 
                 match manager.reserve(request).await {
@@ -125,5 +181,104 @@ impl PipelineStage for RateLimitReserveStage {
 
     fn name(&self) -> &'static str {
         "RateLimitReserve"
+    }
+}
+
+#[cfg(test)]
+mod cell_drop_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    use async_trait::async_trait;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::rate_limit::{RateLimitBackend, ReserveOutcome, UsageSettlement};
+
+    #[derive(Default)]
+    struct CountingBackend {
+        abandon_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl RateLimitBackend for CountingBackend {
+        async fn reserve(&self, _request: ReserveRequest) -> ReserveOutcome {
+            ReserveOutcome::Admitted
+        }
+        async fn settle_success(&self, _request_charge_id: Uuid, _usage: UsageSettlement) {}
+        async fn close_reserved_only(&self, _request_charge_id: Uuid) {}
+        async fn abandon(&self, _request_charge_id: Uuid) {
+            self.abandon_calls.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+    }
+
+    fn admitted_cell(backend: &Arc<CountingBackend>) -> RateLimitCell {
+        let handle = Arc::new(SharedReservationHandle::new(
+            backend.clone() as Arc<dyn RateLimitBackend>,
+            Uuid::now_v7(),
+        ));
+        let cell = RateLimitCell::new();
+        cell.set(RateLimitOutcome::Admitted(handle));
+        cell
+    }
+
+    /// Simulates preemption: the cell is dropped while still holding an
+    /// open, un-handed-off reservation (no streaming response body ever
+    /// took it over) -- `Drop` must abandon it rather than leak it.
+    #[tokio::test]
+    async fn drop_without_handoff_abandons_the_reservation() {
+        let backend = Arc::new(CountingBackend::default());
+        let cell = admitted_cell(&backend);
+
+        drop(cell);
+        tokio::task::yield_now().await; // let abandon_if_open's spawned task run
+
+        assert_eq!(backend.abandon_calls.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    /// Simulates a streaming response taking ownership via
+    /// `take_for_streaming_handoff`: the cell's own `Drop` must not also
+    /// abandon, or it would win the CAS race against the real, later
+    /// settle and permanently abandon a reservation that should have been
+    /// trued up with real usage instead.
+    #[tokio::test]
+    async fn drop_after_streaming_handoff_does_not_abandon() {
+        let backend = Arc::new(CountingBackend::default());
+        let cell = admitted_cell(&backend);
+
+        let handed_off = cell.take_for_streaming_handoff();
+        assert!(handed_off.is_some());
+
+        drop(cell);
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            backend.abandon_calls.load(AtomicOrdering::SeqCst),
+            0,
+            "a cell that handed off must not also abandon on drop"
+        );
+
+        // The handed-off handle is still independently resolvable (e.g. via
+        // the streaming path's own later settle, or -- as production code
+        // does -- by wrapping it in a `ReservationAttachment`, whose own
+        // Drop is the actual cleanup trigger; a bare handle alone does not
+        // self-abandon).
+        let handle = handed_off.expect("handed off");
+        drop(ReservationAttachment::new(handle));
+        tokio::task::yield_now().await;
+        assert_eq!(backend.abandon_calls.load(AtomicOrdering::SeqCst), 1);
+    }
+
+    /// A denied reservation never reaches `Admitted`, so `Drop` has nothing
+    /// to abandon.
+    #[tokio::test]
+    async fn drop_after_denial_does_not_abandon() {
+        let backend = Arc::new(CountingBackend::default());
+        let cell = RateLimitCell::new();
+        cell.set(RateLimitOutcome::Denied);
+
+        drop(cell);
+        tokio::task::yield_now().await;
+
+        assert_eq!(backend.abandon_calls.load(AtomicOrdering::SeqCst), 0);
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/rate_limit.rs
+++ b/model_gateway/src/routers/grpc/common/stages/rate_limit.rs
@@ -16,7 +16,7 @@ use std::sync::{
 use async_trait::async_trait;
 use axum::response::Response;
 use parking_lot::Mutex;
-use tracing::error;
+use tracing::{error, warn};
 
 use super::PipelineStage;
 use crate::{
@@ -145,6 +145,10 @@ impl PipelineStage for RateLimitReserveStage {
                     // No tenant identity resolved (shouldn't happen once
                     // tenant_resolution middleware runs, but fail open rather
                     // than block a request over missing rate-limit context).
+                    warn!(
+                        function = "RateLimitReserveStage::execute",
+                        "tenant_request_meta missing; skipping rate-limit reservation"
+                    );
                     return Ok(None);
                 };
                 let prep = ctx.state.preparation.as_ref().ok_or_else(|| {

--- a/model_gateway/src/routers/grpc/common/stages/rate_limit.rs
+++ b/model_gateway/src/routers/grpc/common/stages/rate_limit.rs
@@ -1,0 +1,129 @@
+//! Tenant rate-limit reserve stage: admit or reject a logical request once,
+//! before dispatch, reusing the exact input-token count preparation just
+//! produced.
+//!
+//! `RetryExecutor` reruns the whole pipeline (this stage included) fresh on
+//! every retry attempt, so [`RateLimitCell`] is threaded in from the router
+//! and shared across attempts of one logical request: the first attempt to
+//! reach this stage reserves (or is denied) and caches the outcome; every
+//! later attempt sees the cached outcome and skips straight through.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::response::Response;
+use parking_lot::Mutex;
+use tracing::error;
+
+use super::PipelineStage;
+use crate::{
+    rate_limit::{
+        rejection_response, RateLimitManager, Reservation, ReserveRequest, SharedReservationHandle,
+    },
+    routers::{error, grpc::context::RequestContext},
+};
+
+/// Outcome of the first reserve attempt for one logical request, cached so
+/// later retry attempts don't reserve again.
+#[derive(Clone)]
+pub(crate) enum RateLimitOutcome {
+    Admitted(Arc<SharedReservationHandle>),
+    Denied,
+}
+
+/// Shared across every retry attempt of one logical request. `parking_lot::Mutex`
+/// (not `tokio::sync::Mutex`) is fine: `peek`/`set` never hold the lock
+/// across an `.await`, and `RetryExecutor` runs attempts strictly
+/// sequentially, so there's no real contention -- this is just correct
+/// check-then-act bookkeeping, not a concurrency primitive.
+pub(crate) struct RateLimitCell(Mutex<Option<RateLimitOutcome>>);
+
+impl RateLimitCell {
+    pub(crate) fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+
+    pub(crate) fn peek(&self) -> Option<RateLimitOutcome> {
+        self.0.lock().clone()
+    }
+
+    fn set(&self, outcome: RateLimitOutcome) {
+        *self.0.lock() = Some(outcome);
+    }
+}
+
+/// Reserve tenant rate-limit budget once per logical request. No-ops when
+/// the feature is disabled (`manager: None`) or the calling endpoint hasn't
+/// opted in (`ctx.input.rate_limit_cell: None` -- Responses/embeddings/classify
+/// today).
+pub(crate) struct RateLimitReserveStage {
+    manager: Option<Arc<RateLimitManager>>,
+}
+
+impl RateLimitReserveStage {
+    pub fn new(manager: Option<Arc<RateLimitManager>>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl PipelineStage for RateLimitReserveStage {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+        let Some(manager) = &self.manager else {
+            return Ok(None);
+        };
+        let Some(cell) = ctx.input.rate_limit_cell.as_ref() else {
+            return Ok(None);
+        };
+
+        match cell.peek() {
+            Some(RateLimitOutcome::Admitted(_)) => Ok(None),
+            Some(RateLimitOutcome::Denied) => {
+                // Defensive: `should_retry` in router.rs stops the retry loop
+                // as soon as a Denied outcome is cached, so a second attempt
+                // should never actually reach this stage.
+                Err(rejection_response(0))
+            }
+            None => {
+                let Some(tenant_meta) = ctx.input.tenant_request_meta.as_ref() else {
+                    // No tenant identity resolved (shouldn't happen once
+                    // tenant_resolution middleware runs, but fail open rather
+                    // than block a request over missing rate-limit context).
+                    return Ok(None);
+                };
+                let prep = ctx.state.preparation.as_ref().ok_or_else(|| {
+                    error!(
+                        function = "RateLimitReserveStage::execute",
+                        "Preparation stage not completed"
+                    );
+                    error::internal_error(
+                        "preparation_stage_not_completed",
+                        "Preparation stage not completed",
+                    )
+                })?;
+
+                let request = ReserveRequest {
+                    request_charge_id: tenant_meta.request_charge_id,
+                    tenant_key: tenant_meta.tenant_key.clone(),
+                    model_id: Some(ctx.input.model_id.clone()),
+                    estimated_input_tokens: prep.token_ids().len() as u32,
+                };
+
+                match manager.reserve(request).await {
+                    Reservation::Admitted(handle) => {
+                        cell.set(RateLimitOutcome::Admitted(handle));
+                        Ok(None)
+                    }
+                    Reservation::Denied { retry_after_secs } => {
+                        cell.set(RateLimitOutcome::Denied);
+                        Err(rejection_response(retry_after_secs))
+                    }
+                }
+            }
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "RateLimitReserve"
+    }
+}

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -343,6 +343,17 @@ impl PreparationOutput {
         }
     }
 
+    /// Total input token count across every item -- for accounting (rate-limit
+    /// reservation), not routing. Unlike `token_ids()`, which exposes only the
+    /// first prompt as a routing-affinity proxy, a batched `Completion`
+    /// request's real input cost is the sum of every prompt in the batch.
+    pub fn total_input_token_count(&self) -> usize {
+        match self {
+            Self::Completion { items, .. } => items.iter().map(|item| item.token_ids.len()).sum(),
+            other => other.token_ids().len(),
+        }
+    }
+
     /// Text for worker routing: original_text for regular pipelines, selection_text for Harmony.
     /// Chat/Messages borrow from processed_messages.text to avoid a redundant clone.
     pub fn routing_text(&self) -> Option<&str> {
@@ -992,6 +1003,35 @@ mod tests {
         let batch = completion_prep(&["a", "b"], Some("a b"));
         assert_eq!(batch.routing_text(), Some("a b"));
         assert_eq!(batch.token_ids(), &[0]);
+    }
+
+    /// `token_ids()` is deliberately a single-item routing-affinity proxy
+    /// (see the test above), but a batched Completion's real input cost is
+    /// every prompt in the batch -- `total_input_token_count()` must sum
+    /// them all, not just echo the first item like `token_ids()` does.
+    #[test]
+    fn total_input_token_count_sums_every_batched_completion_item() {
+        let batch = PreparationOutput::Completion {
+            items: vec![
+                CompletionItem {
+                    text: "short".to_string(),
+                    token_ids: vec![1],
+                },
+                CompletionItem {
+                    text: "much longer prompt".to_string(),
+                    token_ids: vec![2, 3, 4, 5, 6],
+                },
+            ],
+            joined_routing_text: Some("short much longer prompt".to_string()),
+        };
+
+        // The routing proxy only ever sees the first item...
+        assert_eq!(batch.token_ids().len(), 1);
+        // ...but reservation accounting must see the whole batch's cost.
+        assert_eq!(batch.total_input_token_count(), 6);
+
+        let scalar = completion_prep(&["hello"], None);
+        assert_eq!(scalar.total_input_token_count(), scalar.token_ids().len());
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -23,7 +23,7 @@ use tracing::debug;
 
 use super::{
     backend_client::BackendClient,
-    common::stages::encode::EncodeDispatchPlan,
+    common::stages::{encode::EncodeDispatchPlan, RateLimitCell},
     multimodal::{MultimodalComponents, MultimodalIntermediate},
     proto_wrapper::{
         EncodeItemBootstrapInfo, ProtoEmbedComplete, ProtoEmbedRequest, ProtoGenerateRequest,
@@ -53,6 +53,11 @@ pub(crate) struct RequestInput {
     /// Canonical model ID used after aliases are resolved at request entry.
     pub model_id: String,
     pub tenant_request_meta: Option<TenantRequestMeta>,
+    /// Shared across every retry attempt of one logical request so
+    /// `RateLimitReserveStage` reserves at most once. `None` for endpoints
+    /// that haven't opted into tenant rate limiting yet (Responses,
+    /// embeddings, classify).
+    pub rate_limit_cell: Option<Arc<RateLimitCell>>,
 }
 
 /// Request type variants
@@ -508,6 +513,7 @@ impl RequestContext {
                 headers,
                 model_id,
                 tenant_request_meta: None,
+                rate_limit_cell: None,
             },
             components,
             state: ProcessingState::default(),

--- a/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -8,10 +8,11 @@ use tracing::error;
 
 use super::super::{HarmonyResponseProcessor, HarmonyStreamingProcessor};
 use crate::{
+    rate_limit::ReservationAttachment,
     routers::{
         error,
         grpc::{
-            common::stages::PipelineStage,
+            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
             context::{FinalResponse, RequestContext, RequestType},
         },
     },
@@ -81,6 +82,20 @@ impl PipelineStage for HarmonyResponseProcessingStage {
 
                 // For streaming, delegate to streaming processor and return SSE response
                 if is_streaming {
+                    // Reserved (if tenant rate limiting is enabled): settled
+                    // with real usage inside the streaming processor on
+                    // success, or abandoned via ReservationAttachment's Drop
+                    // below on early disconnect/error.
+                    let reservation = ctx
+                        .input
+                        .rate_limit_cell
+                        .as_deref()
+                        .and_then(RateLimitCell::peek)
+                        .and_then(|outcome| match outcome {
+                            RateLimitOutcome::Admitted(handle) => Some(handle),
+                            RateLimitOutcome::Denied => None,
+                        });
+
                     let response = self
                         .streaming_processor
                         .clone()
@@ -89,12 +104,23 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                             ctx.chat_request_arc(),
                             dispatch,
                             router_stop_strings(ctx),
+                            reservation.clone(),
                         );
 
-                    // Attach load guards to response body for proper RAII lifecycle
-                    let response = match ctx.state.load_guards.take() {
-                        Some(guards) => AttachedBody::wrap_response(response, guards),
-                        None => response,
+                    // Attach load guards (and the reservation's
+                    // disconnect/error safety net) to the response body for
+                    // proper RAII lifecycle.
+                    let response = match (ctx.state.load_guards.take(), reservation) {
+                        (Some(guards), Some(handle)) => AttachedBody::wrap_response(
+                            response,
+                            (guards, ReservationAttachment::new(handle)),
+                        ),
+                        (Some(guards), None) => AttachedBody::wrap_response(response, guards),
+                        (None, Some(handle)) => AttachedBody::wrap_response(
+                            response,
+                            ReservationAttachment::new(handle),
+                        ),
+                        (None, None) => response,
                     };
 
                     return Ok(Some(response));

--- a/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -7,16 +7,12 @@ use axum::response::Response;
 use tracing::error;
 
 use super::super::{HarmonyResponseProcessor, HarmonyStreamingProcessor};
-use crate::{
-    rate_limit::ReservationAttachment,
-    routers::{
-        error,
-        grpc::{
-            common::stages::{PipelineStage, RateLimitCell},
-            context::{FinalResponse, RequestContext, RequestType},
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::{helpers, PipelineStage, RateLimitCell},
+        context::{FinalResponse, RequestContext, RequestType},
     },
-    worker::AttachedBody,
 };
 
 /// String `stop` sequences the ROUTER must enforce, as reported by the
@@ -84,8 +80,9 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                 if is_streaming {
                     // Reserved (if tenant rate limiting is enabled): settled
                     // with real usage inside the streaming processor on
-                    // success, or abandoned via ReservationAttachment's Drop
-                    // below on early disconnect/error.
+                    // success, or abandoned via the attached
+                    // ReservationAttachment's Drop below on early
+                    // disconnect/error.
                     let reservation = ctx
                         .input
                         .rate_limit_cell
@@ -106,18 +103,11 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                     // Attach load guards (and the reservation's
                     // disconnect/error safety net) to the response body for
                     // proper RAII lifecycle.
-                    let response = match (ctx.state.load_guards.take(), reservation) {
-                        (Some(guards), Some(handle)) => AttachedBody::wrap_response(
-                            response,
-                            (guards, ReservationAttachment::new(handle)),
-                        ),
-                        (Some(guards), None) => AttachedBody::wrap_response(response, guards),
-                        (None, Some(handle)) => AttachedBody::wrap_response(
-                            response,
-                            ReservationAttachment::new(handle),
-                        ),
-                        (None, None) => response,
-                    };
+                    let response = helpers::attach_response_guards(
+                        response,
+                        ctx.state.load_guards.take(),
+                        reservation,
+                    );
 
                     return Ok(Some(response));
                 }

--- a/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -12,7 +12,7 @@ use crate::{
     routers::{
         error,
         grpc::{
-            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
+            common::stages::{PipelineStage, RateLimitCell},
             context::{FinalResponse, RequestContext, RequestType},
         },
     },
@@ -90,11 +90,7 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                         .input
                         .rate_limit_cell
                         .as_deref()
-                        .and_then(RateLimitCell::peek)
-                        .and_then(|outcome| match outcome {
-                            RateLimitOutcome::Admitted(handle) => Some(handle),
-                            RateLimitOutcome::Denied => None,
-                        });
+                        .and_then(RateLimitCell::take_for_streaming_handoff);
 
                     let response = self
                         .streaming_processor

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -33,6 +33,7 @@ use super::{
 };
 use crate::{
     observability::metrics::{metrics_labels, Metrics, StreamingMetricsParams},
+    rate_limit::{SharedReservationHandle, UsageSettlement},
     routers::{
         common::{
             openai_bridge::{self, descriptor, FormatRegistry, ResponseFormat},
@@ -110,6 +111,7 @@ impl HarmonyStreamingProcessor {
         chat_request: Arc<ChatCompletionRequest>,
         dispatch: context::DispatchMetadata,
         router_stop_strings: Vec<String>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Response {
         // Create SSE channel
         let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
@@ -124,6 +126,7 @@ impl HarmonyStreamingProcessor {
                         chat_request,
                         &tx,
                         router_stop_strings,
+                        reservation,
                     )
                     .await;
 
@@ -149,6 +152,7 @@ impl HarmonyStreamingProcessor {
                         chat_request,
                         &tx,
                         router_stop_strings,
+                        reservation,
                     )
                     .await;
 
@@ -192,6 +196,7 @@ impl HarmonyStreamingProcessor {
         original_request: Arc<ChatCompletionRequest>,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
         router_stop_strings: Vec<String>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         let mut prompt_tokens = HashMap::new();
         let mut cached_tokens = HashMap::new();
@@ -203,6 +208,7 @@ impl HarmonyStreamingProcessor {
             &mut prompt_tokens,
             &mut cached_tokens,
             &router_stop_strings,
+            reservation,
         )
         .await
     }
@@ -215,6 +221,7 @@ impl HarmonyStreamingProcessor {
         original_request: Arc<ChatCompletionRequest>,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
         router_stop_strings: Vec<String>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         // Phase 1: Process prefill stream (collect metadata)
         let mut prompt_tokens: HashMap<u32, u32> = HashMap::new();
@@ -238,6 +245,7 @@ impl HarmonyStreamingProcessor {
             &mut prompt_tokens,
             &mut cached_tokens,
             &router_stop_strings,
+            reservation,
         )
         .await?;
 
@@ -261,6 +269,7 @@ impl HarmonyStreamingProcessor {
         prompt_tokens: &mut HashMap<u32, u32>,
         cached_tokens: &mut HashMap<u32, u32>,
         router_stop_strings: &[String],
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         // Timing for metrics
         let start_time = Instant::now();
@@ -472,6 +481,15 @@ impl HarmonyStreamingProcessor {
         let total_prompt: u32 = prompt_tokens.values().sum();
         let total_completion: u32 = completion_tokens.total();
         let total_cached: u32 = cached_tokens.values().sum();
+
+        if let Some(handle) = reservation {
+            handle
+                .settle_success(UsageSettlement {
+                    actual_input_tokens: total_prompt,
+                    completion_tokens: total_completion,
+                })
+                .await;
+        }
 
         // Emit final usage if requested
         if let Some(true) = stream_options.as_ref().and_then(|so| so.include_usage) {

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -483,12 +483,21 @@ impl HarmonyStreamingProcessor {
         let total_cached: u32 = cached_tokens.values().sum();
 
         if let Some(handle) = reservation {
-            handle
-                .settle_success(UsageSettlement {
-                    actual_input_tokens: total_prompt,
-                    completion_tokens: total_completion,
-                })
-                .await;
+            // `prompt_tokens` is only ever populated from a `Complete` message
+            // (prefill or decode); a clean EOF that never produced one has no
+            // authoritative usage to settle with -- treating that as "0 input
+            // tokens" would incorrectly refund the reservation's estimate.
+            // Keep the reserved amount as final instead.
+            if prompt_tokens.is_empty() {
+                handle.close_reserved_only().await;
+            } else {
+                handle
+                    .settle_success(UsageSettlement {
+                        actual_input_tokens: total_prompt,
+                        completion_tokens: total_completion,
+                    })
+                    .await;
+            }
         }
 
         // Emit final usage if requested

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -486,10 +486,12 @@ impl HarmonyStreamingProcessor {
 
         // Compute totals once for both usage chunk and metrics. Every `n>1`
         // choice shares one prompt; each Complete reports that same full
-        // length, so max (not sum) is the actual prompt cost.
+        // length, so max (not sum) is the actual prompt cost. cached_tokens
+        // is a property of that same shared prompt, not of the individual
+        // completion, so it takes the same treatment.
         let total_prompt: u32 = prompt_tokens.values().copied().max().unwrap_or(0);
         let total_completion: u32 = completion_tokens.total();
-        let total_cached: u32 = cached_tokens.values().sum();
+        let total_cached: u32 = cached_tokens.values().copied().max().unwrap_or(0);
 
         if let Some(handle) = reservation {
             // A clean decode EOF with fewer decode `Complete` messages than

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -1,7 +1,7 @@
 //! Harmony streaming response processor
 
 use std::{
-    collections::{hash_map::Entry::Vacant, HashMap},
+    collections::{hash_map::Entry::Vacant, HashMap, HashSet},
     io,
     sync::Arc,
     time::Instant,
@@ -286,6 +286,12 @@ impl HarmonyStreamingProcessor {
         let mut final_scanners: HashMap<u32, TextStopScanner> = HashMap::new();
         let mut router_stopped: std::collections::HashSet<u32> = std::collections::HashSet::new();
         let mut completion_tokens = CompletionTokenTracker::new();
+        // Indices that received a *decode* `Complete` -- unlike `prompt_tokens`
+        // (which may already be populated from the prefill phase before this
+        // loop even starts, in PD mode), this is only ever set from this
+        // stream's own Complete messages, so it can't be fooled by prefill
+        // data into thinking decode produced authoritative usage it didn't.
+        let mut decode_completed_indices: HashSet<u32> = HashSet::new();
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut encoder = SseEncoder::new();
 
@@ -410,6 +416,7 @@ impl HarmonyStreamingProcessor {
                 }
                 ProtoResponseVariant::Complete(complete_wrapper) => {
                     let index = complete_wrapper.index();
+                    decode_completed_indices.insert(index);
 
                     // Store final metadata
                     matched_stops.insert(index, complete_wrapper.matched_stop_json());
@@ -477,18 +484,23 @@ impl HarmonyStreamingProcessor {
         // Mark stream as completed successfully to prevent abort on drop
         decode_stream.mark_completed();
 
-        // Compute totals once for both usage chunk and metrics
-        let total_prompt: u32 = prompt_tokens.values().sum();
+        // Compute totals once for both usage chunk and metrics. Every `n>1`
+        // choice shares one prompt; each Complete reports that same full
+        // length, so max (not sum) is the actual prompt cost.
+        let total_prompt: u32 = prompt_tokens.values().copied().max().unwrap_or(0);
         let total_completion: u32 = completion_tokens.total();
         let total_cached: u32 = cached_tokens.values().sum();
 
         if let Some(handle) = reservation {
-            // `prompt_tokens` is only ever populated from a `Complete` message
-            // (prefill or decode); a clean EOF that never produced one has no
-            // authoritative usage to settle with -- treating that as "0 input
-            // tokens" would incorrectly refund the reservation's estimate.
-            // Keep the reserved amount as final instead.
-            if prompt_tokens.is_empty() {
+            // A clean decode EOF with fewer decode `Complete` messages than
+            // this request's `n>1` choices has only partial usage -- settling
+            // with that would understate the real cost. Deliberately checked
+            // against `decode_completed_indices`, not `prompt_tokens`: in PD
+            // mode `prompt_tokens` can already be non-empty from the prefill
+            // phase alone, which would otherwise mask a decode phase that
+            // never actually finished.
+            let expected_choices = original_request.n.unwrap_or(1).max(1);
+            if (decode_completed_indices.len() as u32) < expected_choices {
                 handle.close_reserved_only().await;
             } else {
                 handle

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -261,6 +261,7 @@ impl HarmonyStreamingProcessor {
     /// and `cached_tokens` maps may be pre-populated from a prefill phase
     /// (prefill/decode stream) or empty (single stream). Values from `Complete` messages
     /// are inserted only if not already present.
+    #[expect(clippy::too_many_arguments)]
     async fn process_chat_decode_stream(
         mut decode_stream: ProtoStream,
         dispatch: &context::DispatchMetadata,
@@ -284,7 +285,7 @@ impl HarmonyStreamingProcessor {
         // the engine's own Complete is not re-emitted.
         let mut analysis_scanners: HashMap<u32, TextStopScanner> = HashMap::new();
         let mut final_scanners: HashMap<u32, TextStopScanner> = HashMap::new();
-        let mut router_stopped: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        let mut router_stopped: HashSet<u32> = HashSet::new();
         let mut completion_tokens = CompletionTokenTracker::new();
         // Indices that received a *decode* `Complete` -- unlike `prompt_tokens`
         // (which may already be populated from the prefill phase before this

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -52,6 +52,7 @@ use crate::{
     middleware::TenantRequestMeta,
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     policies::PolicyRegistry,
+    rate_limit::{RateLimitManager, UsageSettlement},
     routers::error,
     worker::WorkerRegistry,
 };
@@ -82,6 +83,9 @@ pub(crate) struct PipelineDeps {
     reasoning_parser_factory: ReasoningParserFactory,
     configured_tool_parser: Option<String>,
     configured_reasoning_parser: Option<String>,
+    /// `None` when tenant rate limiting is disabled; read only by the
+    /// endpoints that insert `RateLimitReserveStage` (chat/messages/completion/harmony).
+    rate_limit_manager: Option<Arc<RateLimitManager>>,
 }
 
 impl PipelineDeps {
@@ -94,6 +98,7 @@ impl PipelineDeps {
         reasoning_parser_factory: ReasoningParserFactory,
         configured_tool_parser: Option<String>,
         configured_reasoning_parser: Option<String>,
+        rate_limit_manager: Option<Arc<RateLimitManager>>,
     ) -> Self {
         Self {
             worker_registry,
@@ -102,6 +107,7 @@ impl PipelineDeps {
             reasoning_parser_factory,
             configured_tool_parser,
             configured_reasoning_parser,
+            rate_limit_manager,
         }
     }
 
@@ -110,6 +116,7 @@ impl PipelineDeps {
     pub(crate) fn pair(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
+        rate_limit_manager: Option<Arc<RateLimitManager>>,
     ) -> Self {
         Self {
             worker_registry,
@@ -118,6 +125,7 @@ impl PipelineDeps {
             reasoning_parser_factory: ReasoningParserFactory::default(),
             configured_tool_parser: None,
             configured_reasoning_parser: None,
+            rate_limit_manager,
         }
     }
 
@@ -180,6 +188,7 @@ impl PipelineDeps {
             reasoning_parser_factory: ReasoningParserFactory::default(),
             configured_tool_parser: None,
             configured_reasoning_parser: None,
+            rate_limit_manager: None,
         }
     }
 }
@@ -218,6 +227,27 @@ impl RequestPipeline {
             metrics_labels::ERROR_INTERNAL,
         );
         error::internal_error("wrong_response_type", "Internal error: wrong response type")
+    }
+
+    /// Settle a non-streaming success's reservation with real usage, if this
+    /// logical request reserved one. No-op if the cell is unset (feature
+    /// disabled or endpoint opted out) or was never admitted (e.g. prep
+    /// failed before the reserve stage ran). Idempotent -- `settle_success`
+    /// is a no-op if the handle was already resolved.
+    async fn settle_reservation(
+        cell: Option<&RateLimitCell>,
+        actual_input_tokens: u32,
+        completion_tokens: u32,
+    ) {
+        let Some(RateLimitOutcome::Admitted(handle)) = cell.and_then(RateLimitCell::peek) else {
+            return;
+        };
+        handle
+            .settle_success(UsageSettlement {
+                actual_input_tokens,
+                completion_tokens,
+            })
+            .await;
     }
 
     fn no_response_produced(
@@ -259,6 +289,7 @@ impl RequestPipeline {
                 let (processor, streaming_processor) = deps.configured_processors(backend);
                 let mut stages: Vec<Box<dyn PipelineStage>> = vec![
                     Box::new(ChatGeneratePreparationStage::new()),
+                    Box::new(RateLimitReserveStage::new(deps.rate_limit_manager.clone())),
                     Box::new(WorkerSelectionStage::new(
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
@@ -287,6 +318,7 @@ impl RequestPipeline {
                 let (processor, streaming_processor) = deps.configured_processors(backend);
                 let mut stages: Vec<Box<dyn PipelineStage>> = vec![
                     Box::new(MessagePreparationStage),
+                    Box::new(RateLimitReserveStage::new(deps.rate_limit_manager.clone())),
                     Box::new(WorkerSelectionStage::new(
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
@@ -316,6 +348,7 @@ impl RequestPipeline {
                 let (processor, streaming_processor) = PipelineDeps::default_processors(backend);
                 let mut stages: Vec<Box<dyn PipelineStage>> = vec![
                     Box::new(CompletionPreparationStage),
+                    Box::new(RateLimitReserveStage::new(deps.rate_limit_manager.clone())),
                     Box::new(WorkerSelectionStage::new(
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
@@ -347,6 +380,7 @@ impl RequestPipeline {
                 }
                 vec![
                     Box::new(harmony::stages::HarmonyPreparationStage::new()),
+                    Box::new(RateLimitReserveStage::new(deps.rate_limit_manager.clone())),
                     Box::new(WorkerSelectionStage::new(
                         deps.worker_registry.clone(),
                         deps.policy_registry.clone(),
@@ -416,11 +450,13 @@ impl RequestPipeline {
         model_id: String,
         components: Arc<SharedComponents>,
         tenant_request_meta: Option<TenantRequestMeta>,
+        rate_limit_cell: Option<Arc<RateLimitCell>>,
     ) -> Response {
         let start = Instant::now();
         let streaming = request.stream;
         let mut ctx = RequestContext::for_chat(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
+        ctx.input.rate_limit_cell = rate_limit_cell;
         let model = ctx.input.model_id.clone();
 
         // Record request start
@@ -469,6 +505,13 @@ impl RequestPipeline {
 
         match ctx.state.response.final_response {
             Some(FinalResponse::Chat(response)) => {
+                let usage = response.usage.as_ref();
+                Self::settle_reservation(
+                    ctx.input.rate_limit_cell.as_deref(),
+                    usage.map_or(0, |u| u.prompt_tokens),
+                    usage.map_or(0, |u| u.completion_tokens),
+                )
+                .await;
                 Metrics::record_router_duration(
                     metrics_labels::ROUTER_GRPC,
                     self.backend_type,
@@ -506,11 +549,13 @@ impl RequestPipeline {
         model_id: String,
         components: Arc<SharedComponents>,
         tenant_request_meta: Option<TenantRequestMeta>,
+        rate_limit_cell: Option<Arc<RateLimitCell>>,
     ) -> Response {
         let start = Instant::now();
         let streaming = request.stream;
         let mut ctx = RequestContext::for_generate(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
+        ctx.input.rate_limit_cell = rate_limit_cell;
         let model_id = ctx.input.model_id.clone();
 
         // Record request start
@@ -558,6 +603,15 @@ impl RequestPipeline {
 
         match ctx.state.response.final_response {
             Some(FinalResponse::Generate(response)) => {
+                let actual_input_tokens = response.first().map_or(0, |r| r.meta_info.prompt_tokens);
+                let completion_tokens =
+                    response.iter().map(|r| r.meta_info.completion_tokens).sum();
+                Self::settle_reservation(
+                    ctx.input.rate_limit_cell.as_deref(),
+                    actual_input_tokens,
+                    completion_tokens,
+                )
+                .await;
                 Metrics::record_router_duration(
                     metrics_labels::ROUTER_GRPC,
                     self.backend_type,
@@ -597,11 +651,13 @@ impl RequestPipeline {
         model_id: String,
         components: Arc<SharedComponents>,
         tenant_request_meta: Option<TenantRequestMeta>,
+        rate_limit_cell: Option<Arc<RateLimitCell>>,
     ) -> Response {
         let start = Instant::now();
         let streaming = request.stream;
         let mut ctx = RequestContext::for_completion(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
+        ctx.input.rate_limit_cell = rate_limit_cell;
         let model = ctx.input.model_id.clone();
 
         Metrics::record_router_request(
@@ -648,6 +704,13 @@ impl RequestPipeline {
 
         match ctx.state.response.final_response {
             Some(FinalResponse::Completion(response)) => {
+                let usage = response.usage.as_ref();
+                Self::settle_reservation(
+                    ctx.input.rate_limit_cell.as_deref(),
+                    usage.map_or(0, |u| u.prompt_tokens),
+                    usage.map_or(0, |u| u.completion_tokens),
+                )
+                .await;
                 Metrics::record_router_duration(
                     metrics_labels::ROUTER_GRPC,
                     self.backend_type,
@@ -891,11 +954,13 @@ impl RequestPipeline {
         model_id: String,
         components: Arc<SharedComponents>,
         tenant_request_meta: Option<TenantRequestMeta>,
+        rate_limit_cell: Option<Arc<RateLimitCell>>,
     ) -> Response {
         let start = Instant::now();
         let streaming = request.stream.unwrap_or(false);
         let mut ctx = RequestContext::for_messages(request, headers, model_id, components);
         ctx.input.tenant_request_meta = tenant_request_meta;
+        ctx.input.rate_limit_cell = rate_limit_cell;
         let model = ctx.input.model_id.clone();
 
         // Record request start
@@ -944,6 +1009,12 @@ impl RequestPipeline {
 
         match ctx.state.response.final_response {
             Some(FinalResponse::Messages(response)) => {
+                Self::settle_reservation(
+                    ctx.input.rate_limit_cell.as_deref(),
+                    response.usage.input_tokens,
+                    response.usage.output_tokens,
+                )
+                .await;
                 Metrics::record_router_duration(
                     metrics_labels::ROUTER_GRPC,
                     self.backend_type,
@@ -1216,6 +1287,7 @@ mod build_parity_tests {
             (Endpoint::Chat, Mode::Regular) => (
                 v(&[
                     "ChatGeneratePreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(Regular)",
                     "ClientAcquisitionStage",
                     "ChatGenerateRequestBuildingStage(ChatRequestBuildingStage(inject_pd_metadata=false, Single), GenerateRequestBuildingStage(inject_pd_metadata=false, Single))",
@@ -1228,6 +1300,7 @@ mod build_parity_tests {
             (Endpoint::Chat, Mode::PrefillDecode) => (
                 v(&[
                     "ChatGeneratePreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(PrefillDecode)",
                     "ClientAcquisitionStage",
                     "ChatGenerateRequestBuildingStage(ChatRequestBuildingStage(inject_pd_metadata=true, PrefillDecode), GenerateRequestBuildingStage(inject_pd_metadata=true, PrefillDecode))",
@@ -1240,6 +1313,7 @@ mod build_parity_tests {
             (Endpoint::Chat, Mode::EncodePrefillDecode) => (
                 v(&[
                     "ChatGeneratePreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(EncodePrefillDecode)",
                     "ClientAcquisitionStage",
                     "EncodeStage",
@@ -1253,6 +1327,7 @@ mod build_parity_tests {
             (Endpoint::Messages, Mode::Regular) => (
                 v(&[
                     "MessagePreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(Regular)",
                     "ClientAcquisitionStage",
                     "MessageRequestBuildingStage(inject_pd_metadata=false, Single)",
@@ -1265,6 +1340,7 @@ mod build_parity_tests {
             (Endpoint::Messages, Mode::PrefillDecode) => (
                 v(&[
                     "MessagePreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(PrefillDecode)",
                     "ClientAcquisitionStage",
                     "MessageRequestBuildingStage(inject_pd_metadata=true, PrefillDecode)",
@@ -1277,6 +1353,7 @@ mod build_parity_tests {
             (Endpoint::Messages, Mode::EncodePrefillDecode) => (
                 v(&[
                     "MessagePreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(EncodePrefillDecode)",
                     "ClientAcquisitionStage",
                     "EncodeStage",
@@ -1290,6 +1367,7 @@ mod build_parity_tests {
             (Endpoint::Completion, Mode::Regular) => (
                 v(&[
                     "CompletionPreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(Regular)",
                     "ClientAcquisitionStage",
                     "CompletionRequestBuildingStage(inject_pd_metadata=false, Single)",
@@ -1302,6 +1380,7 @@ mod build_parity_tests {
             (Endpoint::Completion, Mode::PrefillDecode) => (
                 v(&[
                     "CompletionPreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(PrefillDecode)",
                     "ClientAcquisitionStage",
                     "CompletionRequestBuildingStage(inject_pd_metadata=true, PrefillDecode)",
@@ -1314,6 +1393,7 @@ mod build_parity_tests {
             (Endpoint::Completion, Mode::EncodePrefillDecode) => (
                 v(&[
                     "CompletionPreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(EncodePrefillDecode)",
                     "ClientAcquisitionStage",
                     "EncodeStage",
@@ -1327,6 +1407,7 @@ mod build_parity_tests {
             (Endpoint::Harmony, Mode::Regular) => (
                 v(&[
                     "HarmonyPreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(Regular)",
                     "ClientAcquisitionStage",
                     "HarmonyRequestBuildingStage(inject_pd_metadata=false, Single)",
@@ -1339,6 +1420,7 @@ mod build_parity_tests {
             (Endpoint::Harmony, Mode::PrefillDecode) => (
                 v(&[
                     "HarmonyPreparationStage",
+                    "RateLimitReserveStage",
                     "WorkerSelectionStage(PrefillDecode)",
                     "ClientAcquisitionStage",
                     "HarmonyRequestBuildingStage(inject_pd_metadata=true, PrefillDecode)",
@@ -1481,7 +1563,7 @@ mod alias_pipeline_tests {
             .unwrap();
 
         let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::RoundRobin));
-        let deps = PipelineDeps::pair(worker_registry.clone(), policy_registry);
+        let deps = PipelineDeps::pair(worker_registry.clone(), policy_registry, None);
         let pipeline = RequestPipeline::build(Endpoint::Chat, Mode::PrefillDecode, &deps).unwrap();
         let components = Arc::new(SharedComponents {
             tokenizer_registry,
@@ -1526,5 +1608,148 @@ mod alias_pipeline_tests {
             }
             WorkerSelection::Single { .. } => panic!("expected PD worker selection"),
         }
+    }
+}
+
+#[cfg(test)]
+mod rate_limit_reserve_tests {
+    use llm_tokenizer::{traits::Tokenizer, MockTokenizer, TokenizerRegistry};
+    use openai_protocol::generate::GenerateRequest;
+    use serde_json::json;
+
+    use super::*;
+    use crate::{config::types::RouterConfig, rate_limit::RateLimitManager, tenant::TenantKey};
+
+    const MODEL: &str = "reserve-test-model";
+
+    async fn test_components() -> Arc<SharedComponents> {
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let tokenizer_registry = Arc::new(TokenizerRegistry::new());
+        let tokenizer = Arc::new(MockTokenizer::new()) as Arc<dyn Tokenizer>;
+        tokenizer_registry
+            .load(
+                "tokenizer-id",
+                MODEL,
+                "test",
+                || async move { Ok(tokenizer) },
+            )
+            .await
+            .unwrap();
+        Arc::new(SharedComponents {
+            tokenizer_registry,
+            worker_registry,
+            tool_parser_factory: ToolParserFactory::default(),
+            reasoning_parser_factory: ReasoningParserFactory::default(),
+            configured_tool_parser: None,
+            configured_reasoning_parser: None,
+            multimodal: None,
+        })
+    }
+
+    /// Real `RateLimitManager` backed by a tiny in-memory budget --
+    /// `RateLimitManager::new` is private to the `rate_limit` module, so
+    /// `from_config` (with a temp YAML) is the only way to build one from
+    /// here. The YAML is read synchronously inside `from_config`, before the
+    /// tempdir is dropped at the end of this function, so no leak is needed.
+    fn manager_with_tokens_per_minute(tpm: u32) -> Arc<RateLimitManager> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rate_limit.yaml");
+        std::fs::write(
+            &path,
+            format!("default_policy:\n  tokens_per_minute: {tpm}\n  requests_per_minute: 1000\n"),
+        )
+        .unwrap();
+        let rc = RouterConfig::builder()
+            .worker_startup_timeout_secs(1)
+            .tenant_rate_limit_enabled(true)
+            .tenant_rate_limit_config(Some(path.to_str().unwrap().to_string()))
+            .build_unchecked();
+        RateLimitManager::from_config(&rc).unwrap().unwrap()
+    }
+
+    fn ctx_with_tokens(components: Arc<SharedComponents>, num_tokens: usize) -> RequestContext {
+        let request: GenerateRequest = serde_json::from_value(json!({
+            "model": MODEL,
+            "text": "Hello"
+        }))
+        .unwrap();
+        let mut ctx =
+            RequestContext::for_generate(Arc::new(request), None, MODEL.to_string(), components);
+        ctx.state.preparation = Some(PreparationOutput::Generate {
+            original_text: None,
+            token_ids: vec![0; num_tokens],
+        });
+        ctx.input.tenant_request_meta = Some(TenantRequestMeta::new(TenantKey::new("test-tenant")));
+        ctx
+    }
+
+    #[tokio::test]
+    async fn reserves_exactly_once_across_retry_attempts() {
+        // Admits one 5-token reservation but not two (5 + 5 > 6).
+        let manager = manager_with_tokens_per_minute(6);
+        let components = test_components().await;
+        let mut ctx = ctx_with_tokens(components, 5);
+        ctx.input.rate_limit_cell = Some(Arc::new(RateLimitCell::new()));
+
+        let stage = RateLimitReserveStage::new(Some(manager));
+
+        // Simulate two retry attempts sharing the same cell, as router.rs does.
+        assert!(
+            stage.execute(&mut ctx).await.unwrap().is_none(),
+            "first attempt should reserve and be admitted"
+        );
+        assert!(
+            stage.execute(&mut ctx).await.unwrap().is_none(),
+            "second attempt should see the cached Admitted outcome and skip reserving again"
+        );
+
+        assert!(matches!(
+            ctx.input.rate_limit_cell.as_ref().unwrap().peek(),
+            Some(RateLimitOutcome::Admitted(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn denial_is_cached_for_should_retry_to_read() {
+        // Too small for even one 5-token reservation.
+        let manager = manager_with_tokens_per_minute(3);
+        let components = test_components().await;
+        let mut ctx = ctx_with_tokens(components, 5);
+        ctx.input.rate_limit_cell = Some(Arc::new(RateLimitCell::new()));
+
+        let stage = RateLimitReserveStage::new(Some(manager));
+
+        let result = stage.execute(&mut ctx).await;
+        let response = result.expect_err("should be denied");
+        assert_eq!(response.status(), http::StatusCode::TOO_MANY_REQUESTS);
+
+        // This is the signal router.rs's `should_retry` reads to stop the
+        // retry loop instead of retrying a rate-limit denial.
+        assert!(matches!(
+            ctx.input.rate_limit_cell.as_ref().unwrap().peek(),
+            Some(RateLimitOutcome::Denied)
+        ));
+    }
+
+    #[tokio::test]
+    async fn disabled_manager_is_a_no_op() {
+        let components = test_components().await;
+        let mut ctx = ctx_with_tokens(components, 5);
+        ctx.input.rate_limit_cell = Some(Arc::new(RateLimitCell::new()));
+
+        let stage = RateLimitReserveStage::new(None);
+        assert!(stage.execute(&mut ctx).await.unwrap().is_none());
+        assert!(ctx.input.rate_limit_cell.as_ref().unwrap().peek().is_none());
+    }
+
+    #[tokio::test]
+    async fn endpoint_without_a_cell_is_a_no_op() {
+        // Responses/embeddings/classify don't set rate_limit_cell today.
+        let manager = manager_with_tokens_per_minute(6);
+        let components = test_components().await;
+        let mut ctx = ctx_with_tokens(components, 5);
+
+        let stage = RateLimitReserveStage::new(Some(manager));
+        assert!(stage.execute(&mut ctx).await.unwrap().is_none());
     }
 }

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -1618,7 +1618,11 @@ mod rate_limit_reserve_tests {
     use serde_json::json;
 
     use super::*;
-    use crate::{config::types::RouterConfig, rate_limit::RateLimitManager, tenant::TenantKey};
+    use crate::{
+        config::types::RouterConfig,
+        rate_limit::{RateLimitManager, Reservation, ReserveRequest},
+        tenant::TenantKey,
+    };
 
     const MODEL: &str = "reserve-test-model";
 
@@ -1751,5 +1755,38 @@ mod rate_limit_reserve_tests {
 
         let stage = RateLimitReserveStage::new(Some(manager));
         assert!(stage.execute(&mut ctx).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn settle_reservation_with_zero_usage_refunds_the_full_estimate() {
+        // Budget 6; reserve 5 leaves 1. A response with no `usage` settles
+        // with 0/0 (see the `usage.map_or(0, ...)` call sites in
+        // execute_chat/execute_generate/etc.) -- that must refund the full
+        // 5-token debit back to the tenant, not silently keep it (nothing
+        // was actually consumed) and not leave the reservation stuck open
+        // (which would leak budget forever).
+        let manager = manager_with_tokens_per_minute(6);
+        let components = test_components().await;
+        let mut ctx = ctx_with_tokens(components, 5);
+        ctx.input.rate_limit_cell = Some(Arc::new(RateLimitCell::new()));
+
+        let stage = RateLimitReserveStage::new(Some(manager.clone()));
+        assert!(stage.execute(&mut ctx).await.unwrap().is_none());
+
+        RequestPipeline::settle_reservation(ctx.input.rate_limit_cell.as_deref(), 0, 0).await;
+
+        // The full 6-token budget must be available again -- would be
+        // denied if settle had kept the original 5-token debit instead of
+        // truing it up to the real (zero) usage.
+        let check = ReserveRequest {
+            request_charge_id: uuid::Uuid::now_v7(),
+            tenant_key: TenantKey::new("test-tenant"),
+            model_id: Some(MODEL.to_string()),
+            estimated_input_tokens: 6,
+        };
+        assert!(matches!(
+            manager.reserve(check).await,
+            Reservation::Admitted(_)
+        ));
     }
 }

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -94,6 +94,10 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
             params.model_id,
             ctx.components.clone(),
             Some(params.tenant_request_meta),
+            // Responses endpoint hasn't opted into tenant rate limiting yet
+            // (out of scope for this phase; see RequestPipeline::build's
+            // stage-insertion comment).
+            None,
         )
         .await;
 
@@ -582,6 +586,8 @@ async fn execute_tool_loop_streaming_internal(
                 params.model_id.clone(),
                 ctx.components.clone(),
                 Some(params.tenant_request_meta.clone()),
+                // Responses endpoint hasn't opted into tenant rate limiting yet.
+                None,
             )
             .await;
 

--- a/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
@@ -9,17 +9,13 @@ use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
 
-use crate::{
-    rate_limit::ReservationAttachment,
-    routers::{
-        error,
-        grpc::{
-            common::stages::{PipelineStage, RateLimitCell},
-            context::{FinalResponse, RequestContext},
-            regular::{processor, streaming},
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::{helpers, PipelineStage, RateLimitCell},
+        context::{FinalResponse, RequestContext},
+        regular::{processor, streaming},
     },
-    worker::AttachedBody,
 };
 
 /// Chat response processing stage
@@ -103,7 +99,8 @@ impl ChatResponseProcessingStage {
 
             // Reserved (if tenant rate limiting is enabled): settled with real
             // usage inside the streaming processor on success, or abandoned
-            // via ReservationAttachment's Drop below on early disconnect/error.
+            // via the attached ReservationAttachment's Drop below on early
+            // disconnect/error.
             let reservation = ctx
                 .input
                 .rate_limit_cell
@@ -122,17 +119,11 @@ impl ChatResponseProcessingStage {
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) to the response body for proper RAII lifecycle.
-            let response = match (ctx.state.load_guards.take(), reservation) {
-                (Some(guards), Some(handle)) => AttachedBody::wrap_response(
-                    response,
-                    (guards, ReservationAttachment::new(handle)),
-                ),
-                (Some(guards), None) => AttachedBody::wrap_response(response, guards),
-                (None, Some(handle)) => {
-                    AttachedBody::wrap_response(response, ReservationAttachment::new(handle))
-                }
-                (None, None) => response,
-            };
+            let response = helpers::attach_response_guards(
+                response,
+                ctx.state.load_guards.take(),
+                reservation,
+            );
 
             return Ok(Some(response));
         }

--- a/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
@@ -10,10 +10,11 @@ use axum::response::Response;
 use tracing::error;
 
 use crate::{
+    rate_limit::ReservationAttachment,
     routers::{
         error,
         grpc::{
-            common::stages::PipelineStage,
+            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
             context::{FinalResponse, RequestContext},
             regular::{processor, streaming},
         },
@@ -100,6 +101,19 @@ impl ChatResponseProcessingStage {
                 .skip_special_tokens
                 .unwrap_or_else(|| ctx.chat_request().skip_special_tokens);
 
+            // Reserved (if tenant rate limiting is enabled): settled with real
+            // usage inside the streaming processor on success, or abandoned
+            // via ReservationAttachment's Drop below on early disconnect/error.
+            let reservation = ctx
+                .input
+                .rate_limit_cell
+                .as_deref()
+                .and_then(RateLimitCell::peek)
+                .and_then(|outcome| match outcome {
+                    RateLimitOutcome::Admitted(handle) => Some(handle),
+                    RateLimitOutcome::Denied => None,
+                });
+
             // Streaming: Use StreamingProcessor and return SSE response
             let response = self.streaming_processor.clone().process_streaming_response(
                 execution_result,
@@ -107,12 +121,21 @@ impl ChatResponseProcessingStage {
                 dispatch,
                 tokenizer,
                 skip_special_tokens,
+                reservation.clone(),
             );
 
-            // Attach load guards to response body for proper RAII lifecycle
-            let response = match ctx.state.load_guards.take() {
-                Some(guards) => AttachedBody::wrap_response(response, guards),
-                None => response,
+            // Attach load guards (and the reservation's disconnect/error
+            // safety net) to the response body for proper RAII lifecycle.
+            let response = match (ctx.state.load_guards.take(), reservation) {
+                (Some(guards), Some(handle)) => AttachedBody::wrap_response(
+                    response,
+                    (guards, ReservationAttachment::new(handle)),
+                ),
+                (Some(guards), None) => AttachedBody::wrap_response(response, guards),
+                (None, Some(handle)) => {
+                    AttachedBody::wrap_response(response, ReservationAttachment::new(handle))
+                }
+                (None, None) => response,
             };
 
             return Ok(Some(response));

--- a/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
@@ -14,7 +14,7 @@ use crate::{
     routers::{
         error,
         grpc::{
-            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
+            common::stages::{PipelineStage, RateLimitCell},
             context::{FinalResponse, RequestContext},
             regular::{processor, streaming},
         },
@@ -108,11 +108,7 @@ impl ChatResponseProcessingStage {
                 .input
                 .rate_limit_cell
                 .as_deref()
-                .and_then(RateLimitCell::peek)
-                .and_then(|outcome| match outcome {
-                    RateLimitOutcome::Admitted(handle) => Some(handle),
-                    RateLimitOutcome::Denied => None,
-                });
+                .and_then(RateLimitCell::take_for_streaming_handoff);
 
             // Streaming: Use StreamingProcessor and return SSE response
             let response = self.streaming_processor.clone().process_streaming_response(

--- a/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
@@ -13,10 +13,11 @@ use axum::response::Response;
 use tracing::error;
 
 use crate::{
+    rate_limit::ReservationAttachment,
     routers::{
         error,
         grpc::{
-            common::stages::PipelineStage,
+            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
             context::{FinalResponse, RequestContext},
             regular::{processor, streaming},
         },
@@ -80,6 +81,19 @@ impl PipelineStage for CompletionResponseProcessingStage {
         })?;
 
         if is_streaming {
+            // Reserved (if tenant rate limiting is enabled): settled with real
+            // usage inside the streaming processor on success, or abandoned
+            // via ReservationAttachment's Drop below on early disconnect/error.
+            let reservation = ctx
+                .input
+                .rate_limit_cell
+                .as_deref()
+                .and_then(RateLimitCell::peek)
+                .and_then(|outcome| match outcome {
+                    RateLimitOutcome::Admitted(handle) => Some(handle),
+                    RateLimitOutcome::Denied => None,
+                });
+
             let response = self
                 .streaming_processor
                 .clone()
@@ -88,11 +102,21 @@ impl PipelineStage for CompletionResponseProcessingStage {
                     ctx.completion_request_arc(),
                     dispatch,
                     tokenizer,
+                    reservation.clone(),
                 );
 
-            let response = match ctx.state.load_guards.take() {
-                Some(guards) => AttachedBody::wrap_response(response, guards),
-                None => response,
+            // Attach load guards (and the reservation's disconnect/error
+            // safety net) to the response body for proper RAII lifecycle.
+            let response = match (ctx.state.load_guards.take(), reservation) {
+                (Some(guards), Some(handle)) => AttachedBody::wrap_response(
+                    response,
+                    (guards, ReservationAttachment::new(handle)),
+                ),
+                (Some(guards), None) => AttachedBody::wrap_response(response, guards),
+                (None, Some(handle)) => {
+                    AttachedBody::wrap_response(response, ReservationAttachment::new(handle))
+                }
+                (None, None) => response,
             };
 
             return Ok(Some(response));

--- a/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
@@ -12,17 +12,13 @@ use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
 
-use crate::{
-    rate_limit::ReservationAttachment,
-    routers::{
-        error,
-        grpc::{
-            common::stages::{PipelineStage, RateLimitCell},
-            context::{FinalResponse, RequestContext},
-            regular::{processor, streaming},
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::{helpers, PipelineStage, RateLimitCell},
+        context::{FinalResponse, RequestContext},
+        regular::{processor, streaming},
     },
-    worker::AttachedBody,
 };
 
 /// Completion response processing stage
@@ -83,7 +79,8 @@ impl PipelineStage for CompletionResponseProcessingStage {
         if is_streaming {
             // Reserved (if tenant rate limiting is enabled): settled with real
             // usage inside the streaming processor on success, or abandoned
-            // via ReservationAttachment's Drop below on early disconnect/error.
+            // via the attached ReservationAttachment's Drop below on early
+            // disconnect/error.
             let reservation = ctx
                 .input
                 .rate_limit_cell
@@ -103,17 +100,11 @@ impl PipelineStage for CompletionResponseProcessingStage {
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) to the response body for proper RAII lifecycle.
-            let response = match (ctx.state.load_guards.take(), reservation) {
-                (Some(guards), Some(handle)) => AttachedBody::wrap_response(
-                    response,
-                    (guards, ReservationAttachment::new(handle)),
-                ),
-                (Some(guards), None) => AttachedBody::wrap_response(response, guards),
-                (None, Some(handle)) => {
-                    AttachedBody::wrap_response(response, ReservationAttachment::new(handle))
-                }
-                (None, None) => response,
-            };
+            let response = helpers::attach_response_guards(
+                response,
+                ctx.state.load_guards.take(),
+                reservation,
+            );
 
             return Ok(Some(response));
         }

--- a/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
@@ -17,7 +17,7 @@ use crate::{
     routers::{
         error,
         grpc::{
-            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
+            common::stages::{PipelineStage, RateLimitCell},
             context::{FinalResponse, RequestContext},
             regular::{processor, streaming},
         },
@@ -88,11 +88,7 @@ impl PipelineStage for CompletionResponseProcessingStage {
                 .input
                 .rate_limit_cell
                 .as_deref()
-                .and_then(RateLimitCell::peek)
-                .and_then(|outcome| match outcome {
-                    RateLimitOutcome::Admitted(handle) => Some(handle),
-                    RateLimitOutcome::Denied => None,
-                });
+                .and_then(RateLimitCell::take_for_streaming_handoff);
 
             let response = self
                 .streaming_processor

--- a/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
@@ -11,7 +11,7 @@ use crate::{
     routers::{
         error,
         grpc::{
-            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
+            common::stages::{PipelineStage, RateLimitCell},
             context::{FinalResponse, RequestContext},
             regular::{processor, streaming},
         },
@@ -101,11 +101,7 @@ impl GenerateResponseProcessingStage {
                 .input
                 .rate_limit_cell
                 .as_deref()
-                .and_then(RateLimitCell::peek)
-                .and_then(|outcome| match outcome {
-                    RateLimitOutcome::Admitted(handle) => Some(handle),
-                    RateLimitOutcome::Denied => None,
-                });
+                .and_then(RateLimitCell::take_for_streaming_handoff);
 
             // Streaming: Use StreamingProcessor and return SSE response
             let response = self.streaming_processor.clone().process_streaming_generate(

--- a/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
@@ -6,17 +6,13 @@ use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
 
-use crate::{
-    rate_limit::ReservationAttachment,
-    routers::{
-        error,
-        grpc::{
-            common::stages::{PipelineStage, RateLimitCell},
-            context::{FinalResponse, RequestContext},
-            regular::{processor, streaming},
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::{helpers, PipelineStage, RateLimitCell},
+        context::{FinalResponse, RequestContext},
+        regular::{processor, streaming},
     },
-    worker::AttachedBody,
 };
 
 /// Generate response processing stage
@@ -96,7 +92,8 @@ impl GenerateResponseProcessingStage {
         if is_streaming {
             // Reserved (if tenant rate limiting is enabled): settled with real
             // usage inside the streaming processor on success, or abandoned
-            // via ReservationAttachment's Drop below on early disconnect/error.
+            // via the attached ReservationAttachment's Drop below on early
+            // disconnect/error.
             let reservation = ctx
                 .input
                 .rate_limit_cell
@@ -114,17 +111,11 @@ impl GenerateResponseProcessingStage {
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) to the response body for proper RAII lifecycle.
-            let response = match (ctx.state.load_guards.take(), reservation) {
-                (Some(guards), Some(handle)) => AttachedBody::wrap_response(
-                    response,
-                    (guards, ReservationAttachment::new(handle)),
-                ),
-                (Some(guards), None) => AttachedBody::wrap_response(response, guards),
-                (None, Some(handle)) => {
-                    AttachedBody::wrap_response(response, ReservationAttachment::new(handle))
-                }
-                (None, None) => response,
-            };
+            let response = helpers::attach_response_guards(
+                response,
+                ctx.state.load_guards.take(),
+                reservation,
+            );
 
             return Ok(Some(response));
         }

--- a/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
@@ -7,10 +7,11 @@ use axum::response::Response;
 use tracing::error;
 
 use crate::{
+    rate_limit::ReservationAttachment,
     routers::{
         error,
         grpc::{
-            common::stages::PipelineStage,
+            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
             context::{FinalResponse, RequestContext},
             regular::{processor, streaming},
         },
@@ -93,18 +94,40 @@ impl GenerateResponseProcessingStage {
         })?;
 
         if is_streaming {
+            // Reserved (if tenant rate limiting is enabled): settled with real
+            // usage inside the streaming processor on success, or abandoned
+            // via ReservationAttachment's Drop below on early disconnect/error.
+            let reservation = ctx
+                .input
+                .rate_limit_cell
+                .as_deref()
+                .and_then(RateLimitCell::peek)
+                .and_then(|outcome| match outcome {
+                    RateLimitOutcome::Admitted(handle) => Some(handle),
+                    RateLimitOutcome::Denied => None,
+                });
+
             // Streaming: Use StreamingProcessor and return SSE response
             let response = self.streaming_processor.clone().process_streaming_generate(
                 execution_result,
                 ctx.generate_request_arc(), // Cheap Arc clone (8 bytes)
                 dispatch,
                 tokenizer,
+                reservation.clone(),
             );
 
-            // Attach load guards to response body for proper RAII lifecycle
-            let response = match ctx.state.load_guards.take() {
-                Some(guards) => AttachedBody::wrap_response(response, guards),
-                None => response,
+            // Attach load guards (and the reservation's disconnect/error
+            // safety net) to the response body for proper RAII lifecycle.
+            let response = match (ctx.state.load_guards.take(), reservation) {
+                (Some(guards), Some(handle)) => AttachedBody::wrap_response(
+                    response,
+                    (guards, ReservationAttachment::new(handle)),
+                ),
+                (Some(guards), None) => AttachedBody::wrap_response(response, guards),
+                (None, Some(handle)) => {
+                    AttachedBody::wrap_response(response, ReservationAttachment::new(handle))
+                }
+                (None, None) => response,
             };
 
             return Ok(Some(response));

--- a/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
@@ -11,10 +11,11 @@ use axum::response::Response;
 use tracing::error;
 
 use crate::{
+    rate_limit::ReservationAttachment,
     routers::{
         error,
         grpc::{
-            common::stages::PipelineStage,
+            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
             context::{FinalResponse, RequestContext},
             regular::{processor, streaming},
         },
@@ -84,6 +85,19 @@ impl PipelineStage for MessageResponseProcessingStage {
             // Read derived skip_special_tokens (set in preparation, survives request_building .take())
             let skip_special_tokens = ctx.state.response.skip_special_tokens.unwrap_or(true);
 
+            // Reserved (if tenant rate limiting is enabled): settled with real
+            // usage inside the streaming processor on success, or abandoned
+            // via ReservationAttachment's Drop below on early disconnect/error.
+            let reservation = ctx
+                .input
+                .rate_limit_cell
+                .as_deref()
+                .and_then(RateLimitCell::peek)
+                .and_then(|outcome| match outcome {
+                    RateLimitOutcome::Admitted(handle) => Some(handle),
+                    RateLimitOutcome::Denied => None,
+                });
+
             // Streaming: use StreamingProcessor and return SSE response
             let response = self
                 .streaming_processor
@@ -94,12 +108,21 @@ impl PipelineStage for MessageResponseProcessingStage {
                     dispatch,
                     tokenizer,
                     skip_special_tokens,
+                    reservation.clone(),
                 );
 
-            // Attach load guards for RAII lifecycle
-            let response = match ctx.state.load_guards.take() {
-                Some(guards) => AttachedBody::wrap_response(response, guards),
-                None => response,
+            // Attach load guards (and the reservation's disconnect/error
+            // safety net) for RAII lifecycle.
+            let response = match (ctx.state.load_guards.take(), reservation) {
+                (Some(guards), Some(handle)) => AttachedBody::wrap_response(
+                    response,
+                    (guards, ReservationAttachment::new(handle)),
+                ),
+                (Some(guards), None) => AttachedBody::wrap_response(response, guards),
+                (None, Some(handle)) => {
+                    AttachedBody::wrap_response(response, ReservationAttachment::new(handle))
+                }
+                (None, None) => response,
             };
 
             return Ok(Some(response));

--- a/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
@@ -15,7 +15,7 @@ use crate::{
     routers::{
         error,
         grpc::{
-            common::stages::{PipelineStage, RateLimitCell, RateLimitOutcome},
+            common::stages::{PipelineStage, RateLimitCell},
             context::{FinalResponse, RequestContext},
             regular::{processor, streaming},
         },
@@ -92,11 +92,7 @@ impl PipelineStage for MessageResponseProcessingStage {
                 .input
                 .rate_limit_cell
                 .as_deref()
-                .and_then(RateLimitCell::peek)
-                .and_then(|outcome| match outcome {
-                    RateLimitOutcome::Admitted(handle) => Some(handle),
-                    RateLimitOutcome::Denied => None,
-                });
+                .and_then(RateLimitCell::take_for_streaming_handoff);
 
             // Streaming: use StreamingProcessor and return SSE response
             let response = self

--- a/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
@@ -10,17 +10,13 @@ use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
 
-use crate::{
-    rate_limit::ReservationAttachment,
-    routers::{
-        error,
-        grpc::{
-            common::stages::{PipelineStage, RateLimitCell},
-            context::{FinalResponse, RequestContext},
-            regular::{processor, streaming},
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::{helpers, PipelineStage, RateLimitCell},
+        context::{FinalResponse, RequestContext},
+        regular::{processor, streaming},
     },
-    worker::AttachedBody,
 };
 
 /// Message response processing stage
@@ -87,7 +83,8 @@ impl PipelineStage for MessageResponseProcessingStage {
 
             // Reserved (if tenant rate limiting is enabled): settled with real
             // usage inside the streaming processor on success, or abandoned
-            // via ReservationAttachment's Drop below on early disconnect/error.
+            // via the attached ReservationAttachment's Drop below on early
+            // disconnect/error.
             let reservation = ctx
                 .input
                 .rate_limit_cell
@@ -109,17 +106,11 @@ impl PipelineStage for MessageResponseProcessingStage {
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) for RAII lifecycle.
-            let response = match (ctx.state.load_guards.take(), reservation) {
-                (Some(guards), Some(handle)) => AttachedBody::wrap_response(
-                    response,
-                    (guards, ReservationAttachment::new(handle)),
-                ),
-                (Some(guards), None) => AttachedBody::wrap_response(response, guards),
-                (None, Some(handle)) => {
-                    AttachedBody::wrap_response(response, ReservationAttachment::new(handle))
-                }
-                (None, None) => response,
-            };
+            let response = helpers::attach_response_guards(
+                response,
+                ctx.state.load_guards.take(),
+                reservation,
+            );
 
             return Ok(Some(response));
         }

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -36,6 +36,7 @@ use tracing::{debug, error, warn};
 
 use crate::{
     observability::metrics::{metrics_labels, Metrics, StreamingMetricsParams},
+    rate_limit::{SharedReservationHandle, UsageSettlement},
     routers::{
         common::sse::SseEncoder,
         grpc::{
@@ -120,6 +121,7 @@ impl StreamingProcessor {
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         skip_special_tokens: bool,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Response {
         use bytes::Bytes;
         use tokio::sync::mpsc;
@@ -154,6 +156,7 @@ impl StreamingProcessor {
                             stop_params,
                             chat_request,
                             &tx,
+                            reservation,
                         )
                         .await;
 
@@ -186,6 +189,7 @@ impl StreamingProcessor {
                             chat_request,
                             &tx,
                             pd_timing,
+                            reservation,
                         )
                         .await;
 
@@ -220,6 +224,7 @@ impl StreamingProcessor {
     }
 
     /// Process streaming chunks from a single stream (Regular mode)
+    #[expect(clippy::too_many_arguments)]
     pub async fn process_streaming_chunks(
         &self,
         grpc_stream: ProtoStream,
@@ -228,6 +233,7 @@ impl StreamingProcessor {
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         self.process_streaming_chunks_inner(
             grpc_stream,
@@ -237,6 +243,7 @@ impl StreamingProcessor {
             original_request,
             tx,
             None,
+            reservation,
         )
         .await
     }
@@ -254,6 +261,7 @@ impl StreamingProcessor {
         original_request: Arc<ChatCompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
         pd_timing: Option<context::PdTiming>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         // Metrics timing
         let start_time = Instant::now();
@@ -698,6 +706,14 @@ impl StreamingProcessor {
         // Record streaming metrics
         let total_prompt: u32 = prompt_tokens.values().sum();
         let total_completion: u32 = completion_tokens.total();
+        if let Some(handle) = reservation {
+            handle
+                .settle_success(UsageSettlement {
+                    actual_input_tokens: total_prompt,
+                    completion_tokens: total_completion,
+                })
+                .await;
+        }
         Metrics::record_streaming_metrics(StreamingMetricsParams {
             router_type: metrics_labels::ROUTER_GRPC,
             backend_type: self.backend_type,
@@ -724,6 +740,7 @@ impl StreamingProcessor {
         original_request: Arc<ChatCompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
         pd_timing: context::PdTiming,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         // Phase 1.5: Collect input_logprobs from prefill stream if requested
         if original_request.logprobs {
@@ -753,6 +770,7 @@ impl StreamingProcessor {
                 original_request,
                 tx,
                 Some(pd_timing),
+                reservation,
             )
             .await;
 
@@ -777,6 +795,7 @@ impl StreamingProcessor {
         generate_request: Arc<GenerateRequest>,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Response {
         // Create SSE channel
         let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
@@ -803,7 +822,8 @@ impl StreamingProcessor {
                 )]
                 tokio::spawn(async move {
                     let result =
-                        Self::process_generate_streaming(tokenizer, stream, ctx, &tx).await;
+                        Self::process_generate_streaming(tokenizer, stream, ctx, &tx, reservation)
+                            .await;
 
                     if let Err(e) = result {
                         utils::send_error_sse(&tx, &e, "internal_error");
@@ -825,7 +845,13 @@ impl StreamingProcessor {
                 )]
                 tokio::spawn(async move {
                     let result = Self::process_generate_prefill_decode_streaming(
-                        tokenizer, prefill, *decode, ctx, &tx, pd_timing,
+                        tokenizer,
+                        prefill,
+                        *decode,
+                        ctx,
+                        &tx,
+                        pd_timing,
+                        reservation,
                     )
                     .await;
 
@@ -866,6 +892,7 @@ impl StreamingProcessor {
         mut stream: ProtoStream,
         ctx: GenerateStreamContext,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         let start_time = Instant::now();
         let mut first_token_time: Option<Instant> = None;
@@ -873,6 +900,8 @@ impl StreamingProcessor {
         // Track state per index for n>1 case
         let mut accumulated_texts: HashMap<u32, String> = HashMap::new();
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
+        // Same prompt for every index; the last Complete's value is as good as any.
+        let mut prompt_tokens: u32 = 0;
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut sse_encoder = SseEncoder::new();
 
@@ -934,6 +963,7 @@ impl StreamingProcessor {
                     let completion_tokens = *completion_tokens_map.get(&index).unwrap_or(&0);
                     let index_id = format!("{}-{}", ctx.request_id, index);
                     let e2e_latency = start_time.elapsed().as_secs_f64();
+                    prompt_tokens = complete.prompt_tokens();
 
                     // Send final chunk with finish_reason
                     let finish_response = serde_json::json!({
@@ -969,6 +999,14 @@ impl StreamingProcessor {
 
         // Record streaming metrics
         let total_completion: u32 = completion_tokens_map.values().sum();
+        if let Some(handle) = reservation {
+            handle
+                .settle_success(UsageSettlement {
+                    actual_input_tokens: prompt_tokens,
+                    completion_tokens: total_completion,
+                })
+                .await;
+        }
         Self::record_generate_metrics(start_time, first_token_time, total_completion, &ctx);
 
         Ok(())
@@ -982,6 +1020,7 @@ impl StreamingProcessor {
         ctx: GenerateStreamContext,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
         pd_timing: context::PdTiming,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         // Collect input_logprobs from prefill stream if requested
         let input_token_logprobs = if ctx.return_logprob {
@@ -1016,6 +1055,7 @@ impl StreamingProcessor {
             input_token_logprobs,
             tx,
             Some(pd_timing),
+            reservation,
         )
         .await;
 
@@ -1036,6 +1076,7 @@ impl StreamingProcessor {
         input_token_logprobs: Option<Vec<Vec<Option<f64>>>>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
         pd_timing: Option<context::PdTiming>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         let start_time = Instant::now();
         let mut first_token_time: Option<Instant> = None;
@@ -1045,6 +1086,8 @@ impl StreamingProcessor {
         let mut accumulated_output_logprobs: HashMap<u32, Option<Vec<Vec<Option<f64>>>>> =
             HashMap::new();
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
+        // Same prompt for every index; the last Complete's value is as good as any.
+        let mut prompt_tokens: u32 = 0;
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut sse_encoder = SseEncoder::new();
 
@@ -1146,6 +1189,7 @@ impl StreamingProcessor {
                         .and_then(|o| o.as_ref());
                     let index_id = format!("{}-{}", ctx.request_id, index);
                     let e2e_latency = start_time.elapsed().as_secs_f64();
+                    prompt_tokens = complete.prompt_tokens();
 
                     // Parse finish_reason
                     let finish_reason = utils::parse_finish_reason(
@@ -1189,6 +1233,14 @@ impl StreamingProcessor {
 
         // Record streaming metrics
         let total_completion: u32 = completion_tokens_map.values().sum();
+        if let Some(handle) = reservation {
+            handle
+                .settle_success(UsageSettlement {
+                    actual_input_tokens: prompt_tokens,
+                    completion_tokens: total_completion,
+                })
+                .await;
+        }
         Self::record_generate_metrics(start_time, first_token_time, total_completion, &ctx);
 
         Ok(())
@@ -1606,6 +1658,7 @@ impl StreamingProcessor {
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
         skip_special_tokens: bool,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Response {
         let stop_params = (
             messages_request
@@ -1638,6 +1691,7 @@ impl StreamingProcessor {
                             stop_params,
                             messages_request,
                             &tx,
+                            reservation,
                         )
                         .await;
 
@@ -1676,6 +1730,7 @@ impl StreamingProcessor {
                             stop_params,
                             messages_request,
                             &tx,
+                            reservation,
                         )
                         .await;
 
@@ -1721,6 +1776,7 @@ impl StreamingProcessor {
     ///
     /// Implements the Anthropic streaming protocol with content block
     /// state tracking. Always n=1 (no per-index HashMap).
+    #[expect(clippy::too_many_arguments)]
     pub async fn process_messages_streaming_chunks(
         &self,
         mut grpc_stream: ProtoStream,
@@ -1729,6 +1785,7 @@ impl StreamingProcessor {
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<CreateMessageRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         let start_time = Instant::now();
         let mut first_token_time: Option<Instant> = None;
@@ -2353,6 +2410,15 @@ impl StreamingProcessor {
         // Mark stream completed
         grpc_stream.mark_completed();
 
+        if let Some(handle) = reservation {
+            handle
+                .settle_success(UsageSettlement {
+                    actual_input_tokens: prompt_tokens,
+                    completion_tokens: completion_tokens.total(),
+                })
+                .await;
+        }
+
         // Record metrics
         Metrics::record_streaming_metrics(StreamingMetricsParams {
             router_type: metrics_labels::ROUTER_GRPC,
@@ -2382,6 +2448,7 @@ impl StreamingProcessor {
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<CreateMessageRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         // Consume prefill stream (Messages API does not expose prompt logprobs)
         while let Some(response) = prefill_stream.next().await {
@@ -2401,6 +2468,7 @@ impl StreamingProcessor {
                 stop_params,
                 original_request,
                 tx,
+                reservation,
             )
             .await;
 
@@ -2427,6 +2495,7 @@ impl StreamingProcessor {
         completion_request: Arc<CompletionRequest>,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
+        reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Response {
         let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
 
@@ -2535,6 +2604,17 @@ impl StreamingProcessor {
                             (Some(current), Some(candidate)) => Some(current.min(candidate)),
                             (current, candidate) => current.or(candidate),
                         };
+                    }
+
+                    // All units succeeded (fail-fast `try_join_all` above), so
+                    // this is the one settle point for every mode (Single/PD/Batch).
+                    if let Some(handle) = &reservation {
+                        handle
+                            .settle_success(UsageSettlement {
+                                actual_input_tokens: total_prompt,
+                                completion_tokens: total_completion,
+                            })
+                            .await;
                     }
 
                     if include_usage {

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -90,6 +90,10 @@ struct GenerateStreamContext {
     return_logprob: bool,
     backend_type: &'static str,
     model: String,
+    /// Number of choices (`sampling_params.n`) this request expects to
+    /// complete -- a clean EOF with fewer `Complete` messages than this has
+    /// only partial usage, not authoritative usage for the whole request.
+    expected_choices: u32,
 }
 
 impl StreamingProcessor {
@@ -681,7 +685,10 @@ impl StreamingProcessor {
         // Phase 5: Usage chunk
         if let Some(stream_opts) = stream_options {
             if stream_opts.include_usage.unwrap_or(false) {
-                let total_prompt: u32 = prompt_tokens.values().sum();
+                // Every `n>1` choice shares one prompt; each Complete reports
+                // that same full length, so max (not sum) is the actual
+                // prompt cost -- summing would multiply it by `n`.
+                let total_prompt: u32 = prompt_tokens.values().copied().max().unwrap_or(0);
                 let total_completion: u32 = completion_tokens.total();
                 let total_cached: u32 = cached_tokens.values().sum();
                 let total_reasoning: u32 = reasoning_tokens.values().sum();
@@ -708,15 +715,16 @@ impl StreamingProcessor {
         grpc_stream.mark_completed();
 
         // Record streaming metrics
-        let total_prompt: u32 = prompt_tokens.values().sum();
+        let total_prompt: u32 = prompt_tokens.values().copied().max().unwrap_or(0);
         let total_completion: u32 = completion_tokens.total();
         if let Some(handle) = reservation {
             // `prompt_tokens` is only ever populated from a `Complete` message
-            // (line ~573 above); a clean EOF that never produced one has no
-            // authoritative usage to settle with -- treating that as "0 input
-            // tokens" would incorrectly refund the reservation's estimate.
+            // (line ~573 above), one entry per index. A clean EOF that didn't
+            // produce one for every expected `n>1` choice has only partial
+            // usage -- settling with that would understate the real cost.
             // Keep the reserved amount as final instead.
-            if prompt_tokens.is_empty() {
+            let expected_choices = original_request.n.unwrap_or(1).max(1);
+            if (prompt_tokens.len() as u32) < expected_choices {
                 handle.close_reserved_only().await;
             } else {
                 handle
@@ -823,6 +831,12 @@ impl StreamingProcessor {
             return_logprob: generate_request.return_logprob.unwrap_or(false),
             backend_type: self.backend_type,
             model: dispatch.model.clone(),
+            expected_choices: generate_request
+                .sampling_params
+                .as_ref()
+                .and_then(|p| p.n)
+                .unwrap_or(1)
+                .max(1),
         };
 
         // Spawn background task based on execution mode
@@ -915,11 +929,10 @@ impl StreamingProcessor {
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
         // Same prompt for every index; the last Complete's value is as good as any.
         let mut prompt_tokens: u32 = 0;
-        // Authoritative usage only ever arrives via a `Complete` message; a
-        // clean EOF without one leaves `prompt_tokens` at its 0 initializer,
-        // which is indistinguishable from a genuinely empty prompt -- track
-        // separately so settle can tell "no usage" from "zero tokens".
-        let mut saw_complete = false;
+        // Indices that received a `Complete` message -- the only source of
+        // authoritative usage. Chunks alone (tracked in `completion_tokens_map`)
+        // don't count: an index can start generating and never finish.
+        let mut completed_indices: HashSet<u32> = HashSet::new();
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut sse_encoder = SseEncoder::new();
 
@@ -982,7 +995,7 @@ impl StreamingProcessor {
                     let index_id = format!("{}-{}", ctx.request_id, index);
                     let e2e_latency = start_time.elapsed().as_secs_f64();
                     prompt_tokens = complete.prompt_tokens();
-                    saw_complete = true;
+                    completed_indices.insert(index);
 
                     // Send final chunk with finish_reason
                     let finish_response = serde_json::json!({
@@ -1019,7 +1032,7 @@ impl StreamingProcessor {
         // Record streaming metrics
         let total_completion: u32 = completion_tokens_map.values().sum();
         if let Some(handle) = reservation {
-            if saw_complete {
+            if completed_indices.len() as u32 >= ctx.expected_choices {
                 handle
                     .settle_success(UsageSettlement {
                         actual_input_tokens: prompt_tokens,
@@ -1111,11 +1124,10 @@ impl StreamingProcessor {
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
         // Same prompt for every index; the last Complete's value is as good as any.
         let mut prompt_tokens: u32 = 0;
-        // Authoritative usage only ever arrives via a `Complete` message; a
-        // clean EOF without one leaves `prompt_tokens` at its 0 initializer,
-        // which is indistinguishable from a genuinely empty prompt -- track
-        // separately so settle can tell "no usage" from "zero tokens".
-        let mut saw_complete = false;
+        // Indices that received a `Complete` message -- the only source of
+        // authoritative usage. Chunks alone (tracked in `completion_tokens_map`)
+        // don't count: an index can start generating and never finish.
+        let mut completed_indices: HashSet<u32> = HashSet::new();
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut sse_encoder = SseEncoder::new();
 
@@ -1218,7 +1230,7 @@ impl StreamingProcessor {
                     let index_id = format!("{}-{}", ctx.request_id, index);
                     let e2e_latency = start_time.elapsed().as_secs_f64();
                     prompt_tokens = complete.prompt_tokens();
-                    saw_complete = true;
+                    completed_indices.insert(index);
 
                     // Parse finish_reason
                     let finish_reason = utils::parse_finish_reason(
@@ -1263,7 +1275,7 @@ impl StreamingProcessor {
         // Record streaming metrics
         let total_completion: u32 = completion_tokens_map.values().sum();
         if let Some(handle) = reservation {
-            if saw_complete {
+            if completed_indices.len() as u32 >= ctx.expected_choices {
                 handle
                     .settle_success(UsageSettlement {
                         actual_input_tokens: prompt_tokens,
@@ -2785,7 +2797,6 @@ impl StreamingProcessor {
         let mut total_cached = 0u32;
         let mut reasoning_tokens: HashMap<u32, u32> = HashMap::new();
         let mut total_completion = CompletionTokenTracker::new();
-        let mut saw_complete = false;
 
         while let Some(response) = grpc_stream.next().await {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
@@ -2903,7 +2914,6 @@ impl StreamingProcessor {
                 }
                 ProtoResponseVariant::Complete(complete) => {
                     let index = index_offset + complete.index();
-                    saw_complete = true;
                     total_prompt = total_prompt.max(complete.prompt_tokens());
                     total_cached = total_cached.max(complete.cached_tokens());
                     reasoning_tokens.insert(index, complete.reasoning_tokens());
@@ -3031,6 +3041,14 @@ impl StreamingProcessor {
         }
 
         grpc_stream.mark_completed();
+
+        // `reasoning_tokens` is populated once per index, only from a
+        // `Complete` message -- its length is exactly the number of this
+        // unit's `n>1` choices that actually finished cleanly. A clean EOF
+        // partway through (some choices completed, others didn't) must not
+        // be treated as full usage.
+        let expected_choices = completion_request.n.unwrap_or(1).max(1);
+        let saw_complete = reasoning_tokens.len() as u32 >= expected_choices;
 
         Ok(CompletionStreamOutcome {
             prompt_tokens: total_prompt,

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -67,9 +67,10 @@ struct CompletionStreamOutcome {
     reasoning_tokens: u32,
     completion_tokens: u32,
     first_token_time: Option<Instant>,
-    /// Whether a `Complete` message (the only source of authoritative usage)
-    /// was ever seen for this unit -- a clean EOF without one leaves
-    /// `prompt_tokens` at 0, indistinguishable from a genuinely empty prompt.
+    /// Whether *every* expected `n>1` choice in this unit received a
+    /// `Complete` message (the only source of authoritative usage) -- a
+    /// clean EOF partway through leaves this `false` even if some choices
+    /// did complete, so a partial result is never mistaken for full usage.
     saw_complete: bool,
 }
 
@@ -2799,6 +2800,12 @@ impl StreamingProcessor {
         let mut total_cached = 0u32;
         let mut reasoning_tokens: HashMap<u32, u32> = HashMap::new();
         let mut total_completion = CompletionTokenTracker::new();
+        // Indices that received a `Complete` message -- tracked separately
+        // from `reasoning_tokens` (which exists for a different purpose and
+        // only incidentally gets exactly one insert per completed index
+        // today) so the completeness gate below doesn't silently break if
+        // that insert behavior ever changes.
+        let mut completed_indices: HashSet<u32> = HashSet::new();
 
         while let Some(response) = grpc_stream.next().await {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
@@ -2916,6 +2923,7 @@ impl StreamingProcessor {
                 }
                 ProtoResponseVariant::Complete(complete) => {
                     let index = index_offset + complete.index();
+                    completed_indices.insert(index);
                     total_prompt = total_prompt.max(complete.prompt_tokens());
                     total_cached = total_cached.max(complete.cached_tokens());
                     reasoning_tokens.insert(index, complete.reasoning_tokens());
@@ -3044,13 +3052,12 @@ impl StreamingProcessor {
 
         grpc_stream.mark_completed();
 
-        // `reasoning_tokens` is populated once per index, only from a
-        // `Complete` message -- its length is exactly the number of this
-        // unit's `n>1` choices that actually finished cleanly. A clean EOF
-        // partway through (some choices completed, others didn't) must not
-        // be treated as full usage.
+        // `completed_indices` counts distinct indices that finished cleanly
+        // via a `Complete` message. A clean EOF partway through this unit's
+        // `n>1` choices (some completed, others didn't) must not be treated
+        // as full usage.
         let expected_choices = completion_request.n.unwrap_or(1).max(1);
-        let saw_complete = reasoning_tokens.len() as u32 >= expected_choices;
+        let saw_complete = completed_indices.len() as u32 >= expected_choices;
 
         Ok(CompletionStreamOutcome {
             prompt_tokens: total_prompt,

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -67,6 +67,10 @@ struct CompletionStreamOutcome {
     reasoning_tokens: u32,
     completion_tokens: u32,
     first_token_time: Option<Instant>,
+    /// Whether a `Complete` message (the only source of authoritative usage)
+    /// was ever seen for this unit -- a clean EOF without one leaves
+    /// `prompt_tokens` at 0, indistinguishable from a genuinely empty prompt.
+    saw_complete: bool,
 }
 
 /// Shared streaming processor for both single and prefill/decode dispatch modes
@@ -707,12 +711,21 @@ impl StreamingProcessor {
         let total_prompt: u32 = prompt_tokens.values().sum();
         let total_completion: u32 = completion_tokens.total();
         if let Some(handle) = reservation {
-            handle
-                .settle_success(UsageSettlement {
-                    actual_input_tokens: total_prompt,
-                    completion_tokens: total_completion,
-                })
-                .await;
+            // `prompt_tokens` is only ever populated from a `Complete` message
+            // (line ~573 above); a clean EOF that never produced one has no
+            // authoritative usage to settle with -- treating that as "0 input
+            // tokens" would incorrectly refund the reservation's estimate.
+            // Keep the reserved amount as final instead.
+            if prompt_tokens.is_empty() {
+                handle.close_reserved_only().await;
+            } else {
+                handle
+                    .settle_success(UsageSettlement {
+                        actual_input_tokens: total_prompt,
+                        completion_tokens: total_completion,
+                    })
+                    .await;
+            }
         }
         Metrics::record_streaming_metrics(StreamingMetricsParams {
             router_type: metrics_labels::ROUTER_GRPC,
@@ -902,6 +915,11 @@ impl StreamingProcessor {
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
         // Same prompt for every index; the last Complete's value is as good as any.
         let mut prompt_tokens: u32 = 0;
+        // Authoritative usage only ever arrives via a `Complete` message; a
+        // clean EOF without one leaves `prompt_tokens` at its 0 initializer,
+        // which is indistinguishable from a genuinely empty prompt -- track
+        // separately so settle can tell "no usage" from "zero tokens".
+        let mut saw_complete = false;
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut sse_encoder = SseEncoder::new();
 
@@ -964,6 +982,7 @@ impl StreamingProcessor {
                     let index_id = format!("{}-{}", ctx.request_id, index);
                     let e2e_latency = start_time.elapsed().as_secs_f64();
                     prompt_tokens = complete.prompt_tokens();
+                    saw_complete = true;
 
                     // Send final chunk with finish_reason
                     let finish_response = serde_json::json!({
@@ -1000,12 +1019,16 @@ impl StreamingProcessor {
         // Record streaming metrics
         let total_completion: u32 = completion_tokens_map.values().sum();
         if let Some(handle) = reservation {
-            handle
-                .settle_success(UsageSettlement {
-                    actual_input_tokens: prompt_tokens,
-                    completion_tokens: total_completion,
-                })
-                .await;
+            if saw_complete {
+                handle
+                    .settle_success(UsageSettlement {
+                        actual_input_tokens: prompt_tokens,
+                        completion_tokens: total_completion,
+                    })
+                    .await;
+            } else {
+                handle.close_reserved_only().await;
+            }
         }
         Self::record_generate_metrics(start_time, first_token_time, total_completion, &ctx);
 
@@ -1088,6 +1111,11 @@ impl StreamingProcessor {
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
         // Same prompt for every index; the last Complete's value is as good as any.
         let mut prompt_tokens: u32 = 0;
+        // Authoritative usage only ever arrives via a `Complete` message; a
+        // clean EOF without one leaves `prompt_tokens` at its 0 initializer,
+        // which is indistinguishable from a genuinely empty prompt -- track
+        // separately so settle can tell "no usage" from "zero tokens".
+        let mut saw_complete = false;
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut sse_encoder = SseEncoder::new();
 
@@ -1190,6 +1218,7 @@ impl StreamingProcessor {
                     let index_id = format!("{}-{}", ctx.request_id, index);
                     let e2e_latency = start_time.elapsed().as_secs_f64();
                     prompt_tokens = complete.prompt_tokens();
+                    saw_complete = true;
 
                     // Parse finish_reason
                     let finish_reason = utils::parse_finish_reason(
@@ -1234,12 +1263,16 @@ impl StreamingProcessor {
         // Record streaming metrics
         let total_completion: u32 = completion_tokens_map.values().sum();
         if let Some(handle) = reservation {
-            handle
-                .settle_success(UsageSettlement {
-                    actual_input_tokens: prompt_tokens,
-                    completion_tokens: total_completion,
-                })
-                .await;
+            if saw_complete {
+                handle
+                    .settle_success(UsageSettlement {
+                        actual_input_tokens: prompt_tokens,
+                        completion_tokens: total_completion,
+                    })
+                    .await;
+            } else {
+                handle.close_reserved_only().await;
+            }
         }
         Self::record_generate_metrics(start_time, first_token_time, total_completion, &ctx);
 
@@ -1825,6 +1858,11 @@ impl StreamingProcessor {
         // Token tracking
         let mut completion_tokens = CompletionTokenTracker::new();
         let mut prompt_tokens: u32 = 0;
+        // Authoritative usage only ever arrives via a `Complete` message; a
+        // clean EOF without one leaves `prompt_tokens` at its 0 initializer,
+        // which is indistinguishable from a genuinely empty prompt -- track
+        // separately so settle can tell "no usage" from "zero tokens".
+        let mut saw_complete = false;
         let mut finish_reason_str = String::new();
         let mut matched_stop: Option<Value> = None;
         // Set once the local stop decoder fires: pins "stop" and ignores later
@@ -2257,6 +2295,7 @@ impl StreamingProcessor {
                     }
 
                     prompt_tokens = complete.prompt_tokens();
+                    saw_complete = true;
                     completion_tokens.record_complete(&complete);
                     // A local stop-decoder match already pinned "stop"; don't let
                     // the engine's finish reason overwrite it.
@@ -2411,12 +2450,16 @@ impl StreamingProcessor {
         grpc_stream.mark_completed();
 
         if let Some(handle) = reservation {
-            handle
-                .settle_success(UsageSettlement {
-                    actual_input_tokens: prompt_tokens,
-                    completion_tokens: completion_tokens.total(),
-                })
-                .await;
+            if saw_complete {
+                handle
+                    .settle_success(UsageSettlement {
+                        actual_input_tokens: prompt_tokens,
+                        completion_tokens: completion_tokens.total(),
+                    })
+                    .await;
+            } else {
+                handle.close_reserved_only().await;
+            }
         }
 
         // Record metrics
@@ -2595,11 +2638,13 @@ impl StreamingProcessor {
                     let mut total_reasoning = 0u32;
                     let mut total_completion = 0u32;
                     let mut first_token_time: Option<Instant> = None;
+                    let mut all_saw_complete = true;
                     for outcome in outcomes {
                         total_prompt += outcome.prompt_tokens;
                         total_cached += outcome.cached_tokens;
                         total_reasoning += outcome.reasoning_tokens;
                         total_completion += outcome.completion_tokens;
+                        all_saw_complete &= outcome.saw_complete;
                         first_token_time = match (first_token_time, outcome.first_token_time) {
                             (Some(current), Some(candidate)) => Some(current.min(candidate)),
                             (current, candidate) => current.or(candidate),
@@ -2608,13 +2653,21 @@ impl StreamingProcessor {
 
                     // All units succeeded (fail-fast `try_join_all` above), so
                     // this is the one settle point for every mode (Single/PD/Batch).
+                    // But a unit that never saw a `Complete` message has no
+                    // authoritative usage to contribute -- settling the
+                    // aggregate anyway would understate total_prompt/total_completion
+                    // and incorrectly refund part of the reservation.
                     if let Some(handle) = &reservation {
-                        handle
-                            .settle_success(UsageSettlement {
-                                actual_input_tokens: total_prompt,
-                                completion_tokens: total_completion,
-                            })
-                            .await;
+                        if all_saw_complete {
+                            handle
+                                .settle_success(UsageSettlement {
+                                    actual_input_tokens: total_prompt,
+                                    completion_tokens: total_completion,
+                                })
+                                .await;
+                        } else {
+                            handle.close_reserved_only().await;
+                        }
                     }
 
                     if include_usage {
@@ -2732,6 +2785,7 @@ impl StreamingProcessor {
         let mut total_cached = 0u32;
         let mut reasoning_tokens: HashMap<u32, u32> = HashMap::new();
         let mut total_completion = CompletionTokenTracker::new();
+        let mut saw_complete = false;
 
         while let Some(response) = grpc_stream.next().await {
             let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
@@ -2849,6 +2903,7 @@ impl StreamingProcessor {
                 }
                 ProtoResponseVariant::Complete(complete) => {
                     let index = index_offset + complete.index();
+                    saw_complete = true;
                     total_prompt = total_prompt.max(complete.prompt_tokens());
                     total_cached = total_cached.max(complete.cached_tokens());
                     reasoning_tokens.insert(index, complete.reasoning_tokens());
@@ -2983,6 +3038,7 @@ impl StreamingProcessor {
             reasoning_tokens: reasoning_tokens.values().sum(),
             completion_tokens: total_completion.total(),
             first_token_time,
+            saw_complete,
         })
     }
 

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -687,10 +687,12 @@ impl StreamingProcessor {
             if stream_opts.include_usage.unwrap_or(false) {
                 // Every `n>1` choice shares one prompt; each Complete reports
                 // that same full length, so max (not sum) is the actual
-                // prompt cost -- summing would multiply it by `n`.
+                // prompt cost -- summing would multiply it by `n`. cached_tokens
+                // is a property of that same shared prompt, not of the
+                // individual completion, so it takes the same treatment.
                 let total_prompt: u32 = prompt_tokens.values().copied().max().unwrap_or(0);
                 let total_completion: u32 = completion_tokens.total();
-                let total_cached: u32 = cached_tokens.values().sum();
+                let total_cached: u32 = cached_tokens.values().copied().max().unwrap_or(0);
                 let total_reasoning: u32 = reasoning_tokens.values().sum();
 
                 let usage_chunk = ChatCompletionStreamResponse::builder(request_id, model)

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -21,8 +21,11 @@ use serde_json::json;
 use tracing::debug;
 
 use super::{
-    common::responses::{
-        handlers::cancel_response_impl, utils::validate_worker_availability, ResponsesContext,
+    common::{
+        responses::{
+            handlers::cancel_response_impl, utils::validate_worker_availability, ResponsesContext,
+        },
+        stages::{RateLimitCell, RateLimitOutcome},
     },
     context::SharedComponents,
     harmony::{serve_harmony_responses, serve_harmony_responses_stream, HarmonyDetector},
@@ -364,9 +367,16 @@ impl GrpcRouter {
             reasoning_parser_factory.clone(),
             ctx.configured_tool_parser.clone(),
             ctx.configured_reasoning_parser.clone(),
+            ctx.rate_limit_manager.clone(),
         );
         // Deps for the parser-free endpoints (completion/embeddings/classify).
-        let pair_deps = PipelineDeps::pair(worker_registry.clone(), policy_registry.clone());
+        // Only completion's stage list actually reads `rate_limit_manager`;
+        // embeddings/classify never insert `RateLimitReserveStage`.
+        let pair_deps = PipelineDeps::pair(
+            worker_registry.clone(),
+            policy_registry.clone(),
+            ctx.rate_limit_manager.clone(),
+        );
 
         // Present in every mode: chat/generate, messages, completion.
         let pipeline = RequestPipeline::build(Endpoint::Chat, mode, &configured_deps)
@@ -479,6 +489,22 @@ impl GrpcRouter {
         }
     }
 
+    /// Close a reservation that a non-2xx final response never got the
+    /// chance to settle (prep failure repeated across every attempt,
+    /// retries exhausted, a non-retryable dispatch failure). No-op if
+    /// nothing was ever reserved. Safe to call unconditionally alongside a
+    /// success path's own inline `settle_success`/streaming `settle_success`+
+    /// `ReservationAttachment` -- `close_reserved_only` is CAS-guarded, only
+    /// the first resolution of a handle wins.
+    async fn close_reservation_if_unsettled(cell: &RateLimitCell, status: StatusCode) {
+        if status.is_success() {
+            return;
+        }
+        if let Some(RateLimitOutcome::Admitted(handle)) = cell.peek() {
+            handle.close_reserved_only().await;
+        }
+    }
+
     /// Main route_chat implementation
     async fn route_chat_impl(
         &self,
@@ -512,10 +538,11 @@ impl GrpcRouter {
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
+        let rate_limit_cell = Arc::new(RateLimitCell::new());
 
         let retry_config = self.resolve_retry_config(model_id);
 
-        RetryExecutor::execute_response_with_retry(
+        let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
             // Operation: execute pipeline (creates fresh context each attempt)
             |_attempt| {
@@ -524,14 +551,29 @@ impl GrpcRouter {
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
                 let tenant_meta = tenant_meta_cloned.clone();
+                let rate_limit_cell = Arc::clone(&rate_limit_cell);
                 async move {
                     pipeline
-                        .execute_chat(request, headers, model_id, components, Some(tenant_meta))
+                        .execute_chat(
+                            request,
+                            headers,
+                            model_id,
+                            components,
+                            Some(tenant_meta),
+                            Some(rate_limit_cell),
+                        )
                         .await
                 }
             },
-            // Should retry: check if status is retryable
-            |res, _attempt| is_retryable_status(res.status()),
+            // Should retry: a rate-limit denial must never be retried
+            // (retrying immediately against the same tenant budget defeats
+            // retry_after_secs); otherwise check if status is retryable.
+            |res, _attempt| {
+                if matches!(rate_limit_cell.peek(), Some(RateLimitOutcome::Denied)) {
+                    return false;
+                }
+                is_retryable_status(res.status())
+            },
             // On backoff: record retry metrics
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_CHAT);
@@ -542,7 +584,10 @@ impl GrpcRouter {
                 self.record_retries_exhausted(metrics_labels::ENDPOINT_CHAT);
             },
         )
-        .await
+        .await;
+
+        Self::close_reservation_if_unsettled(&rate_limit_cell, response.status()).await;
+        response
     }
 
     /// Main route_generate implementation
@@ -562,10 +607,11 @@ impl GrpcRouter {
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.pipeline;
+        let rate_limit_cell = Arc::new(RateLimitCell::new());
 
         let retry_config = self.resolve_retry_config(model_id);
 
-        RetryExecutor::execute_response_with_retry(
+        let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
             // Operation: execute pipeline (creates fresh context each attempt)
             |_attempt| {
@@ -574,14 +620,27 @@ impl GrpcRouter {
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
                 let tenant_meta = tenant_meta_cloned.clone();
+                let rate_limit_cell = Arc::clone(&rate_limit_cell);
                 async move {
                     pipeline
-                        .execute_generate(request, headers, model_id, components, Some(tenant_meta))
+                        .execute_generate(
+                            request,
+                            headers,
+                            model_id,
+                            components,
+                            Some(tenant_meta),
+                            Some(rate_limit_cell),
+                        )
                         .await
                 }
             },
-            // Should retry: check if status is retryable
-            |res, _attempt| is_retryable_status(res.status()),
+            // Should retry: a rate-limit denial must never be retried; see route_chat_impl.
+            |res, _attempt| {
+                if matches!(rate_limit_cell.peek(), Some(RateLimitOutcome::Denied)) {
+                    return false;
+                }
+                is_retryable_status(res.status())
+            },
             // On backoff: record retry metrics
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_GENERATE);
@@ -592,7 +651,10 @@ impl GrpcRouter {
                 self.record_retries_exhausted(metrics_labels::ENDPOINT_GENERATE);
             },
         )
-        .await
+        .await;
+
+        Self::close_reservation_if_unsettled(&rate_limit_cell, response.status()).await;
+        response
     }
 
     /// Main route_responses implementation
@@ -709,10 +771,11 @@ impl GrpcRouter {
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.messages_pipeline;
+        let rate_limit_cell = Arc::new(RateLimitCell::new());
 
         let retry_config = self.resolve_retry_config(model_id);
 
-        RetryExecutor::execute_response_with_retry(
+        let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
             |_attempt| {
                 let request = Arc::clone(&request);
@@ -720,13 +783,27 @@ impl GrpcRouter {
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
                 let tenant_meta = tenant_meta_cloned.clone();
+                let rate_limit_cell = Arc::clone(&rate_limit_cell);
                 async move {
                     pipeline
-                        .execute_messages(request, headers, model_id, components, Some(tenant_meta))
+                        .execute_messages(
+                            request,
+                            headers,
+                            model_id,
+                            components,
+                            Some(tenant_meta),
+                            Some(rate_limit_cell),
+                        )
                         .await
                 }
             },
-            |res, _attempt| is_retryable_status(res.status()),
+            // Should retry: a rate-limit denial must never be retried; see route_chat_impl.
+            |res, _attempt| {
+                if matches!(rate_limit_cell.peek(), Some(RateLimitOutcome::Denied)) {
+                    return false;
+                }
+                is_retryable_status(res.status())
+            },
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_MESSAGES);
                 Metrics::record_worker_retry_backoff(attempt, delay);
@@ -735,7 +812,10 @@ impl GrpcRouter {
                 self.record_retries_exhausted(metrics_labels::ENDPOINT_MESSAGES);
             },
         )
-        .await
+        .await;
+
+        Self::close_reservation_if_unsettled(&rate_limit_cell, response.status()).await;
+        response
     }
 
     /// Main route_completion implementation
@@ -754,10 +834,11 @@ impl GrpcRouter {
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.completion_pipeline;
+        let rate_limit_cell = Arc::new(RateLimitCell::new());
 
         let retry_config = self.resolve_retry_config(model_id);
 
-        RetryExecutor::execute_response_with_retry(
+        let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
             |_attempt| {
                 let request = Arc::clone(&request);
@@ -765,6 +846,7 @@ impl GrpcRouter {
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
                 let tenant_meta = tenant_meta_cloned.clone();
+                let rate_limit_cell = Arc::clone(&rate_limit_cell);
                 async move {
                     pipeline
                         .execute_completion(
@@ -773,11 +855,18 @@ impl GrpcRouter {
                             model_id,
                             components,
                             Some(tenant_meta),
+                            Some(rate_limit_cell),
                         )
                         .await
                 }
             },
-            |res, _attempt| is_retryable_status(res.status()),
+            // Should retry: a rate-limit denial must never be retried; see route_chat_impl.
+            |res, _attempt| {
+                if matches!(rate_limit_cell.peek(), Some(RateLimitOutcome::Denied)) {
+                    return false;
+                }
+                is_retryable_status(res.status())
+            },
             |delay, attempt| {
                 self.record_retry(metrics_labels::ENDPOINT_COMPLETIONS);
                 Metrics::record_worker_retry_backoff(attempt, delay);
@@ -786,7 +875,10 @@ impl GrpcRouter {
                 self.record_retries_exhausted(metrics_labels::ENDPOINT_COMPLETIONS);
             },
         )
-        .await
+        .await;
+
+        Self::close_reservation_if_unsettled(&rate_limit_cell, response.status()).await;
+        response
     }
 
     /// Main route_classify implementation

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -461,6 +461,21 @@ impl GrpcRouter {
             .unwrap_or_else(|| self.retry_config.clone())
     }
 
+    /// Resolve `model_id` to its canonical form once, before a retry loop
+    /// starts. Every dispatch attempt for that logical request must reuse
+    /// this same value -- re-resolving the alias fresh per attempt (as
+    /// `RequestContext::new` otherwise would) lets an alias repointed
+    /// mid-retry dispatch a different model than whatever the tenant
+    /// rate-limit reservation was actually made for, bypassing that model's
+    /// own policy and settling its usage against the wrong budget.
+    fn resolve_canonical_model_id(&self, model_id: &str) -> String {
+        self.worker_registry
+            .resolve_model_alias(model_id)
+            .as_deref()
+            .unwrap_or(model_id)
+            .to_string()
+    }
+
     /// Retry metrics for one backoff, labeled per mode: Regular emits a single
     /// `regular` worker label; PD/EPD emit `prefill` and `decode` (never
     /// `encode`).
@@ -532,15 +547,18 @@ impl GrpcRouter {
             _ => &self.pipeline,
         };
 
-        // Clone values needed for retry closure
+        // Clone values needed for retry closure. Canonicalize once, up
+        // front, so every attempt (and the reservation `RateLimitReserveStage`
+        // makes on the first one) targets the same model -- see
+        // `resolve_canonical_model_id`'s doc comment.
         let request = Arc::new(body.clone());
         let headers_cloned = headers.cloned();
-        let model_id_cloned = model_id.to_string();
+        let model_id_cloned = self.resolve_canonical_model_id(model_id);
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let rate_limit_cell = Arc::new(RateLimitCell::new());
 
-        let retry_config = self.resolve_retry_config(model_id);
+        let retry_config = self.resolve_retry_config(&model_id_cloned);
 
         let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
@@ -600,16 +618,17 @@ impl GrpcRouter {
     ) -> Response {
         debug!("Processing generate request for model: {}", model_id);
 
-        // Clone values needed for retry closure
+        // Clone values needed for retry closure. Canonicalize once, up
+        // front -- see `resolve_canonical_model_id`'s doc comment.
         let request = Arc::new(body.clone());
         let headers_cloned = headers.cloned();
-        let model_id_cloned = model_id.to_string();
+        let model_id_cloned = self.resolve_canonical_model_id(model_id);
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.pipeline;
         let rate_limit_cell = Arc::new(RateLimitCell::new());
 
-        let retry_config = self.resolve_retry_config(model_id);
+        let retry_config = self.resolve_retry_config(&model_id_cloned);
 
         let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
@@ -764,16 +783,17 @@ impl GrpcRouter {
     ) -> Response {
         debug!("Processing messages request for model: {}", model_id);
 
-        // Clone values needed for retry closure
+        // Clone values needed for retry closure. Canonicalize once, up
+        // front -- see `resolve_canonical_model_id`'s doc comment.
         let request = Arc::new(body.clone());
         let headers_cloned = headers.cloned();
-        let model_id_cloned = model_id.to_string();
+        let model_id_cloned = self.resolve_canonical_model_id(model_id);
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.messages_pipeline;
         let rate_limit_cell = Arc::new(RateLimitCell::new());
 
-        let retry_config = self.resolve_retry_config(model_id);
+        let retry_config = self.resolve_retry_config(&model_id_cloned);
 
         let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
@@ -828,15 +848,17 @@ impl GrpcRouter {
     ) -> Response {
         debug!("Processing completion request for model: {}", model_id);
 
+        // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
+        // doc comment.
         let request = Arc::new(body.clone());
         let headers_cloned = headers.cloned();
-        let model_id_cloned = model_id.to_string();
+        let model_id_cloned = self.resolve_canonical_model_id(model_id);
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.completion_pipeline;
         let rate_limit_cell = Arc::new(RateLimitCell::new());
 
-        let retry_config = self.resolve_retry_config(model_id);
+        let retry_config = self.resolve_retry_config(&model_id_cloned);
 
         let response = RetryExecutor::execute_response_with_retry(
             &retry_config,

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -550,10 +550,16 @@ impl GrpcRouter {
         // Clone values needed for retry closure. Canonicalize once, up
         // front, so every attempt (and the reservation `RateLimitReserveStage`
         // makes on the first one) targets the same model -- see
-        // `resolve_canonical_model_id`'s doc comment.
-        let request = Arc::new(body.clone());
-        let headers_cloned = headers.cloned();
+        // `resolve_canonical_model_id`'s doc comment. The body's own `model`
+        // field is rewritten to match: by this point `model_id_cloned` is
+        // already canonical, so `RequestContext::new`'s own alias resolve
+        // would no-op and otherwise leave the alias sitting in the body for
+        // response metadata and parser selection to read.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
+        let mut canonical_body = body.clone();
+        canonical_body.model = model_id_cloned.clone();
+        let request = Arc::new(canonical_body);
+        let headers_cloned = headers.cloned();
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let rate_limit_cell = Arc::new(RateLimitCell::new());
@@ -619,10 +625,13 @@ impl GrpcRouter {
         debug!("Processing generate request for model: {}", model_id);
 
         // Clone values needed for retry closure. Canonicalize once, up
-        // front -- see `resolve_canonical_model_id`'s doc comment.
-        let request = Arc::new(body.clone());
-        let headers_cloned = headers.cloned();
+        // front -- see `resolve_canonical_model_id`'s doc comment. Rewrite
+        // the body's `model` field to match; see `route_chat_impl`.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
+        let mut canonical_body = body.clone();
+        canonical_body.model = model_id_cloned.clone();
+        let request = Arc::new(canonical_body);
+        let headers_cloned = headers.cloned();
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.pipeline;
@@ -784,10 +793,13 @@ impl GrpcRouter {
         debug!("Processing messages request for model: {}", model_id);
 
         // Clone values needed for retry closure. Canonicalize once, up
-        // front -- see `resolve_canonical_model_id`'s doc comment.
-        let request = Arc::new(body.clone());
-        let headers_cloned = headers.cloned();
+        // front -- see `resolve_canonical_model_id`'s doc comment. Rewrite
+        // the body's `model` field to match; see `route_chat_impl`.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
+        let mut canonical_body = body.clone();
+        canonical_body.model = model_id_cloned.clone();
+        let request = Arc::new(canonical_body);
+        let headers_cloned = headers.cloned();
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.messages_pipeline;
@@ -849,10 +861,13 @@ impl GrpcRouter {
         debug!("Processing completion request for model: {}", model_id);
 
         // Canonicalize once, up front -- see `resolve_canonical_model_id`'s
-        // doc comment.
-        let request = Arc::new(body.clone());
-        let headers_cloned = headers.cloned();
+        // doc comment. Rewrite the body's `model` field to match; see
+        // `route_chat_impl`.
         let model_id_cloned = self.resolve_canonical_model_id(model_id);
+        let mut canonical_body = body.clone();
+        canonical_body.model = model_id_cloned.clone();
+        let request = Arc::new(canonical_body);
+        let headers_cloned = headers.cloned();
         let components = self.shared_components.clone();
         let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.completion_pipeline;

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -449,16 +449,23 @@ impl GrpcRouter {
     /// default. Applied at every retrying endpoint
     /// (chat/generate/messages/completion) in every mode.
     ///
-    /// Resolves the alias itself. Retry overrides are keyed by canonical model
-    /// ID, and this runs before the pipeline canonicalizes in
-    /// `RequestContext::new`, so an alias would miss the override and fall
-    /// back to the router default without saying so.
-    fn resolve_retry_config(&self, model_id: &str) -> RetryConfig {
-        let canonical_model = self.worker_registry.resolve_model_alias(model_id);
-        let model_id = canonical_model.as_deref().unwrap_or(model_id);
+    /// Retry overrides are keyed by canonical model ID, so `model_id` must
+    /// already be canonical (e.g. via [`Self::resolve_canonical_model_id`]) --
+    /// every `route_*_impl` resolves that once before the retry loop starts,
+    /// so this never needs to resolve an alias itself. Retry overrides are
+    /// read before the pipeline canonicalizes in `RequestContext::new`, so an
+    /// alias reaching this unresolved would miss the override and silently
+    /// fall back to the router default.
+    fn resolve_retry_config_for_canonical(&self, canonical_model_id: &str) -> RetryConfig {
         self.worker_registry
-            .get_retry_config(model_id)
+            .get_retry_config(canonical_model_id)
             .unwrap_or_else(|| self.retry_config.clone())
+    }
+
+    /// A rate-limit denial must never be retried -- retrying immediately
+    /// against the same tenant budget defeats `retry_after_secs`.
+    fn reservation_denied(cell: &RateLimitCell) -> bool {
+        matches!(cell.peek(), Some(RateLimitOutcome::Denied))
     }
 
     /// Resolve `model_id` to its canonical form once, before a retry loop
@@ -564,7 +571,7 @@ impl GrpcRouter {
         let tenant_meta_cloned = tenant_meta.clone();
         let rate_limit_cell = Arc::new(RateLimitCell::new());
 
-        let retry_config = self.resolve_retry_config(&model_id_cloned);
+        let retry_config = self.resolve_retry_config_for_canonical(&model_id_cloned);
 
         let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
@@ -593,7 +600,7 @@ impl GrpcRouter {
             // (retrying immediately against the same tenant budget defeats
             // retry_after_secs); otherwise check if status is retryable.
             |res, _attempt| {
-                if matches!(rate_limit_cell.peek(), Some(RateLimitOutcome::Denied)) {
+                if Self::reservation_denied(&rate_limit_cell) {
                     return false;
                 }
                 is_retryable_status(res.status())
@@ -637,7 +644,7 @@ impl GrpcRouter {
         let pipeline = &self.pipeline;
         let rate_limit_cell = Arc::new(RateLimitCell::new());
 
-        let retry_config = self.resolve_retry_config(&model_id_cloned);
+        let retry_config = self.resolve_retry_config_for_canonical(&model_id_cloned);
 
         let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
@@ -664,7 +671,7 @@ impl GrpcRouter {
             },
             // Should retry: a rate-limit denial must never be retried; see route_chat_impl.
             |res, _attempt| {
-                if matches!(rate_limit_cell.peek(), Some(RateLimitOutcome::Denied)) {
+                if Self::reservation_denied(&rate_limit_cell) {
                     return false;
                 }
                 is_retryable_status(res.status())
@@ -805,7 +812,7 @@ impl GrpcRouter {
         let pipeline = &self.messages_pipeline;
         let rate_limit_cell = Arc::new(RateLimitCell::new());
 
-        let retry_config = self.resolve_retry_config(&model_id_cloned);
+        let retry_config = self.resolve_retry_config_for_canonical(&model_id_cloned);
 
         let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
@@ -831,7 +838,7 @@ impl GrpcRouter {
             },
             // Should retry: a rate-limit denial must never be retried; see route_chat_impl.
             |res, _attempt| {
-                if matches!(rate_limit_cell.peek(), Some(RateLimitOutcome::Denied)) {
+                if Self::reservation_denied(&rate_limit_cell) {
                     return false;
                 }
                 is_retryable_status(res.status())
@@ -873,7 +880,7 @@ impl GrpcRouter {
         let pipeline = &self.completion_pipeline;
         let rate_limit_cell = Arc::new(RateLimitCell::new());
 
-        let retry_config = self.resolve_retry_config(&model_id_cloned);
+        let retry_config = self.resolve_retry_config_for_canonical(&model_id_cloned);
 
         let response = RetryExecutor::execute_response_with_retry(
             &retry_config,
@@ -899,7 +906,7 @@ impl GrpcRouter {
             },
             // Should retry: a rate-limit denial must never be retried; see route_chat_impl.
             |res, _attempt| {
-                if matches!(rate_limit_cell.peek(), Some(RateLimitOutcome::Denied)) {
+                if Self::reservation_denied(&rate_limit_cell) {
                     return false;
                 }
                 is_retryable_status(res.status())
@@ -1468,13 +1475,13 @@ mod pd_tests {
         ctx.worker_registry
             .set_model_retry_config("model-a", override_config, true);
 
-        let resolved = router.resolve_retry_config("model-a");
+        let resolved = router.resolve_retry_config_for_canonical("model-a");
         assert_eq!(
             resolved.max_retries, override_retries,
             "PD completion must use the per-model override, not the router default"
         );
 
-        let fallback = router.resolve_retry_config("model-without-override");
+        let fallback = router.resolve_retry_config_for_canonical("model-without-override");
         assert_eq!(fallback.max_retries, default_retries);
     }
 
@@ -1641,17 +1648,23 @@ mod pd_tests {
             true,
         );
 
+        // Mirrors the real call sequence every route_*_impl uses: resolve the
+        // canonical model once, then look up the retry config for it.
+        let retry_config_for = |model_id: &str| {
+            router.resolve_retry_config_for_canonical(&router.resolve_canonical_model_id(model_id))
+        };
+
         assert_eq!(
-            router.resolve_retry_config("canonical-model").max_retries,
+            retry_config_for("canonical-model").max_retries,
             override_retries
         );
         assert_eq!(
-            router.resolve_retry_config("model-alias").max_retries,
+            retry_config_for("model-alias").max_retries,
             override_retries,
             "an aliased request must get the same retry override as the canonical ID"
         );
         assert_eq!(
-            router.resolve_retry_config("unrelated-model").max_retries,
+            retry_config_for("unrelated-model").max_retries,
             default_retries
         );
     }

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -309,16 +309,37 @@ impl AppTestContext {
 }
 
 /// Helper function to create AppContext for tests
+pub fn create_test_context(
+    config: RouterConfig,
+) -> Pin<Box<dyn Future<Output = Arc<AppContext>> + Send>> {
+    create_test_context_with_tokenizer_registry(config, Arc::new(TokenizerRegistry::new()))
+}
+
+/// Same as [`create_test_context`], but with a caller-supplied tokenizer
+/// registry instead of an always-empty one, and real (not `None`) parser
+/// factories -- `GrpcRouter::new` requires both to be `Some`. For tests that
+/// build a real gRPC router (e.g. against a gRPC mock worker, which has no
+/// tokenizer artifacts of its own to autoload from).
 #[expect(
     clippy::unwrap_used,
     clippy::expect_used,
     reason = "test helper - panicking on failure is intentional"
 )]
-pub fn create_test_context(
+pub fn create_test_context_with_tokenizer_registry(
     config: RouterConfig,
+    tokenizer_registry: Arc<TokenizerRegistry>,
 ) -> Pin<Box<dyn Future<Output = Arc<AppContext>> + Send>> {
     Box::pin(async move {
         let client = reqwest::Client::new();
+        let reasoning_parser_factory = Some(ReasoningParserFactory::new());
+        let tool_parser_factory = Some(ToolParserFactory::new());
+
+        // Build the tenant rate limiter from `config` the same way
+        // `AppContext::from_config` does (that path's own
+        // `maybe_rate_limit_manager` is private, so it's replicated here via
+        // the public direct setter added for this purpose).
+        let tenant_rate_limit_manager = smg::rate_limit::RateLimitManager::from_config(&config)
+            .expect("tenant rate limit config should be valid");
 
         // Initialize rate limiter
         let rate_limiter = match config.max_concurrent_requests {
@@ -363,9 +384,10 @@ pub fn create_test_context(
                 .router_config(config.clone())
                 .client(client)
                 .rate_limiter(rate_limiter)
-                .tokenizer_registry(Arc::new(TokenizerRegistry::new())) // tokenizer
-                .reasoning_parser_factory(None) // reasoning_parser_factory
-                .tool_parser_factory(None) // tool_parser_factory
+                .rate_limit_manager(tenant_rate_limit_manager)
+                .tokenizer_registry(tokenizer_registry) // tokenizer
+                .reasoning_parser_factory(reasoning_parser_factory)
+                .tool_parser_factory(tool_parser_factory)
                 .worker_registry(worker_registry)
                 .policy_registry(policy_registry)
                 .response_storage(response_storage)

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -308,6 +308,162 @@ impl AppTestContext {
     }
 }
 
+/// Shared `AppContext` construction tail for the `create_test_context_*`
+/// family below: registries, storage backends, worker monitor, job queue,
+/// workflow engines, OpenAI-mode external worker registration, and MCP
+/// orchestrator startup are identical across all of them. Only the
+/// tokenizer registry, parser factories, rate-limit manager, and MCP config
+/// vary by caller, so those are the only parameters.
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+async fn build_test_app_context(
+    config: RouterConfig,
+    tokenizer_registry: Arc<TokenizerRegistry>,
+    reasoning_parser_factory: Option<ReasoningParserFactory>,
+    tool_parser_factory: Option<ToolParserFactory>,
+    rate_limit_manager: Option<Arc<smg::rate_limit::RateLimitManager>>,
+    mcp_config: smg_mcp::McpConfig,
+) -> Arc<AppContext> {
+    use smg_mcp::McpOrchestrator;
+
+    let client = reqwest::Client::new();
+
+    // Initialize rate limiter
+    let rate_limiter = match config.max_concurrent_requests {
+        n if n <= 0 => None,
+        n => {
+            let rate_limit_tokens = config
+                .rate_limit_tokens_per_second
+                .filter(|&t| t > 0)
+                .unwrap_or(n);
+            Some(Arc::new(TokenBucket::new(
+                n as usize,
+                rate_limit_tokens as usize,
+            )))
+        }
+    };
+
+    // Initialize registries
+    let worker_registry = Arc::new(WorkerRegistry::new());
+    let policy_registry = Arc::new(PolicyRegistry::new(config.policy.clone()));
+
+    // Initialize storage backends (Memory for tests).
+    let response_storage = Arc::new(MemoryResponseStorage::new());
+    let conversation_storage = Arc::new(MemoryConversationStorage::new());
+    let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+
+    // Initialize load monitor
+    let worker_monitor = Some(Arc::new(WorkerMonitor::new(
+        worker_registry.clone(),
+        policy_registry.clone(),
+        client.clone(),
+        config.load_monitor_interval_secs,
+        config.engine_metrics,
+    )));
+
+    // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator
+    let worker_job_queue = Arc::new(OnceLock::new());
+    let workflow_engines = Arc::new(OnceLock::new());
+    let mcp_orchestrator_lock = Arc::new(OnceLock::new());
+
+    let app_context = Arc::new(
+        AppContext::builder()
+            .router_config(config.clone())
+            .client(client)
+            .rate_limiter(rate_limiter)
+            .rate_limit_manager(rate_limit_manager)
+            .tokenizer_registry(tokenizer_registry)
+            .reasoning_parser_factory(reasoning_parser_factory)
+            .tool_parser_factory(tool_parser_factory)
+            .worker_registry(worker_registry)
+            .policy_registry(policy_registry)
+            .response_storage(response_storage)
+            .conversation_storage(conversation_storage)
+            .conversation_item_storage(conversation_item_storage)
+            .worker_monitor(worker_monitor)
+            .worker_job_queue(worker_job_queue)
+            .workflow_engines(workflow_engines)
+            .mcp_orchestrator(mcp_orchestrator_lock)
+            .build()
+            .unwrap(),
+    );
+
+    // Mirror production wiring: start the WorkerMonitor event
+    // loop so tests exercise the event-driven group reconciliation
+    // path instead of an inert monitor.
+    if let Some(monitor) = &app_context.worker_monitor {
+        monitor.start_event_loop();
+    }
+
+    // Initialize JobQueue after AppContext is created
+    let weak_context = Arc::downgrade(&app_context);
+    let job_queue =
+        smg::workflow::JobQueue::new(smg::workflow::JobQueueConfig::default(), weak_context);
+    app_context
+        .worker_job_queue
+        .set(job_queue)
+        .expect("JobQueue should only be initialized once");
+
+    // Initialize typed workflow engines
+    use smg::workflow::WorkflowEngines;
+    let engines = WorkflowEngines::new(&config);
+    app_context
+        .workflow_engines
+        .set(engines)
+        .expect("WorkflowEngines should only be initialized once");
+
+    // Register external workers for OpenAI mode
+    if let RoutingMode::OpenAI { worker_urls, .. } = &config.mode {
+        for url in worker_urls {
+            // Create a worker that supports common test models
+            let models = vec![
+                ModelCard::new("mock-model"),
+                ModelCard::new("gpt-4"),
+                ModelCard::new("gpt-3.5-turbo"),
+            ];
+            let worker: Arc<dyn Worker> = Arc::new(
+                BasicWorkerBuilder::new(url)
+                    .worker_type(WorkerType::Regular)
+                    .runtime_type(RuntimeType::External)
+                    .models(models)
+                    .health_config(openai_protocol::worker::HealthCheckConfig {
+                        disable_health_check: true,
+                        ..Default::default()
+                    })
+                    .build(),
+            );
+            app_context.worker_registry.register(worker);
+        }
+    }
+
+    let mcp_orchestrator = McpOrchestrator::new(mcp_config)
+        .await
+        .expect("Failed to create MCP orchestrator");
+    app_context
+        .mcp_orchestrator
+        .set(Arc::new(mcp_orchestrator))
+        .ok()
+        .expect("McpOrchestrator should only be initialized once");
+
+    app_context
+}
+
+/// An empty MCP config -- no servers, defaults everywhere -- for the
+/// `create_test_context_*` variants that don't exercise MCP themselves.
+fn empty_mcp_config() -> smg_mcp::McpConfig {
+    smg_mcp::McpConfig {
+        servers: vec![],
+        pool: Default::default(),
+        proxy: None,
+        warmup: vec![],
+        inventory: Default::default(),
+        policy: Default::default(),
+    }
+}
+
 /// Helper function to create AppContext for tests
 pub fn create_test_context(
     config: RouterConfig,
@@ -321,7 +477,6 @@ pub fn create_test_context(
 /// build a real gRPC router (e.g. against a gRPC mock worker, which has no
 /// tokenizer artifacts of its own to autoload from).
 #[expect(
-    clippy::unwrap_used,
     clippy::expect_used,
     reason = "test helper - panicking on failure is intentional"
 )]
@@ -330,298 +485,40 @@ pub fn create_test_context_with_tokenizer_registry(
     tokenizer_registry: Arc<TokenizerRegistry>,
 ) -> Pin<Box<dyn Future<Output = Arc<AppContext>> + Send>> {
     Box::pin(async move {
-        let client = reqwest::Client::new();
-        let reasoning_parser_factory = Some(ReasoningParserFactory::new());
-        let tool_parser_factory = Some(ToolParserFactory::new());
-
         // Build the tenant rate limiter from `config` the same way
         // `AppContext::from_config` does (that path's own
         // `maybe_rate_limit_manager` is private, so it's replicated here via
         // the public direct setter added for this purpose).
         let tenant_rate_limit_manager = smg::rate_limit::RateLimitManager::from_config(&config)
             .expect("tenant rate limit config should be valid");
-
-        // Initialize rate limiter
-        let rate_limiter = match config.max_concurrent_requests {
-            n if n <= 0 => None,
-            n => {
-                let rate_limit_tokens = config
-                    .rate_limit_tokens_per_second
-                    .filter(|&t| t > 0)
-                    .unwrap_or(n);
-                Some(Arc::new(TokenBucket::new(
-                    n as usize,
-                    rate_limit_tokens as usize,
-                )))
-            }
-        };
-
-        // Initialize registries
-        let worker_registry = Arc::new(WorkerRegistry::new());
-        let policy_registry = Arc::new(PolicyRegistry::new(config.policy.clone()));
-
-        // Initialize storage backends (Memory for tests).
-        let response_storage = Arc::new(MemoryResponseStorage::new());
-        let conversation_storage = Arc::new(MemoryConversationStorage::new());
-        let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
-
-        // Initialize load monitor
-        let worker_monitor = Some(Arc::new(WorkerMonitor::new(
-            worker_registry.clone(),
-            policy_registry.clone(),
-            client.clone(),
-            config.load_monitor_interval_secs,
-            config.engine_metrics,
-        )));
-
-        // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator
-        let worker_job_queue = Arc::new(OnceLock::new());
-        let workflow_engines = Arc::new(OnceLock::new());
-        let mcp_orchestrator_lock = Arc::new(OnceLock::new());
-
-        let app_context = Arc::new(
-            AppContext::builder()
-                .router_config(config.clone())
-                .client(client)
-                .rate_limiter(rate_limiter)
-                .rate_limit_manager(tenant_rate_limit_manager)
-                .tokenizer_registry(tokenizer_registry) // tokenizer
-                .reasoning_parser_factory(reasoning_parser_factory)
-                .tool_parser_factory(tool_parser_factory)
-                .worker_registry(worker_registry)
-                .policy_registry(policy_registry)
-                .response_storage(response_storage)
-                .conversation_storage(conversation_storage)
-                .conversation_item_storage(conversation_item_storage)
-                .worker_monitor(worker_monitor)
-                .worker_job_queue(worker_job_queue)
-                .workflow_engines(workflow_engines)
-                .mcp_orchestrator(mcp_orchestrator_lock)
-                .build()
-                .unwrap(),
-        );
-
-        // Mirror production wiring: start the WorkerMonitor event
-        // loop so tests exercise the event-driven group reconciliation
-        // path instead of an inert monitor.
-        if let Some(monitor) = &app_context.worker_monitor {
-            monitor.start_event_loop();
-        }
-
-        // Initialize JobQueue after AppContext is created
-        let weak_context = Arc::downgrade(&app_context);
-        let job_queue =
-            smg::workflow::JobQueue::new(smg::workflow::JobQueueConfig::default(), weak_context);
-        app_context
-            .worker_job_queue
-            .set(job_queue)
-            .expect("JobQueue should only be initialized once");
-
-        // Initialize typed workflow engines
-        use smg::workflow::WorkflowEngines;
-        let engines = WorkflowEngines::new(&config);
-        app_context
-            .workflow_engines
-            .set(engines)
-            .expect("WorkflowEngines should only be initialized once");
-
-        // Register external workers for OpenAI mode
-        if let RoutingMode::OpenAI { worker_urls, .. } = &config.mode {
-            for url in worker_urls {
-                // Create a worker that supports common test models
-                let models = vec![
-                    ModelCard::new("mock-model"),
-                    ModelCard::new("gpt-4"),
-                    ModelCard::new("gpt-3.5-turbo"),
-                ];
-                let worker: Arc<dyn Worker> = Arc::new(
-                    BasicWorkerBuilder::new(url)
-                        .worker_type(WorkerType::Regular)
-                        .runtime_type(RuntimeType::External)
-                        .models(models)
-                        .health_config(openai_protocol::worker::HealthCheckConfig {
-                            disable_health_check: true,
-                            ..Default::default()
-                        })
-                        .build(),
-                );
-                app_context.worker_registry.register(worker);
-            }
-        }
-
-        // Initialize MCP orchestrator with empty config
-        use smg_mcp::{McpConfig, McpOrchestrator};
-        let empty_config = McpConfig {
-            servers: vec![],
-            pool: Default::default(),
-            proxy: None,
-            warmup: vec![],
-            inventory: Default::default(),
-            policy: Default::default(),
-        };
-        let mcp_orchestrator = McpOrchestrator::new(empty_config)
-            .await
-            .expect("Failed to create MCP orchestrator");
-        app_context
-            .mcp_orchestrator
-            .set(Arc::new(mcp_orchestrator))
-            .ok()
-            .expect("McpOrchestrator should only be initialized once");
-
-        app_context
+        build_test_app_context(
+            config,
+            tokenizer_registry,
+            Some(ReasoningParserFactory::new()),
+            Some(ToolParserFactory::new()),
+            tenant_rate_limit_manager,
+            empty_mcp_config(),
+        )
+        .await
     })
 }
 
 /// Helper function to create AppContext for tests with parser factories initialized
-#[expect(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    reason = "test helper - panicking on failure is intentional"
-)]
 pub fn create_test_context_with_parsers(
     config: RouterConfig,
 ) -> Pin<Box<dyn Future<Output = Arc<AppContext>> + Send>> {
-    Box::pin(async move {
-        let client = reqwest::Client::new();
-
-        // Initialize rate limiter
-        let rate_limiter = match config.max_concurrent_requests {
-            n if n <= 0 => None,
-            n => {
-                let rate_limit_tokens = config
-                    .rate_limit_tokens_per_second
-                    .filter(|&t| t > 0)
-                    .unwrap_or(n);
-                Some(Arc::new(TokenBucket::new(
-                    n as usize,
-                    rate_limit_tokens as usize,
-                )))
-            }
-        };
-
-        // Initialize registries
-        let tokenizer_registry = Arc::new(TokenizerRegistry::new());
-        let worker_registry = Arc::new(WorkerRegistry::new());
-        let policy_registry = Arc::new(PolicyRegistry::new(config.policy.clone()));
-
-        // Initialize storage backends (Memory for tests).
-        let response_storage = Arc::new(MemoryResponseStorage::new());
-        let conversation_storage = Arc::new(MemoryConversationStorage::new());
-        let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
-
-        // Initialize load monitor
-        let worker_monitor = Some(Arc::new(WorkerMonitor::new(
-            worker_registry.clone(),
-            policy_registry.clone(),
-            client.clone(),
-            config.load_monitor_interval_secs,
-            config.engine_metrics,
-        )));
-
-        // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator
-        let worker_job_queue = Arc::new(OnceLock::new());
-        let workflow_engines = Arc::new(OnceLock::new());
-        let mcp_orchestrator_lock = Arc::new(OnceLock::new());
-
-        // Initialize parser factories
-        let reasoning_parser_factory = Some(ReasoningParserFactory::new());
-        let tool_parser_factory = Some(ToolParserFactory::new());
-
-        let app_context = Arc::new(
-            AppContext::builder()
-                .router_config(config.clone())
-                .client(client)
-                .rate_limiter(rate_limiter)
-                .tokenizer_registry(tokenizer_registry)
-                .reasoning_parser_factory(reasoning_parser_factory)
-                .tool_parser_factory(tool_parser_factory)
-                .worker_registry(worker_registry)
-                .policy_registry(policy_registry)
-                .response_storage(response_storage)
-                .conversation_storage(conversation_storage)
-                .conversation_item_storage(conversation_item_storage)
-                .worker_monitor(worker_monitor)
-                .worker_job_queue(worker_job_queue)
-                .workflow_engines(workflow_engines)
-                .mcp_orchestrator(mcp_orchestrator_lock)
-                .build()
-                .unwrap(),
-        );
-
-        // Mirror production wiring: start the WorkerMonitor event
-        // loop so tests exercise the event-driven group reconciliation
-        // path instead of an inert monitor.
-        if let Some(monitor) = &app_context.worker_monitor {
-            monitor.start_event_loop();
-        }
-
-        // Initialize JobQueue after AppContext is created
-        let weak_context = Arc::downgrade(&app_context);
-        let job_queue =
-            smg::workflow::JobQueue::new(smg::workflow::JobQueueConfig::default(), weak_context);
-        app_context
-            .worker_job_queue
-            .set(job_queue)
-            .expect("JobQueue should only be initialized once");
-
-        // Initialize typed workflow engines
-        use smg::workflow::WorkflowEngines;
-        let engines = WorkflowEngines::new(&config);
-        app_context
-            .workflow_engines
-            .set(engines)
-            .expect("WorkflowEngines should only be initialized once");
-
-        // Register external workers for OpenAI mode
-        if let RoutingMode::OpenAI { worker_urls, .. } = &config.mode {
-            for url in worker_urls {
-                // Create a worker that supports common test models
-                let models = vec![
-                    ModelCard::new("mock-model"),
-                    ModelCard::new("gpt-4"),
-                    ModelCard::new("gpt-3.5-turbo"),
-                ];
-                let worker: Arc<dyn Worker> = Arc::new(
-                    BasicWorkerBuilder::new(url)
-                        .worker_type(WorkerType::Regular)
-                        .runtime_type(RuntimeType::External)
-                        .models(models)
-                        .health_config(openai_protocol::worker::HealthCheckConfig {
-                            disable_health_check: true,
-                            ..Default::default()
-                        })
-                        .build(),
-                );
-                app_context.worker_registry.register(worker);
-            }
-        }
-
-        // Initialize MCP orchestrator with empty config
-        use smg_mcp::{McpConfig, McpOrchestrator};
-        let empty_config = McpConfig {
-            servers: vec![],
-            pool: Default::default(),
-            proxy: None,
-            warmup: vec![],
-            inventory: Default::default(),
-            policy: Default::default(),
-        };
-        let mcp_orchestrator = McpOrchestrator::new(empty_config)
-            .await
-            .expect("Failed to create MCP orchestrator");
-        app_context
-            .mcp_orchestrator
-            .set(Arc::new(mcp_orchestrator))
-            .ok()
-            .expect("McpOrchestrator should only be initialized once");
-
-        app_context
-    })
+    Box::pin(build_test_app_context(
+        config,
+        Arc::new(TokenizerRegistry::new()),
+        Some(ReasoningParserFactory::new()),
+        Some(ToolParserFactory::new()),
+        None,
+        empty_mcp_config(),
+    ))
 }
 
 /// Helper function to create AppContext for tests with MCP config from file
 #[expect(
-    clippy::unwrap_used,
     clippy::expect_used,
     reason = "test helper - panicking on failure is intentional"
 )]
@@ -629,133 +526,20 @@ pub fn create_test_context_with_mcp_config(
     config: RouterConfig,
     mcp_config_path: &str,
 ) -> Pin<Box<dyn Future<Output = Arc<AppContext>> + Send>> {
-    use smg_mcp::{McpConfig, McpOrchestrator};
-
     let mcp_config_path = mcp_config_path.to_owned();
     Box::pin(async move {
-        let client = reqwest::Client::new();
-
-        // Initialize rate limiter
-        let rate_limiter = match config.max_concurrent_requests {
-            n if n <= 0 => None,
-            n => {
-                let rate_limit_tokens = config
-                    .rate_limit_tokens_per_second
-                    .filter(|&t| t > 0)
-                    .unwrap_or(n);
-                Some(Arc::new(TokenBucket::new(
-                    n as usize,
-                    rate_limit_tokens as usize,
-                )))
-            }
-        };
-
-        // Initialize registries
-        let worker_registry = Arc::new(WorkerRegistry::new());
-        let policy_registry = Arc::new(PolicyRegistry::new(config.policy.clone()));
-
-        // Initialize storage backends (Memory for tests).
-        let response_storage = Arc::new(MemoryResponseStorage::new());
-        let conversation_storage = Arc::new(MemoryConversationStorage::new());
-        let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
-
-        // Initialize load monitor
-        let worker_monitor = Some(Arc::new(WorkerMonitor::new(
-            worker_registry.clone(),
-            policy_registry.clone(),
-            client.clone(),
-            config.load_monitor_interval_secs,
-            config.engine_metrics,
-        )));
-
-        // Create empty OnceLock for worker job queue, workflow engines, and mcp orchestrator
-        let worker_job_queue = Arc::new(OnceLock::new());
-        let workflow_engines = Arc::new(OnceLock::new());
-        let mcp_orchestrator_lock = Arc::new(OnceLock::new());
-
-        let app_context = Arc::new(
-            AppContext::builder()
-                .router_config(config.clone())
-                .client(client)
-                .rate_limiter(rate_limiter)
-                .tokenizer_registry(Arc::new(TokenizerRegistry::new())) // tokenizer
-                .reasoning_parser_factory(None) // reasoning_parser_factory
-                .tool_parser_factory(None) // tool_parser_factory
-                .worker_registry(worker_registry)
-                .policy_registry(policy_registry)
-                .response_storage(response_storage)
-                .conversation_storage(conversation_storage)
-                .conversation_item_storage(conversation_item_storage)
-                .worker_monitor(worker_monitor)
-                .worker_job_queue(worker_job_queue)
-                .workflow_engines(workflow_engines)
-                .mcp_orchestrator(mcp_orchestrator_lock)
-                .build()
-                .unwrap(),
-        );
-
-        // Mirror production wiring: start the WorkerMonitor event
-        // loop so tests exercise the event-driven group reconciliation
-        // path instead of an inert monitor.
-        if let Some(monitor) = &app_context.worker_monitor {
-            monitor.start_event_loop();
-        }
-
-        // Initialize JobQueue after AppContext is created
-        let weak_context = Arc::downgrade(&app_context);
-        let job_queue =
-            smg::workflow::JobQueue::new(smg::workflow::JobQueueConfig::default(), weak_context);
-        app_context
-            .worker_job_queue
-            .set(job_queue)
-            .expect("JobQueue should only be initialized once");
-
-        // Initialize typed workflow engines
-        use smg::workflow::WorkflowEngines;
-        let engines = WorkflowEngines::new(&config);
-        app_context
-            .workflow_engines
-            .set(engines)
-            .expect("WorkflowEngines should only be initialized once");
-
-        // Register external workers for OpenAI mode
-        if let RoutingMode::OpenAI { worker_urls, .. } = &config.mode {
-            for url in worker_urls {
-                // Create a worker that supports common test models
-                let models = vec![
-                    ModelCard::new("mock-model"),
-                    ModelCard::new("gpt-4"),
-                    ModelCard::new("gpt-3.5-turbo"),
-                ];
-                let worker: Arc<dyn Worker> = Arc::new(
-                    BasicWorkerBuilder::new(url)
-                        .worker_type(WorkerType::Regular)
-                        .runtime_type(RuntimeType::External)
-                        .models(models)
-                        .health_config(openai_protocol::worker::HealthCheckConfig {
-                            disable_health_check: true,
-                            ..Default::default()
-                        })
-                        .build(),
-                );
-                app_context.worker_registry.register(worker);
-            }
-        }
-
-        // Initialize MCP orchestrator from config file
-        let mcp_config = McpConfig::from_file(&mcp_config_path)
+        let mcp_config = smg_mcp::McpConfig::from_file(&mcp_config_path)
             .await
             .expect("Failed to load MCP config from file");
-        let mcp_orchestrator = McpOrchestrator::new(mcp_config)
-            .await
-            .expect("Failed to create MCP orchestrator");
-        app_context
-            .mcp_orchestrator
-            .set(Arc::new(mcp_orchestrator))
-            .ok()
-            .expect("McpOrchestrator should only be initialized once");
-
-        app_context
+        build_test_app_context(
+            config,
+            Arc::new(TokenizerRegistry::new()),
+            None,
+            None,
+            None,
+            mcp_config,
+        )
+        .await
     })
 }
 

--- a/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
+++ b/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
@@ -26,7 +26,8 @@ use std::{sync::Arc, time::Duration};
 
 use llm_tokenizer::{traits::Tokenizer, MockTokenizer, TokenizerRegistry};
 use openai_protocol::{
-    generate::GenerateRequest, model_card::ModelCard, worker::HealthCheckConfig,
+    completion::CompletionRequest, generate::GenerateRequest, model_card::ModelCard,
+    worker::HealthCheckConfig,
 };
 use portpicker::pick_unused_port;
 use smg::{
@@ -186,6 +187,19 @@ fn generate_request() -> GenerateRequest {
     .unwrap()
 }
 
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+fn completion_request() -> CompletionRequest {
+    serde_json::from_value(serde_json::json!({
+        "model": MODEL,
+        "prompt": PROMPT_TEXT,
+        "stream": false,
+    }))
+    .unwrap()
+}
+
 fn fresh_tenant() -> TenantRequestMeta {
     TenantRequestMeta::new(TenantKey::new("integration-test-tenant"))
 }
@@ -297,4 +311,46 @@ async fn feature_disabled_is_a_no_op() {
         .await;
 
     assert_eq!(response.status(), http::StatusCode::OK);
+}
+
+/// `RateLimitReserveStage` is inserted identically into the Chat, Messages,
+/// Completion, and Generate pipelines (`pipeline.rs::build()`), and the
+/// tests above already prove the mechanism end-to-end (real reserve, real
+/// settle, real denial with/without `Retry-After`) through Generate. This
+/// mirrors that same impossible-budget proof through Completion, to confirm
+/// the stage is actually live on a second wired pipeline too, not just
+/// constructed and never reached.
+///
+/// Chat and Messages are deliberately not covered the same way here: both
+/// need `apply_chat_template` to turn their `messages` array into a prompt
+/// before preparation ever reaches the reserve stage, and `MockTokenizer`
+/// (`crates/tokenizer/src/mock.rs`) doesn't implement it -- confirmed by
+/// running this exact test against `route_chat`, which fails earlier with
+/// `process_messages_failed: Chat template not supported by this
+/// tokenizer`, a 400 from the Chat preparation stage, not a 429 from rate
+/// limiting. That's a pre-existing gap in the shared mock tokenizer,
+/// unrelated to this PR; extending it (or swapping in a template-capable
+/// fake) is out of scope here. Harmony and PD dispatch are also not covered:
+/// Harmony needs a harmony-flavored model registered so `HarmonyDetector`
+/// routes into it, and PD needs a distinct prefill+decode worker pair --
+/// both larger harness investments than this suite carries for its other
+/// cases, and the underlying reserve/settle mechanics they'd exercise are
+/// identical to what's already proven above and in `pipeline.rs`'s own
+/// `rate_limit_reserve_tests` (which drives `RateLimitReserveStage` directly
+/// rather than through a real backend).
+#[tokio::test]
+async fn completion_denial_reaches_the_client() {
+    let grpc_port = start_mock_grpc_worker(4).await;
+    let (router, _dir) = build_router(Some(1), grpc_port).await;
+
+    let request = completion_request();
+    let response = router
+        .route_completion(None, &fresh_tenant(), &request, MODEL)
+        .await;
+
+    assert_eq!(
+        response.status(),
+        http::StatusCode::TOO_MANY_REQUESTS,
+        "RateLimitReserveStage must be reachable through route_completion, not just route_generate"
+    );
 }

--- a/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
+++ b/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
@@ -1,0 +1,266 @@
+//! Integration tests for tenant rate limiting wired into the gRPC router
+//! (`routers/grpc/common/stages/rate_limit.rs`), verified end-to-end against
+//! a real (mock) gRPC backend rather than by driving `RateLimitReserveStage`
+//! in isolation.
+//!
+//! Calls `RouterTrait` methods directly, mirroring
+//! `routers/grpc/router.rs`'s own `pd_tests` module, rather than going
+//! through the full HTTP app: `tests/common/test_app.rs`'s lightweight test
+//! app doesn't wire the tenant-resolution middleware that would otherwise
+//! populate `tenant_request_meta`, so a real per-request tenant identity is
+//! constructed here directly, same as the real middleware would produce.
+//!
+//! Determinism relies on `mock-worker`'s canned (non-`realistic`) gRPC mode:
+//! it always reports `prompt_tokens: 1` in its final response regardless of
+//! the real input length, while `completion_tokens` is exactly the
+//! configured `output_tokens`. Reserve-time debits use the gateway's own
+//! tokenization (via `MockTokenizer`'s tiny fixed vocab); settle-time trueup
+//! uses the backend's reported usage. Choosing a token budget between those
+//! two numbers proves settle actually ran with real backend-reported usage,
+//! not just the initial reserve estimate.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::{sync::Arc, time::Duration};
+
+use llm_tokenizer::{traits::Tokenizer, MockTokenizer, TokenizerRegistry};
+use openai_protocol::{
+    generate::GenerateRequest, model_card::ModelCard, worker::HealthCheckConfig,
+};
+use portpicker::pick_unused_port;
+use smg::{
+    config::RouterConfig,
+    middleware::TenantRequestMeta,
+    routers::{RouterFactory, RouterTrait},
+    tenant::TenantKey,
+    worker::{BasicWorkerBuilder, ConnectionMode, RuntimeType, WorkerType},
+};
+use tokio::net::TcpStream;
+
+/// "Hello world" through `MockTokenizer`'s fixed vocab ("Hello"=1, "world"=2)
+/// tokenizes to exactly 2 ids -- the gateway's reserve-time estimate.
+const PROMPT_TEXT: &str = "Hello world";
+const ESTIMATED_INPUT_TOKENS: u32 = 2;
+const MODEL: &str = "tenant-rl-test-model";
+
+#[expect(
+    clippy::panic,
+    reason = "test helper - panicking on failure is intentional"
+)]
+async fn wait_for_port(port: u16) {
+    let addr = format!("127.0.0.1:{port}");
+    for _ in 0..100 {
+        if TcpStream::connect(&addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("mock gRPC worker on {addr} never came up");
+}
+
+/// Spawn a real (mock) gRPC worker in-process, canned mode: always reports
+/// `prompt_tokens: 1` and `completion_tokens: output_tokens`, regardless of
+/// what was actually sent.
+#[expect(
+    clippy::expect_used,
+    clippy::disallowed_methods,
+    reason = "test helper - panicking on failure is intentional; the spawned \
+              mock server task is fire-and-forget for the test process's lifetime"
+)]
+async fn start_mock_grpc_worker(output_tokens: u32) -> u16 {
+    let port = pick_unused_port().expect("no free port for mock gRPC worker");
+    let cfg = Arc::new(mock_worker::config::Config {
+        host: "127.0.0.1".to_string(),
+        http_base_port: 0,
+        http_count: 0,
+        grpc_base_port: port,
+        grpc_count: 1,
+        zmq_handshake: None,
+        zmq_count: 0,
+        zmq_start_index: 0,
+        model_id: MODEL.to_string(),
+        tokenizer_path: MODEL.to_string(),
+        gen_delay: Duration::ZERO,
+        output_tokens,
+        realistic: false,
+        engine: mock_worker::engine::EngineParams::default(),
+    });
+    tokio::spawn(mock_worker::grpc::serve(cfg, "127.0.0.1".to_string(), port));
+    wait_for_port(port).await;
+    port
+}
+
+/// Build a real gRPC router with tenant rate limiting configured against a
+/// tiny in-memory budget, and a real mock gRPC worker registered. Returns
+/// the router and the config's backing tempdir (must outlive the call --
+/// the YAML is read synchronously during router construction, but keeping
+/// it bound for the caller's whole test avoids any doubt about timing).
+#[expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+async fn build_router(
+    tokens_per_minute: Option<u32>,
+    grpc_port: u16,
+) -> (Box<dyn RouterTrait>, Option<tempfile::TempDir>) {
+    let mut builder = RouterConfig::builder()
+        .grpc_connection()
+        .regular_mode(vec![])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .max_concurrent_requests(64)
+        .queue_timeout_secs(60);
+
+    let dir = if let Some(tpm) = tokens_per_minute {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rate_limit.yaml");
+        std::fs::write(
+            &path,
+            format!("default_policy:\n  tokens_per_minute: {tpm}\n  requests_per_minute: 1000\n"),
+        )
+        .unwrap();
+        builder = builder
+            .tenant_rate_limit_enabled(true)
+            .tenant_rate_limit_config(Some(path.to_str().unwrap().to_string()));
+        Some(dir)
+    } else {
+        None
+    };
+
+    let mut config = builder.build_unchecked();
+    config.health_check.disable_health_check = true;
+
+    let tokenizer_registry = Arc::new(TokenizerRegistry::new());
+    let tokenizer = Arc::new(MockTokenizer::new()) as Arc<dyn Tokenizer>;
+    tokenizer_registry
+        .load(
+            "tokenizer-id",
+            MODEL,
+            "test",
+            || async move { Ok(tokenizer) },
+        )
+        .await
+        .unwrap();
+
+    let app_context =
+        common::create_test_context_with_tokenizer_registry(config, tokenizer_registry).await;
+
+    let worker = BasicWorkerBuilder::new(format!("grpc://127.0.0.1:{grpc_port}"))
+        .worker_type(WorkerType::Regular)
+        .connection_mode(ConnectionMode::Grpc)
+        .runtime_type(RuntimeType::TokenSpeed)
+        .model(ModelCard::new(MODEL))
+        .health_config(HealthCheckConfig {
+            disable_health_check: true,
+            ..Default::default()
+        })
+        .build();
+    app_context
+        .worker_registry
+        .register(Arc::new(worker))
+        .unwrap();
+
+    let router = RouterFactory::create_router(&app_context)
+        .await
+        .expect("gRPC router should build");
+    (router, dir)
+}
+
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper - panicking on failure is intentional"
+)]
+fn generate_request() -> GenerateRequest {
+    serde_json::from_value(serde_json::json!({
+        "model": MODEL,
+        "text": PROMPT_TEXT,
+        "stream": false,
+    }))
+    .unwrap()
+}
+
+fn fresh_tenant() -> TenantRequestMeta {
+    TenantRequestMeta::new(TenantKey::new("integration-test-tenant"))
+}
+
+/// A budget too small for even one reservation must deny immediately, with
+/// `Retry-After`, before ever reaching the worker.
+#[tokio::test]
+async fn denial_returns_429_with_retry_after() {
+    let grpc_port = start_mock_grpc_worker(4).await;
+    // 1 token/minute can't admit a 2-token reserve.
+    let (router, _dir) = build_router(Some(1), grpc_port).await;
+
+    let request = generate_request();
+    let tenant = fresh_tenant();
+    let response = router.route_generate(None, &tenant, &request, MODEL).await;
+
+    assert_eq!(response.status(), http::StatusCode::TOO_MANY_REQUESTS);
+    assert!(
+        response.headers().get(http::header::RETRY_AFTER).is_some(),
+        "denial response must carry Retry-After"
+    );
+}
+
+/// Proves settle_success runs with the backend's real reported usage, not
+/// just the reserve-time estimate. Canned mock backend always reports
+/// prompt_tokens=1 and completion_tokens=OUTPUT_TOKENS regardless of what
+/// was actually sent, so real settled usage (1 + OUTPUT_TOKENS) is provably
+/// larger than the reserve-time estimate alone (ESTIMATED_INPUT_TOKENS).
+///
+/// Budget=6: request 1 reserves 2 (estimate), settles to a true cost of
+/// 1+4=5 (trueup delta +3), leaving 1 token remaining. Request 2 needs to
+/// reserve another 2 estimated tokens -- only 1 remains, so it's denied. If
+/// settle had never run (a regression back to "just reserve, no trueup"),
+/// only 2 tokens would ever have been spent, leaving 4 remaining, and
+/// request 2 (needing 2) would have been admitted instead.
+#[tokio::test]
+async fn non_streaming_settle_uses_real_usage_not_just_the_estimate() {
+    const OUTPUT_TOKENS: u32 = 4;
+    let grpc_port = start_mock_grpc_worker(OUTPUT_TOKENS).await;
+    let (router, _dir) = build_router(Some(6), grpc_port).await;
+
+    let request = generate_request();
+
+    let first = router
+        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .await;
+    assert_eq!(
+        first.status(),
+        http::StatusCode::OK,
+        "first request should be admitted and dispatched successfully"
+    );
+
+    let second = router
+        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .await;
+    assert_eq!(
+        second.status(),
+        http::StatusCode::TOO_MANY_REQUESTS,
+        "second request should be denied -- only true if settle used real \
+         usage (1 + {OUTPUT_TOKENS} completion) rather than leaving only the \
+         {ESTIMATED_INPUT_TOKENS}-token reserve estimate debited"
+    );
+}
+
+/// With tenant rate limiting disabled entirely, requests must behave exactly
+/// as they did before this feature existed -- no interference.
+#[tokio::test]
+async fn feature_disabled_is_a_no_op() {
+    let grpc_port = start_mock_grpc_worker(4).await;
+    let (router, _dir) = build_router(None, grpc_port).await;
+
+    let request = generate_request();
+    let response = router
+        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .await;
+
+    assert_eq!(response.status(), http::StatusCode::OK);
+}

--- a/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
+++ b/model_gateway/tests/tenant_rate_limiting_grpc_test.rs
@@ -190,22 +190,56 @@ fn fresh_tenant() -> TenantRequestMeta {
     TenantRequestMeta::new(TenantKey::new("integration-test-tenant"))
 }
 
-/// A budget too small for even one reservation must deny immediately, with
-/// `Retry-After`, before ever reaching the worker.
+/// A denial with a finite wait (the request *could* eventually fit, just
+/// not right now) must carry `Retry-After`. A fresh bucket always starts
+/// full, so a finite-wait denial requires a prior request to have already
+/// consumed some of the budget -- unlike the "can never fit, no matter how
+/// long you wait" case (see `impossible_request_denies_without_retry_after`
+/// below), which can be hit on the very first request.
 #[tokio::test]
 async fn denial_returns_429_with_retry_after() {
     let grpc_port = start_mock_grpc_worker(4).await;
-    // 1 token/minute can't admit a 2-token reserve.
+    let (router, _dir) = build_router(Some(6), grpc_port).await;
+    let request = generate_request();
+
+    let first = router
+        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .await;
+    assert_eq!(first.status(), http::StatusCode::OK);
+
+    // Same budget arithmetic as the settle test below: after settling the
+    // first request's real usage, only 1 token remains -- not enough for a
+    // second 2-token reserve, but well within the 6-token capacity, so this
+    // is a genuine "wait and retry" denial, not an impossible one.
+    let second = router
+        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .await;
+    assert_eq!(second.status(), http::StatusCode::TOO_MANY_REQUESTS);
+    assert!(
+        second.headers().get(http::header::RETRY_AFTER).is_some(),
+        "a finite-wait denial must carry Retry-After"
+    );
+}
+
+/// A request whose estimated cost exceeds the tenant's *total* budget can
+/// never be admitted, no matter how long the client waits -- the backend's
+/// `u64::MAX` "never" sentinel must not leak into the HTTP response as a
+/// literal ~584-billion-year `Retry-After` value.
+#[tokio::test]
+async fn impossible_request_denies_without_retry_after() {
+    let grpc_port = start_mock_grpc_worker(4).await;
+    // 1 token/minute can never admit this request's 2-token reserve, ever.
     let (router, _dir) = build_router(Some(1), grpc_port).await;
 
     let request = generate_request();
-    let tenant = fresh_tenant();
-    let response = router.route_generate(None, &tenant, &request, MODEL).await;
+    let response = router
+        .route_generate(None, &fresh_tenant(), &request, MODEL)
+        .await;
 
     assert_eq!(response.status(), http::StatusCode::TOO_MANY_REQUESTS);
     assert!(
-        response.headers().get(http::header::RETRY_AFTER).is_some(),
-        "denial response must carry Retry-After"
+        response.headers().get(http::header::RETRY_AFTER).is_none(),
+        "an impossible request's 'never' sentinel must not leak into Retry-After"
     );
 }
 


### PR DESCRIPTION
## Description

### Problem

`RateLimitManager::reserve()` / `settle_success()` / `close_reserved_only()` (Phase 1, already merged on `main`) aren't called anywhere yet — nothing enforces tenant token-per-minute limits on the gRPC router's chat/generate/completion/messages endpoints.

### Solution

Wire tenant rate limiting into the gRPC pipeline with a "guarded reserve-once" mechanism: a small `RateLimitCell` shared across all retry attempts of one logical request, checked by a new `RateLimitReserveStage` inserted right after preparation. The first attempt to reach the stage reserves (or is denied) and caches the outcome; every later retry attempt sees the cached outcome and skips straight through. `RetryExecutor` reruns the full pipeline per attempt unchanged — no prepare/dispatch split, no independently-constructed state that has to be kept in sync by hand.

## Changes

- `RateLimitCell` / `RateLimitOutcome` / `RateLimitReserveStage` (new, `routers/grpc/common/stages/rate_limit.rs`), inserted into the Chat/Messages/Completion/Harmony pipelines right after preparation.
- `router.rs`: each `route_*_impl` constructs the cell, canonicalizes the model once before the retry loop (reused for both the reservation and every dispatch attempt, including the request body's own `model` field), stops retrying on a cached denial, and closes any reservation a non-2xx final response never got to settle.
- Non-streaming success settles inline with the response's real usage; streaming settles with real accumulated totals via a new `reservation: Option<Arc<SharedReservationHandle>>` parameter threaded through `regular/streaming.rs` and `harmony/streaming.rs`, with a `ReservationAttachment` layered onto `AttachedBody` as the Drop-based safety net for disconnect/preemption before that point.
- `crates/mock_worker` gained a `[lib]` target so its real (mock) gRPC server is spawnable in-process from `model_gateway/tests/`, enabling real end-to-end integration coverage (`tests/tenant_rate_limiting_grpc_test.rs`) rather than only unit tests against the pipeline stage in isolation.
- Several rounds of review-driven correctness fixes on top of the initial wiring — see commit messages for full detail:
  - Batched-completion undercount (only the first prompt's tokens were reserved), preemption/cancellation reservation leak, alias handover across retries, and an unusable `Retry-After: 18446744073709551615` for impossible requests.
  - Alias-pinning left the request body itself uncanonicalized (response metadata/parser selection still saw the client's alias); a clean streaming EOF without an authoritative `Complete` frame was settling with 0 input tokens instead of keeping the reservation; `n>1` requests were charging the shared prompt once per choice instead of once per request.
  - A clean EOF partway through an `n>1` stream (some choices finished, others didn't) was accepted as fully authoritative instead of requiring every expected choice's `Complete`; Harmony PD mode's prefill-populated map could mask a decode phase that never actually finished.
  - `cached_tokens` had the same per-choice multiplication bug as `prompt_tokens`.
- Explicitly out of scope (matches the original Phase 2 cut): Responses endpoint, embeddings, classify (none use `RetryExecutor` today); OpenAI/Anthropic/Gemini routers (Phase 3).

## Test Plan

- New integration tests (`model_gateway/tests/tenant_rate_limiting_grpc_test.rs`), driven against a real (mock) gRPC backend: a finite-wait 429 with `Retry-After`, an impossible-request 429 without `Retry-After`, non-streaming settle using the backend's real reported usage (not just the reserve-time estimate), and the feature-disabled no-op path.
- New unit tests throughout the touched modules: `RateLimitCell::drop` safety-net behavior (abandons on preemption, doesn't double-resolve after streaming handoff or denial), `total_input_token_count` batching, the `u64::MAX` `Retry-After` sentinel, and `build_usage`'s per-choice `prompt_tokens`/`cached_tokens` max-not-sum behavior.
- Full lib suite (1345 tests) + this branch's integration suite (13 tests), all green.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
