### PR TITLE
fix(reasoning): support DeepSeek V4 Flash 0731 effort encoding

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -336,17 +336,14 @@ pub struct ChatCompletionRequest {
 ///
 /// This is the protocol-level interpretation of "does the caller want
 /// reasoning?" — independent of any model/template. `reasoning_effort` is a
-/// *level* (`"low"`/`"medium"`/`"high"`) plus the vendor-extension `"none"`.
-///
-/// Both `"none"` and `"minimal"` map to thinking OFF (`Some(false)`).
-/// `"minimal"` is treated as an off-signal deliberately: templates that expose
-/// only a boolean thinking toggle (GLM/Qwen3) cannot do "a little" reasoning,
-/// so the lowest OpenAI level is the closest available "do not reason".
-/// Level values return `None` — no opinion, defer to the template default or an
-/// explicit thinking kwarg.
+/// *level* plus `"none"`, which explicitly disables reasoning. Every known
+/// non-`none` OpenAI level requests some reasoning and therefore enables the
+/// model's thinking mode. Unknown scalar values remain pass-through data and
+/// do not implicitly toggle thinking.
 pub fn thinking_from_reasoning_effort(reasoning_effort: Option<&str>) -> Option<bool> {
     match reasoning_effort {
-        Some("none") | Some("minimal") => Some(false),
+        Some("none") => Some(false),
+        Some("minimal" | "low" | "medium" | "high" | "xhigh" | "max") => Some(true),
         _ => None,
     }
 }
@@ -816,14 +813,15 @@ mod tests {
     }
 
     #[test]
-    fn thinking_from_reasoning_effort_maps_disable_values() {
-        // "none"/"minimal" mean do-not-reason -> thinking OFF.
+    fn thinking_from_reasoning_effort_maps_known_openai_values() {
         assert_eq!(thinking_from_reasoning_effort(Some("none")), Some(false));
-        assert_eq!(thinking_from_reasoning_effort(Some("minimal")), Some(false));
-        // Level values do not toggle thinking on their own.
-        assert_eq!(thinking_from_reasoning_effort(Some("low")), None);
-        assert_eq!(thinking_from_reasoning_effort(Some("medium")), None);
-        assert_eq!(thinking_from_reasoning_effort(Some("high")), None);
+        for effort in ["minimal", "low", "medium", "high", "xhigh", "max"] {
+            assert_eq!(
+                thinking_from_reasoning_effort(Some(effort)),
+                Some(true),
+                "effort: {effort}"
+            );
+        }
         // Unspecified / unknown -> defer.
         assert_eq!(thinking_from_reasoning_effort(None), None);
         assert_eq!(thinking_from_reasoning_effort(Some("bogus")), None);

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1515,26 +1515,21 @@ pub enum ComputerCallOutputContent {
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 pub struct ResponseReasoningParam {
-    #[serde(default = "default_reasoning_effort")]
     pub effort: Option<ReasoningEffort>,
     pub summary: Option<ReasoningSummary>,
-}
-
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "serde default function must match field type Option<T>"
-)]
-fn default_reasoning_effort() -> Option<ReasoningEffort> {
-    Some(ReasoningEffort::Medium)
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
+    None,
     Minimal,
     Low,
     Medium,
     High,
+    #[serde(rename = "xhigh")]
+    XHigh,
+    Max,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -3908,6 +3903,34 @@ impl ResponseReasoningContent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reasoning_effort_accepts_openai_compatible_union() {
+        for effort in ["none", "minimal", "low", "medium", "high", "xhigh", "max"] {
+            let parsed: ResponseReasoningParam =
+                serde_json::from_value(serde_json::json!({ "effort": effort }))
+                    .unwrap_or_else(|error| panic!("failed to deserialize {effort}: {error}"));
+            let serialized = serde_json::to_value(parsed).unwrap();
+            assert_eq!(
+                serialized.get("effort").and_then(Value::as_str),
+                Some(effort)
+            );
+        }
+    }
+
+    #[test]
+    fn reasoning_effort_rejects_unknown_value() {
+        let result = serde_json::from_value::<ResponseReasoningParam>(
+            serde_json::json!({ "effort": "unlimited" }),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_reasoning_object_leaves_effort_unspecified() {
+        let parsed: ResponseReasoningParam = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(parsed.effort.is_none());
+    }
 
     /// Lock `as_str()` to the canonical serde tag for the unit variants
     /// — drift between the two would produce inconsistent wire labels

--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -162,6 +162,20 @@ impl ParserFactory {
             Box::new(BaseReasoningParser::new(config).with_model_type("deepseek_v31".to_string()))
         });
 
+        // DeepSeek V4 consumes <think> in the generation prompt when thinking
+        // is enabled, so request processing marks the parser as already in
+        // reasoning before the first generated token arrives.
+        registry.register_parser("deepseek_v4", || {
+            let config = ParserConfig {
+                think_start_token: "<think>".to_string(),
+                think_end_token: "</think>".to_string(),
+                stream_reasoning: true,
+                max_buffer_size: DEFAULT_MAX_BUFFER_SIZE,
+                always_in_reasoning: false,
+            };
+            Box::new(BaseReasoningParser::new(config).with_model_type("deepseek_v4".to_string()))
+        });
+
         registry.register_parser("kimi_k25", || {
             let config = ParserConfig {
                 think_start_token: "<think>".to_string(),
@@ -188,6 +202,8 @@ impl ParserFactory {
         registry.register_parser("kimi_k3", || Box::new(KimiK3Parser::new()));
 
         registry.register_pattern("deepseek-r1", "deepseek_r1");
+        registry.register_pattern("deepseek-v4", "deepseek_v4");
+        registry.register_pattern("deepseek_v4", "deepseek_v4");
         registry.register_pattern("deepseek-v3.1", "deepseek_v31");
         registry.register_pattern("deepseek-v3-1", "deepseek_v31");
         registry.register_pattern("qwen3-thinking", "qwen3_thinking");
@@ -271,6 +287,35 @@ mod tests {
         let factory = ParserFactory::new();
         let parser = factory.create("deepseek-r1-distill");
         assert_eq!(parser.model_type(), "deepseek_r1");
+    }
+
+    #[test]
+    fn test_factory_auto_registers_deepseek_v4_models() {
+        let factory = ParserFactory::new();
+        assert!(factory.list_parsers().contains(&"deepseek_v4".to_string()));
+
+        for model in [
+            "deepseek-ai/DeepSeek-V4-Flash",
+            "deepseek-ai/DeepSeek-V4-Flash-0731",
+            "deepseek-ai/DeepSeek-V4-Flash-DSpark",
+            "deepseek-ai/DeepSeek-V4-Pro",
+            "DEEPSEEK_V4_LOCAL",
+        ] {
+            assert_eq!(
+                factory.create(model).model_type(),
+                "deepseek_v4",
+                "model: {model}"
+            );
+        }
+
+        let mut parser = factory.create("deepseek-ai/DeepSeek-V4-Flash-0731");
+        assert!(!parser.is_in_reasoning());
+        parser.mark_reasoning_started();
+        let parsed = parser
+            .detect_and_parse_reasoning("analysis</think>answer")
+            .unwrap();
+        assert_eq!(parsed.reasoning_text, "analysis");
+        assert_eq!(parsed.normal_text, "answer");
     }
 
     #[test]

--- a/crates/tokenizer/src/cache/mod.rs
+++ b/crates/tokenizer/src/cache/mod.rs
@@ -297,6 +297,11 @@ impl Tokenizer for CachedTokenizer {
     fn thinking_key_name(&self) -> Option<ThinkingKeyName> {
         self.inner.thinking_key_name()
     }
+
+    fn template_reasoning_effort_enables_thinking(&self) -> bool {
+        self.inner.template_reasoning_effort_enables_thinking()
+    }
+
     fn think_in_prefill(&self) -> bool {
         self.inner.think_in_prefill()
     }

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -481,6 +481,13 @@ pub struct ChatTemplateParams<'a> {
     /// this value as a default. An explicit `template_kwargs` entry for that
     /// key still wins.
     pub thinking: Option<bool>,
+    /// OpenAI-compatible effort selected by the public request field. Native
+    /// renderers may map this value into their model-specific effort buckets.
+    pub reasoning_effort: Option<&'a str>,
+    /// Explicit native `chat_template_kwargs.reasoning_effort`, kept separate
+    /// from the merged kwargs map so it can override the public request effort
+    /// without being confused with it.
+    pub template_reasoning_effort: Option<&'a serde_json::Value>,
 }
 
 /// JSON separator pair passed through HuggingFace's `tojson` filter.

--- a/crates/tokenizer/src/encoders/deepseek_v4.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v4.rs
@@ -21,16 +21,6 @@ pub enum ReasoningEffort {
     Max,
 }
 
-/// Selects the reasoning-effort prompt format used by a DeepSeek V4 checkpoint.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum ReasoningEffortProfile {
-    /// Original Flash, Flash-DSpark, Pro, and unidentified V4 checkpoints.
-    #[default]
-    Original,
-    /// The newer effort encoding used only by DeepSeek-V4-Flash-0731.
-    Flash0731,
-}
-
 impl ReasoningEffort {
     /// Parse a native 0731 effort name.
     pub fn from_native(value: &str) -> Option<Self> {
@@ -62,7 +52,6 @@ pub struct EncodeParams {
     pub add_default_bos_token: bool,
     pub drop_thinking: bool,
     pub reasoning_effort: Option<ReasoningEffort>,
-    pub reasoning_effort_profile: ReasoningEffortProfile,
 }
 impl Default for EncodeParams {
     fn default() -> Self {
@@ -70,7 +59,6 @@ impl Default for EncodeParams {
             add_default_bos_token: true,
             drop_thinking: true,
             reasoning_effort: None,
-            reasoning_effort_profile: ReasoningEffortProfile::Original,
         }
     }
 }
@@ -270,7 +258,6 @@ fn render_message(
     thinking_mode: ThinkingMode,
     drop_thinking: bool,
     reasoning_effort: Option<ReasoningEffort>,
-    reasoning_effort_profile: ReasoningEffortProfile,
 ) -> Result<String, DsEncodingError> {
     if index >= messages.len() {
         return Err(DsEncodingError::IndexOutOfRange {
@@ -299,19 +286,14 @@ fn render_message(
 
     // Reasoning effort prefix (only at index 0 in thinking mode).
     if index == 0 && thinking_mode == ThinkingMode::Thinking {
-        match (reasoning_effort_profile, reasoning_effort) {
-            (ReasoningEffortProfile::Original, Some(ReasoningEffort::Max))
-            | (ReasoningEffortProfile::Flash0731, Some(ReasoningEffort::High)) => {
+        match reasoning_effort {
+            Some(ReasoningEffort::High) => {
                 prompt.push_str(REASONING_EFFORT_HIGH);
             }
-            (ReasoningEffortProfile::Flash0731, Some(ReasoningEffort::Max)) => {
+            Some(ReasoningEffort::Max) => {
                 prompt.push_str(REASONING_EFFORT_MAX);
             }
-            (
-                ReasoningEffortProfile::Original,
-                Some(ReasoningEffort::Low | ReasoningEffort::High) | None,
-            )
-            | (ReasoningEffortProfile::Flash0731, Some(ReasoningEffort::Low) | None) => {}
+            Some(ReasoningEffort::Low) | None => {}
         }
     }
 
@@ -718,7 +700,6 @@ pub fn encode_messages(
             thinking_mode,
             effective_drop_thinking,
             params.reasoning_effort,
-            params.reasoning_effort_profile,
         )?);
     }
     Ok(prompt)
@@ -757,7 +738,6 @@ mod tests {
         let msgs = [user("Hello")];
         let params = EncodeParams {
             reasoning_effort: Some(ReasoningEffort::Max),
-            reasoning_effort_profile: ReasoningEffortProfile::Flash0731,
             ..EncodeParams::default()
         };
         let out = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();
@@ -779,7 +759,6 @@ mod tests {
         let msgs = [user("Hello")];
         let params = EncodeParams {
             reasoning_effort: Some(ReasoningEffort::High),
-            reasoning_effort_profile: ReasoningEffortProfile::Flash0731,
             ..EncodeParams::default()
         };
         let out = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();
@@ -793,7 +772,6 @@ mod tests {
         let msgs = [user("Hello")];
         let params = EncodeParams {
             reasoning_effort: Some(ReasoningEffort::Low),
-            reasoning_effort_profile: ReasoningEffortProfile::Flash0731,
             ..EncodeParams::default()
         };
         let out = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();

--- a/crates/tokenizer/src/encoders/deepseek_v4.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v4.rs
@@ -1,4 +1,4 @@
-// Ported from https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py
+// Ported from https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/main/encoding/encoding_dsv4.py
 
 use std::fmt::Write as _;
 
@@ -11,13 +11,46 @@ pub use super::deepseek_v32::ThinkingMode;
 
 /// Reasoning effort for the V4 prompt prefix.
 ///
-/// Mirrors the Python `reasoning_effort` parameter, which only accepts
-/// `None`, `"high"`, or `"max"`. Only `Max` actually emits a prefix today;
-/// `High` is accepted for parity with the Python signature.
+/// Mirrors the 0731 Python `reasoning_effort` parameter. `Low` is the default
+/// and emits no prefix; `High` and `Max` emit distinct prefixes in thinking
+/// mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReasoningEffort {
+    Low,
     High,
     Max,
+}
+
+/// Selects the reasoning-effort prompt format used by a DeepSeek V4 checkpoint.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ReasoningEffortProfile {
+    /// Original Flash, Flash-DSpark, Pro, and unidentified V4 checkpoints.
+    #[default]
+    Original,
+    /// The newer effort encoding used only by DeepSeek-V4-Flash-0731.
+    Flash0731,
+}
+
+impl ReasoningEffort {
+    /// Parse a native 0731 effort name.
+    pub fn from_native(value: &str) -> Option<Self> {
+        match value {
+            "low" => Some(Self::Low),
+            "high" => Some(Self::High),
+            "max" => Some(Self::Max),
+            _ => None,
+        }
+    }
+
+    /// Map OpenAI-compatible effort names into the three native 0731 buckets.
+    pub fn from_openai(value: &str) -> Option<Self> {
+        match value {
+            "none" | "minimal" | "low" => Some(Self::Low),
+            "medium" | "high" => Some(Self::High),
+            "xhigh" | "max" => Some(Self::Max),
+            _ => None,
+        }
+    }
 }
 
 /// Parameters for [`encode_messages`].
@@ -29,6 +62,7 @@ pub struct EncodeParams {
     pub add_default_bos_token: bool,
     pub drop_thinking: bool,
     pub reasoning_effort: Option<ReasoningEffort>,
+    pub reasoning_effort_profile: ReasoningEffortProfile,
 }
 impl Default for EncodeParams {
     fn default() -> Self {
@@ -36,6 +70,7 @@ impl Default for EncodeParams {
             add_default_bos_token: true,
             drop_thinking: true,
             reasoning_effort: None,
+            reasoning_effort_profile: ReasoningEffortProfile::Original,
         }
     }
 }
@@ -95,7 +130,8 @@ fn task_sp_token(task: &str) -> Option<&'static str> {
 // ---------------------------------------------------------------------------
 // Templates
 // ---------------------------------------------------------------------------
-const REASONING_EFFORT_MAX: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
+const REASONING_EFFORT_HIGH: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
+const REASONING_EFFORT_MAX: &str = "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\nYou MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\nDo not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n";
 
 /// Mirrors V4's `TOOLS_TEMPLATE`. The block name is `tool_calls` (not
 /// `function_calls` like V3.2) and the wording is updated.
@@ -234,6 +270,7 @@ fn render_message(
     thinking_mode: ThinkingMode,
     drop_thinking: bool,
     reasoning_effort: Option<ReasoningEffort>,
+    reasoning_effort_profile: ReasoningEffortProfile,
 ) -> Result<String, DsEncodingError> {
     if index >= messages.len() {
         return Err(DsEncodingError::IndexOutOfRange {
@@ -260,12 +297,22 @@ fn render_message(
     let tool_calls_owned = tool_calls_raw.map(|tc| tool_calls_from_openai_format(tc));
     let tool_calls = tool_calls_owned.as_deref();
 
-    // Reasoning effort prefix (only at index 0 in thinking mode with max effort)
-    if index == 0
-        && thinking_mode == ThinkingMode::Thinking
-        && reasoning_effort == Some(ReasoningEffort::Max)
-    {
-        prompt.push_str(REASONING_EFFORT_MAX);
+    // Reasoning effort prefix (only at index 0 in thinking mode).
+    if index == 0 && thinking_mode == ThinkingMode::Thinking {
+        match (reasoning_effort_profile, reasoning_effort) {
+            (ReasoningEffortProfile::Original, Some(ReasoningEffort::Max))
+            | (ReasoningEffortProfile::Flash0731, Some(ReasoningEffort::High)) => {
+                prompt.push_str(REASONING_EFFORT_HIGH);
+            }
+            (ReasoningEffortProfile::Flash0731, Some(ReasoningEffort::Max)) => {
+                prompt.push_str(REASONING_EFFORT_MAX);
+            }
+            (
+                ReasoningEffortProfile::Original,
+                Some(ReasoningEffort::Low | ReasoningEffort::High) | None,
+            )
+            | (ReasoningEffortProfile::Flash0731, Some(ReasoningEffort::Low) | None) => {}
+        }
     }
 
     match role {
@@ -671,6 +718,7 @@ pub fn encode_messages(
             thinking_mode,
             effective_drop_thinking,
             params.reasoning_effort,
+            params.reasoning_effort_profile,
         )?);
     }
     Ok(prompt)
@@ -705,23 +753,52 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_effort_max_prepends_prefix() {
+    fn reasoning_effort_max_uses_0731_prefix() {
         let msgs = [user("Hello")];
         let params = EncodeParams {
             reasoning_effort: Some(ReasoningEffort::Max),
+            reasoning_effort_profile: ReasoningEffortProfile::Flash0731,
             ..EncodeParams::default()
         };
         let out = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();
-        // The prefix appears immediately after BOS, before the user message.
-        let expected_start = format!("{BOS_TOKEN}{REASONING_EFFORT_MAX}");
+        // The 0731 max prefix appears immediately after BOS, before the user message.
+        let expected_start = format!("{BOS_TOKEN}Reasoning Effort: Beyond maximum");
         assert!(
             out.starts_with(&expected_start),
-            "expected prompt to start with BOS+REASONING_EFFORT_MAX, got: {:?}",
+            "expected prompt to start with the 0731 max prefix, got: {:?}",
             &out[..120.min(out.len())]
         );
+        assert!(!out.contains("Reasoning Effort: Absolute maximum"));
         // Without max effort, the prefix is absent.
         let out_chat = encode_messages(&msgs, ThinkingMode::Chat, &params).unwrap();
         assert!(!out_chat.contains("Reasoning Effort"));
+    }
+
+    #[test]
+    fn reasoning_effort_high_uses_absolute_maximum_prefix() {
+        let msgs = [user("Hello")];
+        let params = EncodeParams {
+            reasoning_effort: Some(ReasoningEffort::High),
+            reasoning_effort_profile: ReasoningEffortProfile::Flash0731,
+            ..EncodeParams::default()
+        };
+        let out = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();
+        assert!(out.starts_with(&format!(
+            "{BOS_TOKEN}Reasoning Effort: Absolute maximum with no shortcuts permitted."
+        )));
+    }
+
+    #[test]
+    fn reasoning_effort_low_emits_no_prefix() {
+        let msgs = [user("Hello")];
+        let params = EncodeParams {
+            reasoning_effort: Some(ReasoningEffort::Low),
+            reasoning_effort_profile: ReasoningEffortProfile::Flash0731,
+            ..EncodeParams::default()
+        };
+        let out = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();
+        assert!(!out.contains("Reasoning Effort:"));
+        assert!(out.ends_with(THINKING_START_TOKEN));
     }
 
     #[test]

--- a/crates/tokenizer/src/factory.rs
+++ b/crates/tokenizer/src/factory.rs
@@ -33,15 +33,6 @@ pub fn create_tokenizer_with_chat_template(
     file_path: &str,
     chat_template_path: Option<&str>,
 ) -> Result<Arc<dyn traits::Tokenizer>> {
-    create_tokenizer_with_chat_template_and_model_id(file_path, chat_template_path, None)
-}
-
-/// Create a tokenizer from a file path with an optional model identity hint.
-pub fn create_tokenizer_with_chat_template_and_model_id(
-    file_path: &str,
-    chat_template_path: Option<&str>,
-    model_id: Option<&str>,
-) -> Result<Arc<dyn traits::Tokenizer>> {
     // Special case for testing
     if file_path == "mock" || file_path == "test" {
         return Ok(Arc::new(super::mock::MockTokenizer::new()));
@@ -66,10 +57,9 @@ pub fn create_tokenizer_with_chat_template_and_model_id(
                     "Tokenizer path is not valid UTF-8: {tokenizer_json:?}"
                 ))
             })?;
-            return create_tokenizer_with_chat_template_and_model_id(
+            return create_tokenizer_with_chat_template(
                 tokenizer_path_str,
                 final_chat_template.as_deref(),
-                model_id,
             );
         }
 
@@ -126,11 +116,8 @@ pub fn create_tokenizer_with_chat_template_and_model_id(
 
     let result = match extension.as_deref() {
         Some("json") => {
-            let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template_and_model_id(
-                file_path,
-                chat_template_path,
-                model_id,
-            )?;
+            let tokenizer =
+                HuggingFaceTokenizer::from_file_with_chat_template(file_path, chat_template_path)?;
 
             Ok(Arc::new(tokenizer) as Arc<dyn traits::Tokenizer>)
         }
@@ -151,7 +138,7 @@ pub fn create_tokenizer_with_chat_template_and_model_id(
         }
         _ => {
             // Try to auto-detect by reading file content
-            auto_detect_tokenizer(file_path, model_id)
+            auto_detect_tokenizer(file_path)
         }
     };
 
@@ -172,10 +159,7 @@ fn has_qwen2_tokenizer_class(dir: &Path) -> bool {
 }
 
 /// Auto-detect tokenizer type by examining file content
-fn auto_detect_tokenizer(
-    file_path: &str,
-    model_id: Option<&str>,
-) -> Result<Arc<dyn traits::Tokenizer>> {
+fn auto_detect_tokenizer(file_path: &str) -> Result<Arc<dyn traits::Tokenizer>> {
     let mut file = File::open(file_path)?;
     let mut buffer = vec![0u8; 512]; // Read first 512 bytes for detection
     let bytes_read = file.read(&mut buffer)?;
@@ -183,9 +167,7 @@ fn auto_detect_tokenizer(
 
     // Check for JSON (HuggingFace format)
     if is_likely_json(&buffer) {
-        let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template_and_model_id(
-            file_path, None, model_id,
-        )?;
+        let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template(file_path, None)?;
         return Ok(Arc::new(tokenizer));
     }
 
@@ -376,28 +358,10 @@ pub async fn create_tokenizer_async_with_chat_template(
     model_name_or_path: &str,
     chat_template_path: Option<&str>,
 ) -> Result<Arc<dyn traits::Tokenizer>> {
-    create_tokenizer_async_with_chat_template_and_model_id(
-        model_name_or_path,
-        chat_template_path,
-        Some(model_name_or_path),
-    )
-    .await
-}
-
-/// Create a tokenizer asynchronously with an optional model identity hint.
-pub async fn create_tokenizer_async_with_chat_template_and_model_id(
-    model_name_or_path: &str,
-    chat_template_path: Option<&str>,
-    model_id: Option<&str>,
-) -> Result<Arc<dyn traits::Tokenizer>> {
     // Check if it's a file path
     let path = Path::new(model_name_or_path);
     if path.exists() {
-        return create_tokenizer_with_chat_template_and_model_id(
-            model_name_or_path,
-            chat_template_path,
-            model_id,
-        );
+        return create_tokenizer_with_chat_template(model_name_or_path, chat_template_path);
     }
 
     // Check if it's a GPT model name that should use Tiktoken
@@ -432,10 +396,9 @@ pub async fn create_tokenizer_async_with_chat_template_and_model_id(
                         "Tokenizer path is not valid UTF-8: {tokenizer_path:?}"
                     ))
                 })?;
-                create_tokenizer_with_chat_template_and_model_id(
+                create_tokenizer_with_chat_template(
                     tokenizer_path_str,
                     final_chat_template.as_deref(),
-                    model_id.or(Some(model_name_or_path)),
                 )
             } else if has_tiktoken_file(&cache_dir) {
                 Ok(Arc::new(TiktokenTokenizer::from_dir_with_chat_template(
@@ -458,10 +421,9 @@ pub async fn create_tokenizer_async_with_chat_template_and_model_id(
                         let file_path_str = file_path.to_str().ok_or_else(|| {
                             Error::msg(format!("File path is not valid UTF-8: {file_path:?}"))
                         })?;
-                        return create_tokenizer_with_chat_template_and_model_id(
+                        return create_tokenizer_with_chat_template(
                             file_path_str,
                             final_chat_template.as_deref(),
-                            model_id.or(Some(model_name_or_path)),
                         );
                     }
                 }

--- a/crates/tokenizer/src/factory.rs
+++ b/crates/tokenizer/src/factory.rs
@@ -33,6 +33,15 @@ pub fn create_tokenizer_with_chat_template(
     file_path: &str,
     chat_template_path: Option<&str>,
 ) -> Result<Arc<dyn traits::Tokenizer>> {
+    create_tokenizer_with_chat_template_and_model_id(file_path, chat_template_path, None)
+}
+
+/// Create a tokenizer from a file path with an optional model identity hint.
+pub fn create_tokenizer_with_chat_template_and_model_id(
+    file_path: &str,
+    chat_template_path: Option<&str>,
+    model_id: Option<&str>,
+) -> Result<Arc<dyn traits::Tokenizer>> {
     // Special case for testing
     if file_path == "mock" || file_path == "test" {
         return Ok(Arc::new(super::mock::MockTokenizer::new()));
@@ -57,9 +66,10 @@ pub fn create_tokenizer_with_chat_template(
                     "Tokenizer path is not valid UTF-8: {tokenizer_json:?}"
                 ))
             })?;
-            return create_tokenizer_with_chat_template(
+            return create_tokenizer_with_chat_template_and_model_id(
                 tokenizer_path_str,
                 final_chat_template.as_deref(),
+                model_id,
             );
         }
 
@@ -116,8 +126,11 @@ pub fn create_tokenizer_with_chat_template(
 
     let result = match extension.as_deref() {
         Some("json") => {
-            let tokenizer =
-                HuggingFaceTokenizer::from_file_with_chat_template(file_path, chat_template_path)?;
+            let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template_and_model_id(
+                file_path,
+                chat_template_path,
+                model_id,
+            )?;
 
             Ok(Arc::new(tokenizer) as Arc<dyn traits::Tokenizer>)
         }
@@ -138,7 +151,7 @@ pub fn create_tokenizer_with_chat_template(
         }
         _ => {
             // Try to auto-detect by reading file content
-            auto_detect_tokenizer(file_path)
+            auto_detect_tokenizer(file_path, model_id)
         }
     };
 
@@ -159,7 +172,10 @@ fn has_qwen2_tokenizer_class(dir: &Path) -> bool {
 }
 
 /// Auto-detect tokenizer type by examining file content
-fn auto_detect_tokenizer(file_path: &str) -> Result<Arc<dyn traits::Tokenizer>> {
+fn auto_detect_tokenizer(
+    file_path: &str,
+    model_id: Option<&str>,
+) -> Result<Arc<dyn traits::Tokenizer>> {
     let mut file = File::open(file_path)?;
     let mut buffer = vec![0u8; 512]; // Read first 512 bytes for detection
     let bytes_read = file.read(&mut buffer)?;
@@ -167,7 +183,9 @@ fn auto_detect_tokenizer(file_path: &str) -> Result<Arc<dyn traits::Tokenizer>> 
 
     // Check for JSON (HuggingFace format)
     if is_likely_json(&buffer) {
-        let tokenizer = HuggingFaceTokenizer::from_file(file_path)?;
+        let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template_and_model_id(
+            file_path, None, model_id,
+        )?;
         return Ok(Arc::new(tokenizer));
     }
 
@@ -358,10 +376,28 @@ pub async fn create_tokenizer_async_with_chat_template(
     model_name_or_path: &str,
     chat_template_path: Option<&str>,
 ) -> Result<Arc<dyn traits::Tokenizer>> {
+    create_tokenizer_async_with_chat_template_and_model_id(
+        model_name_or_path,
+        chat_template_path,
+        Some(model_name_or_path),
+    )
+    .await
+}
+
+/// Create a tokenizer asynchronously with an optional model identity hint.
+pub async fn create_tokenizer_async_with_chat_template_and_model_id(
+    model_name_or_path: &str,
+    chat_template_path: Option<&str>,
+    model_id: Option<&str>,
+) -> Result<Arc<dyn traits::Tokenizer>> {
     // Check if it's a file path
     let path = Path::new(model_name_or_path);
     if path.exists() {
-        return create_tokenizer_with_chat_template(model_name_or_path, chat_template_path);
+        return create_tokenizer_with_chat_template_and_model_id(
+            model_name_or_path,
+            chat_template_path,
+            model_id,
+        );
     }
 
     // Check if it's a GPT model name that should use Tiktoken
@@ -396,9 +432,10 @@ pub async fn create_tokenizer_async_with_chat_template(
                         "Tokenizer path is not valid UTF-8: {tokenizer_path:?}"
                     ))
                 })?;
-                create_tokenizer_with_chat_template(
+                create_tokenizer_with_chat_template_and_model_id(
                     tokenizer_path_str,
                     final_chat_template.as_deref(),
+                    model_id.or(Some(model_name_or_path)),
                 )
             } else if has_tiktoken_file(&cache_dir) {
                 Ok(Arc::new(TiktokenTokenizer::from_dir_with_chat_template(
@@ -421,9 +458,10 @@ pub async fn create_tokenizer_async_with_chat_template(
                         let file_path_str = file_path.to_str().ok_or_else(|| {
                             Error::msg(format!("File path is not valid UTF-8: {file_path:?}"))
                         })?;
-                        return create_tokenizer_with_chat_template(
+                        return create_tokenizer_with_chat_template_and_model_id(
                             file_path_str,
                             final_chat_template.as_deref(),
+                            model_id.or(Some(model_name_or_path)),
                         );
                     }
                 }

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -30,7 +30,7 @@ use crate::{
 enum Renderer {
     Jinja,
     DeepseekV32,
-    DeepseekV4,
+    DeepseekV4(deepseek_v4::ReasoningEffortProfile),
 }
 
 /// HuggingFace tokenizer wrapper
@@ -78,9 +78,23 @@ impl HuggingFaceTokenizer {
         file_path: &str,
         chat_template_path: Option<&str>,
     ) -> Result<Self> {
+        Self::from_file_with_chat_template_and_model_id(file_path, chat_template_path, None)
+    }
+
+    /// Create a tokenizer with an optional model identity used for variant-specific rendering.
+    pub fn from_file_with_chat_template_and_model_id(
+        file_path: &str,
+        chat_template_path: Option<&str>,
+        model_id: Option<&str>,
+    ) -> Result<Self> {
         let tokenizer = HfTokenizer::from_file(file_path)
             .map_err(|e| Error::msg(format!("Failed to load tokenizer: {e}")))?;
-        Self::from_built_tokenizer(tokenizer, Path::new(file_path), chat_template_path)
+        Self::from_built_tokenizer(
+            tokenizer,
+            Path::new(file_path),
+            chat_template_path,
+            model_id,
+        )
     }
 
     /// Create a Qwen2-compatible byte-level BPE tokenizer from a Hugging Face
@@ -101,7 +115,7 @@ impl HuggingFaceTokenizer {
         // Shared initialization only needs this path to locate sibling config
         // files. The file itself intentionally does not exist in this layout.
         let logical_tokenizer_path = dir.join("tokenizer.json");
-        Self::from_built_tokenizer(tokenizer, &logical_tokenizer_path, chat_template_path)
+        Self::from_built_tokenizer(tokenizer, &logical_tokenizer_path, chat_template_path, None)
     }
 
     fn build_qwen2_bpe_tokenizer(dir: &Path) -> Result<HfTokenizer> {
@@ -221,6 +235,7 @@ impl HuggingFaceTokenizer {
         mut tokenizer: HfTokenizer,
         tokenizer_path: &Path,
         chat_template_path: Option<&str>,
+        model_id: Option<&str>,
     ) -> Result<Self> {
         // Build vocab mappings (include special tokens to get added_tokens like <|im_start|>)
         let vocab = tokenizer.get_vocab(true); // true = include special tokens and added_tokens
@@ -270,7 +285,7 @@ impl HuggingFaceTokenizer {
         // Detect a custom Python-encoder model from config.json::architectures.
         let renderer = tokenizer_path
             .parent()
-            .map(detect_renderer_from_config)
+            .map(|dir| detect_renderer_from_config(dir, model_id))
             .unwrap_or(Renderer::Jinja);
 
         Ok(HuggingFaceTokenizer {
@@ -570,7 +585,7 @@ impl TokenizerTrait for HuggingFaceTokenizer {
                 self.chat_template.apply(messages, params)
             }
             Renderer::DeepseekV32 => apply_deepseek_v32(messages, &params),
-            Renderer::DeepseekV4 => apply_deepseek_v4(messages, &params),
+            Renderer::DeepseekV4(profile) => apply_deepseek_v4(messages, &params, profile),
         }
     }
 
@@ -583,14 +598,14 @@ impl TokenizerTrait for HuggingFaceTokenizer {
             // DeepSeek V3.2 and V4 encoders gate thinking on the `thinking`
             // kwarg, default off. The Jinja processor has no knowledge of
             // the native encoder so we must report it directly.
-            Renderer::DeepseekV32 | Renderer::DeepseekV4 => ThinkingToggle::DefaultOff,
+            Renderer::DeepseekV32 | Renderer::DeepseekV4(_) => ThinkingToggle::DefaultOff,
             Renderer::Jinja => self.chat_template.thinking_toggle(),
         }
     }
 
     fn thinking_key_name(&self) -> Option<ThinkingKeyName> {
         match self.renderer {
-            Renderer::DeepseekV32 | Renderer::DeepseekV4 => Some(ThinkingKeyName::Thinking),
+            Renderer::DeepseekV32 | Renderer::DeepseekV4(_) => Some(ThinkingKeyName::Thinking),
             Renderer::Jinja => self.chat_template.thinking_key_name(),
         }
     }
@@ -599,7 +614,7 @@ impl TokenizerTrait for HuggingFaceTokenizer {
             // Both encoders emit `<｜Assistant｜><think>` at the end of the
             // prompt when thinking mode is on; the completion therefore starts
             // mid-reasoning and the parser must be told so.
-            Renderer::DeepseekV32 | Renderer::DeepseekV4 => true,
+            Renderer::DeepseekV32 | Renderer::DeepseekV4(_) => true,
             Renderer::Jinja => self.chat_template.think_in_prefill(),
         }
     }
@@ -616,7 +631,7 @@ impl TokenizerTrait for HuggingFaceTokenizer {
 /// use. A missing or malformed file falls back to [`Renderer::Jinja`] without
 /// erroring (debug-logged), preserving backward compatibility for every model
 /// not in the architecture list.
-fn detect_renderer_from_config(dir: &Path) -> Renderer {
+fn detect_renderer_from_config(dir: &Path, model_id: Option<&str>) -> Renderer {
     let path = dir.join("config.json");
     if !path.exists() {
         return Renderer::Jinja;
@@ -644,8 +659,19 @@ fn detect_renderer_from_config(dir: &Path) -> Renderer {
         return Renderer::DeepseekV32;
     }
     if arch_strs.contains(&"DeepseekV4ForCausalLM") {
-        debug!(?path, "selected DeepseekV4 chat-template renderer");
-        return Renderer::DeepseekV4;
+        let profile = if model_id.is_some_and(is_deepseek_v4_flash_0731)
+            || is_deepseek_v4_flash_0731(&dir.to_string_lossy())
+        {
+            deepseek_v4::ReasoningEffortProfile::Flash0731
+        } else {
+            deepseek_v4::ReasoningEffortProfile::Original
+        };
+        debug!(
+            ?path,
+            ?profile,
+            "selected DeepseekV4 chat-template renderer"
+        );
+        return Renderer::DeepseekV4(profile);
     }
     Renderer::Jinja
 }
@@ -728,26 +754,77 @@ fn apply_deepseek_v32(
 fn apply_deepseek_v4(
     messages: &[serde_json::Value],
     params: &ChatTemplateParams,
+    reasoning_effort_profile: deepseek_v4::ReasoningEffortProfile,
 ) -> Result<String> {
     let owned = inject_tools_into_messages(messages, params.tools);
     let msgs: &[serde_json::Value] = owned.as_deref().unwrap_or(messages);
     let thinking_mode = derive_thinking_mode(params);
-    let reasoning_effort = params
-        .template_kwargs
-        .and_then(|k| k.get("reasoning_effort"))
-        .and_then(|v| v.as_str())
-        .and_then(|s| match s {
-            "max" => Some(deepseek_v4::ReasoningEffort::Max),
-            "high" => Some(deepseek_v4::ReasoningEffort::High),
-            _ => None,
-        });
+    let reasoning_effort = resolve_deepseek_v4_reasoning_effort(params, reasoning_effort_profile)?;
     let encode_params = deepseek_v4::EncodeParams {
         add_default_bos_token: true,
         drop_thinking: resolve_drop_thinking(msgs),
         reasoning_effort,
+        reasoning_effort_profile,
     };
     deepseek_v4::encode_messages(msgs, thinking_mode, &encode_params)
         .map_err(|e| Error::msg(format!("DeepSeek V4 encode failed: {e}")))
+}
+
+fn resolve_deepseek_v4_reasoning_effort(
+    params: &ChatTemplateParams,
+    profile: deepseek_v4::ReasoningEffortProfile,
+) -> Result<Option<deepseek_v4::ReasoningEffort>> {
+    let combined_effort = params
+        .template_kwargs
+        .and_then(|kwargs| kwargs.get("reasoning_effort"));
+    match profile {
+        deepseek_v4::ReasoningEffortProfile::Original => {
+            let effort = match params.template_reasoning_effort.or(combined_effort) {
+                Some(value) => value.as_str(),
+                None => params.reasoning_effort,
+            };
+            Ok(effort.and_then(|effort| match effort {
+                "high" => Some(deepseek_v4::ReasoningEffort::High),
+                "max" => Some(deepseek_v4::ReasoningEffort::Max),
+                _ => None,
+            }))
+        }
+        deepseek_v4::ReasoningEffortProfile::Flash0731 => {
+            let template_effort = params.template_reasoning_effort.or_else(|| {
+                if params.reasoning_effort.is_none() {
+                    combined_effort
+                } else {
+                    None
+                }
+            });
+            template_effort
+                .map(|value| {
+                    value
+                        .as_str()
+                        .and_then(deepseek_v4::ReasoningEffort::from_native)
+                        .ok_or_else(|| {
+                            Error::msg(
+                                "chat_template_kwargs.reasoning_effort must be one of low, high, max",
+                            )
+                        })
+                })
+                .transpose()
+                .map(|effort| {
+                    effort.or_else(|| {
+                        params
+                            .reasoning_effort
+                            .and_then(deepseek_v4::ReasoningEffort::from_openai)
+                    })
+                })
+        }
+    }
+}
+
+fn is_deepseek_v4_flash_0731(identity: &str) -> bool {
+    identity
+        .to_ascii_lowercase()
+        .replace('_', "-")
+        .contains("deepseek-v4-flash-0731")
 }
 
 #[cfg(test)]

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -731,8 +731,22 @@ fn apply_deepseek_v4(
 ) -> Result<String> {
     let owned = inject_tools_into_messages(messages, params.tools);
     let msgs: &[serde_json::Value] = owned.as_deref().unwrap_or(messages);
-    let thinking_mode = derive_thinking_mode(params);
     let reasoning_effort = resolve_deepseek_v4_reasoning_effort(params)?;
+    let explicit_thinking = params
+        .template_kwargs
+        .and_then(|kwargs| kwargs.get("thinking"))
+        .and_then(serde_json::Value::as_bool);
+    let has_native_effort = params.template_reasoning_effort.is_some()
+        || (params.reasoning_effort.is_none()
+            && params
+                .template_kwargs
+                .is_some_and(|kwargs| kwargs.contains_key("reasoning_effort")));
+    let thinking_mode = match explicit_thinking {
+        Some(true) => deepseek_v32::ThinkingMode::Thinking,
+        Some(false) => deepseek_v32::ThinkingMode::Chat,
+        None if has_native_effort => deepseek_v32::ThinkingMode::Thinking,
+        None => derive_thinking_mode(params),
+    };
     let encode_params = deepseek_v4::EncodeParams {
         add_default_bos_token: true,
         drop_thinking: resolve_drop_thinking(msgs),

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -30,7 +30,7 @@ use crate::{
 enum Renderer {
     Jinja,
     DeepseekV32,
-    DeepseekV4(deepseek_v4::ReasoningEffortProfile),
+    DeepseekV4,
 }
 
 /// HuggingFace tokenizer wrapper
@@ -78,23 +78,9 @@ impl HuggingFaceTokenizer {
         file_path: &str,
         chat_template_path: Option<&str>,
     ) -> Result<Self> {
-        Self::from_file_with_chat_template_and_model_id(file_path, chat_template_path, None)
-    }
-
-    /// Create a tokenizer with an optional model identity used for variant-specific rendering.
-    pub fn from_file_with_chat_template_and_model_id(
-        file_path: &str,
-        chat_template_path: Option<&str>,
-        model_id: Option<&str>,
-    ) -> Result<Self> {
         let tokenizer = HfTokenizer::from_file(file_path)
             .map_err(|e| Error::msg(format!("Failed to load tokenizer: {e}")))?;
-        Self::from_built_tokenizer(
-            tokenizer,
-            Path::new(file_path),
-            chat_template_path,
-            model_id,
-        )
+        Self::from_built_tokenizer(tokenizer, Path::new(file_path), chat_template_path)
     }
 
     /// Create a Qwen2-compatible byte-level BPE tokenizer from a Hugging Face
@@ -115,7 +101,7 @@ impl HuggingFaceTokenizer {
         // Shared initialization only needs this path to locate sibling config
         // files. The file itself intentionally does not exist in this layout.
         let logical_tokenizer_path = dir.join("tokenizer.json");
-        Self::from_built_tokenizer(tokenizer, &logical_tokenizer_path, chat_template_path, None)
+        Self::from_built_tokenizer(tokenizer, &logical_tokenizer_path, chat_template_path)
     }
 
     fn build_qwen2_bpe_tokenizer(dir: &Path) -> Result<HfTokenizer> {
@@ -235,7 +221,6 @@ impl HuggingFaceTokenizer {
         mut tokenizer: HfTokenizer,
         tokenizer_path: &Path,
         chat_template_path: Option<&str>,
-        model_id: Option<&str>,
     ) -> Result<Self> {
         // Build vocab mappings (include special tokens to get added_tokens like <|im_start|>)
         let vocab = tokenizer.get_vocab(true); // true = include special tokens and added_tokens
@@ -285,7 +270,7 @@ impl HuggingFaceTokenizer {
         // Detect a custom Python-encoder model from config.json::architectures.
         let renderer = tokenizer_path
             .parent()
-            .map(|dir| detect_renderer_from_config(dir, model_id))
+            .map(detect_renderer_from_config)
             .unwrap_or(Renderer::Jinja);
 
         Ok(HuggingFaceTokenizer {
@@ -585,7 +570,7 @@ impl TokenizerTrait for HuggingFaceTokenizer {
                 self.chat_template.apply(messages, params)
             }
             Renderer::DeepseekV32 => apply_deepseek_v32(messages, &params),
-            Renderer::DeepseekV4(profile) => apply_deepseek_v4(messages, &params, profile),
+            Renderer::DeepseekV4 => apply_deepseek_v4(messages, &params),
         }
     }
 
@@ -598,14 +583,14 @@ impl TokenizerTrait for HuggingFaceTokenizer {
             // DeepSeek V3.2 and V4 encoders gate thinking on the `thinking`
             // kwarg, default off. The Jinja processor has no knowledge of
             // the native encoder so we must report it directly.
-            Renderer::DeepseekV32 | Renderer::DeepseekV4(_) => ThinkingToggle::DefaultOff,
+            Renderer::DeepseekV32 | Renderer::DeepseekV4 => ThinkingToggle::DefaultOff,
             Renderer::Jinja => self.chat_template.thinking_toggle(),
         }
     }
 
     fn thinking_key_name(&self) -> Option<ThinkingKeyName> {
         match self.renderer {
-            Renderer::DeepseekV32 | Renderer::DeepseekV4(_) => Some(ThinkingKeyName::Thinking),
+            Renderer::DeepseekV32 | Renderer::DeepseekV4 => Some(ThinkingKeyName::Thinking),
             Renderer::Jinja => self.chat_template.thinking_key_name(),
         }
     }
@@ -614,7 +599,7 @@ impl TokenizerTrait for HuggingFaceTokenizer {
             // Both encoders emit `<｜Assistant｜><think>` at the end of the
             // prompt when thinking mode is on; the completion therefore starts
             // mid-reasoning and the parser must be told so.
-            Renderer::DeepseekV32 | Renderer::DeepseekV4(_) => true,
+            Renderer::DeepseekV32 | Renderer::DeepseekV4 => true,
             Renderer::Jinja => self.chat_template.think_in_prefill(),
         }
     }
@@ -631,7 +616,7 @@ impl TokenizerTrait for HuggingFaceTokenizer {
 /// use. A missing or malformed file falls back to [`Renderer::Jinja`] without
 /// erroring (debug-logged), preserving backward compatibility for every model
 /// not in the architecture list.
-fn detect_renderer_from_config(dir: &Path, model_id: Option<&str>) -> Renderer {
+fn detect_renderer_from_config(dir: &Path) -> Renderer {
     let path = dir.join("config.json");
     if !path.exists() {
         return Renderer::Jinja;
@@ -659,19 +644,8 @@ fn detect_renderer_from_config(dir: &Path, model_id: Option<&str>) -> Renderer {
         return Renderer::DeepseekV32;
     }
     if arch_strs.contains(&"DeepseekV4ForCausalLM") {
-        let profile = if model_id.is_some_and(is_deepseek_v4_flash_0731)
-            || is_deepseek_v4_flash_0731(&dir.to_string_lossy())
-        {
-            deepseek_v4::ReasoningEffortProfile::Flash0731
-        } else {
-            deepseek_v4::ReasoningEffortProfile::Original
-        };
-        debug!(
-            ?path,
-            ?profile,
-            "selected DeepseekV4 chat-template renderer"
-        );
-        return Renderer::DeepseekV4(profile);
+        debug!(?path, "selected DeepseekV4 chat-template renderer");
+        return Renderer::DeepseekV4;
     }
     Renderer::Jinja
 }
@@ -754,17 +728,15 @@ fn apply_deepseek_v32(
 fn apply_deepseek_v4(
     messages: &[serde_json::Value],
     params: &ChatTemplateParams,
-    reasoning_effort_profile: deepseek_v4::ReasoningEffortProfile,
 ) -> Result<String> {
     let owned = inject_tools_into_messages(messages, params.tools);
     let msgs: &[serde_json::Value] = owned.as_deref().unwrap_or(messages);
     let thinking_mode = derive_thinking_mode(params);
-    let reasoning_effort = resolve_deepseek_v4_reasoning_effort(params, reasoning_effort_profile)?;
+    let reasoning_effort = resolve_deepseek_v4_reasoning_effort(params)?;
     let encode_params = deepseek_v4::EncodeParams {
         add_default_bos_token: true,
         drop_thinking: resolve_drop_thinking(msgs),
         reasoning_effort,
-        reasoning_effort_profile,
     };
     deepseek_v4::encode_messages(msgs, thinking_mode, &encode_params)
         .map_err(|e| Error::msg(format!("DeepSeek V4 encode failed: {e}")))
@@ -772,59 +744,36 @@ fn apply_deepseek_v4(
 
 fn resolve_deepseek_v4_reasoning_effort(
     params: &ChatTemplateParams,
-    profile: deepseek_v4::ReasoningEffortProfile,
 ) -> Result<Option<deepseek_v4::ReasoningEffort>> {
     let combined_effort = params
         .template_kwargs
         .and_then(|kwargs| kwargs.get("reasoning_effort"));
-    match profile {
-        deepseek_v4::ReasoningEffortProfile::Original => {
-            let effort = match params.template_reasoning_effort.or(combined_effort) {
-                Some(value) => value.as_str(),
-                None => params.reasoning_effort,
-            };
-            Ok(effort.and_then(|effort| match effort {
-                "high" => Some(deepseek_v4::ReasoningEffort::High),
-                "max" => Some(deepseek_v4::ReasoningEffort::Max),
-                _ => None,
-            }))
+    let template_effort = params.template_reasoning_effort.or_else(|| {
+        if params.reasoning_effort.is_none() {
+            combined_effort
+        } else {
+            None
         }
-        deepseek_v4::ReasoningEffortProfile::Flash0731 => {
-            let template_effort = params.template_reasoning_effort.or_else(|| {
-                if params.reasoning_effort.is_none() {
-                    combined_effort
-                } else {
-                    None
-                }
-            });
-            template_effort
-                .map(|value| {
-                    value
-                        .as_str()
-                        .and_then(deepseek_v4::ReasoningEffort::from_native)
-                        .ok_or_else(|| {
-                            Error::msg(
-                                "chat_template_kwargs.reasoning_effort must be one of low, high, max",
-                            )
-                        })
+    });
+    template_effort
+        .map(|value| {
+            value
+                .as_str()
+                .and_then(deepseek_v4::ReasoningEffort::from_native)
+                .ok_or_else(|| {
+                    Error::msg(
+                        "chat_template_kwargs.reasoning_effort must be one of low, high, max",
+                    )
                 })
-                .transpose()
-                .map(|effort| {
-                    effort.or_else(|| {
-                        params
-                            .reasoning_effort
-                            .and_then(deepseek_v4::ReasoningEffort::from_openai)
-                    })
-                })
-        }
-    }
-}
-
-fn is_deepseek_v4_flash_0731(identity: &str) -> bool {
-    identity
-        .to_ascii_lowercase()
-        .replace('_', "-")
-        .contains("deepseek-v4-flash-0731")
+        })
+        .transpose()
+        .map(|effort| {
+            effort.or_else(|| {
+                params
+                    .reasoning_effort
+                    .and_then(deepseek_v4::ReasoningEffort::from_openai)
+            })
+        })
 }
 
 #[cfg(test)]

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -594,6 +594,11 @@ impl TokenizerTrait for HuggingFaceTokenizer {
             Renderer::Jinja => self.chat_template.thinking_key_name(),
         }
     }
+
+    fn template_reasoning_effort_enables_thinking(&self) -> bool {
+        matches!(self.renderer, Renderer::DeepseekV4)
+    }
+
     fn think_in_prefill(&self) -> bool {
         match self.renderer {
             // Both encoders emit `<｜Assistant｜><think>` at the end of the

--- a/crates/tokenizer/src/traits.rs
+++ b/crates/tokenizer/src/traits.rs
@@ -109,6 +109,12 @@ pub trait Tokenizer: Encoder + Decoder {
         None
     }
 
+    /// Whether a native `chat_template_kwargs.reasoning_effort` value enables
+    /// thinking for this tokenizer's renderer.
+    fn template_reasoning_effort_enables_thinking(&self) -> bool {
+        false
+    }
+
     /// Whether the template injects `<think>` in the generation prompt.
     fn think_in_prefill(&self) -> bool {
         false

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -6,7 +6,6 @@ mod tests {
 
     use llm_tokenizer::{
         chat_template::{ChatTemplateParams, ThinkingKeyName, ThinkingToggle},
-        factory::create_tokenizer_with_chat_template_and_model_id,
         huggingface::HuggingFaceTokenizer,
         TokenizerTrait,
     };
@@ -342,6 +341,29 @@ mod tests {
     }
 
     #[test]
+    fn deepseek_v4_distinguishes_merged_public_effort_from_native_template_effort() {
+        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash");
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let kwargs = HashMap::from([("reasoning_effort".to_string(), json!("medium"))]);
+
+        let output = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    thinking: Some(true),
+                    reasoning_effort: Some("medium"),
+                    template_kwargs: Some(&kwargs),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(output.contains("Reasoning Effort: Absolute maximum"));
+        assert!(!output.contains("Reasoning Effort: Beyond maximum"));
+    }
+
+    #[test]
     fn deepseek_v4_native_template_effort_overrides_openai_effort() {
         let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash-0731");
         let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
@@ -366,10 +388,38 @@ mod tests {
 
     #[test]
     fn deepseek_v4_rejects_invalid_native_template_effort() {
-        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash-0731");
-        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
         let messages = vec![json!({ "role": "user", "content": "Hello" })];
 
+        for model_name in [
+            "DeepSeek-V4-Flash",
+            "DeepSeek-V4-Flash-0731",
+            "DeepSeek-V4-Flash-DSpark",
+            "DeepSeek-V4-Pro",
+        ] {
+            let (_tmp, tok) = write_named_v4_dir(model_name);
+            let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+            for native_effort in [json!("medium"), json!(3)] {
+                let error = tokenizer
+                    .apply_chat_template(
+                        &messages,
+                        ChatTemplateParams {
+                            thinking: Some(true),
+                            template_reasoning_effort: Some(&native_effort),
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap_err();
+                assert!(
+                    error.to_string().contains(
+                        "chat_template_kwargs.reasoning_effort must be one of low, high, max"
+                    ),
+                    "{model_name}: unexpected error: {error}"
+                );
+            }
+        }
+
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
         for native_effort in [json!("medium"), json!(3)] {
             let error = tokenizer
                 .apply_chat_template(
@@ -385,7 +435,7 @@ mod tests {
                 error.to_string().contains(
                     "chat_template_kwargs.reasoning_effort must be one of low, high, max"
                 ),
-                "unexpected error: {error}"
+                "anonymous V4: unexpected error: {error}"
             );
         }
     }
@@ -454,28 +504,12 @@ mod tests {
     }
 
     #[test]
-    fn deepseek_v4_effort_profile_follows_local_model_path() {
-        for (model_name, expected, unexpected) in [
-            (
-                "DeepSeek-V4-Flash-0731",
-                "Reasoning Effort: Beyond maximum",
-                "Reasoning Effort: Absolute maximum",
-            ),
-            (
-                "DeepSeek-V4-Flash",
-                "Reasoning Effort: Absolute maximum",
-                "Reasoning Effort: Beyond maximum",
-            ),
-            (
-                "DeepSeek-V4-Flash-DSpark",
-                "Reasoning Effort: Absolute maximum",
-                "Reasoning Effort: Beyond maximum",
-            ),
-            (
-                "DeepSeek-V4-Pro",
-                "Reasoning Effort: Absolute maximum",
-                "Reasoning Effort: Beyond maximum",
-            ),
+    fn deepseek_v4_effort_encoding_is_independent_of_local_model_path() {
+        for model_name in [
+            "DeepSeek-V4-Flash-0731",
+            "DeepSeek-V4-Flash",
+            "DeepSeek-V4-Flash-DSpark",
+            "DeepSeek-V4-Pro",
         ] {
             let (_tmp, tok) = write_named_v4_dir(model_name);
             let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
@@ -492,13 +526,19 @@ mod tests {
                 )
                 .unwrap();
 
-            assert!(output.contains(expected), "{model_name}: {output}");
-            assert!(!output.contains(unexpected), "{model_name}: {output}");
+            assert!(
+                output.contains("Reasoning Effort: Beyond maximum"),
+                "{model_name}: {output}"
+            );
+            assert!(
+                !output.contains("Reasoning Effort: Absolute maximum"),
+                "{model_name}: {output}"
+            );
         }
     }
 
     #[test]
-    fn deepseek_v4_effort_profile_defaults_anonymous_v4_to_original() {
+    fn deepseek_v4_anonymous_renderer_uses_0731_effort_encoding() {
         let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
         let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
         let messages = vec![json!({ "role": "user", "content": "Hello" })];
@@ -514,81 +554,7 @@ mod tests {
             )
             .unwrap();
 
-        assert!(output.contains("Reasoning Effort: Absolute maximum"));
-        assert!(!output.contains("Reasoning Effort: Beyond maximum"));
-    }
-
-    #[test]
-    fn deepseek_v4_effort_profile_uses_explicit_model_identity() {
-        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
-        let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template_and_model_id(
-            &tok,
-            None,
-            Some("deepseek-ai/DeepSeek-V4-Flash-0731"),
-        )
-        .unwrap();
-        let messages = vec![json!({ "role": "user", "content": "Hello" })];
-        let native_effort = json!("max");
-        let output = tokenizer
-            .apply_chat_template(
-                &messages,
-                ChatTemplateParams {
-                    thinking: Some(true),
-                    template_reasoning_effort: Some(&native_effort),
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-
         assert!(output.contains("Reasoning Effort: Beyond maximum"));
         assert!(!output.contains("Reasoning Effort: Absolute maximum"));
-    }
-
-    #[test]
-    fn tokenizer_factory_propagates_explicit_model_identity() {
-        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
-        let tokenizer = create_tokenizer_with_chat_template_and_model_id(
-            &tok,
-            None,
-            Some("deepseek-ai/DeepSeek-V4-Flash-0731"),
-        )
-        .unwrap();
-        let messages = vec![json!({ "role": "user", "content": "Hello" })];
-        let native_effort = json!("max");
-        let output = tokenizer
-            .apply_chat_template(
-                &messages,
-                ChatTemplateParams {
-                    thinking: Some(true),
-                    template_reasoning_effort: Some(&native_effort),
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-
-        assert!(output.contains("Reasoning Effort: Beyond maximum"));
-        assert!(!output.contains("Reasoning Effort: Absolute maximum"));
-    }
-
-    #[test]
-    fn original_v4_keeps_permissive_invalid_template_effort_override() {
-        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Pro");
-        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
-        let messages = vec![json!({ "role": "user", "content": "Hello" })];
-        let invalid_native_effort = json!(3);
-        let output = tokenizer
-            .apply_chat_template(
-                &messages,
-                ChatTemplateParams {
-                    thinking: Some(true),
-                    reasoning_effort: Some("max"),
-                    template_reasoning_effort: Some(&invalid_native_effort),
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-
-        assert!(!output.contains("Reasoning Effort:"), "{output}");
-        assert!(output.ends_with("<think>"));
     }
 }

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -341,6 +341,50 @@ mod tests {
     }
 
     #[test]
+    fn deepseek_v4_top_level_and_template_efforts_render_identically() {
+        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash-0731");
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+
+        for (effort, expected_prefix) in [
+            ("low", None),
+            ("high", Some("Reasoning Effort: Absolute maximum")),
+            ("max", Some("Reasoning Effort: Beyond maximum")),
+        ] {
+            let top_level = tokenizer
+                .apply_chat_template(
+                    &messages,
+                    ChatTemplateParams {
+                        thinking: Some(true),
+                        reasoning_effort: Some(effort),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            let template_kwargs = HashMap::from([("reasoning_effort".to_string(), json!(effort))]);
+            let native = tokenizer
+                .apply_chat_template(
+                    &messages,
+                    ChatTemplateParams {
+                        template_kwargs: Some(&template_kwargs),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+
+            assert_eq!(native, top_level, "effort {effort}");
+            assert!(native.ends_with("<think>"), "effort {effort}: {native}");
+            match expected_prefix {
+                Some(prefix) => assert!(native.contains(prefix), "effort {effort}: {native}"),
+                None => assert!(
+                    !native.contains("Reasoning Effort:"),
+                    "effort {effort}: {native}"
+                ),
+            }
+        }
+    }
+
+    #[test]
     fn deepseek_v4_distinguishes_merged_public_effort_from_native_template_effort() {
         let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash");
         let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
@@ -441,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn deepseek_v4_resolves_effort_and_thinking_independently() {
+    fn deepseek_v4_explicit_thinking_overrides_effort_defaults() {
         let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash-0731");
         let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
         let messages = vec![json!({ "role": "user", "content": "Hello" })];
@@ -457,8 +501,8 @@ mod tests {
                 },
             )
             .unwrap();
-        assert!(out.ends_with("</think>"));
-        assert!(!out.contains("Reasoning Effort:"));
+        assert!(out.ends_with("<think>"));
+        assert!(out.contains("Reasoning Effort: Beyond maximum"));
 
         let thinking_off = HashMap::from([("thinking".to_string(), json!(false))]);
         let out = tokenizer

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -6,6 +6,7 @@ mod tests {
 
     use llm_tokenizer::{
         chat_template::{ChatTemplateParams, ThinkingKeyName, ThinkingToggle},
+        factory::create_tokenizer_with_chat_template_and_model_id,
         huggingface::HuggingFaceTokenizer,
         TokenizerTrait,
     };
@@ -39,6 +40,21 @@ mod tests {
         }
         let p = tok_path.to_str().unwrap().to_string();
         (temp, p)
+    }
+
+    fn write_named_v4_dir(model_name: &str) -> (TempDir, String) {
+        let temp = TempDir::new().unwrap();
+        let model_dir = temp.path().join(model_name);
+        fs::create_dir(&model_dir).unwrap();
+        let tok_path = model_dir.join("tokenizer.json");
+        fs::write(&tok_path, MIN_TOKENIZER_JSON).unwrap();
+        fs::write(
+            model_dir.join("config.json"),
+            json!({ "architectures": ["DeepseekV4ForCausalLM"] }).to_string(),
+        )
+        .unwrap();
+        let path = tok_path.to_str().unwrap().to_string();
+        (temp, path)
     }
 
     #[test]
@@ -268,7 +284,7 @@ mod tests {
 
     #[test]
     fn deepseek_v4_renderer_passes_reasoning_effort() {
-        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash-0731");
         let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
         let messages = vec![json!({ "role": "user", "content": "Hello" })];
         let mut kwargs: HashMap<String, serde_json::Value> = HashMap::new();
@@ -283,12 +299,296 @@ mod tests {
         };
         let out = tokenizer.apply_chat_template(&messages, params).unwrap();
         assert!(
-            out.contains("Reasoning Effort: Absolute maximum"),
-            "expected reasoning-effort prefix in V4 output"
+            out.contains("Reasoning Effort: Beyond maximum"),
+            "expected 0731 max reasoning-effort prefix in V4 output"
         );
         assert!(
             out.ends_with("<think>"),
             "thinking mode should leave a <think> token open"
         );
+    }
+
+    #[test]
+    fn deepseek_v4_maps_openai_efforts_to_0731_buckets() {
+        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash-0731");
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+
+        for (effort, expected_prefix) in [
+            ("minimal", None),
+            ("low", None),
+            ("medium", Some("Reasoning Effort: Absolute maximum")),
+            ("high", Some("Reasoning Effort: Absolute maximum")),
+            ("xhigh", Some("Reasoning Effort: Beyond maximum")),
+            ("max", Some("Reasoning Effort: Beyond maximum")),
+        ] {
+            let out = tokenizer
+                .apply_chat_template(
+                    &messages,
+                    ChatTemplateParams {
+                        thinking: Some(true),
+                        reasoning_effort: Some(effort),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+
+            match expected_prefix {
+                Some(prefix) => assert!(out.contains(prefix), "effort {effort}: {out}"),
+                None => assert!(!out.contains("Reasoning Effort:"), "effort {effort}: {out}"),
+            }
+            assert!(out.ends_with("<think>"), "effort {effort}: {out}");
+        }
+    }
+
+    #[test]
+    fn deepseek_v4_native_template_effort_overrides_openai_effort() {
+        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash-0731");
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let native_effort = json!("max");
+
+        let out = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    thinking: Some(true),
+                    reasoning_effort: Some("medium"),
+                    template_reasoning_effort: Some(&native_effort),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(out.contains("Reasoning Effort: Beyond maximum"));
+        assert!(!out.contains("Reasoning Effort: Absolute maximum"));
+    }
+
+    #[test]
+    fn deepseek_v4_rejects_invalid_native_template_effort() {
+        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash-0731");
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+
+        for native_effort in [json!("medium"), json!(3)] {
+            let error = tokenizer
+                .apply_chat_template(
+                    &messages,
+                    ChatTemplateParams {
+                        thinking: Some(true),
+                        template_reasoning_effort: Some(&native_effort),
+                        ..Default::default()
+                    },
+                )
+                .unwrap_err();
+            assert!(
+                error.to_string().contains(
+                    "chat_template_kwargs.reasoning_effort must be one of low, high, max"
+                ),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn deepseek_v4_resolves_effort_and_thinking_independently() {
+        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Flash-0731");
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+
+        let mut effort_only = HashMap::new();
+        effort_only.insert("reasoning_effort".to_string(), json!("max"));
+        let out = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    template_kwargs: Some(&effort_only),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(out.ends_with("</think>"));
+        assert!(!out.contains("Reasoning Effort:"));
+
+        let thinking_off = HashMap::from([("thinking".to_string(), json!(false))]);
+        let out = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    template_kwargs: Some(&thinking_off),
+                    thinking: Some(true),
+                    reasoning_effort: Some("max"),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(out.ends_with("</think>"));
+        assert!(!out.contains("Reasoning Effort:"));
+
+        let thinking_on = HashMap::from([("thinking".to_string(), json!(true))]);
+        let out = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    template_kwargs: Some(&thinking_on),
+                    thinking: Some(false),
+                    reasoning_effort: Some("none"),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(out.ends_with("<think>"));
+        assert!(!out.contains("Reasoning Effort:"));
+
+        let out = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    reasoning_effort: Some("turbo"),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(out.ends_with("</think>"));
+        assert!(!out.contains("Reasoning Effort:"));
+    }
+
+    #[test]
+    fn deepseek_v4_effort_profile_follows_local_model_path() {
+        for (model_name, expected, unexpected) in [
+            (
+                "DeepSeek-V4-Flash-0731",
+                "Reasoning Effort: Beyond maximum",
+                "Reasoning Effort: Absolute maximum",
+            ),
+            (
+                "DeepSeek-V4-Flash",
+                "Reasoning Effort: Absolute maximum",
+                "Reasoning Effort: Beyond maximum",
+            ),
+            (
+                "DeepSeek-V4-Flash-DSpark",
+                "Reasoning Effort: Absolute maximum",
+                "Reasoning Effort: Beyond maximum",
+            ),
+            (
+                "DeepSeek-V4-Pro",
+                "Reasoning Effort: Absolute maximum",
+                "Reasoning Effort: Beyond maximum",
+            ),
+        ] {
+            let (_tmp, tok) = write_named_v4_dir(model_name);
+            let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+            let messages = vec![json!({ "role": "user", "content": "Hello" })];
+            let native_effort = json!("max");
+            let output = tokenizer
+                .apply_chat_template(
+                    &messages,
+                    ChatTemplateParams {
+                        thinking: Some(true),
+                        template_reasoning_effort: Some(&native_effort),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+
+            assert!(output.contains(expected), "{model_name}: {output}");
+            assert!(!output.contains(unexpected), "{model_name}: {output}");
+        }
+    }
+
+    #[test]
+    fn deepseek_v4_effort_profile_defaults_anonymous_v4_to_original() {
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let native_effort = json!("max");
+        let output = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    thinking: Some(true),
+                    template_reasoning_effort: Some(&native_effort),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(output.contains("Reasoning Effort: Absolute maximum"));
+        assert!(!output.contains("Reasoning Effort: Beyond maximum"));
+    }
+
+    #[test]
+    fn deepseek_v4_effort_profile_uses_explicit_model_identity() {
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template_and_model_id(
+            &tok,
+            None,
+            Some("deepseek-ai/DeepSeek-V4-Flash-0731"),
+        )
+        .unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let native_effort = json!("max");
+        let output = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    thinking: Some(true),
+                    template_reasoning_effort: Some(&native_effort),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(output.contains("Reasoning Effort: Beyond maximum"));
+        assert!(!output.contains("Reasoning Effort: Absolute maximum"));
+    }
+
+    #[test]
+    fn tokenizer_factory_propagates_explicit_model_identity() {
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let tokenizer = create_tokenizer_with_chat_template_and_model_id(
+            &tok,
+            None,
+            Some("deepseek-ai/DeepSeek-V4-Flash-0731"),
+        )
+        .unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let native_effort = json!("max");
+        let output = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    thinking: Some(true),
+                    template_reasoning_effort: Some(&native_effort),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(output.contains("Reasoning Effort: Beyond maximum"));
+        assert!(!output.contains("Reasoning Effort: Absolute maximum"));
+    }
+
+    #[test]
+    fn original_v4_keeps_permissive_invalid_template_effort_override() {
+        let (_tmp, tok) = write_named_v4_dir("DeepSeek-V4-Pro");
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let invalid_native_effort = json!(3);
+        let output = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    thinking: Some(true),
+                    reasoning_effort: Some("max"),
+                    template_reasoning_effort: Some(&invalid_native_effort),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(!output.contains("Reasoning Effort:"), "{output}");
+        assert!(output.ends_with("<think>"));
     }
 }

--- a/model_gateway/src/routers/grpc/common/responses/mod.rs
+++ b/model_gateway/src/routers/grpc/common/responses/mod.rs
@@ -7,7 +7,50 @@ pub(crate) mod utils;
 
 // Re-export commonly used items
 pub(crate) use context::ResponsesContext;
+use openai_protocol::{
+    common::{Usage, UsageInfo},
+    responses::ResponsesUsage,
+};
+use serde_json::{json, Value};
 pub(crate) use streaming::build_sse_response;
 pub(crate) use utils::{ensure_mcp_connection, persist_response_if_needed};
 
 pub(crate) use crate::routers::common::mcp_utils::collect_user_function_names;
+
+/// Convert Chat usage into the Responses API's modern usage wire shape.
+pub(crate) fn responses_usage_from_chat_usage(usage: &Usage) -> ResponsesUsage {
+    let usage_info = UsageInfo {
+        prompt_tokens: usage.prompt_tokens,
+        completion_tokens: usage.completion_tokens,
+        total_tokens: usage.total_tokens,
+        reasoning_tokens: usage
+            .completion_tokens_details
+            .as_ref()
+            .and_then(|details| details.reasoning_tokens),
+        prompt_tokens_details: usage.prompt_tokens_details.clone(),
+    };
+
+    ResponsesUsage::Modern(usage_info.to_response_usage())
+}
+
+/// Build the usage object embedded in regular Responses `response.completed` events.
+pub(crate) fn response_completed_usage(usage: &Usage) -> Value {
+    let usage = responses_usage_from_chat_usage(usage).to_response_usage();
+    json!({
+        "input_tokens": usage.input_tokens,
+        "input_tokens_details": {
+            "cached_tokens": usage
+                .input_tokens_details
+                .as_ref()
+                .map_or(0, |details| details.cached_tokens),
+        },
+        "output_tokens": usage.output_tokens,
+        "output_tokens_details": {
+            "reasoning_tokens": usage
+                .output_tokens_details
+                .as_ref()
+                .map_or(0, |details| details.reasoning_tokens),
+        },
+        "total_tokens": usage.total_tokens,
+    })
+}

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -5,14 +5,12 @@ use bytes::Bytes;
 use http::header::{HeaderValue, CONTENT_TYPE};
 use openai_protocol::{
     chat::ChatCompletionStreamResponse,
-    common::{Usage, UsageInfo},
+    common::Usage,
     event_types::{
         ContentPartEvent, FunctionCallEvent, McpEvent, OutputItemEvent, OutputTextEvent,
         ResponseEvent,
     },
-    responses::{
-        ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse, ResponsesUsage,
-    },
+    responses::{ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse},
 };
 use serde_json::json;
 use smg_mcp::{self as mcp};
@@ -21,6 +19,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::warn;
 use uuid::Uuid;
 
+use super::responses_usage_from_chat_usage;
 use crate::routers::{
     common::openai_bridge::{self, descriptor, ResponseFormat},
     grpc::harmony::responses::ToolResult,
@@ -690,19 +689,7 @@ impl ResponseStreamEventEmitter {
             .collect();
 
         // Convert Usage to ResponsesUsage
-        let responses_usage = usage.map(|u| {
-            let usage_info = UsageInfo {
-                prompt_tokens: u.prompt_tokens,
-                completion_tokens: u.completion_tokens,
-                total_tokens: u.total_tokens,
-                reasoning_tokens: u
-                    .completion_tokens_details
-                    .as_ref()
-                    .and_then(|d| d.reasoning_tokens),
-                prompt_tokens_details: u.prompt_tokens_details.clone(),
-            };
-            ResponsesUsage::Modern(usage_info.to_response_usage())
-        });
+        let responses_usage = usage.as_ref().map(responses_usage_from_chat_usage);
 
         // Build response using builder
         ResponsesResponse::builder(&self.response_id, &self.model)
@@ -1027,10 +1014,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn finalized_streaming_response_serializes_responses_api_usage() {
+    fn finalized_streaming_response_serializes_modern_usage_with_token_details() {
         let emitter =
             ResponseStreamEventEmitter::new("resp_test".to_string(), "test-model".to_string(), 1);
-
         let usage = Usage::from_counts(12, 7)
             .with_cached_tokens(3)
             .with_reasoning_tokens(2);

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -445,11 +445,11 @@ impl HarmonyBuilder {
             .reasoning_effort
             .as_deref()
             .map(|effort| match effort {
-                "high" => ReasoningEffort::High,
+                "high" | "xhigh" | "max" => ReasoningEffort::High,
                 "medium" => ReasoningEffort::Medium,
-                "low" => ReasoningEffort::Low,
-                // Harmony does not support minimal reasoning effort
-                "minimal" => ReasoningEffort::Low,
+                // Harmony has no disabled or minimal bucket, so clamp both
+                // to its lowest supported effort.
+                "none" | "minimal" | "low" => ReasoningEffort::Low,
                 _ => ReasoningEffort::Medium,
             });
 
@@ -472,10 +472,13 @@ impl HarmonyBuilder {
             .as_ref()
             .and_then(|r| r.effort.as_ref())
             .map(|effort| match effort {
-                ResponsesReasoningEffort::High => ReasoningEffort::High,
+                ResponsesReasoningEffort::High
+                | ResponsesReasoningEffort::XHigh
+                | ResponsesReasoningEffort::Max => ReasoningEffort::High,
                 ResponsesReasoningEffort::Medium => ReasoningEffort::Medium,
-                ResponsesReasoningEffort::Low => ReasoningEffort::Low,
-                ResponsesReasoningEffort::Minimal => ReasoningEffort::Low,
+                ResponsesReasoningEffort::None
+                | ResponsesReasoningEffort::Minimal
+                | ResponsesReasoningEffort::Low => ReasoningEffort::Low,
             });
 
         self.build_system_message(reasoning_effort, with_custom_tools)
@@ -1207,10 +1210,45 @@ mod tests {
 
     use openai_protocol::{
         common::{AudioUrl, InputAudio},
-        responses::{ImageGenerationTool, ResponseInput, ResponseTool, ResponsesRequest},
+        responses::{
+            ImageGenerationTool, ResponseInput, ResponseReasoningParam, ResponseTool,
+            ResponsesRequest,
+        },
     };
 
     use super::*;
+
+    #[test]
+    fn chat_and_responses_reasoning_efforts_build_the_same_system_message() {
+        let builder = HarmonyBuilder::new();
+
+        for (chat_effort, responses_effort) in [
+            ("none", ResponsesReasoningEffort::None),
+            ("minimal", ResponsesReasoningEffort::Minimal),
+            ("low", ResponsesReasoningEffort::Low),
+            ("medium", ResponsesReasoningEffort::Medium),
+            ("high", ResponsesReasoningEffort::High),
+            ("xhigh", ResponsesReasoningEffort::XHigh),
+            ("max", ResponsesReasoningEffort::Max),
+        ] {
+            let chat_request = ChatCompletionRequest {
+                reasoning_effort: Some(chat_effort.to_string()),
+                ..Default::default()
+            };
+            let responses_request = ResponsesRequest {
+                reasoning: Some(ResponseReasoningParam {
+                    effort: Some(responses_effort),
+                    summary: None,
+                }),
+                ..Default::default()
+            };
+
+            let chat_message = builder.build_system_message_from_chat(&chat_request);
+            let responses_message =
+                builder.build_system_message_from_responses(&responses_request, false);
+            assert_eq!(chat_message, responses_message, "effort: {chat_effort}");
+        }
+    }
 
     #[test]
     fn chat_audio_is_explicitly_rejected() {

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -426,3 +426,29 @@ pub(super) fn build_next_request(
         repetition_penalty: current_request.repetition_penalty,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::responses::{ReasoningEffort, ResponseReasoningParam, ResponsesRequest};
+
+    use super::*;
+
+    #[test]
+    fn stateful_tool_loop_preserves_reasoning_effort() {
+        let state = ToolLoopState::new(ResponseInput::Text("use a tool".to_string()));
+        let request = ResponsesRequest {
+            input: ResponseInput::Text("use a tool".to_string()),
+            reasoning: Some(ResponseReasoningParam {
+                effort: Some(ReasoningEffort::Max),
+                summary: None,
+            }),
+            ..Default::default()
+        };
+
+        let next = build_next_request(&state, request);
+        assert!(matches!(
+            next.reasoning.and_then(|reasoning| reasoning.effort),
+            Some(ReasoningEffort::Max)
+        ));
+    }
+}

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -685,6 +685,36 @@ mod tests {
     }
 
     #[test]
+    fn deepseek_v4_template_effort_enables_response_reasoning_parsing() {
+        let (_temp, tokenizer) = deepseek_v4_tokenizer();
+        let native_effort = std::collections::HashMap::from([(
+            "reasoning_effort".to_string(),
+            serde_json::json!("max"),
+        )]);
+        let explicit_off = std::collections::HashMap::from([
+            ("reasoning_effort".to_string(), serde_json::json!("max")),
+            ("thinking".to_string(), serde_json::json!(false)),
+        ]);
+
+        assert_eq!(
+            crate::routers::grpc::utils::resolve_user_thinking(
+                Some(&native_effort),
+                Some("none"),
+                &tokenizer,
+            ),
+            Some(true)
+        );
+        assert_eq!(
+            crate::routers::grpc::utils::resolve_user_thinking(
+                Some(&explicit_off),
+                Some("max"),
+                &tokenizer,
+            ),
+            Some(false)
+        );
+    }
+
+    #[test]
     fn test_items_input_conversion() {
         let req = ResponsesRequest {
             input: ResponseInput::Items(vec![

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -9,18 +9,19 @@
 
 use openai_protocol::{
     chat::{ChatCompletionRequest, ChatCompletionResponse, ChatMessage, MessageContent},
-    common::{FunctionCallResponse, JsonSchemaFormat, ResponseFormat, ToolCall, UsageInfo},
+    common::{FunctionCallResponse, JsonSchemaFormat, ResponseFormat, ToolCall},
     responses::{
         ReasoningEffort, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
         ResponseOutputItem, ResponseReasoningContent::ReasoningText, ResponseStatus,
-        ResponsesRequest, ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig,
-        TextFormat,
+        ResponsesRequest, ResponsesResponse, StringOrContentParts, TextConfig, TextFormat,
     },
     UNKNOWN_MODEL_ID,
 };
 use tracing::warn;
 
-use crate::routers::grpc::common::responses::utils::extract_tools_from_response_tools;
+use crate::routers::grpc::common::responses::{
+    responses_usage_from_chat_usage, utils::extract_tools_from_response_tools,
+};
 
 /// Convert a ResponsesRequest to ChatCompletionRequest for processing through the chat pipeline
 ///
@@ -247,6 +248,8 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
         tools,
         tool_choice: req.tool_choice.as_ref().map(|tc| tc.to_chat_tool_choice()),
         response_format: map_text_to_response_format(req.text.as_ref()),
+        separate_reasoning: true,
+        stream_reasoning: true,
         reasoning_effort: req
             .reasoning
             .as_ref()
@@ -418,20 +421,11 @@ pub(crate) fn chat_to_responses(
         _ => ResponseStatus::Completed, // Default to completed
     };
 
-    // Convert usage from Usage to UsageInfo, then wrap in ResponsesUsage
-    let usage = chat_resp.usage.as_ref().map(|u| {
-        let usage_info = UsageInfo {
-            prompt_tokens: u.prompt_tokens,
-            completion_tokens: u.completion_tokens,
-            total_tokens: u.total_tokens,
-            reasoning_tokens: u
-                .completion_tokens_details
-                .as_ref()
-                .and_then(|d| d.reasoning_tokens),
-            prompt_tokens_details: u.prompt_tokens_details.clone(),
-        };
-        ResponsesUsage::Modern(usage_info.to_response_usage())
-    });
+    // Convert usage to the modern Responses API shape.
+    let usage = chat_resp
+        .usage
+        .as_ref()
+        .map(responses_usage_from_chat_usage);
 
     // Generate response
     let response_id = response_id_override.unwrap_or_else(|| chat_resp.id.clone());
@@ -552,6 +546,22 @@ mod tests {
         assert_eq!(chat_req.messages.len(), 2); // system + user
         assert_eq!(chat_req.model, "gpt-4");
         assert_eq!(chat_req.temperature, Some(0.7));
+    }
+
+    #[test]
+    fn responses_requests_enable_reasoning_separation_for_streaming_and_non_streaming() {
+        for stream in [false, true] {
+            let request = ResponsesRequest {
+                input: ResponseInput::Text("reason about this".to_string()),
+                stream: Some(stream),
+                ..Default::default()
+            };
+
+            let chat_request = responses_to_chat(&request).expect("request should convert");
+
+            assert!(chat_request.separate_reasoning);
+            assert!(chat_request.stream_reasoning);
+        }
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -451,6 +451,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::routers::grpc::utils::{process_chat_messages, resolve_user_thinking};
 
     const MIN_TOKENIZER_JSON: &str = r#"{
         "version": "1.0",
@@ -657,25 +658,19 @@ mod tests {
             ..Default::default()
         };
 
-        let responses_prompt =
-            crate::routers::grpc::utils::process_chat_messages(&responses_chat, &tokenizer, None)
+        let responses_prompt = process_chat_messages(&responses_chat, &tokenizer, None)
+            .unwrap()
+            .text;
+        let chat_prompt = process_chat_messages(&chat_request, &tokenizer, None)
+            .unwrap()
+            .text;
+        let template_prompt = process_chat_messages(&template_request, &tokenizer, None)
+            .unwrap()
+            .text;
+        let native_override_prompt =
+            process_chat_messages(&native_override_request, &tokenizer, None)
                 .unwrap()
                 .text;
-        let chat_prompt =
-            crate::routers::grpc::utils::process_chat_messages(&chat_request, &tokenizer, None)
-                .unwrap()
-                .text;
-        let template_prompt =
-            crate::routers::grpc::utils::process_chat_messages(&template_request, &tokenizer, None)
-                .unwrap()
-                .text;
-        let native_override_prompt = crate::routers::grpc::utils::process_chat_messages(
-            &native_override_request,
-            &tokenizer,
-            None,
-        )
-        .unwrap()
-        .text;
 
         assert_eq!(responses_prompt, chat_prompt);
         assert_eq!(template_prompt, chat_prompt);
@@ -697,19 +692,11 @@ mod tests {
         ]);
 
         assert_eq!(
-            crate::routers::grpc::utils::resolve_user_thinking(
-                Some(&native_effort),
-                Some("none"),
-                &tokenizer,
-            ),
+            resolve_user_thinking(Some(&native_effort), Some("none"), &tokenizer),
             Some(true)
         );
         assert_eq!(
-            crate::routers::grpc::utils::resolve_user_thinking(
-                Some(&explicit_off),
-                Some("max"),
-                &tokenizer,
-            ),
+            resolve_user_thinking(Some(&explicit_off), Some("max"), &tokenizer),
             Some(false)
         );
     }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -261,10 +261,13 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
 /// string (verbatim snake_case, as the Chat pipeline expects).
 fn reasoning_effort_to_str(effort: &ReasoningEffort) -> &'static str {
     match effort {
+        ReasoningEffort::None => "none",
         ReasoningEffort::Minimal => "minimal",
         ReasoningEffort::Low => "low",
         ReasoningEffort::Medium => "medium",
         ReasoningEffort::High => "high",
+        ReasoningEffort::XHigh => "xhigh",
+        ReasoningEffort::Max => "max",
     }
 }
 
@@ -444,12 +447,50 @@ pub(crate) fn chat_to_responses(
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use llm_tokenizer::huggingface::HuggingFaceTokenizer;
     use openai_protocol::{
         chat::{ChatChoice, ChatCompletionMessage},
         common::{StreamOptions, Usage},
     };
+    use tempfile::TempDir;
 
     use super::*;
+
+    const MIN_TOKENIZER_JSON: &str = r#"{
+        "version": "1.0",
+        "truncation": null,
+        "padding": null,
+        "added_tokens": [],
+        "normalizer": null,
+        "pre_tokenizer": { "type": "Whitespace" },
+        "post_processor": null,
+        "decoder": null,
+        "model": {
+            "type": "BPE",
+            "vocab": { "hello": 0, "<s>": 1, "</s>": 2 },
+            "merges": []
+        }
+    }"#;
+
+    fn deepseek_v4_tokenizer() -> (TempDir, HuggingFaceTokenizer) {
+        let temp = TempDir::new().unwrap();
+        let tokenizer_path = temp.path().join("tokenizer.json");
+        fs::write(&tokenizer_path, MIN_TOKENIZER_JSON).unwrap();
+        fs::write(
+            temp.path().join("config.json"),
+            r#"{"architectures":["DeepseekV4ForCausalLM"]}"#,
+        )
+        .unwrap();
+        let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template_and_model_id(
+            tokenizer_path.to_str().unwrap(),
+            None,
+            Some("deepseek-ai/DeepSeek-V4-Flash-0731"),
+        )
+        .unwrap();
+        (temp, tokenizer)
+    }
 
     #[test]
     fn chat_to_responses_serializes_responses_api_usage() {
@@ -515,20 +556,30 @@ mod tests {
     }
 
     #[test]
-    fn test_reasoning_effort_flows_through() {
+    fn test_reasoning_effort_values_flow_through_verbatim() {
         use openai_protocol::responses::ResponseReasoningParam;
 
-        let req = ResponsesRequest {
-            input: ResponseInput::Text("hi".to_string()),
-            reasoning: Some(ResponseReasoningParam {
-                effort: Some(ReasoningEffort::High),
-                summary: None,
-            }),
-            ..Default::default()
-        };
+        for (effort, expected) in [
+            (ReasoningEffort::None, "none"),
+            (ReasoningEffort::Minimal, "minimal"),
+            (ReasoningEffort::Low, "low"),
+            (ReasoningEffort::Medium, "medium"),
+            (ReasoningEffort::High, "high"),
+            (ReasoningEffort::XHigh, "xhigh"),
+            (ReasoningEffort::Max, "max"),
+        ] {
+            let req = ResponsesRequest {
+                input: ResponseInput::Text("hi".to_string()),
+                reasoning: Some(ResponseReasoningParam {
+                    effort: Some(effort),
+                    summary: None,
+                }),
+                ..Default::default()
+            };
 
-        let chat_req = responses_to_chat(&req).unwrap();
-        assert_eq!(chat_req.reasoning_effort.as_deref(), Some("high"));
+            let chat_req = responses_to_chat(&req).unwrap();
+            assert_eq!(chat_req.reasoning_effort.as_deref(), Some(expected));
+        }
     }
 
     #[test]
@@ -540,6 +591,59 @@ mod tests {
 
         let chat_req = responses_to_chat(&req).unwrap();
         assert_eq!(chat_req.reasoning_effort, None);
+    }
+
+    #[test]
+    fn test_reasoning_effort_absent_when_reasoning_object_is_empty() {
+        use openai_protocol::responses::ResponseReasoningParam;
+
+        let req = ResponsesRequest {
+            input: ResponseInput::Text("hi".to_string()),
+            reasoning: Some(ResponseReasoningParam {
+                effort: None,
+                summary: None,
+            }),
+            ..Default::default()
+        };
+
+        let chat_req = responses_to_chat(&req).unwrap();
+        assert_eq!(chat_req.reasoning_effort, None);
+    }
+
+    #[test]
+    fn chat_and_responses_max_render_the_same_deepseek_v4_prompt() {
+        use openai_protocol::responses::ResponseReasoningParam;
+
+        let (_temp, tokenizer) = deepseek_v4_tokenizer();
+        let responses_request = ResponsesRequest {
+            model: "deepseek-ai/DeepSeek-V4-Flash-0731".to_string(),
+            input: ResponseInput::Text("hello".to_string()),
+            reasoning: Some(ResponseReasoningParam {
+                effort: Some(ReasoningEffort::Max),
+                summary: None,
+            }),
+            ..Default::default()
+        };
+        let responses_chat = responses_to_chat(&responses_request).unwrap();
+        let chat_request = ChatCompletionRequest {
+            model: responses_request.model.clone(),
+            messages: responses_chat.messages.clone(),
+            reasoning_effort: Some("max".to_string()),
+            ..Default::default()
+        };
+
+        let responses_prompt =
+            crate::routers::grpc::utils::process_chat_messages(&responses_chat, &tokenizer, None)
+                .unwrap()
+                .text;
+        let chat_prompt =
+            crate::routers::grpc::utils::process_chat_messages(&chat_request, &tokenizer, None)
+                .unwrap()
+                .text;
+
+        assert_eq!(responses_prompt, chat_prompt);
+        assert!(chat_prompt.contains("Reasoning Effort: Beyond maximum"));
+        assert!(chat_prompt.ends_with("<think>"));
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -483,10 +483,9 @@ mod tests {
             r#"{"architectures":["DeepseekV4ForCausalLM"]}"#,
         )
         .unwrap();
-        let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template_and_model_id(
+        let tokenizer = HuggingFaceTokenizer::from_file_with_chat_template(
             tokenizer_path.to_str().unwrap(),
             None,
-            Some("deepseek-ai/DeepSeek-V4-Flash-0731"),
         )
         .unwrap();
         (temp, tokenizer)

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -620,7 +620,7 @@ mod tests {
     }
 
     #[test]
-    fn chat_and_responses_max_render_the_same_deepseek_v4_prompt() {
+    fn chat_responses_and_template_kwargs_render_the_same_deepseek_v4_prompt() {
         use openai_protocol::responses::ResponseReasoningParam;
 
         let (_temp, tokenizer) = deepseek_v4_tokenizer();
@@ -640,6 +640,22 @@ mod tests {
             reasoning_effort: Some("max".to_string()),
             ..Default::default()
         };
+        let template_request = ChatCompletionRequest {
+            model: responses_request.model.clone(),
+            messages: responses_chat.messages.clone(),
+            chat_template_kwargs: Some(std::collections::HashMap::from([(
+                "reasoning_effort".to_string(),
+                serde_json::json!("max"),
+            )])),
+            ..Default::default()
+        };
+        let native_override_request = ChatCompletionRequest {
+            model: responses_request.model.clone(),
+            messages: responses_chat.messages.clone(),
+            reasoning_effort: Some("none".to_string()),
+            chat_template_kwargs: template_request.chat_template_kwargs.clone(),
+            ..Default::default()
+        };
 
         let responses_prompt =
             crate::routers::grpc::utils::process_chat_messages(&responses_chat, &tokenizer, None)
@@ -649,8 +665,21 @@ mod tests {
             crate::routers::grpc::utils::process_chat_messages(&chat_request, &tokenizer, None)
                 .unwrap()
                 .text;
+        let template_prompt =
+            crate::routers::grpc::utils::process_chat_messages(&template_request, &tokenizer, None)
+                .unwrap()
+                .text;
+        let native_override_prompt = crate::routers::grpc::utils::process_chat_messages(
+            &native_override_request,
+            &tokenizer,
+            None,
+        )
+        .unwrap()
+        .text;
 
         assert_eq!(responses_prompt, chat_prompt);
+        assert_eq!(template_prompt, chat_prompt);
+        assert_eq!(native_override_prompt, chat_prompt);
         assert!(chat_prompt.contains("Reasoning Effort: Beyond maximum"));
         assert!(chat_prompt.ends_with("<think>"));
     }

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -23,10 +23,10 @@ use openai_protocol::{
         ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse,
         ChatCompletionStreamResponse,
     },
-    common::{FunctionCallResponse, ToolCall, Usage, UsageInfo},
+    common::{FunctionCallResponse, ToolCall, Usage},
     responses::{
         ResponseContentPart, ResponseOutputItem, ResponseReasoningContent, ResponseStatus,
-        ResponsesRequest, ResponsesResponse, ResponsesUsage,
+        ResponsesRequest, ResponsesResponse,
     },
 };
 use serde_json::{json, Value};
@@ -56,7 +56,8 @@ use crate::{
         },
         grpc::{
             common::responses::{
-                build_sse_response, persist_response_if_needed,
+                build_sse_response, persist_response_if_needed, response_completed_usage,
+                responses_usage_from_chat_usage,
                 streaming::{attach_mcp_server_label, OutputItemKind, ResponseStreamEventEmitter},
                 ResponsesContext,
             },
@@ -210,23 +211,7 @@ async fn process_and_transform_sse_stream(
     }
 
     // Emit final response.completed event with accumulated usage
-    let usage_json = accumulator.usage.as_ref().map(|u| {
-        let mut usage_obj = json!({
-            "input_tokens": u.prompt_tokens,
-            "output_tokens": u.completion_tokens,
-            "total_tokens": u.total_tokens
-        });
-
-        // Include reasoning_tokens if present
-        if let Some(details) = &u.completion_tokens_details {
-            if let Some(reasoning_tokens) = details.reasoning_tokens {
-                usage_obj["output_tokens_details"] =
-                    json!({ "reasoning_tokens": reasoning_tokens });
-            }
-        }
-
-        usage_obj
-    });
+    let usage_json = accumulator.usage.as_ref().map(response_completed_usage);
 
     let completed_event = event_emitter.emit_completed(usage_json.as_ref());
     event_emitter.send_event(&completed_event, &tx)?;
@@ -398,19 +383,7 @@ impl StreamingResponseAccumulator {
         };
 
         // Convert usage
-        let usage = self.usage.as_ref().map(|u| {
-            let usage_info = UsageInfo {
-                prompt_tokens: u.prompt_tokens,
-                completion_tokens: u.completion_tokens,
-                total_tokens: u.total_tokens,
-                reasoning_tokens: u
-                    .completion_tokens_details
-                    .as_ref()
-                    .and_then(|d| d.reasoning_tokens),
-                prompt_tokens_details: u.prompt_tokens_details.clone(),
-            };
-            ResponsesUsage::Modern(usage_info.to_response_usage())
-        });
+        let usage = self.usage.as_ref().map(responses_usage_from_chat_usage);
 
         ResponsesResponse::builder(&self.response_id, &self.model)
             .copy_from_request(&self.original_request)
@@ -914,13 +887,10 @@ async fn execute_tool_loop_streaming_internal(
         // (OpenAI router approach - text only appears on final iteration when no tool calls)
 
         // Emit final response.completed event
-        let usage_json = accumulated_response.usage.as_ref().map(|u| {
-            json!({
-                "input_tokens": u.prompt_tokens,
-                "output_tokens": u.completion_tokens,
-                "total_tokens": u.total_tokens
-            })
-        });
+        let usage_json = accumulated_response
+            .usage
+            .as_ref()
+            .map(response_completed_usage);
         let event = emitter.emit_completed(usage_json.as_ref());
         emitter.send_event(&event, &tx)?;
 
@@ -1088,7 +1058,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn streaming_accumulator_serializes_responses_api_usage() {
+    fn response_completed_usage_preserves_modern_usage_details() {
+        let usage = response_completed_usage(
+            &Usage::from_counts(12, 7)
+                .with_cached_tokens(3)
+                .with_reasoning_tokens(2),
+        );
+
+        assert_eq!(usage.get("input_tokens"), Some(&json!(12)));
+        assert_eq!(usage.get("output_tokens"), Some(&json!(7)));
+        assert_eq!(usage.get("total_tokens"), Some(&json!(19)));
+        assert_eq!(
+            usage.pointer("/input_tokens_details/cached_tokens"),
+            Some(&json!(3))
+        );
+        assert_eq!(
+            usage.pointer("/output_tokens_details/reasoning_tokens"),
+            Some(&json!(2))
+        );
+        assert!(usage.get("prompt_tokens").is_none());
+        assert!(usage.get("completion_tokens").is_none());
+    }
+
+    #[test]
+    fn streaming_accumulator_serializes_modern_usage_with_token_details() {
         let request = ResponsesRequest::default();
         let mut accumulator = StreamingResponseAccumulator::new(&request);
         accumulator.usage = Some(
@@ -1101,16 +1094,16 @@ mod tests {
             .expect("streaming response should serialize");
         let usage = wire.get("usage").expect("usage should be present");
 
-        assert_eq!(usage.get("input_tokens"), Some(&serde_json::json!(12)));
-        assert_eq!(usage.get("output_tokens"), Some(&serde_json::json!(7)));
-        assert_eq!(usage.get("total_tokens"), Some(&serde_json::json!(19)));
+        assert_eq!(usage.get("input_tokens"), Some(&json!(12)));
+        assert_eq!(usage.get("output_tokens"), Some(&json!(7)));
+        assert_eq!(usage.get("total_tokens"), Some(&json!(19)));
         assert_eq!(
             usage.pointer("/input_tokens_details/cached_tokens"),
-            Some(&serde_json::json!(3))
+            Some(&json!(3))
         );
         assert_eq!(
             usage.pointer("/output_tokens_details/reasoning_tokens"),
-            Some(&serde_json::json!(2))
+            Some(&json!(2))
         );
         assert!(usage.get("prompt_tokens").is_none());
         assert!(usage.get("completion_tokens").is_none());

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -501,6 +501,11 @@ pub(crate) fn process_chat_messages_with_placeholders(
             thinking: openai_protocol::chat::thinking_from_reasoning_effort(
                 request.reasoning_effort.as_deref(),
             ),
+            reasoning_effort: request.reasoning_effort.as_deref(),
+            template_reasoning_effort: request
+                .chat_template_kwargs
+                .as_ref()
+                .and_then(|kwargs| kwargs.get(REASONING_EFFORT_KEY)),
             ..Default::default()
         };
 
@@ -779,7 +784,10 @@ pub(crate) fn parse_finish_reason(
 
 #[cfg(test)]
 mod tests {
-    use llm_tokenizer::chat_template::ChatTemplateContentFormat;
+    use llm_tokenizer::{
+        chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
+        traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer},
+    };
     use openai_protocol::{
         chat::{ChatCompletionRequest, ChatMessage, MessageContent},
         common::{AudioUrl, ContentPart, ImageUrl, InputAudio, VideoUrl},
@@ -1332,6 +1340,88 @@ mod tests {
             reasoning_effort: reasoning_effort.map(str::to_string),
             ..Default::default()
         }
+    }
+
+    #[derive(Default)]
+    struct ReasoningProvenanceTokenizer {
+        special_tokens: SpecialTokens,
+    }
+
+    impl Encoder for ReasoningProvenanceTokenizer {
+        fn encode(&self, _input: &str, _add_special_tokens: bool) -> anyhow::Result<Encoding> {
+            Ok(Encoding::Plain(Vec::new()))
+        }
+
+        fn encode_batch(
+            &self,
+            _inputs: &[&str],
+            _add_special_tokens: bool,
+        ) -> anyhow::Result<Vec<Encoding>> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl Decoder for ReasoningProvenanceTokenizer {
+        fn decode(
+            &self,
+            _token_ids: &[TokenIdType],
+            _skip_special_tokens: bool,
+        ) -> anyhow::Result<String> {
+            Ok(String::new())
+        }
+    }
+
+    impl Tokenizer for ReasoningProvenanceTokenizer {
+        fn vocab_size(&self) -> usize {
+            0
+        }
+
+        fn get_special_tokens(&self) -> &SpecialTokens {
+            &self.special_tokens
+        }
+
+        fn token_to_id(&self, _token: &str) -> Option<TokenIdType> {
+            None
+        }
+
+        fn id_to_token(&self, _id: TokenIdType) -> Option<String> {
+            None
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn apply_chat_template(
+            &self,
+            _messages: &[Value],
+            params: ChatTemplateParams,
+        ) -> anyhow::Result<String> {
+            assert_eq!(params.reasoning_effort, Some("high"));
+            assert_eq!(params.template_reasoning_effort, Some(&json!("max")));
+            assert_eq!(params.thinking, Some(true));
+            assert_eq!(
+                params
+                    .template_kwargs
+                    .and_then(|kwargs| kwargs.get("thinking")),
+                Some(&json!(false))
+            );
+            Ok("rendered".to_string())
+        }
+    }
+
+    #[test]
+    fn process_chat_messages_preserves_reasoning_effort_provenance() {
+        let mut request = effort_request(Some("high"));
+        request.chat_template_kwargs = Some(HashMap::from([
+            (REASONING_EFFORT_KEY.to_string(), json!("max")),
+            ("thinking".to_string(), json!(false)),
+        ]));
+
+        let processed =
+            process_chat_messages(&request, &ReasoningProvenanceTokenizer::default(), None)
+                .unwrap();
+        assert_eq!(processed.text, "rendered");
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -204,8 +204,9 @@ mod tests {
         );
         // No explicit toggle -> fall back to the reasoning_effort mapping.
         assert_eq!(resolve_thinking_pref(None, Some("none")), Some(false));
-        assert_eq!(resolve_thinking_pref(None, Some("minimal")), Some(false));
-        assert_eq!(resolve_thinking_pref(None, Some("high")), None);
+        assert_eq!(resolve_thinking_pref(None, Some("minimal")), Some(true));
+        assert_eq!(resolve_thinking_pref(None, Some("high")), Some(true));
+        assert_eq!(resolve_thinking_pref(None, Some("max")), Some(true));
         assert_eq!(resolve_thinking_pref(None, None), None);
     }
 
@@ -241,6 +242,18 @@ mod tests {
         let parser = create_reasoning_parser(&factory, Some("qwen3"), "unknown-model")
             .expect("configured qwen3 parser exists");
         assert_eq!(parser.model_type(), "qwen3");
+    }
+
+    #[test]
+    fn deepseek_v4_reasoning_parser_is_available_without_override() {
+        let factory = ReasoningParserFactory::new();
+        let model = "deepseek-ai/DeepSeek-V4-Flash-0731";
+
+        assert!(check_reasoning_parser_availability(&factory, None, model));
+        let parser = create_reasoning_parser(&factory, None, model)
+            .expect("DeepSeek V4 parser should be selected automatically");
+        assert_eq!(parser.model_type(), "deepseek_v4");
+        assert!(!parser.is_in_reasoning());
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -46,12 +46,30 @@ pub(crate) fn extract_thinking_from_kwargs(
     .and_then(|v| v.as_bool())
 }
 
+fn extract_template_effort_thinking(
+    kwargs: Option<&std::collections::HashMap<String, Value>>,
+    tokenizer: &dyn Tokenizer,
+) -> Option<bool> {
+    if !tokenizer.template_reasoning_effort_enables_thinking() {
+        return None;
+    }
+    match kwargs?.get("reasoning_effort").and_then(Value::as_str) {
+        Some("low" | "high" | "max") => Some(true),
+        _ => None,
+    }
+}
+
 /// Precedence for the effective thinking preference: an explicit template
-/// toggle (already extracted from kwargs) always wins; otherwise fall back to
-/// the protocol-level OpenAI `reasoning_effort` mapping
-/// ([`thinking_from_reasoning_effort`]).
-fn resolve_thinking_pref(explicit: Option<bool>, reasoning_effort: Option<&str>) -> Option<bool> {
-    explicit.or_else(|| thinking_from_reasoning_effort(reasoning_effort))
+/// toggle always wins, followed by a native template effort for renderers that
+/// support it, then the protocol-level OpenAI `reasoning_effort` mapping.
+fn resolve_thinking_pref(
+    explicit: Option<bool>,
+    template_effort: Option<bool>,
+    reasoning_effort: Option<&str>,
+) -> Option<bool> {
+    explicit
+        .or(template_effort)
+        .or_else(|| thinking_from_reasoning_effort(reasoning_effort))
 }
 
 /// Resolve the user's effective thinking preference, honoring an explicit
@@ -64,6 +82,7 @@ pub fn resolve_user_thinking(
 ) -> Option<bool> {
     resolve_thinking_pref(
         extract_thinking_from_kwargs(kwargs, tokenizer),
+        extract_template_effort_thinking(kwargs, tokenizer),
         reasoning_effort,
     )
 }
@@ -197,17 +216,28 @@ mod tests {
     #[test]
     fn resolve_thinking_pref_explicit_kwarg_wins() {
         // An explicit template toggle always wins over the reasoning_effort mapping.
-        assert_eq!(resolve_thinking_pref(Some(true), Some("none")), Some(true));
         assert_eq!(
-            resolve_thinking_pref(Some(false), Some("high")),
+            resolve_thinking_pref(Some(true), Some(false), Some("none")),
+            Some(true)
+        );
+        assert_eq!(
+            resolve_thinking_pref(Some(false), Some(true), Some("high")),
             Some(false)
         );
+        // Native template effort wins over the public effort.
+        assert_eq!(
+            resolve_thinking_pref(None, Some(true), Some("none")),
+            Some(true)
+        );
         // No explicit toggle -> fall back to the reasoning_effort mapping.
-        assert_eq!(resolve_thinking_pref(None, Some("none")), Some(false));
-        assert_eq!(resolve_thinking_pref(None, Some("minimal")), Some(true));
-        assert_eq!(resolve_thinking_pref(None, Some("high")), Some(true));
-        assert_eq!(resolve_thinking_pref(None, Some("max")), Some(true));
-        assert_eq!(resolve_thinking_pref(None, None), None);
+        assert_eq!(resolve_thinking_pref(None, None, Some("none")), Some(false));
+        assert_eq!(
+            resolve_thinking_pref(None, None, Some("minimal")),
+            Some(true)
+        );
+        assert_eq!(resolve_thinking_pref(None, None, Some("high")), Some(true));
+        assert_eq!(resolve_thinking_pref(None, None, Some("max")), Some(true));
+        assert_eq!(resolve_thinking_pref(None, None, None), None);
     }
 
     #[test]

--- a/model_gateway/src/workflow/tokenizer_registration.rs
+++ b/model_gateway/src/workflow/tokenizer_registration.rs
@@ -120,12 +120,12 @@ impl StepExecutor<TokenizerWorkflowData> for LoadTokenizerStep {
                 let name = name.clone();
                 let id = id.clone();
                 async move {
-                    let base_tokenizer = match factory::create_tokenizer_async_with_chat_template(
+                    let base_tokenizer = match factory::create_tokenizer_async_with_chat_template_and_model_id(
                         &source,
                         chat_template.as_deref(),
+                        Some(&name),
                     )
-                    .await
-                    {
+                    .await {
                         Ok(tok) => tok,
                         Err(local_err) => {
                             debug!(
@@ -221,6 +221,7 @@ fn with_optional_cache(
 
 fn load_tokenizer_from_bundle(
     bundle: &StreamBundle,
+    model_id: &str,
 ) -> Result<(Arc<dyn Tokenizer>, Option<MultimodalModelConfig>), String> {
     tokenizer_bundle::with_extracted_bundle(bundle, |tokenizer_dir| {
         let tokenizer_path = tokenizer_dir.to_string_lossy().into_owned();
@@ -229,8 +230,12 @@ fn load_tokenizer_from_bundle(
             tokenizer_path
         );
 
-        let tokenizer = factory::create_tokenizer_with_chat_template(&tokenizer_path, None)
-            .map_err(|e| format!("tokenizer load failed: {e}"))?;
+        let tokenizer = factory::create_tokenizer_with_chat_template_and_model_id(
+            &tokenizer_path,
+            None,
+            Some(model_id),
+        )
+        .map_err(|e| format!("tokenizer load failed: {e}"))?;
 
         let mm_config = try_load_multimodal_config(tokenizer_dir);
 
@@ -364,7 +369,7 @@ async fn fetch_tokenizer_from_worker(
             worker.url()
         );
 
-        match load_tokenizer_from_bundle(&bundle) {
+        match load_tokenizer_from_bundle(&bundle, model_id) {
             Ok((tokenizer, mm_config)) => {
                 if let Some(cfg) = mm_config {
                     app_context
@@ -436,7 +441,48 @@ pub fn create_tokenizer_workflow_data(
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Cursor, Write};
+
+    use llm_tokenizer::chat_template::ChatTemplateParams;
+    use serde_json::json;
+    use zip::{write::SimpleFileOptions, ZipWriter};
+
     use super::*;
+
+    const MIN_TOKENIZER_JSON: &str = r#"{
+        "version": "1.0",
+        "truncation": null,
+        "padding": null,
+        "added_tokens": [],
+        "normalizer": null,
+        "pre_tokenizer": { "type": "Whitespace" },
+        "post_processor": null,
+        "decoder": null,
+        "model": {
+            "type": "BPE",
+            "vocab": { "hello": 0, "<s>": 1, "</s>": 2 },
+            "merges": []
+        }
+    }"#;
+
+    fn deepseek_v4_bundle() -> StreamBundle {
+        let cursor = Cursor::new(Vec::new());
+        let mut writer = ZipWriter::new(cursor);
+        writer
+            .start_file("tokenizer.json", SimpleFileOptions::default())
+            .unwrap();
+        writer.write_all(MIN_TOKENIZER_JSON.as_bytes()).unwrap();
+        writer
+            .start_file("config.json", SimpleFileOptions::default())
+            .unwrap();
+        writer
+            .write_all(br#"{"architectures":["DeepseekV4ForCausalLM"]}"#)
+            .unwrap();
+        StreamBundle {
+            sha256: String::new(),
+            compressed_data: writer.finish().unwrap().into_inner(),
+        }
+    }
 
     #[test]
     fn test_tokenizer_config_request_serialization() {
@@ -522,5 +568,27 @@ mod tests {
         workflow
             .validate()
             .expect("Workflow validation should pass");
+    }
+
+    #[test]
+    fn grpc_bundle_load_preserves_flash_0731_model_identity() {
+        let bundle = deepseek_v4_bundle();
+        let (tokenizer, _) =
+            load_tokenizer_from_bundle(&bundle, "deepseek-ai/DeepSeek-V4-Flash-0731").unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let native_effort = json!("max");
+        let output = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    thinking: Some(true),
+                    template_reasoning_effort: Some(&native_effort),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(output.contains("Reasoning Effort: Beyond maximum"));
+        assert!(!output.contains("Reasoning Effort: Absolute maximum"));
     }
 }

--- a/model_gateway/src/workflow/tokenizer_registration.rs
+++ b/model_gateway/src/workflow/tokenizer_registration.rs
@@ -120,10 +120,9 @@ impl StepExecutor<TokenizerWorkflowData> for LoadTokenizerStep {
                 let name = name.clone();
                 let id = id.clone();
                 async move {
-                    let base_tokenizer = match factory::create_tokenizer_async_with_chat_template_and_model_id(
+                    let base_tokenizer = match factory::create_tokenizer_async_with_chat_template(
                         &source,
                         chat_template.as_deref(),
-                        Some(&name),
                     )
                     .await {
                         Ok(tok) => tok,
@@ -221,7 +220,6 @@ fn with_optional_cache(
 
 fn load_tokenizer_from_bundle(
     bundle: &StreamBundle,
-    model_id: &str,
 ) -> Result<(Arc<dyn Tokenizer>, Option<MultimodalModelConfig>), String> {
     tokenizer_bundle::with_extracted_bundle(bundle, |tokenizer_dir| {
         let tokenizer_path = tokenizer_dir.to_string_lossy().into_owned();
@@ -230,12 +228,8 @@ fn load_tokenizer_from_bundle(
             tokenizer_path
         );
 
-        let tokenizer = factory::create_tokenizer_with_chat_template_and_model_id(
-            &tokenizer_path,
-            None,
-            Some(model_id),
-        )
-        .map_err(|e| format!("tokenizer load failed: {e}"))?;
+        let tokenizer = factory::create_tokenizer_with_chat_template(&tokenizer_path, None)
+            .map_err(|e| format!("tokenizer load failed: {e}"))?;
 
         let mm_config = try_load_multimodal_config(tokenizer_dir);
 
@@ -369,7 +363,7 @@ async fn fetch_tokenizer_from_worker(
             worker.url()
         );
 
-        match load_tokenizer_from_bundle(&bundle, model_id) {
+        match load_tokenizer_from_bundle(&bundle) {
             Ok((tokenizer, mm_config)) => {
                 if let Some(cfg) = mm_config {
                     app_context
@@ -571,10 +565,9 @@ mod tests {
     }
 
     #[test]
-    fn grpc_bundle_load_preserves_flash_0731_model_identity() {
+    fn grpc_bundle_load_uses_deepseek_v4_effort_encoding() {
         let bundle = deepseek_v4_bundle();
-        let (tokenizer, _) =
-            load_tokenizer_from_bundle(&bundle, "deepseek-ai/DeepSeek-V4-Flash-0731").unwrap();
+        let (tokenizer, _) = load_tokenizer_from_bundle(&bundle).unwrap();
         let messages = vec![json!({ "role": "user", "content": "Hello" })];
         let native_effort = json!("max");
         let output = tokenizer


### PR DESCRIPTION
## Description

### Problem

DeepSeek V4 Flash 0731 defines a three-level `low` / `high` / `max` reasoning-effort encoding, but SMG's native Rust renderer did not consistently receive the OpenAI-compatible Chat Completions and Responses API effort fields. DeepSeek V4 models were also not automatically selecting the appropriate reasoning parser, and regular Responses conversion could merge reasoning into output text or lose modern usage details on some completion paths.

### Solution

Map the official OpenAI request fields into the native DeepSeek V4 renderer while keeping an explicit native `chat_template_kwargs.reasoning_effort` override. Use the 0731 effort encoding for the DeepSeek V4 renderer, keep thinking disabled when no effort is requested, and automatically register the DeepSeek V4 reasoning parser. Preserve separated reasoning and modern Responses API usage details in non-streaming, streaming, and tool-loop completion paths.

## Changes

- Accept Chat Completions `reasoning_effort` and Responses API `reasoning.effort`.
- Map public effort values into DeepSeek V4 `low`, `high`, and `max` buckets.
- Respect an explicit native `chat_template_kwargs.reasoning_effort` value and reject invalid native buckets.
- Render the official 0731 high/max effort prefixes in the Rust DeepSeek V4 encoder.
- Keep thinking disabled by default when neither public nor native effort is supplied.
- Automatically select the DeepSeek V4 reasoning parser from model identity.
- Keep Chat and Responses rendering behavior in parity, including stateful Responses tool loops.
- Preserve cached-token and reasoning-token usage details in the modern Responses API shape.

## Test Plan

- `cargo test -p smg responses --lib` — 51 passed.
- `cargo test --workspace -- --skip dsml_one_shot_and_incremental_decode_match --skip test_router_with_tracing` — passed, including unit, integration, and doc tests.
- `cargo +nightly fmt --all -- --check` — passed.
- `pre-commit run --all-files` — every hook passed except Clippy, which could not start because the local macOS environment has no `pkg-config`/OpenCV installation.
- The excluded `dsml_one_shot_and_incremental_decode_match` is a pre-existing untracked debug probe requiring `DSV4_TOKENIZER`.
- The excluded upstream `test_router_with_tracing` was run twice independently and consistently received zero OTLP spans; this branch does not modify tracing or observability code.

Live B300 validation used the original `deepseek-ai/DeepSeek-V4-Flash` weights with TP2 on GPUs 4–5. Because the deployed SMG 1.9.0 image predates this patch, the benchmark injected the exact official 0731 prefixes that the new Rust unit tests verify:

| Prompt | Effort | Completion tokens | Reasoning chars | Finish |
| --- | ---: | ---: | ---: | --- |
| 12-coin balance puzzle | low | 4,472 | 10,270 | stop |
| 12-coin balance puzzle | high | 8,192 | 27,138 | length |
| 12-coin balance puzzle | max | 5,038 | 14,190 | stop |
| Decimal comparison | low | 186 | 312 | stop |
| Decimal comparison | high | 242 | 400 | stop |
| Decimal comparison | max | 170 | 300 | stop |

The original Flash weights clearly respond to the 0731 effort prompts. Reasoning length is task-dependent rather than strictly monotonic, so these prefixes should be understood as instructions, not hard token budgets.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (blocked locally by missing `pkg-config`/OpenCV)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
