### PR TITLE
feat(worker): introduce ZMQ connection mode

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -491,12 +491,16 @@ struct Router {
 
 impl Router {
     fn determine_connection_mode(worker_urls: &[String]) -> worker::ConnectionMode {
-        for url in worker_urls {
-            if url.starts_with("grpc://") || url.starts_with("grpcs://") {
-                return worker::ConnectionMode::Grpc;
-            }
-        }
-        worker::ConnectionMode::Http
+        use worker::ConnectionMode;
+        // First worker URL that declares ipc:// or grpc:// wins; http:// and bare
+        // host:port fall through to the HTTP default. See ConnectionMode::from_url.
+        worker_urls
+            .iter()
+            .find_map(|url| match ConnectionMode::from_url(url) {
+                mode @ (Some(ConnectionMode::Zmq) | Some(ConnectionMode::Grpc)) => mode,
+                _ => None,
+            })
+            .unwrap_or(ConnectionMode::Http)
     }
 
     fn parse_mesh_socket_addr(

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -84,6 +84,36 @@ pub enum ConnectionMode {
     Http,
     /// gRPC connection.
     Grpc,
+    /// Direct ZMQ connection to a same-host engine core (bypasses the gRPC
+    /// Python servicer). Speaks the engine's native ZMQ IPC.
+    Zmq,
+}
+
+impl ConnectionMode {
+    /// Classify a worker URL by its scheme — the single source of truth for
+    /// scheme → connection mode. Returns `None` for a bare `host:port` (no
+    /// scheme) or an unrecognized scheme, leaving the default to the caller
+    /// (some probe both protocols; some default to HTTP).
+    pub fn from_url(url: &str) -> Option<Self> {
+        if url.starts_with("ipc://") {
+            Some(ConnectionMode::Zmq)
+        } else if url.starts_with("grpc://") || url.starts_with("grpcs://") {
+            Some(ConnectionMode::Grpc)
+        } else if url.starts_with("http://") || url.starts_with("https://") {
+            Some(ConnectionMode::Http)
+        } else {
+            None
+        }
+    }
+
+    /// Whether the gateway speaks the engine's wire protocol directly for this
+    /// mode. gRPC and direct-ZMQ are distinct transports that both ride the
+    /// gRPC-router pipeline (differing only in the client behind it); HTTP is
+    /// proxied and has its own router. Callers use this to treat gRPC and ZMQ
+    /// workers uniformly.
+    pub fn uses_grpc_pipeline(self) -> bool {
+        matches!(self, ConnectionMode::Grpc | ConnectionMode::Zmq)
+    }
 }
 
 impl std::fmt::Display for ConnectionMode {
@@ -91,6 +121,7 @@ impl std::fmt::Display for ConnectionMode {
         match self {
             ConnectionMode::Http => write!(f, "http"),
             ConnectionMode::Grpc => write!(f, "grpc"),
+            ConnectionMode::Zmq => write!(f, "zmq"),
         }
     }
 }
@@ -1352,6 +1383,41 @@ impl IntoResponse for WorkerLoadsResult {
             })
             .collect();
         Json(json!({"workers": loads})).into_response()
+    }
+}
+
+#[cfg(test)]
+mod connection_mode_tests {
+    use super::ConnectionMode;
+
+    #[test]
+    fn from_url_classifies_known_schemes() {
+        assert_eq!(
+            ConnectionMode::from_url("ipc:///tmp/e"),
+            Some(ConnectionMode::Zmq)
+        );
+        assert_eq!(
+            ConnectionMode::from_url("grpc://h:1"),
+            Some(ConnectionMode::Grpc)
+        );
+        assert_eq!(
+            ConnectionMode::from_url("grpcs://h:1"),
+            Some(ConnectionMode::Grpc)
+        );
+        assert_eq!(
+            ConnectionMode::from_url("http://h:1"),
+            Some(ConnectionMode::Http)
+        );
+        assert_eq!(
+            ConnectionMode::from_url("https://h"),
+            Some(ConnectionMode::Http)
+        );
+    }
+
+    #[test]
+    fn from_url_returns_none_for_bare_or_unknown() {
+        assert_eq!(ConnectionMode::from_url("host:30000"), None);
+        assert_eq!(ConnectionMode::from_url("ftp://host"), None);
     }
 }
 

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -40,16 +40,29 @@ pub fn validate_worker_url(url: &str) -> ConfigResult<()> {
     // matches schemes case-sensitively, so a mixed-case scheme would be
     // rewritten downstream and diverge from the reservation key — the
     // same orphan failure as a schemeless URL.
-    const ALLOWED_SCHEMES: &[&str] = &["http", "https", "grpc", "grpcs"];
+    const ALLOWED_SCHEMES: &[&str] = &["http", "https", "grpc", "grpcs", "ipc"];
     let scheme = url.split_once("://").map_or("", |(s, _)| s);
     if !ALLOWED_SCHEMES.contains(&scheme) {
         return Err(ConfigError::InvalidValue {
             field: "worker_url".to_string(),
             value: url.to_string(),
-            reason:
-                "URL must start with a lowercase http://, https://, grpc://, or grpcs:// scheme"
-                    .to_string(),
+            reason: "URL must start with a lowercase http://, https://, grpc://, grpcs://, or ipc:// scheme"
+                .to_string(),
         });
+    }
+
+    // ipc:// worker URLs are same-host ZMQ unix-socket paths (no host); validate
+    // the path is present rather than requiring a host below.
+    if scheme == "ipc" {
+        let path = url.strip_prefix("ipc://").unwrap_or("");
+        if path.is_empty() {
+            return Err(ConfigError::InvalidValue {
+                field: "worker_url".to_string(),
+                value: url.to_string(),
+                reason: "ipc:// worker URL must include a socket path".to_string(),
+            });
+        }
+        return Ok(());
     }
 
     match ::url::Url::parse(url) {

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -992,12 +992,15 @@ impl CliArgs {
     }
 
     fn determine_connection_mode(worker_urls: &[String]) -> ConnectionMode {
-        for url in worker_urls {
-            if url.starts_with("grpc://") || url.starts_with("grpcs://") {
-                return ConnectionMode::Grpc;
-            }
-        }
-        ConnectionMode::Http
+        // First worker URL that declares ipc:// or grpc:// wins; http:// and bare
+        // host:port fall through to the HTTP default. See ConnectionMode::from_url.
+        worker_urls
+            .iter()
+            .find_map(|url| match ConnectionMode::from_url(url) {
+                mode @ (Some(ConnectionMode::Zmq) | Some(ConnectionMode::Grpc)) => mode,
+                _ => None,
+            })
+            .unwrap_or(ConnectionMode::Http)
     }
 
     fn parse_selector(selector_list: &[String]) -> HashMap<String, String> {

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -478,6 +478,7 @@ pub mod metrics_labels {
     // Connection modes
     pub const CONNECTION_HTTP: &str = "http";
     pub const CONNECTION_GRPC: &str = "grpc";
+    pub const CONNECTION_ZMQ: &str = "zmq";
 
     // Endpoints
     pub const ENDPOINT_CHAT: &str = "chat";

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -54,7 +54,7 @@ impl RouterFactory {
     /// Create a router instance from application context
     pub async fn create_router(ctx: &Arc<AppContext>) -> Result<Box<dyn RouterTrait>, String> {
         match ctx.router_config.connection_mode {
-            ConnectionMode::Grpc => {
+            ConnectionMode::Grpc | ConnectionMode::Zmq => {
                 // Register the per-role policies each disaggregation mode needs,
                 // then build the mode-parameterized gRPC router.
                 match &ctx.router_config.mode {

--- a/model_gateway/src/routers/grpc/mode.rs
+++ b/model_gateway/src/routers/grpc/mode.rs
@@ -45,7 +45,11 @@ impl Mode {
 
 /// Derive the gRPC mode from config. `None` for non-gRPC backends.
 pub(crate) fn grpc_mode(cfg: &RouterConfig) -> Option<Mode> {
-    if cfg.connection_mode != ConnectionMode::Grpc {
+    // ZMQ reuses the gRPC router pipeline (same ProtoStream/execution stages).
+    if !matches!(
+        cfg.connection_mode,
+        ConnectionMode::Grpc | ConnectionMode::Zmq
+    ) {
         return None;
     }
     match cfg.mode {

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -155,15 +155,25 @@ impl RouterManager {
             (ConnectionMode::Http, RoutingMode::PrefillDecode { .. }) => router_ids::HTTP_PD,
             (ConnectionMode::Http, RoutingMode::OpenAI { .. }) => router_ids::HTTP_OPENAI,
             (ConnectionMode::Http, RoutingMode::Anthropic { .. }) => router_ids::HTTP_ANTHROPIC,
-            (ConnectionMode::Grpc, RoutingMode::Regular { .. }) => router_ids::GRPC_REGULAR,
-            (ConnectionMode::Grpc, RoutingMode::PrefillDecode { .. }) => router_ids::GRPC_PD,
+            (ConnectionMode::Grpc | ConnectionMode::Zmq, RoutingMode::Regular { .. }) => {
+                router_ids::GRPC_REGULAR
+            }
+            (ConnectionMode::Grpc | ConnectionMode::Zmq, RoutingMode::PrefillDecode { .. }) => {
+                router_ids::GRPC_PD
+            }
             // EPD only runs on gRPC; the HTTP arm never reaches a real router
             // (the factory errors), but the match must stay exhaustive.
             (_, RoutingMode::EncodePrefillDecode { .. }) => router_ids::GRPC_EPD,
             (ConnectionMode::Http, RoutingMode::Gemini { .. }) => router_ids::HTTP_GEMINI,
-            (ConnectionMode::Grpc, RoutingMode::OpenAI { .. }) => router_ids::GRPC_REGULAR,
-            (ConnectionMode::Grpc, RoutingMode::Anthropic { .. }) => router_ids::GRPC_REGULAR,
-            (ConnectionMode::Grpc, RoutingMode::Gemini { .. }) => router_ids::GRPC_REGULAR,
+            (ConnectionMode::Grpc | ConnectionMode::Zmq, RoutingMode::OpenAI { .. }) => {
+                router_ids::GRPC_REGULAR
+            }
+            (ConnectionMode::Grpc | ConnectionMode::Zmq, RoutingMode::Anthropic { .. }) => {
+                router_ids::GRPC_REGULAR
+            }
+            (ConnectionMode::Grpc | ConnectionMode::Zmq, RoutingMode::Gemini { .. }) => {
+                router_ids::GRPC_REGULAR
+            }
         }
     }
 
@@ -267,13 +277,21 @@ impl RouterManager {
 
         for w in workers {
             match (w.worker_type(), w.connection_mode()) {
-                (WorkerType::Encode, ConnectionMode::Grpc) => grpc_encode += 1,
+                (WorkerType::Encode, ConnectionMode::Grpc | ConnectionMode::Zmq) => {
+                    grpc_encode += 1;
+                }
                 (WorkerType::Encode, ConnectionMode::Http) => {}
-                (WorkerType::Prefill, ConnectionMode::Grpc) => grpc_prefill += 1,
+                (WorkerType::Prefill, ConnectionMode::Grpc | ConnectionMode::Zmq) => {
+                    grpc_prefill += 1;
+                }
                 (WorkerType::Prefill, ConnectionMode::Http) => http_prefill += 1,
-                (WorkerType::Decode, ConnectionMode::Grpc) => grpc_decode += 1,
+                (WorkerType::Decode, ConnectionMode::Grpc | ConnectionMode::Zmq) => {
+                    grpc_decode += 1;
+                }
                 (WorkerType::Decode, ConnectionMode::Http) => http_decode += 1,
-                (WorkerType::Regular, ConnectionMode::Grpc) => grpc_regular += 1,
+                (WorkerType::Regular, ConnectionMode::Grpc | ConnectionMode::Zmq) => {
+                    grpc_regular += 1;
+                }
                 (WorkerType::Regular, ConnectionMode::Http) => http_regular += 1,
             }
         }

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -237,8 +237,14 @@ impl BasicWorkerBuilder {
 
         use tokio::sync::OnceCell;
 
-        // Derive bootstrap_host from URL at construction time
-        self.spec.bootstrap_host = parse_bootstrap_host(&self.spec.url);
+        // bootstrap_host is a PD/TCP-disaggregation concept (a host:port peer),
+        // so derive it only for transports that carry a host. An ipc:// ZMQ
+        // worker has no host; leave bootstrap_host empty rather than forcing the
+        // URL through host:port parsing (which would warn and default to
+        // localhost).
+        if self.spec.connection_mode != ConnectionMode::Zmq {
+            self.spec.bootstrap_host = parse_bootstrap_host(&self.spec.url);
+        }
 
         // Resolve health config: use explicit config if set, otherwise
         // apply per-worker overrides from spec.health to defaults.

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -954,7 +954,9 @@ impl WorkerManager {
                         ConnectionMode::Http => {
                             WorkerMonitor::fetch_http_load(&client, &worker).await
                         }
-                        ConnectionMode::Grpc => WorkerMonitor::fetch_grpc_load(&worker).await,
+                        ConnectionMode::Grpc | ConnectionMode::Zmq => {
+                            WorkerMonitor::fetch_grpc_load(&worker).await
+                        }
                     };
                     // `load` is the absolute used-token count. Report it only
                     // when the backend actually provides absolute tokens

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -834,6 +834,10 @@ async fn group_monitor_loop(
                             WorkerMonitor::fetch_http_load(&client, &worker).await
                         }
                         ConnectionMode::Grpc => WorkerMonitor::fetch_grpc_load(&worker).await,
+                        // ZMQ load monitoring lands with the backend client; a
+                        // ZMQ worker reports no load until then (never via the
+                        // gRPC load path).
+                        ConnectionMode::Zmq => None,
                     };
                     (worker.url().to_string(), response)
                 }

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -608,7 +608,7 @@ impl WorkerRegistry {
 
             match worker.connection_mode() {
                 ConnectionMode::Http => http_count += 1,
-                ConnectionMode::Grpc => grpc_count += 1,
+                ConnectionMode::Grpc | ConnectionMode::Zmq => grpc_count += 1,
             }
 
             match worker.circuit_breaker_state() {

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -93,6 +93,17 @@ fn require_grpc_client(
     })
 }
 
+/// Error for an admin op invoked on a ZMQ worker. ZMQ backend operations are
+/// wired in a follow-up; until then a ZMQ worker is recognized but its admin
+/// surface is unavailable (it never routes through the gRPC client).
+fn zmq_admin_unsupported(url: &str, operation: &str) -> WorkerError {
+    WorkerError::OperationFailed {
+        url: url.to_string(),
+        operation: operation.to_string(),
+        reason: "admin operations are not yet supported for ZMQ workers".to_string(),
+    }
+}
+
 /// Map a gRPC admin-op outcome (`success` flag plus message) to a
 /// [`WorkerResult`].
 fn admin_grpc_result(
@@ -532,6 +543,7 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                     result.map(|r| (r.success, r.message)),
                 )
             }
+            ConnectionMode::Zmq => Err(zmq_admin_unsupported(self.url(), "flush_cache")),
         }
     }
 
@@ -577,6 +589,7 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                     result.map(|r| (r.success, r.message)),
                 )
             }
+            ConnectionMode::Zmq => Err(zmq_admin_unsupported(self.url(), "start_profile")),
         }
     }
 
@@ -605,6 +618,7 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                     result.map(|r| (r.success, r.message)),
                 )
             }
+            ConnectionMode::Zmq => Err(zmq_admin_unsupported(self.url(), "stop_profile")),
         }
     }
 }
@@ -619,6 +633,7 @@ impl ConnectionModeExt for ConnectionMode {
         match self {
             ConnectionMode::Http => metrics_labels::CONNECTION_HTTP,
             ConnectionMode::Grpc => metrics_labels::CONNECTION_GRPC,
+            ConnectionMode::Zmq => metrics_labels::CONNECTION_ZMQ,
         }
     }
 }
@@ -1054,6 +1069,9 @@ impl Worker for BasicWorker {
         let probe_ok = match &self.metadata.spec.connection_mode {
             ConnectionMode::Http => self.http_health_check().await?,
             ConnectionMode::Grpc => self.grpc_health_check().await?,
+            // ZMQ liveness lands with the backend client; until then a ZMQ
+            // worker is recognized but never becomes ready (not routable).
+            ConnectionMode::Zmq => false,
         };
 
         if probe_ok {
@@ -1204,7 +1222,10 @@ impl Worker for BasicWorker {
 
     async fn get_grpc_client(&self) -> WorkerResult<Option<Arc<GrpcClient>>> {
         match self.metadata.spec.connection_mode {
-            ConnectionMode::Http => Ok(None),
+            // Neither HTTP nor ZMQ has a gRPC client. A ZMQ worker's backend
+            // client is a separate type wired in a follow-up; it is never a
+            // gRPC client.
+            ConnectionMode::Http | ConnectionMode::Zmq => Ok(None),
             ConnectionMode::Grpc => {
                 // OnceCell provides lock-free reads after initialization.
                 // get_or_try_init only acquires internal lock on first call.

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -64,6 +64,26 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
         let kv_engine_id = labels.remove("kv_engine_id").filter(|s| !s.is_empty());
 
         let model_id = resolve_model_id(config, &labels);
+        // ZMQ EngineCore does not report a served model name over the wire, so a
+        // ZMQ worker's model identity must come from config (`--model-path`).
+        // Without it the worker would register as UNKNOWN and be unroutable, so
+        // fail loudly at registration rather than silently.
+        let model_id = if model_id == UNKNOWN_MODEL_ID && *connection_mode == ConnectionMode::Zmq {
+            app_context
+                .router_config
+                .model_path
+                .as_deref()
+                .ok_or_else(|| WorkflowError::StepFailed {
+                    step_id: StepId::new("create_worker"),
+                    message: format!(
+                        "ZMQ worker {} has no model identity: EngineCore does not report a \
+                         served model name, so --model-path (or a model_id label) is required",
+                        config.url
+                    ),
+                })?
+        } else {
+            model_id
+        };
 
         let model_card = build_model_card(
             model_id,
@@ -332,12 +352,14 @@ fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
         || url.starts_with("https://")
         || url.starts_with("grpc://")
         || url.starts_with("grpcs://")
+        || url.starts_with("ipc://")
     {
         url.to_string()
     } else {
         match connection_mode {
             ConnectionMode::Http => format!("http://{url}"),
             ConnectionMode::Grpc => format!("grpc://{url}"),
+            ConnectionMode::Zmq => format!("ipc://{url}"),
         }
     }
 }

--- a/model_gateway/src/workflow/steps/local/detect_backend.rs
+++ b/model_gateway/src/workflow/steps/local/detect_backend.rs
@@ -285,6 +285,8 @@ impl StepExecutor<WorkerWorkflowData> for DetectBackendStep {
                     step_id: wfaas::StepId::new("detect_backend"),
                     message: format!("gRPC backend detection failed for {}: {}", config.url, e),
                 })?,
+            // A ZMQ EngineCore is always vLLM; there is nothing to probe.
+            ConnectionMode::Zmq => "vllm".to_string(),
         };
 
         debug!(

--- a/model_gateway/src/workflow/steps/local/detect_connection.rs
+++ b/model_gateway/src/workflow/steps/local/detect_connection.rs
@@ -16,16 +16,6 @@ use crate::{
     },
 };
 
-fn explicit_connection_mode(url: &str) -> Option<ConnectionMode> {
-    if url.starts_with("grpc://") || url.starts_with("grpcs://") {
-        Some(ConnectionMode::Grpc)
-    } else if url.starts_with("http://") || url.starts_with("https://") {
-        Some(ConnectionMode::Http)
-    } else {
-        None
-    }
-}
-
 /// Step 1: Detect connection mode (HTTP vs gRPC).
 ///
 /// Explicit URL schemes are honored. For bare host:port URLs, probes both
@@ -62,10 +52,14 @@ impl StepExecutor<WorkerWorkflowData> for DetectConnectionModeStep {
             .unwrap_or(app_context.router_config.health_check.timeout_secs);
         let client = &app_context.client;
 
-        if let Some(connection_mode) = explicit_connection_mode(&url) {
+        if let Some(connection_mode) = ConnectionMode::from_url(&url) {
             let result = match connection_mode {
                 ConnectionMode::Http => try_http_reachable(&url, timeout, client).await,
                 ConnectionMode::Grpc => try_grpc_reachable(&url, timeout).await,
+                // SMG binds the ZMQ sockets and the engine dials in, so there is
+                // no endpoint to probe before binding; an explicit ipc:// URL is
+                // taken as reachable.
+                ConnectionMode::Zmq => Ok(()),
             };
 
             match result {
@@ -120,39 +114,5 @@ impl StepExecutor<WorkerWorkflowData> for DetectConnectionModeStep {
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         true
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn explicit_connection_mode_honors_grpc_scheme() {
-        assert_eq!(
-            explicit_connection_mode("grpc://localhost:30001"),
-            Some(ConnectionMode::Grpc)
-        );
-        assert_eq!(
-            explicit_connection_mode("grpcs://localhost:30001"),
-            Some(ConnectionMode::Grpc)
-        );
-    }
-
-    #[test]
-    fn explicit_connection_mode_honors_http_schemes() {
-        assert_eq!(
-            explicit_connection_mode("http://localhost:30000"),
-            Some(ConnectionMode::Http)
-        );
-        assert_eq!(
-            explicit_connection_mode("https://example.com"),
-            Some(ConnectionMode::Http)
-        );
-    }
-
-    #[test]
-    fn explicit_connection_mode_leaves_bare_urls_for_probe_detection() {
-        assert_eq!(explicit_connection_mode("localhost:30000"), None);
     }
 }

--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -373,6 +373,9 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverMetadataStep {
                     .await
                     .map(|(labels, rt)| (labels, Some(rt)))
             }
+            // EngineCore does not report model/tokenizer metadata over ZMQ; it is
+            // configured at worker registration. The runtime is always vLLM.
+            ConnectionMode::Zmq => Ok((HashMap::new(), Some("vllm".to_string()))),
         }
         .unwrap_or_else(|e| {
             warn!("Failed to fetch metadata for {}: {}", config.url, e);


### PR DESCRIPTION
## Description

### Problem

Before the gateway can talk to a same-host vLLM EngineCore over ZMQ (#2000), it must first *recognize* a ZMQ worker as a first-class connection mode. Wiring the whole path (backend client + routing) in one PR made the change hard to review, so this PR is the connection-mode layer only.

### Solution

Introduce `ConnectionMode::Zmq` and everything that recognizes, validates, and classifies a ZMQ worker — but **not** how to talk to it. A ZMQ worker is created, grouped, metriced, and health-checked like a gRPC-pipeline worker, but stays **not-ready (not routable)** until the backend client lands in a follow-up. Critically, ZMQ never routes through the gRPC client.

## Changes

- **protocols**: `ConnectionMode::Zmq` variant; canonical `ConnectionMode::from_url` (single source of truth for scheme→mode); `uses_grpc_pipeline()` predicate; `Display`; unit tests.
- **config/detection**: `ipc://` URL validation; `detect_connection` maps `ipc://`→Zmq (SMG binds the sockets, so there is no endpoint to probe); `determine_connection_mode` (CLI + Python) delegates to `from_url`.
- **classification**: registry/monitor/manager/factory/router_manager/mode group and count ZMQ workers with the gRPC pipeline.
- **builder**: skip the PD-only `bootstrap_host` derivation for `ipc://` (no host to parse).
- **boundary**: ZMQ never returns/uses a gRPC client — `get_grpc_client` → `None`, admin ops → explicit "not yet supported", load → `None`, health → not-ready. All pending the backend-client PR.
- **workflow**: `detect_backend`(Zmq)=vllm; model id resolved from `--model-path`; `normalize_url` handles `ipc://`.

## Test Plan

- `cargo test -p openai-protocol` (new `from_url` / classification tests).
- `cargo check` on `llm-multimodal`, `bindings/python`, `bindings/golang` (CI's default-multimodal step) — all compile.
- `cargo clippy -p smg --all-targets -- -D warnings` — clean.
- A ZMQ worker (`--worker-urls ipc://...`) is accepted, registered, and grouped; it stays not-ready (no client yet), which is the intended state for this PR.

Follow-up PRs stack the backend client (`BackendClient`/`ZmqEngineClient`) + routing + workflow metadata on top (tracked in #2015).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
