### PR TITLE
fix(responses): serialize usage in Responses API format

### DIFF
--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -699,7 +699,7 @@ impl ResponseStreamEventEmitter {
                     .completion_tokens_details
                     .as_ref()
                     .and_then(|d| d.reasoning_tokens),
-                prompt_tokens_details: None,
+                prompt_tokens_details: u.prompt_tokens_details.clone(),
             };
             ResponsesUsage::Modern(usage_info.to_response_usage())
         });
@@ -1031,13 +1031,24 @@ mod tests {
         let emitter =
             ResponseStreamEventEmitter::new("resp_test".to_string(), "test-model".to_string(), 1);
 
-        let wire = serde_json::to_value(emitter.finalize(Some(Usage::from_counts(12, 7))))
+        let usage = Usage::from_counts(12, 7)
+            .with_cached_tokens(3)
+            .with_reasoning_tokens(2);
+        let wire = serde_json::to_value(emitter.finalize(Some(usage)))
             .expect("finalized response should serialize");
         let usage = wire.get("usage").expect("usage should be present");
 
         assert_eq!(usage.get("input_tokens"), Some(&serde_json::json!(12)));
         assert_eq!(usage.get("output_tokens"), Some(&serde_json::json!(7)));
         assert_eq!(usage.get("total_tokens"), Some(&serde_json::json!(19)));
+        assert_eq!(
+            usage.pointer("/input_tokens_details/cached_tokens"),
+            Some(&serde_json::json!(3))
+        );
+        assert_eq!(
+            usage.pointer("/output_tokens_details/reasoning_tokens"),
+            Some(&serde_json::json!(2))
+        );
         assert!(usage.get("prompt_tokens").is_none());
         assert!(usage.get("completion_tokens").is_none());
     }

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -701,7 +701,7 @@ impl ResponseStreamEventEmitter {
                     .and_then(|d| d.reasoning_tokens),
                 prompt_tokens_details: None,
             };
-            ResponsesUsage::Classic(usage_info)
+            ResponsesUsage::Modern(usage_info.to_response_usage())
         });
 
         // Build response using builder
@@ -1019,5 +1019,26 @@ pub(crate) fn attach_mcp_server_label(
 ) {
     if let (Some(label), Some(ResponseFormat::Passthrough)) = (server_label, response_format) {
         item["server_label"] = json!(label);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finalized_streaming_response_serializes_responses_api_usage() {
+        let emitter =
+            ResponseStreamEventEmitter::new("resp_test".to_string(), "test-model".to_string(), 1);
+
+        let wire = serde_json::to_value(emitter.finalize(Some(Usage::from_counts(12, 7))))
+            .expect("finalized response should serialize");
+        let usage = wire.get("usage").expect("usage should be present");
+
+        assert_eq!(usage.get("input_tokens"), Some(&serde_json::json!(12)));
+        assert_eq!(usage.get("output_tokens"), Some(&serde_json::json!(7)));
+        assert_eq!(usage.get("total_tokens"), Some(&serde_json::json!(19)));
+        assert!(usage.get("prompt_tokens").is_none());
+        assert!(usage.get("completion_tokens").is_none());
     }
 }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -425,7 +425,7 @@ pub(crate) fn chat_to_responses(
                 .completion_tokens_details
                 .as_ref()
                 .and_then(|d| d.reasoning_tokens),
-            prompt_tokens_details: None, // Chat response doesn't have this
+            prompt_tokens_details: u.prompt_tokens_details.clone(),
         };
         ResponsesUsage::Modern(usage_info.to_response_usage())
     });
@@ -467,7 +467,11 @@ mod tests {
                 matched_stop: None,
                 hidden_states: None,
             }])
-            .usage(Usage::from_counts(12, 7))
+            .usage(
+                Usage::from_counts(12, 7)
+                    .with_cached_tokens(3)
+                    .with_reasoning_tokens(2),
+            )
             .build();
 
         let response = chat_to_responses(
@@ -482,6 +486,14 @@ mod tests {
         assert_eq!(usage.get("input_tokens"), Some(&serde_json::json!(12)));
         assert_eq!(usage.get("output_tokens"), Some(&serde_json::json!(7)));
         assert_eq!(usage.get("total_tokens"), Some(&serde_json::json!(19)));
+        assert_eq!(
+            usage.pointer("/input_tokens_details/cached_tokens"),
+            Some(&serde_json::json!(3))
+        );
+        assert_eq!(
+            usage.pointer("/output_tokens_details/reasoning_tokens"),
+            Some(&serde_json::json!(2))
+        );
         assert!(usage.get("prompt_tokens").is_none());
         assert!(usage.get("completion_tokens").is_none());
     }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -427,7 +427,7 @@ pub(crate) fn chat_to_responses(
                 .and_then(|d| d.reasoning_tokens),
             prompt_tokens_details: None, // Chat response doesn't have this
         };
-        ResponsesUsage::Classic(usage_info)
+        ResponsesUsage::Modern(usage_info.to_response_usage())
     });
 
     // Generate response
@@ -444,9 +444,47 @@ pub(crate) fn chat_to_responses(
 
 #[cfg(test)]
 mod tests {
-    use openai_protocol::common::StreamOptions;
+    use openai_protocol::{
+        chat::{ChatChoice, ChatCompletionMessage},
+        common::{StreamOptions, Usage},
+    };
 
     use super::*;
+
+    #[test]
+    fn chat_to_responses_serializes_responses_api_usage() {
+        let chat_response = ChatCompletionResponse::builder("chatcmpl_test", "test-model")
+            .choices(vec![ChatChoice {
+                index: 0,
+                message: ChatCompletionMessage {
+                    role: "assistant".to_string(),
+                    content: Some("done".to_string()),
+                    tool_calls: None,
+                    reasoning_content: None,
+                },
+                logprobs: None,
+                finish_reason: Some("stop".to_string()),
+                matched_stop: None,
+                hidden_states: None,
+            }])
+            .usage(Usage::from_counts(12, 7))
+            .build();
+
+        let response = chat_to_responses(
+            &chat_response,
+            &ResponsesRequest::default(),
+            Some("resp_test".to_string()),
+        )
+        .expect("chat response should convert");
+        let wire = serde_json::to_value(response).expect("response should serialize");
+        let usage = wire.get("usage").expect("usage should be present");
+
+        assert_eq!(usage.get("input_tokens"), Some(&serde_json::json!(12)));
+        assert_eq!(usage.get("output_tokens"), Some(&serde_json::json!(7)));
+        assert_eq!(usage.get("total_tokens"), Some(&serde_json::json!(19)));
+        assert!(usage.get("prompt_tokens").is_none());
+        assert!(usage.get("completion_tokens").is_none());
+    }
 
     #[test]
     fn test_text_input_conversion() {

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -407,7 +407,7 @@ impl StreamingResponseAccumulator {
                     .completion_tokens_details
                     .as_ref()
                     .and_then(|d| d.reasoning_tokens),
-                prompt_tokens_details: None,
+                prompt_tokens_details: u.prompt_tokens_details.clone(),
             };
             ResponsesUsage::Modern(usage_info.to_response_usage())
         });
@@ -1091,7 +1091,11 @@ mod tests {
     fn streaming_accumulator_serializes_responses_api_usage() {
         let request = ResponsesRequest::default();
         let mut accumulator = StreamingResponseAccumulator::new(&request);
-        accumulator.usage = Some(Usage::from_counts(12, 7));
+        accumulator.usage = Some(
+            Usage::from_counts(12, 7)
+                .with_cached_tokens(3)
+                .with_reasoning_tokens(2),
+        );
 
         let wire = serde_json::to_value(accumulator.finalize())
             .expect("streaming response should serialize");
@@ -1100,6 +1104,14 @@ mod tests {
         assert_eq!(usage.get("input_tokens"), Some(&serde_json::json!(12)));
         assert_eq!(usage.get("output_tokens"), Some(&serde_json::json!(7)));
         assert_eq!(usage.get("total_tokens"), Some(&serde_json::json!(19)));
+        assert_eq!(
+            usage.pointer("/input_tokens_details/cached_tokens"),
+            Some(&serde_json::json!(3))
+        );
+        assert_eq!(
+            usage.pointer("/output_tokens_details/reasoning_tokens"),
+            Some(&serde_json::json!(2))
+        );
         assert!(usage.get("prompt_tokens").is_none());
         assert!(usage.get("completion_tokens").is_none());
     }

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -409,7 +409,7 @@ impl StreamingResponseAccumulator {
                     .and_then(|d| d.reasoning_tokens),
                 prompt_tokens_details: None,
             };
-            ResponsesUsage::Classic(usage_info)
+            ResponsesUsage::Modern(usage_info.to_response_usage())
         });
 
         ResponsesResponse::builder(&self.response_id, &self.model)
@@ -1086,6 +1086,23 @@ impl ChatResponseAccumulator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn streaming_accumulator_serializes_responses_api_usage() {
+        let request = ResponsesRequest::default();
+        let mut accumulator = StreamingResponseAccumulator::new(&request);
+        accumulator.usage = Some(Usage::from_counts(12, 7));
+
+        let wire = serde_json::to_value(accumulator.finalize())
+            .expect("streaming response should serialize");
+        let usage = wire.get("usage").expect("usage should be present");
+
+        assert_eq!(usage.get("input_tokens"), Some(&serde_json::json!(12)));
+        assert_eq!(usage.get("output_tokens"), Some(&serde_json::json!(7)));
+        assert_eq!(usage.get("total_tokens"), Some(&serde_json::json!(19)));
+        assert!(usage.get("prompt_tokens").is_none());
+        assert!(usage.get("completion_tokens").is_none());
+    }
 
     #[test]
     fn streaming_accumulator_populates_call_id_from_tool_delta_id() {


### PR DESCRIPTION
## Description

### Problem

The regular gRPC Responses pipeline serialized usage with Chat Completions field names (prompt_tokens and completion_tokens). OpenAI Responses clients expect input_tokens and output_tokens, so AutomationBench parsed the missing fields as null and crashed before evaluation.

### Solution

Serialize UsageInfo through the existing Responses API conversion in every regular response construction path:

- non-streaming responses
- stored streaming responses
- shared streaming finalization

The conversion also preserves cached-input and reasoning-output token details.

## Changes

- Return Responses API usage field names from the regular gRPC Responses pipeline.
- Preserve input_tokens_details.cached_tokens and output_tokens_details.reasoning_tokens.
- Add wire-format regression coverage for non-streaming and both streaming finalization paths.

## Test Plan

- `cargo test -p smg serializes_responses_api_usage -- --nocapture` — 3 passed.
- `cargo clippy -p smg --all-targets -- -D warnings` — passed.
- `cargo +nightly fmt --all -- --check` — passed.
- `pre-commit run --all-files` — all non-Clippy hooks passed; repository-wide all-features Clippy is blocked on this host because pkg-config/OpenCV is not installed.
- Full `cargo test` — all 1,343 SMG library tests and Responses API tests passed; the run later stopped at unrelated `test_router_with_tracing` because its local OTLP collector received zero spans. A prior full run passed.
- Live `/v1/responses` probe through gRPC vLLM + SMG — verified modern usage keys.
- AutomationBench Public Responses API six-domain slice — completed 6/6 rollouts with zero client errors (23.75% average; CLI rounded to 24%).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
