### PR TITLE
refactor(router): introduce BackendClient seam over the worker client

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -27,7 +27,7 @@ use smg::{
         BucketPolicy, CacheAwarePolicy, LoadBalancingPolicy, PowerOfTwoPolicy, RandomPolicy,
         RoundRobinPolicy, SelectWorkerInfo,
     },
-    routers::grpc::{client::GrpcClient, utils::process_chat_messages},
+    routers::grpc::{backend_client::BackendClient, utils::process_chat_messages},
     worker::{
         circuit_breaker::{CircuitBreaker, CircuitState},
         resilience::ResolvedResilience,
@@ -217,7 +217,7 @@ impl Worker for GrpcWorker {
         &self.http_client
     }
 
-    async fn get_grpc_client(&self) -> WorkerResult<Option<Arc<GrpcClient>>> {
+    async fn get_backend_client(&self) -> WorkerResult<Option<Arc<BackendClient>>> {
         // Not used by policies — the FFI layer handles gRPC directly
         Ok(None)
     }

--- a/model_gateway/src/routers/grpc/backend_client.rs
+++ b/model_gateway/src/routers/grpc/backend_client.rs
@@ -1,0 +1,194 @@
+//! Backend client: the polymorphism point over a worker's transport.
+//!
+//! A worker's backend is reached via the [`GrpcClient`] multiplexer (over
+//! SGLang/vLLM/TRT-LLM/MLX/TokenSpeed). `BackendClient` is the seam the
+//! execution pipeline works against so that additional transports (a direct
+//! ZMQ connection to a same-host vLLM EngineCore) can be added as sibling
+//! variants without the pipeline — which operates on [`ProtoStream`] /
+//! [`ProtoGenerateRequest`] — having to change.
+//!
+//! Today it wraps only gRPC; every method delegates to the inner client, so
+//! this is a behavior-neutral seam.
+
+use openai_protocol::{
+    chat::ChatCompletionRequest, completion::CompletionRequest, generate::GenerateRequest,
+    messages::CreateMessageRequest, worker::WorkerLoadResponse,
+};
+use smg_grpc_client::{common_proto, tokenizer_bundle::StreamBundle, SglangSchedulerClient};
+
+use crate::routers::grpc::{
+    client::{GenerateRequestBuildOptions, GrpcClient, HealthCheckResponse, ModelInfo, ServerInfo},
+    proto_wrapper::{ProtoEmbedComplete, ProtoEmbedRequest, ProtoGenerateRequest, ProtoStream},
+};
+
+/// A worker's backend connection. Currently gRPC-only; a direct-ZMQ variant is
+/// added alongside `Grpc` in a follow-up.
+#[derive(Clone)]
+pub enum BackendClient {
+    Grpc(GrpcClient),
+}
+
+impl BackendClient {
+    /// Runtime type backing this client.
+    pub fn runtime_type(&self) -> crate::worker::RuntimeType {
+        match self {
+            Self::Grpc(client) => client.runtime_type(),
+        }
+    }
+
+    /// True if this backend speaks the vLLM protocol.
+    pub fn is_vllm(&self) -> bool {
+        match self {
+            Self::Grpc(client) => client.is_vllm(),
+        }
+    }
+
+    /// Mutable SGLang client accessor. Only valid for a gRPC-SGLang backend;
+    /// callers guard with a runtime/sglang check.
+    pub fn as_sglang_mut(&mut self) -> &mut SglangSchedulerClient {
+        match self {
+            Self::Grpc(client) => client.as_sglang_mut(),
+        }
+    }
+
+    pub async fn health_check(&self) -> Result<HealthCheckResponse, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.health_check().await,
+        }
+    }
+
+    pub async fn get_model_info(&self) -> Result<ModelInfo, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.get_model_info().await,
+        }
+    }
+
+    pub async fn get_server_info(&self) -> Result<ServerInfo, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.get_server_info().await,
+        }
+    }
+
+    pub async fn get_loads(&self) -> Result<WorkerLoadResponse, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.get_loads().await,
+        }
+    }
+
+    pub async fn flush_cache(
+        &self,
+        timeout_s: f32,
+    ) -> Result<common_proto::FlushCacheResponse, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.flush_cache(timeout_s).await,
+        }
+    }
+
+    pub async fn start_profile(
+        &self,
+        req: common_proto::StartProfileRequest,
+    ) -> Result<common_proto::ProfileResponse, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.start_profile(req).await,
+        }
+    }
+
+    pub async fn stop_profile(&self) -> Result<common_proto::ProfileResponse, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.stop_profile().await,
+        }
+    }
+
+    pub async fn subscribe_kv_events(
+        &self,
+        start_seq: u64,
+    ) -> Result<tonic::Streaming<common_proto::KvEventBatch>, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.subscribe_kv_events(start_seq).await,
+        }
+    }
+
+    pub async fn get_tokenizer(
+        &self,
+    ) -> Result<StreamBundle, Box<dyn std::error::Error + Send + Sync>> {
+        match self {
+            Self::Grpc(client) => client.get_tokenizer().await,
+        }
+    }
+
+    pub async fn generate(
+        &mut self,
+        req: ProtoGenerateRequest,
+    ) -> Result<ProtoStream, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.generate(req).await,
+        }
+    }
+
+    pub async fn embed(
+        &mut self,
+        req: ProtoEmbedRequest,
+    ) -> Result<ProtoEmbedComplete, tonic::Status> {
+        match self {
+            Self::Grpc(client) => client.embed(req).await,
+        }
+    }
+
+    pub fn build_chat_request(
+        &self,
+        request_id: String,
+        body: &ChatCompletionRequest,
+        processed_text: String,
+        token_ids: Vec<u32>,
+        options: GenerateRequestBuildOptions,
+    ) -> Result<ProtoGenerateRequest, String> {
+        match self {
+            Self::Grpc(client) => {
+                client.build_chat_request(request_id, body, processed_text, token_ids, options)
+            }
+        }
+    }
+
+    pub fn build_messages_request(
+        &self,
+        request_id: String,
+        body: &CreateMessageRequest,
+        processed_text: String,
+        token_ids: Vec<u32>,
+        options: GenerateRequestBuildOptions,
+    ) -> Result<ProtoGenerateRequest, String> {
+        match self {
+            Self::Grpc(client) => {
+                client.build_messages_request(request_id, body, processed_text, token_ids, options)
+            }
+        }
+    }
+
+    pub fn build_completion_request(
+        &self,
+        request_id: String,
+        body: &CompletionRequest,
+        original_text: String,
+        token_ids: Vec<u32>,
+    ) -> Result<ProtoGenerateRequest, String> {
+        match self {
+            Self::Grpc(client) => {
+                client.build_completion_request(request_id, body, original_text, token_ids)
+            }
+        }
+    }
+
+    pub fn build_generate_request(
+        &self,
+        request_id: String,
+        body: &GenerateRequest,
+        original_text: Option<String>,
+        token_ids: Vec<u32>,
+    ) -> Result<ProtoGenerateRequest, String> {
+        match self {
+            Self::Grpc(client) => {
+                client.build_generate_request(request_id, body, original_text, token_ids)
+            }
+        }
+    }
+}

--- a/model_gateway/src/routers/grpc/common/stages/client_acquisition.rs
+++ b/model_gateway/src/routers/grpc/common/stages/client_acquisition.rs
@@ -11,7 +11,7 @@ use crate::{
     routers::{
         error,
         grpc::{
-            client::GrpcClient,
+            backend_client::BackendClient,
             context::{ClientSelection, RequestContext, WorkerSelection},
         },
     },
@@ -37,14 +37,14 @@ impl PipelineStage for ClientAcquisitionStage {
 
         let clients = match workers {
             WorkerSelection::Single { worker } => {
-                let client = get_grpc_client_from_worker(worker).await?;
+                let client = get_backend_client_from_worker(worker).await?;
                 ClientSelection::Single { client }
             }
             WorkerSelection::Disaggregated {
                 prefill, decode, ..
             } => {
-                let prefill_client = get_grpc_client_from_worker(prefill).await?;
-                let decode_client = get_grpc_client_from_worker(decode).await?;
+                let prefill_client = get_backend_client_from_worker(prefill).await?;
+                let decode_client = get_backend_client_from_worker(decode).await?;
 
                 ClientSelection::Disaggregated {
                     prefill: prefill_client,
@@ -62,25 +62,27 @@ impl PipelineStage for ClientAcquisitionStage {
     }
 }
 
-async fn get_grpc_client_from_worker(worker: &Arc<dyn Worker>) -> Result<GrpcClient, Response> {
+async fn get_backend_client_from_worker(
+    worker: &Arc<dyn Worker>,
+) -> Result<BackendClient, Response> {
     // Get cached client from worker (or create one if not cached yet)
     let client_arc = worker
-        .get_grpc_client()
+        .get_backend_client()
         .await
         .map_err(|e| {
             error!(
-                function = "get_grpc_client_from_worker",
+                function = "get_backend_client_from_worker",
                 error = %e,
                 "Failed to get gRPC client from worker"
             );
             error::internal_error(
-                "get_grpc_client_failed",
+                "get_backend_client_failed",
                 format!("Failed to get gRPC client: {e}"),
             )
         })?
         .ok_or_else(|| {
             error!(
-                function = "get_grpc_client_from_worker",
+                function = "get_backend_client_from_worker",
                 "Selected worker not configured for gRPC"
             );
             error::internal_error(

--- a/model_gateway/src/routers/grpc/common/stages/encode.rs
+++ b/model_gateway/src/routers/grpc/common/stages/encode.rs
@@ -29,6 +29,7 @@ use crate::{
     routers::{
         error,
         grpc::{
+            backend_client::BackendClient,
             client::GrpcClient,
             context::{ClientSelection, EncodeOutputs, RequestContext, WorkerSelection},
             multimodal::{
@@ -316,7 +317,7 @@ fn prepare_items(
     let clients = clients.ok_or_else(|| anyhow!("Client acquisition stage not completed"))?;
     match clients {
         ClientSelection::Disaggregated {
-            prefill: GrpcClient::TokenSpeed(_),
+            prefill: BackendClient::Grpc(GrpcClient::TokenSpeed(_)),
             ..
         } => prepare_tokenspeed_items(intermediate, workers),
         ClientSelection::Disaggregated { prefill, .. } => Err(anyhow!(
@@ -343,13 +344,13 @@ fn prepare_tokenspeed_items(
         .collect())
 }
 
-fn backend_name(client: &GrpcClient) -> &'static str {
+fn backend_name(client: &BackendClient) -> &'static str {
     match client {
-        GrpcClient::Sglang(_) => "SGLang",
-        GrpcClient::Vllm(_) => "vLLM",
-        GrpcClient::Trtllm(_) => "TRT-LLM",
-        GrpcClient::Mlx(_) => "MLX",
-        GrpcClient::TokenSpeed(_) => "TokenSpeed",
+        BackendClient::Grpc(GrpcClient::Sglang(_)) => "SGLang",
+        BackendClient::Grpc(GrpcClient::Vllm(_)) => "vLLM",
+        BackendClient::Grpc(GrpcClient::Trtllm(_)) => "TRT-LLM",
+        BackendClient::Grpc(GrpcClient::Mlx(_)) => "MLX",
+        BackendClient::Grpc(GrpcClient::TokenSpeed(_)) => "TokenSpeed",
     }
 }
 

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -22,7 +22,7 @@ use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::debug;
 
 use super::{
-    client::GrpcClient,
+    backend_client::BackendClient,
     common::stages::encode::EncodeDispatchPlan,
     multimodal::{MultimodalComponents, MultimodalIntermediate},
     proto_wrapper::{
@@ -386,13 +386,13 @@ pub(crate) enum WorkerSelection {
 #[derive(Clone)]
 pub(crate) enum ClientSelection {
     Single {
-        client: GrpcClient,
+        client: BackendClient,
     },
     /// Disaggregated prefill/decode scheduler clients. EPD encode workers are
     /// contacted directly from `WorkerSelection::Disaggregated` assignments.
     Disaggregated {
-        prefill: GrpcClient,
-        decode: GrpcClient,
+        prefill: BackendClient,
+        decode: BackendClient,
     },
 }
 
@@ -855,49 +855,49 @@ impl WorkerSelection {
 /// Some methods are kept for API completeness even if currently unused.
 #[expect(dead_code)]
 impl ClientSelection {
-    pub fn single(&self) -> Option<&GrpcClient> {
+    pub fn single(&self) -> Option<&BackendClient> {
         match self {
             Self::Single { client } => Some(client),
             Self::Disaggregated { .. } => None,
         }
     }
 
-    pub fn single_mut(&mut self) -> Option<&mut GrpcClient> {
+    pub fn single_mut(&mut self) -> Option<&mut BackendClient> {
         match self {
             Self::Single { client } => Some(client),
             Self::Disaggregated { .. } => None,
         }
     }
 
-    pub fn disaggregated_mut(&mut self) -> Option<(&mut GrpcClient, &mut GrpcClient)> {
+    pub fn disaggregated_mut(&mut self) -> Option<(&mut BackendClient, &mut BackendClient)> {
         match self {
             Self::Disaggregated { prefill, decode } => Some((prefill, decode)),
             Self::Single { .. } => None,
         }
     }
 
-    pub fn prefill_client(&self) -> Option<&GrpcClient> {
+    pub fn prefill_client(&self) -> Option<&BackendClient> {
         match self {
             Self::Disaggregated { prefill, .. } => Some(prefill),
             Self::Single { .. } => None,
         }
     }
 
-    pub fn prefill_client_mut(&mut self) -> Option<&mut GrpcClient> {
+    pub fn prefill_client_mut(&mut self) -> Option<&mut BackendClient> {
         match self {
             Self::Disaggregated { prefill, .. } => Some(prefill),
             Self::Single { .. } => None,
         }
     }
 
-    pub fn decode_client(&self) -> Option<&GrpcClient> {
+    pub fn decode_client(&self) -> Option<&BackendClient> {
         match self {
             Self::Disaggregated { decode, .. } => Some(decode),
             Self::Single { .. } => None,
         }
     }
 
-    pub fn decode_client_mut(&mut self) -> Option<&mut GrpcClient> {
+    pub fn decode_client_mut(&mut self) -> Option<&mut BackendClient> {
         match self {
             Self::Disaggregated { decode, .. } => Some(decode),
             Self::Single { .. } => None,

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -8,6 +8,7 @@ use tracing::{debug, error};
 use crate::routers::{
     error,
     grpc::{
+        backend_client::BackendClient,
         client::GrpcClient,
         common::stages::{helpers, PipelineStage},
         context::{
@@ -116,7 +117,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
 
         // Build proto request based on backend type and request type
         let mut proto_request = match builder_client {
-            GrpcClient::Sglang(sglang_client) => {
+            BackendClient::Grpc(GrpcClient::Sglang(sglang_client)) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());
@@ -164,7 +165,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 };
                 ProtoGenerateRequest::Sglang(Box::new(req))
             }
-            GrpcClient::Vllm(vllm_client) => {
+            BackendClient::Grpc(GrpcClient::Vllm(vllm_client)) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());
@@ -209,7 +210,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 };
                 ProtoGenerateRequest::Vllm(Box::new(req))
             }
-            GrpcClient::Trtllm(trtllm_client) => {
+            BackendClient::Grpc(GrpcClient::Trtllm(trtllm_client)) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());
@@ -254,7 +255,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 };
                 ProtoGenerateRequest::Trtllm(Box::new(req))
             }
-            GrpcClient::Mlx(mlx_client) => {
+            BackendClient::Grpc(GrpcClient::Mlx(mlx_client)) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());
@@ -298,7 +299,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 };
                 ProtoGenerateRequest::Mlx(Box::new(req))
             }
-            GrpcClient::TokenSpeed(tokenspeed_client) => {
+            BackendClient::Grpc(GrpcClient::TokenSpeed(tokenspeed_client)) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());

--- a/model_gateway/src/routers/grpc/mod.rs
+++ b/model_gateway/src/routers/grpc/mod.rs
@@ -5,6 +5,7 @@ use openai_protocol::{chat::ChatCompletionRequest, common::StringOrArray};
 
 use crate::routers::error;
 
+pub mod backend_client; // Used by bindings (Worker trait impl)
 pub mod client; // Used by core/
 pub(crate) mod common;
 pub(crate) mod context;

--- a/model_gateway/src/routers/grpc/multimodal/assemble.rs
+++ b/model_gateway/src/routers/grpc/multimodal/assemble.rs
@@ -29,6 +29,7 @@ use super::{
     MediaBatch, MultimodalIntermediate, PrecomputedMultimodalIntermediate, PromptBinding,
 };
 use crate::routers::grpc::{
+    backend_client::BackendClient,
     client::GrpcClient,
     context::WorkerSelection,
     proto_wrapper::{
@@ -44,7 +45,7 @@ use crate::routers::grpc::{
 /// Called in request_building after worker selection, when the backend is known.
 pub(crate) async fn assemble_multimodal_data(
     intermediate: MultimodalIntermediate,
-    client: &GrpcClient,
+    client: &BackendClient,
     workers: Option<&WorkerSelection>,
 ) -> Result<MultimodalData> {
     assemble_multimodal_data_impl(intermediate, client, workers, false).await
@@ -54,7 +55,7 @@ pub(crate) async fn assemble_multimodal_data(
 /// arrive out-of-band from encode workers.
 pub(crate) async fn assemble_multimodal_data_after_encode(
     intermediate: MultimodalIntermediate,
-    client: &GrpcClient,
+    client: &BackendClient,
     workers: Option<&WorkerSelection>,
 ) -> Result<MultimodalData> {
     assemble_multimodal_data_impl(intermediate, client, workers, true).await
@@ -62,7 +63,7 @@ pub(crate) async fn assemble_multimodal_data_after_encode(
 
 async fn assemble_multimodal_data_impl(
     intermediate: MultimodalIntermediate,
-    client: &GrpcClient,
+    client: &BackendClient,
     workers: Option<&WorkerSelection>,
     omit_prefill_pixels: bool,
 ) -> Result<MultimodalData> {
@@ -72,19 +73,19 @@ async fn assemble_multimodal_data_impl(
     // so assembly can never silently mishandle a modality the backend lacks.
     ensure_client_supports_intermediate(client, &intermediate)?;
     match client {
-        GrpcClient::Sglang(_) => {
+        BackendClient::Grpc(GrpcClient::Sglang(_)) => {
             let batch = into_single_batch(intermediate, "SGLang")?;
             Ok(MultimodalData::Sglang(assemble_sglang(batch)?))
         }
-        GrpcClient::Vllm(_) => {
+        BackendClient::Grpc(GrpcClient::Vllm(_)) => {
             let batch = into_single_batch(intermediate, "vLLM")?;
             Ok(MultimodalData::Vllm(assemble_vllm(batch, workers)?))
         }
-        GrpcClient::Trtllm(_) => {
+        BackendClient::Grpc(GrpcClient::Trtllm(_)) => {
             let batch = into_single_batch(intermediate, "TRT-LLM")?;
             Ok(MultimodalData::Trtllm(assemble_trtllm(batch)?))
         }
-        GrpcClient::TokenSpeed(_) => {
+        BackendClient::Grpc(GrpcClient::TokenSpeed(_)) => {
             let options = intermediate
                 .batches()
                 .iter()
@@ -104,7 +105,9 @@ async fn assemble_multimodal_data_impl(
             .context("TokenSpeed multimodal assembly task failed")??;
             Ok(MultimodalData::TokenSpeed(pending.into_inner()?))
         }
-        GrpcClient::Mlx(_) => anyhow::bail!("MLX does not support multimodal inputs"),
+        BackendClient::Grpc(GrpcClient::Mlx(_)) => {
+            anyhow::bail!("MLX does not support multimodal inputs")
+        }
     }
 }
 
@@ -161,7 +164,7 @@ fn into_single_batch(
 /// check, keyed on the concrete backend client. See
 /// [`crate::routers::grpc::multimodal::capability::ensure_backend_supports_modalities`].
 fn ensure_client_supports_intermediate(
-    client: &GrpcClient,
+    client: &BackendClient,
     intermediate: &MultimodalIntermediate,
 ) -> Result<()> {
     ensure_backend_supports_modalities(client.runtime_type(), intermediate)

--- a/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 use crate::routers::{
     error,
     grpc::{
-        client::GrpcClient,
+        backend_client::BackendClient,
         common::stages::{helpers, PipelineStage},
         context::{
             ClientSelection, CompletionItem, ExecutionPlan, ExecutionPlanKind, PreparationOutput,
@@ -49,7 +49,7 @@ impl CompletionRequestBuildingStage {
     )]
     fn build_proto_request(
         &self,
-        builder_client: &GrpcClient,
+        builder_client: &BackendClient,
         request_id: String,
         item: &CompletionItem,
         completion_request: &CompletionRequest,

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
@@ -7,6 +7,7 @@ use tracing::error;
 use crate::routers::{
     error,
     grpc::{
+        backend_client::BackendClient,
         client::GrpcClient,
         common::stages::{helpers, PipelineStage},
         context::{ExecutionPlan, RequestContext, RequestType},
@@ -72,15 +73,15 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
         let token_ids = prep_output.token_ids().to_vec();
 
         let proto_req = match client {
-            GrpcClient::Sglang(c) => {
+            BackendClient::Grpc(GrpcClient::Sglang(c)) => {
                 let req = c.build_embed_request(request_id.clone(), original_text, token_ids);
                 ProtoEmbedRequest::Sglang(Box::new(req))
             }
-            GrpcClient::Vllm(c) => {
+            BackendClient::Grpc(GrpcClient::Vllm(c)) => {
                 let req = c.build_embed_request(request_id.clone(), original_text, token_ids);
                 ProtoEmbedRequest::Vllm(Box::new(req))
             }
-            GrpcClient::Trtllm(_) => {
+            BackendClient::Grpc(GrpcClient::Trtllm(_)) => {
                 error!(
                     function = "EmbeddingRequestBuildingStage::execute",
                     "TensorRT-LLM embedding not yet supported"
@@ -90,7 +91,7 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
                     "TensorRT-LLM embedding is not yet supported via gRPC",
                 ));
             }
-            GrpcClient::Mlx(_) => {
+            BackendClient::Grpc(GrpcClient::Mlx(_)) => {
                 error!(
                     function = "EmbeddingRequestBuildingStage::execute",
                     "MLX embedding not supported"
@@ -100,7 +101,7 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
                     "MLX embedding is not supported via gRPC",
                 ));
             }
-            GrpcClient::TokenSpeed(_) => {
+            BackendClient::Grpc(GrpcClient::TokenSpeed(_)) => {
                 error!(
                     function = "EmbeddingRequestBuildingStage::execute",
                     "TokenSpeed backend does not support embeddings"

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -14,7 +14,7 @@ use super::{
         DEFAULT_WORKER_HTTP_TIMEOUT_SECS,
     },
 };
-use crate::{observability::metrics::Metrics, routers::grpc::client::GrpcClient};
+use crate::{observability::metrics::Metrics, routers::grpc::backend_client::BackendClient};
 
 /// Builder for creating BasicWorker instances with fluent API.
 ///
@@ -27,7 +27,7 @@ pub struct BasicWorkerBuilder {
     health_config: Option<HealthCheckConfig>,
     health_endpoint: String,
     circuit_breaker_config: CircuitBreakerConfig,
-    grpc_client: Option<GrpcClient>,
+    backend_client: Option<BackendClient>,
     /// Pre-built per-worker HTTP client (if not set, a default is created).
     http_client: Option<reqwest::Client>,
     /// Resolved resilience config (if not set, defaults are used).
@@ -47,7 +47,7 @@ impl BasicWorkerBuilder {
             health_config: None,
             health_endpoint: "/health".to_string(),
             circuit_breaker_config: CircuitBreakerConfig::default(),
-            grpc_client: None,
+            backend_client: None,
             http_client: None,
             resilience: None,
             initial_status: None,
@@ -61,7 +61,7 @@ impl BasicWorkerBuilder {
             health_config: None,
             health_endpoint: "/health".to_string(),
             circuit_breaker_config: CircuitBreakerConfig::default(),
-            grpc_client: None,
+            backend_client: None,
             http_client: None,
             resilience: None,
             initial_status: None,
@@ -77,7 +77,7 @@ impl BasicWorkerBuilder {
             health_config: None,
             health_endpoint: "/health".to_string(),
             circuit_breaker_config: CircuitBreakerConfig::default(),
-            grpc_client: None,
+            backend_client: None,
             http_client: None,
             resilience: None,
             initial_status: None,
@@ -161,8 +161,8 @@ impl BasicWorkerBuilder {
     }
 
     /// Set gRPC client for gRPC workers
-    pub fn grpc_client(mut self, client: GrpcClient) -> Self {
-        self.grpc_client = Some(client);
+    pub fn backend_client(mut self, client: BackendClient) -> Self {
+        self.backend_client = Some(client);
         self
     }
 
@@ -259,7 +259,7 @@ impl BasicWorkerBuilder {
         };
 
         // Use OnceCell for lock-free gRPC client access after initialization
-        let grpc_client = Arc::new(match self.grpc_client {
+        let backend_client = Arc::new(match self.backend_client {
             Some(client) => {
                 let cell = OnceCell::new();
                 // Pre-set the client if provided (blocking set is fine during construction)
@@ -302,7 +302,7 @@ impl BasicWorkerBuilder {
                 metadata.spec.url.clone(),
             )),
             metadata,
-            grpc_client,
+            backend_client,
             models_override: Arc::new(ArcSwap::from_pointee(WorkerModels::Wildcard)),
             http_client,
             resilience,

--- a/model_gateway/src/worker/kv_event_monitor.rs
+++ b/model_gateway/src/worker/kv_event_monitor.rs
@@ -377,7 +377,7 @@ impl KvEventMonitor {
         }
 
         loop {
-            let grpc_client = match worker.get_grpc_client().await {
+            let backend_client = match worker.get_backend_client().await {
                 Ok(Some(client)) => client,
                 Ok(None) => {
                     // HTTP workers are filtered in on_worker_added, so this should
@@ -417,7 +417,7 @@ impl KvEventMonitor {
                 }
             };
 
-            let stream = match grpc_client.subscribe_kv_events(last_seq).await {
+            let stream = match backend_client.subscribe_kv_events(last_seq).await {
                 Ok(stream) => {
                     info!(
                         worker_url = %worker_url,

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -614,7 +614,7 @@ impl WorkerMonitor {
     /// backends. Returns `None` on missing client, RPC error, or empty
     /// `loads` array.
     pub(crate) async fn fetch_grpc_load(worker: &Arc<dyn Worker>) -> Option<WorkerLoadResponse> {
-        let grpc_client = match worker.get_grpc_client().await {
+        let backend_client = match worker.get_backend_client().await {
             Ok(Some(client)) => client,
             Ok(None) => {
                 debug!("No gRPC client for worker {}", worker.url());
@@ -626,7 +626,7 @@ impl WorkerMonitor {
             }
         };
 
-        match grpc_client.get_loads().await {
+        match backend_client.get_loads().await {
             Ok(load) if !load.loads.is_empty() => Some(load),
             Ok(_) => None,
             Err(e) => {

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -24,7 +24,10 @@ use tokio::{sync::OnceCell, time};
 use super::{CircuitBreaker, ResolvedResilience, WorkerError, WorkerResult, UNKNOWN_MODEL_ID};
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    routers::{common::header_utils::extract_routing_key, grpc::client::GrpcClient},
+    routers::{
+        common::header_utils::extract_routing_key,
+        grpc::{backend_client::BackendClient, client::GrpcClient},
+    },
 };
 
 /// Default HTTP client timeout for worker requests (in seconds)
@@ -81,15 +84,15 @@ async fn admin_http_post(
 }
 
 /// Unwrap the optional gRPC client for an admin op, erroring when absent.
-fn require_grpc_client(
+fn require_backend_client(
     url: &str,
     operation: &str,
-    client: Option<Arc<GrpcClient>>,
-) -> WorkerResult<Arc<GrpcClient>> {
+    client: Option<Arc<BackendClient>>,
+) -> WorkerResult<Arc<BackendClient>> {
     client.ok_or_else(|| WorkerError::OperationFailed {
         url: url.to_string(),
         operation: operation.to_string(),
-        reason: "no gRPC client available".to_string(),
+        reason: "no backend client available".to_string(),
     })
 }
 
@@ -501,11 +504,11 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
 
     /// Get or create a gRPC client for this worker
     /// Returns None for HTTP workers, Some(client) for gRPC workers
-    async fn get_grpc_client(&self) -> WorkerResult<Option<Arc<GrpcClient>>>;
+    async fn get_backend_client(&self) -> WorkerResult<Option<Arc<BackendClient>>>;
 
     /// Reset the gRPC client connection (for reconnection scenarios)
     /// No-op for HTTP workers
-    async fn reset_grpc_client(&self) -> WorkerResult<()> {
+    async fn reset_backend_client(&self) -> WorkerResult<()> {
         Ok(())
     }
     async fn grpc_health_check(&self) -> WorkerResult<bool>;
@@ -534,8 +537,11 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                 .await
             }
             ConnectionMode::Grpc => {
-                let client =
-                    require_grpc_client(self.url(), "flush_cache", self.get_grpc_client().await?)?;
+                let client = require_backend_client(
+                    self.url(),
+                    "flush_cache",
+                    self.get_backend_client().await?,
+                )?;
                 let result = client.flush_cache(0.0).await;
                 admin_grpc_result(
                     self.url(),
@@ -568,10 +574,10 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                 .await
             }
             ConnectionMode::Grpc => {
-                let client = require_grpc_client(
+                let client = require_backend_client(
                     self.url(),
                     "start_profile",
-                    self.get_grpc_client().await?,
+                    self.get_backend_client().await?,
                 )?;
                 let req = common_proto::StartProfileRequest {
                     output_dir: options.output_dir.clone(),
@@ -609,8 +615,11 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
                 .await
             }
             ConnectionMode::Grpc => {
-                let client =
-                    require_grpc_client(self.url(), "stop_profile", self.get_grpc_client().await?)?;
+                let client = require_backend_client(
+                    self.url(),
+                    "stop_profile",
+                    self.get_backend_client().await?,
+                )?;
                 let result = client.stop_profile().await;
                 admin_grpc_result(
                     self.url(),
@@ -955,7 +964,7 @@ pub struct BasicWorker {
     pub circuit_breaker: ArcSwap<CircuitBreaker>,
     /// Lazily initialized gRPC client for gRPC workers.
     /// Uses OnceCell for lock-free reads after initialization.
-    pub grpc_client: Arc<OnceCell<Arc<GrpcClient>>>,
+    pub backend_client: Arc<OnceCell<Arc<BackendClient>>>,
     /// Runtime-mutable models override (for lazy discovery).
     /// When not `Wildcard`, overrides metadata.models for routing decisions.
     /// Uses `ArcSwap` for lock-free reads on the hot path (`supports_model`).
@@ -972,7 +981,7 @@ impl Clone for BasicWorker {
             metadata: self.metadata.clone(),
             runtime: ArcSwap::from(self.runtime.load_full()),
             circuit_breaker: ArcSwap::from(self.circuit_breaker.load_full()),
-            grpc_client: Arc::clone(&self.grpc_client),
+            backend_client: Arc::clone(&self.backend_client),
             models_override: Arc::clone(&self.models_override),
             http_client: self.http_client.clone(),
             resilience: self.resilience.clone(),
@@ -988,7 +997,7 @@ impl fmt::Debug for BasicWorker {
             .field("status", &runtime.status())
             .field("revision", &runtime.revision())
             .field("circuit_breaker_state", &self.circuit_breaker_state())
-            .field("grpc_client", &"<OnceCell>")
+            .field("backend_client", &"<OnceCell>")
             .finish()
     }
 }
@@ -1220,7 +1229,7 @@ impl Worker for BasicWorker {
         !self.models_override.load().is_wildcard() || !self.metadata.spec.models.is_wildcard()
     }
 
-    async fn get_grpc_client(&self) -> WorkerResult<Option<Arc<GrpcClient>>> {
+    async fn get_backend_client(&self) -> WorkerResult<Option<Arc<BackendClient>>> {
         match self.metadata.spec.connection_mode {
             // Neither HTTP nor ZMQ has a gRPC client. A ZMQ worker's backend
             // client is a separate type wired in a follow-up; it is never a
@@ -1230,7 +1239,7 @@ impl Worker for BasicWorker {
                 // OnceCell provides lock-free reads after initialization.
                 // get_or_try_init only acquires internal lock on first call.
                 let client = self
-                    .grpc_client
+                    .backend_client
                     .get_or_try_init(|| async {
                         let runtime_str = self.metadata.spec.runtime_type.to_string();
                         tracing::info!(
@@ -1246,7 +1255,7 @@ impl Worker for BasicWorker {
                                     runtime_str,
                                     self.metadata.spec.url
                                 );
-                                Ok(Arc::new(client))
+                                Ok(Arc::new(BackendClient::Grpc(client)))
                             }
                             Err(e) => {
                                 tracing::error!(
@@ -1267,11 +1276,11 @@ impl Worker for BasicWorker {
         }
     }
 
-    async fn reset_grpc_client(&self) -> WorkerResult<()> {
+    async fn reset_backend_client(&self) -> WorkerResult<()> {
         // OnceCell doesn't support resetting. This is intentional for lock-free performance.
         // If a connection fails, the worker should be removed and re-added.
         tracing::debug!(
-            "reset_grpc_client called for {} (no-op with OnceCell)",
+            "reset_backend_client called for {} (no-op with OnceCell)",
             self.metadata.spec.url
         );
         Ok(())
@@ -1279,8 +1288,8 @@ impl Worker for BasicWorker {
 
     async fn grpc_health_check(&self) -> WorkerResult<bool> {
         let timeout = Duration::from_secs(self.metadata.health_config.timeout_secs);
-        let maybe = self.get_grpc_client().await?;
-        let Some(grpc_client) = maybe else {
+        let maybe = self.get_backend_client().await?;
+        let Some(backend_client) = maybe else {
             tracing::error!(
                 "Worker {} is not a gRPC worker but connection mode is gRPC",
                 self.metadata.spec.url
@@ -1288,7 +1297,7 @@ impl Worker for BasicWorker {
             return Ok(false);
         };
 
-        match time::timeout(timeout, grpc_client.health_check()).await {
+        match time::timeout(timeout, backend_client.health_check()).await {
             Ok(Ok(resp)) => {
                 tracing::debug!(
                     "gRPC health OK for {}: healthy={}",

--- a/model_gateway/src/workflow/tokenizer_registration.rs
+++ b/model_gateway/src/workflow/tokenizer_registration.rs
@@ -314,7 +314,7 @@ async fn fetch_tokenizer_from_worker(
             runtime
         );
 
-        let grpc_client = match worker.get_grpc_client().await {
+        let backend_client = match worker.get_backend_client().await {
             Ok(Some(client)) => client,
             Ok(None) => {
                 failures.push(format!(
@@ -332,7 +332,7 @@ async fn fetch_tokenizer_from_worker(
             }
         };
 
-        let bundle = match grpc_client.get_tokenizer().await {
+        let bundle = match backend_client.get_tokenizer().await {
             Ok(bundle) => bundle,
             Err(e) => {
                 let is_unimplemented = e


### PR DESCRIPTION
## Description

### Problem

To route a same-host ZMQ worker through the gRPC-router pipeline (#2000), the pipeline needs a client abstraction it can hold that isn't hard-wired to gRPC. Today the worker exposes `get_grpc_client()`/`GrpcClient` directly, so the pipeline, `ClientSelection`, and every request-building stage are typed against `GrpcClient`.

### Solution

Introduce **`BackendClient`** as the per-worker client the pipeline works against — a behavior-neutral seam. Today it has a single variant, `Grpc(GrpcClient)`, and every method delegates to the inner client. A follow-up adds `Zmq(ZmqEngineClient)` as a sibling variant without the pipeline changing.

**No behavior change.** `BackendClient::Grpc` is a thin wrapper; there is no new transport, no ZMQ, no `engine-zmq-client` dependency.

## Changes

- New `routers/grpc/backend_client.rs`: `enum BackendClient { Grpc(GrpcClient) }` delegating `generate`/`embed`/`health_check`/`get_model_info`/`get_server_info`/`get_loads`/`flush_cache`/`start_profile`/`stop_profile`/`subscribe_kv_events`/`get_tokenizer`/`runtime_type`/`is_vllm`/`as_sglang_mut`/`build_{chat,messages,completion,generate}_request`.
- Worker: `get_grpc_client` → `get_backend_client` (`Option<Arc<BackendClient>>`), `grpc_client` field/OnceCell → `backend_client`, `require_grpc_client` → `require_backend_client`. Builder, load monitor, KV-event monitor, and the Go bindings' `Worker` impl follow the rename.
- `ClientSelection` and the request-building / encode / multimodal-assemble stages carry `BackendClient` (wrapping the `GrpcClient` variants).

## Test Plan

- `cargo check` on `llm-multimodal`, `bindings/python`, `bindings/golang` (CI's default-multimodal step) — all compile.
- `cargo clippy -p smg --all-targets -- -D warnings` — clean.
- `cargo test -p smg --lib` — 1346 pass (the lone failure is the pre-existing `distinct_ids…interner` parallel-test flake, which passes in isolation). Behavior-neutral, so the existing suite is the regression guard.

Stacks toward #2000: the next PR adds `BackendClient::Zmq(ZmqEngineClient)` + the ZMQ routing on top of this seam.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
