### PR TITLE
feat(zmq): teach the direct-backend path to speak TokenSpeed

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -27,6 +27,12 @@ pub enum BackendType {
     Sglang,
     Openai,
     Anthropic,
+    /// vLLM engine. Routing behaves like the default; over ZMQ this pins the
+    /// startup workers' wire protocol to vLLM EngineCore.
+    Vllm,
+    /// TokenSpeed engine. Routing behaves like the default; over ZMQ this pins
+    /// the startup workers' wire protocol to TokenSpeed.
+    Tokenspeed,
 }
 
 #[pyclass(eq, from_py_object)]
@@ -736,6 +742,22 @@ impl Router {
             None
         };
 
+        // `backend` normally only steers the routing mode. Over ZMQ it
+        // additionally pins the startup workers' runtime: the shared EngineCore
+        // handshake carries no engine identity, so the wire protocol cannot be
+        // probed. HTTP/gRPC keep auto-detection (None). Mirrors
+        // `to_router_config` in model_gateway/src/main.rs.
+        let startup_worker_runtime_type =
+            if matches!(self.connection_mode, worker::ConnectionMode::Zmq) {
+                match self.backend {
+                    BackendType::Vllm => Some(worker::RuntimeType::Vllm),
+                    BackendType::Tokenspeed => Some(worker::RuntimeType::TokenSpeed),
+                    _ => None,
+                }
+            } else {
+                None
+            };
+
         config::RouterConfig::builder()
             .mode(mode)
             .policy(policy)
@@ -743,6 +765,7 @@ impl Router {
             .port(self.port)
             .health_check_port(self.health_check_port)
             .connection_mode(self.connection_mode)
+            .startup_worker_runtime_type(startup_worker_runtime_type)
             .max_payload_size(self.max_payload_size)
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -45,6 +45,10 @@ def backend_from_str(backend_str: str | None) -> BackendType:
         "sglang": BackendType.Sglang,
         "openai": BackendType.Openai,
         "anthropic": BackendType.Anthropic,
+        # Engine backends: routing behaves like the default; over ZMQ they pin
+        # the startup workers' wire protocol (vLLM EngineCore vs TokenSpeed).
+        "vllm": BackendType.Vllm,
+        "tokenspeed": BackendType.Tokenspeed,
     }
     backend_lower = backend_str.lower()
     if backend_lower not in backend_map:

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -985,8 +985,11 @@ class RouterArgs:
             f"--{prefix}backend",
             type=str,
             default=RouterArgs.backend,
-            choices=["sglang", "openai", "anthropic"],
-            help="Backend runtime to use (default: sglang)",
+            choices=["sglang", "openai", "anthropic", "vllm", "tokenspeed"],
+            help=(
+                "Backend runtime to use (default: sglang). For ZMQ workers, vllm/"
+                "tokenspeed also pin the wire protocol (it cannot be auto-detected)"
+            ),
         )
         backend_group.add_argument(
             f"--{prefix}enable-wasm",

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -300,6 +300,63 @@ class VllmWorkerLauncher(WorkerLauncher):
         return cmd
 
 
+class TokenspeedWorkerLauncher(WorkerLauncher):
+    """Launcher for TokenSpeed inference workers (ZMQ direct-backend only)."""
+
+    def _get_tp_size(self, args: argparse.Namespace) -> int:
+        return getattr(args, "tensor_parallel_size", 1) or 1
+
+    def build_command(
+        self, args: argparse.Namespace, backend_args: list[str], host: str, port: int
+    ) -> list[str]:
+        if getattr(args, "connection_mode", "grpc") != "zmq":
+            raise ValueError(
+                "TokenSpeed backend only supports --connection-mode zmq "
+                "(the headless engine speaks the ZMQ direct-backend wire)"
+            )
+        return self._build_zmq_command(args, backend_args, port)
+
+    def _build_zmq_command(
+        self, args: argparse.Namespace, backend_args: list[str], port: int
+    ) -> list[str]:
+        """Launch a headless TokenSpeed scheduler that dials SMG's ZMQ handshake.
+
+        SMG (the router) binds the tcp handshake + ipc data-plane sockets it
+        derives from the ipc:// worker URL; this engine connects in. Each worker
+        is a standalone engine (`--zmq-engine-index 0`); running several is
+        dense data parallelism as N independent ZMQ workers.
+        """
+        rpc_port = _zmq_handshake_port(_zmq_ipc_url(port))
+        cmd = [
+            sys.executable,
+            "-m",
+            "tokenspeed.cli",
+            "serve",
+            "--headless",
+            "--model",
+            getattr(args, "model", ""),
+            "--data-parallel-address",
+            "127.0.0.1",
+            "--data-parallel-rpc-port",
+            str(rpc_port),
+            "--zmq-engine-index",
+            "0",
+        ]
+        cmd.extend(
+            self._filter_backend_args(
+                backend_args,
+                [
+                    "--model",
+                    "--headless",
+                    "--data-parallel-address",
+                    "--data-parallel-rpc-port",
+                    "--zmq-engine-index",
+                ],
+            )
+        )
+        return cmd
+
+
 class TrtllmWorkerLauncher(WorkerLauncher):
     """Launcher for TensorRT-LLM inference workers (gRPC mode only).
 
@@ -380,6 +437,7 @@ BACKEND_LAUNCHERS: dict[str, type[WorkerLauncher]] = {
     "sglang": SglangWorkerLauncher,
     "vllm": VllmWorkerLauncher,
     "trtllm": TrtllmWorkerLauncher,
+    "tokenspeed": TokenspeedWorkerLauncher,
 }
 
 
@@ -543,10 +601,32 @@ def _add_trtllm_stub_args(parser: argparse.ArgumentParser) -> None:
     group.add_argument("--tp_size", type=int, help="Tensor parallel size (overrides config file)")
 
 
+def _add_tokenspeed_stub_args(parser: argparse.ArgumentParser) -> None:
+    """Add TokenSpeed-specific arguments.
+
+    TokenSpeed args are passed through verbatim to the engine command; only the
+    flags the launcher itself consumes are declared here (parse_serve_args uses
+    parse_known_args for this backend, like trtllm).
+    """
+    group = parser.add_argument_group("TokenSpeed Options")
+    group.add_argument(
+        "--model",
+        type=str,
+        help="Model path (HuggingFace ID or local path)",
+    )
+    group.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help="Tensor parallel size (for per-worker GPU assignment)",
+    )
+
+
 BACKEND_ARG_ADDERS = {
     "sglang": _add_sglang_args,
     "vllm": _add_vllm_args,
     "trtllm": _add_trtllm_stub_args,
+    "tokenspeed": _add_tokenspeed_stub_args,
 }
 
 BACKEND_CHOICES = list(BACKEND_ARG_ADDERS.keys())
@@ -573,7 +653,8 @@ def add_serve_args(parser: argparse.ArgumentParser) -> None:
         choices=["grpc", "http", "zmq"],
         help=(
             "Connection mode for workers (default: grpc). Note: trtllm only "
-            "supports grpc, and zmq is only supported for the vllm backend"
+            "supports grpc, tokenspeed only supports zmq, and zmq is otherwise "
+            "only supported for the vllm backend"
         ),
     )
     # Router host/port - may be overridden by backend (e.g. sglang)
@@ -652,11 +733,12 @@ def parse_serve_args(
     serve_router_args, backend_args = pre_parser.parse_known_args(argv)
     backend = serve_router_args.backend
 
-    # ZMQ direct-backend is a same-host vLLM EngineCore connection; no other
-    # backend speaks the EngineCore ZMQ protocol.
-    if serve_router_args.connection_mode == "zmq" and backend != "vllm":
+    # ZMQ direct-backend is a same-host engine connection; only vLLM EngineCore
+    # and TokenSpeed speak a supported ZMQ wire protocol.
+    if serve_router_args.connection_mode == "zmq" and backend not in ("vllm", "tokenspeed"):
         pre_parser.error(
-            f"connection-mode zmq is only supported for the vllm backend, not {backend}"
+            "connection-mode zmq is only supported for the vllm and tokenspeed "
+            f"backends, not {backend}"
         )
 
     # Pass 2: full parser with backend-specific args; resolve so backend can override
@@ -671,7 +753,9 @@ def parse_serve_args(
         _add_vllm_frontend_args(parser)
     RouterArgs.add_cli_args(parser, use_router_prefix=True, exclude_host_port=True)
 
-    if backend == "trtllm":
+    # trtllm/tokenspeed only declare stub args (no full engine parser); unknown
+    # tokens stay in backend_args and are passed through to the worker command.
+    if backend in ("trtllm", "tokenspeed"):
         args, _ = parser.parse_known_args(argv)
     else:
         args = parser.parse_args(argv)
@@ -755,6 +839,13 @@ class ServeOrchestrator:
         ]
         router_args = RouterArgs.from_cli_args(self.args, use_router_prefix=True)
         router_args.worker_urls = worker_urls
+        # The ZMQ handshake is shared across engine runtimes, so the router
+        # cannot probe the wire protocol; forward the serve backend so the Rust
+        # side stamps the startup workers' runtime. (RouterArgs.backend
+        # otherwise keeps its own --router-backend value, which serve's
+        # --backend does not reach.)
+        if getattr(self.args, "connection_mode", "grpc") == "zmq":
+            router_args.backend = self.backend
         # Router-level retries and circuit breaker are redundant when there is a
         # single worker — per-worker resilience already handles failures — so
         # disable them by default for dp<=1. Users who want them must run dp>1.

--- a/bindings/python/tests/test_serve.py
+++ b/bindings/python/tests/test_serve.py
@@ -18,6 +18,7 @@ from smg.serve import (
     DEFAULT_BACKEND,
     ServeOrchestrator,
     SglangWorkerLauncher,
+    TokenspeedWorkerLauncher,
     TrtllmWorkerLauncher,
     VllmWorkerLauncher,
     _add_trtllm_stub_args,
@@ -47,6 +48,7 @@ class TestBackendRegistry:
         assert "sglang" in BACKEND_ARG_ADDERS
         assert "vllm" in BACKEND_ARG_ADDERS
         assert "trtllm" in BACKEND_ARG_ADDERS
+        assert "tokenspeed" in BACKEND_ARG_ADDERS
 
     def test_registry_values_are_callable(self):
         for name, adder in BACKEND_ARG_ADDERS.items():
@@ -60,6 +62,7 @@ class TestBackendLauncherRegistry:
         assert "sglang" in BACKEND_LAUNCHERS
         assert "vllm" in BACKEND_LAUNCHERS
         assert "trtllm" in BACKEND_LAUNCHERS
+        assert "tokenspeed" in BACKEND_LAUNCHERS
 
     def test_launcher_classes(self):
         assert BACKEND_LAUNCHERS["sglang"] is SglangWorkerLauncher
@@ -649,6 +652,9 @@ class TestZmqHandshakePort:
         # These MUST equal derive_handshake_port() in worker.rs for the same path.
         assert _zmq_handshake_port("ipc:///tmp/smg-zmq/ts0.ipc") == 25152
         assert _zmq_handshake_port("ipc:///tmp/smg-zmq/ts1.ipc") == 22735
+        assert _zmq_handshake_port("ipc:///tmp/smg-zmq/engine-31000") == 22714
+        # The path after ipc:// is what gets hashed, so the bare path matches.
+        assert _zmq_handshake_port("/tmp/smg-zmq/ts0.ipc") == 25152
         assert _zmq_handshake_port("ts0.ipc") == 23912
 
     def test_always_in_band(self):
@@ -803,6 +809,111 @@ class TestVllmWorkerLauncher:
         for arg in backend_args:
             assert arg in cmd
         assert "--enable-prompt-tokens-details" in cmd
+
+
+class TestTokenspeedWorkerLauncher:
+    """Test TokenspeedWorkerLauncher (ZMQ direct-backend only)."""
+
+    def test_build_zmq_command(self):
+        launcher = TokenspeedWorkerLauncher()
+        args = argparse.Namespace(model="/tmp/model", connection_mode="zmq")
+        backend_args = ["--mem-fraction-static", "0.8"]
+        cmd = launcher.build_command(args, backend_args, "127.0.0.1", 31000)
+
+        assert "tokenspeed.cli" in cmd
+        assert "serve" in cmd
+        assert "--headless" in cmd
+        assert "--model" in cmd
+        assert "/tmp/model" in cmd
+        assert "--data-parallel-address" in cmd
+        assert "127.0.0.1" in cmd
+        # The engine dials the handshake port SMG derives from the worker's
+        # ipc:// URL; both sides must agree without a side channel.
+        expected_port = _zmq_handshake_port(_zmq_ipc_url(31000))
+        assert "--data-parallel-rpc-port" in cmd
+        assert str(expected_port) in cmd
+        assert "--zmq-engine-index" in cmd
+        assert "0" in cmd
+        for arg in backend_args:
+            assert arg in cmd
+
+    def test_build_zmq_command_filters_launcher_owned_flags(self):
+        launcher = TokenspeedWorkerLauncher()
+        args = argparse.Namespace(model="/tmp/model", connection_mode="zmq")
+        backend_args = [
+            "--model",
+            "/tmp/other-model",
+            "--data-parallel-rpc-port",
+            "1234",
+            "--zmq-engine-index",
+            "7",
+            "--mem-fraction-static",
+            "0.8",
+        ]
+        cmd = launcher.build_command(args, backend_args, "127.0.0.1", 31000)
+
+        # Launcher-owned flags from backend_args must not duplicate/override.
+        assert "/tmp/other-model" not in cmd
+        assert "1234" not in cmd
+        assert "7" not in cmd
+        assert "--mem-fraction-static" in cmd
+        assert "0.8" in cmd
+
+    def test_build_command_rejects_non_zmq_modes(self):
+        launcher = TokenspeedWorkerLauncher()
+        for mode in ("grpc", "http"):
+            args = argparse.Namespace(model="/tmp/model", connection_mode=mode)
+            with pytest.raises(ValueError, match="only supports --connection-mode zmq"):
+                launcher.build_command(args, [], "127.0.0.1", 31000)
+
+    def test_worker_url_is_ipc(self):
+        launcher = TokenspeedWorkerLauncher()
+        args = argparse.Namespace(connection_mode="zmq")
+        url = launcher.worker_url(args, "127.0.0.1", 31000)
+        assert url == _zmq_ipc_url(31000)
+        assert url.startswith("ipc://")
+
+    def test_health_check_zmq_always_proceeds(self):
+        # SMG binds the sockets and the engine dials in; there is nothing to
+        # probe, the router's own health checker gates readiness.
+        launcher = TokenspeedWorkerLauncher()
+        args = argparse.Namespace(connection_mode="zmq")
+        assert launcher.health_check(args, "127.0.0.1", 31000, 5.0) is True
+
+    def test_get_tp_size(self):
+        launcher = TokenspeedWorkerLauncher()
+        assert launcher._get_tp_size(argparse.Namespace(tensor_parallel_size=4)) == 4
+        assert launcher._get_tp_size(argparse.Namespace()) == 1
+
+
+class TestTokenspeedServeParsing:
+    """parse_serve_args for the tokenspeed backend (stub args, zmq guard)."""
+
+    def test_tokenspeed_zmq_parses(self):
+        backend, args, backend_args = parse_serve_args(
+            [
+                "--backend",
+                "tokenspeed",
+                "--connection-mode",
+                "zmq",
+                "--model",
+                "/tmp/model",
+                "--mem-fraction-static",
+                "0.8",
+            ]
+        )
+        assert backend == "tokenspeed"
+        assert args.connection_mode == "zmq"
+        assert args.model == "/tmp/model"
+        # Unknown engine flags stay in backend_args for verbatim passthrough.
+        assert "--mem-fraction-static" in backend_args
+        assert "0.8" in backend_args
+
+    def test_zmq_still_rejected_for_sglang_and_trtllm(self):
+        for backend in ("sglang", "trtllm"):
+            with pytest.raises(SystemExit) as exc_info:
+                parse_serve_args(["--backend", backend, "--connection-mode", "zmq"])
+            assert exc_info.value.code == 2
 
 
 class TestTrtllmWorkerLauncher:
@@ -1157,6 +1268,48 @@ class TestServeOrchestrator:
             "grpc://127.0.0.1:32000",
             "grpc://127.0.0.1:32003",
         ]
+
+    def test_build_router_args_zmq_forwards_backend(self):
+        """ZMQ workers cannot be runtime-probed: serve's --backend must reach
+        RouterArgs so the Rust side stamps the startup workers' runtime."""
+        from types import SimpleNamespace
+
+        for backend in ("vllm", "tokenspeed"):
+            args = _make_args(backend=backend, data_parallel_size=1, connection_mode="zmq")
+            orch = ServeOrchestrator(backend, args, [])
+            orch.workers = [(MagicMock(), 31000)]
+
+            router_args = SimpleNamespace(
+                backend="sglang",
+                disable_retries=True,
+                disable_circuit_breaker=True,
+                policy="passthrough",
+            )
+            with patch("smg.serve.RouterArgs.from_cli_args", return_value=router_args):
+                result = orch._build_router_args()
+
+            assert result.backend == backend
+            assert result.worker_urls == [_zmq_ipc_url(31000)]
+
+    def test_build_router_args_grpc_keeps_router_backend(self):
+        """Off the ZMQ path the router backend stays whatever --router-backend
+        chose (gRPC/HTTP workers keep runtime auto-detection)."""
+        from types import SimpleNamespace
+
+        args = _make_args(backend="vllm", data_parallel_size=1, connection_mode="grpc")
+        orch = ServeOrchestrator("vllm", args, [])
+        orch.workers = [(MagicMock(), 31000)]
+
+        router_args = SimpleNamespace(
+            backend="sglang",
+            disable_retries=True,
+            disable_circuit_breaker=True,
+            policy="passthrough",
+        )
+        with patch("smg.serve.RouterArgs.from_cli_args", return_value=router_args):
+            result = orch._build_router_args()
+
+        assert result.backend == "sglang"
 
     def test_build_router_args_dp1_disables_retries_and_cb(self):
         """With dp<=1, router-level retries and circuit breaker are auto-disabled."""

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -12,6 +12,7 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use bytes::Bytes;
 use futures::Stream;
 use parking_lot::Mutex;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -19,30 +20,45 @@ use tracing::{trace, warn};
 use zeromq::RouterSendHalf;
 
 use crate::{
-    codec::encode_msgpack,
     error::{Error, Result},
-    protocol::vllm::{
-        output::{EngineCoreOutput, EngineCoreOutputs},
-        request::{EngineCoreRequest, EngineCoreRequestType},
-        stats::SchedulerStats,
+    protocol::{
+        tokenspeed::TokenSpeedProtocol, vllm::VllmProtocol, EngineBatch, EngineLoad, EngineOutput,
+        EngineProtocol,
     },
     transport::{run_output_loop, send_message, ConnectedEngine, ConnectedTransport, EngineId},
 };
 
-type OutputSender = mpsc::UnboundedSender<Result<EngineCoreOutput>>;
-type OutputReceiver = mpsc::UnboundedReceiver<Result<EngineCoreOutput>>;
+/// The vLLM EngineCore connector (the original engine surface).
+pub type EngineCoreClient = Client<VllmProtocol>;
+/// The per-request output stream for the vLLM EngineCore connector.
+pub type EngineCoreStream = RequestStream<VllmProtocol>;
+/// The TokenSpeed connector.
+pub type TokenSpeedClient = Client<TokenSpeedProtocol>;
+/// The per-request output stream for the TokenSpeed connector.
+pub type TokenSpeedStream = RequestStream<TokenSpeedProtocol>;
+
+type OutputSender<O> = mpsc::UnboundedSender<Result<O>>;
+type OutputReceiver<O> = mpsc::UnboundedReceiver<Result<O>>;
 
 /// Routes engine outputs to per-request streams and tracks in-flight requests.
 /// Keyed by `request_id`; the value is that request's output channel sender.
-#[derive(Default)]
-struct RequestRegistry {
+struct RequestRegistry<O> {
     closed: bool,
-    requests: HashMap<String, OutputSender>,
+    requests: HashMap<String, OutputSender<O>>,
 }
 
-impl RequestRegistry {
+impl<O> Default for RequestRegistry<O> {
+    fn default() -> Self {
+        Self {
+            closed: false,
+            requests: HashMap::new(),
+        }
+    }
+}
+
+impl<O: EngineOutput> RequestRegistry<O> {
     /// Register a new request, returning the receiver for its output stream.
-    fn register(&mut self, request_id: String) -> Result<OutputReceiver> {
+    fn register(&mut self, request_id: String) -> Result<OutputReceiver<O>> {
         if self.closed {
             return Err(Error::ClientClosed {
                 message: "client is shutting down".to_string(),
@@ -57,8 +73,8 @@ impl RequestRegistry {
     }
 
     /// Deliver one output to its request stream; drop the entry when terminal.
-    fn route(&mut self, output: EngineCoreOutput) {
-        let request_id = output.request_id.clone();
+    fn route(&mut self, output: O) {
+        let request_id = output.request_id().to_string();
         let Some(sender) = self.requests.get(&request_id) else {
             trace!(%request_id, "output for unknown/finished request; dropping");
             return;
@@ -86,19 +102,18 @@ impl RequestRegistry {
     }
 }
 
-struct ClientInner {
+struct ClientInner<P: EngineProtocol> {
     /// Shared input ROUTER send half (serialized across concurrent submits).
     input_send: tokio::sync::Mutex<RouterSendHalf>,
     engines: Vec<ConnectedEngine>,
-    registry: Mutex<RequestRegistry>,
-    /// Latest per-rank scheduler load, keyed by engine index. SMG's DP load signal.
-    load: Mutex<HashMap<u32, SchedulerStats>>,
+    registry: Mutex<RequestRegistry<P::Output>>,
+    /// Latest per-rank load, keyed by engine index. SMG's DP load signal.
+    load: Mutex<HashMap<u32, EngineLoad>>,
     /// Auto-abort channel fed by dropped streams.
     abort_tx: mpsc::UnboundedSender<(EngineId, String)>,
-    client_index: u32,
 }
 
-impl ClientInner {
+impl<P: EngineProtocol> ClientInner<P> {
     /// Pick the engine for a request: by `data_parallel_rank` if set, else the
     /// sole engine. SMG routing is authoritative for rank selection. The rank is
     /// matched against the engine's ZMQ index (Python `EngineCoreProc`'s 2-byte
@@ -129,15 +144,15 @@ impl ClientInner {
     async fn send_to_engine(
         &self,
         engine_id: &EngineId,
-        request_type: EngineCoreRequestType,
+        request_type: Bytes,
         payload: Vec<u8>,
-        aux_frames: Vec<bytes::Bytes>,
+        aux_frames: Vec<Bytes>,
     ) -> Result<()> {
         let mut input_send = self.input_send.lock().await;
         send_message(
             &mut input_send,
             engine_id,
-            request_type.to_frame(),
+            request_type,
             payload.into(),
             aux_frames,
         )
@@ -146,20 +161,20 @@ impl ClientInner {
 
     /// Send an Abort for one request id to its engine.
     async fn abort(&self, engine_id: &EngineId, request_id: &str) -> Result<()> {
-        let payload = encode_msgpack(&[request_id.to_string()])?;
-        self.send_to_engine(engine_id, EngineCoreRequestType::Abort, payload, Vec::new())
+        let payload = P::encode_abort(request_id)?;
+        self.send_to_engine(engine_id, P::abort_frame(), payload, Vec::new())
             .await
     }
 }
 
-/// Direct ZMQ connection to a same-host vLLM EngineCore (one or more DP ranks
-/// behind one shared transport).
-pub struct EngineCoreClient {
-    inner: Arc<ClientInner>,
+/// Direct ZMQ connection to a same-host engine (one or more DP ranks behind one
+/// shared transport), generic over the engine's wire protocol `P`.
+pub struct Client<P: EngineProtocol> {
+    inner: Arc<ClientInner<P>>,
     tasks: Vec<JoinHandle<()>>,
 }
 
-impl EngineCoreClient {
+impl<P: EngineProtocol> Client<P> {
     /// Build a client over a connected transport, spawning the output loop and
     /// dispatcher. Background tasks are aborted when the client is dropped.
     pub fn new(transport: ConnectedTransport) -> Self {
@@ -177,21 +192,20 @@ impl EngineCoreClient {
             registry: Mutex::new(RequestRegistry::default()),
             load: Mutex::new(HashMap::new()),
             abort_tx,
-            client_index: 0,
         });
 
-        // Transport output loop: decode raw frames -> EngineCoreOutputs channel.
+        // Transport output loop: decode raw frames -> EngineBatch channel.
         let (out_tx, out_rx) = mpsc::channel(256);
         #[expect(
             clippy::disallowed_methods,
             reason = "background tasks are aborted on client drop"
         )]
-        let output_task = tokio::spawn(run_output_loop(output_socket, out_tx));
+        let output_task = tokio::spawn(run_output_loop::<P>(output_socket, out_tx));
         #[expect(
             clippy::disallowed_methods,
             reason = "background tasks are aborted on client drop"
         )]
-        let dispatch_task = tokio::spawn(run_dispatcher(out_rx, abort_rx, inner.clone()));
+        let dispatch_task = tokio::spawn(run_dispatcher::<P>(out_rx, abort_rx, inner.clone()));
 
         Self {
             inner,
@@ -211,30 +225,26 @@ impl EngineCoreClient {
         !self.inner.registry.lock().closed
     }
 
-    /// The latest scheduler load for one engine index (DP routing signal), if
+    /// The latest per-rank load for one engine index (DP routing signal), if
     /// any batch has been seen from it yet.
-    pub fn scheduler_stats(&self, engine_index: u32) -> Option<SchedulerStats> {
-        self.inner.load.lock().get(&engine_index).cloned()
+    pub fn engine_load(&self, engine_index: u32) -> Option<EngineLoad> {
+        self.inner.load.lock().get(&engine_index).copied()
     }
 
     /// Submit a request and return a stream of its outputs. The request is
     /// routed by `data_parallel_rank` (SMG-pinned) or to the sole engine.
     /// Dropping the returned stream before it finishes aborts the request.
-    pub async fn submit(&self, mut request: EngineCoreRequest) -> Result<EngineCoreStream> {
-        request.validate()?;
-        let engine_id = self.inner.select_engine(request.data_parallel_rank)?;
+    pub async fn submit(&self, request: P::Request) -> Result<RequestStream<P>> {
+        P::validate(&request)?;
+        let engine_id = self.inner.select_engine(P::data_parallel_rank(&request))?;
 
-        request.client_index = self.inner.client_index;
-        // current_wave stays 0 (no DP coordinator in scope for the text path).
-
-        let request_id = request.request_id.clone();
+        let request_id = P::request_id(&request).to_string();
         let receiver = self.inner.registry.lock().register(request_id.clone())?;
 
-        let payload = encode_msgpack(&request)?;
-        // Text path carries no aux tensor frames.
+        let (payload, aux_frames) = P::encode_add(&request)?;
         if let Err(error) = self
             .inner
-            .send_to_engine(&engine_id, EngineCoreRequestType::Add, payload, Vec::new())
+            .send_to_engine(&engine_id, P::add_frame(), payload, aux_frames)
             .await
         {
             // Roll back the registry entry so a failed send doesn't leak it.
@@ -242,7 +252,7 @@ impl EngineCoreClient {
             return Err(error);
         }
 
-        Ok(EngineCoreStream {
+        Ok(RequestStream {
             request_id,
             engine_id,
             receiver,
@@ -261,7 +271,7 @@ impl EngineCoreClient {
     }
 }
 
-impl Drop for EngineCoreClient {
+impl<P: EngineProtocol> Drop for Client<P> {
     fn drop(&mut self) {
         for task in &self.tasks {
             task.abort();
@@ -279,29 +289,25 @@ impl Drop for EngineCoreClient {
 /// infinite hang.
 const ENGINE_SILENCE_DEATH_TIMEOUT: Duration = Duration::from_secs(300);
 
-async fn run_dispatcher(
-    mut out_rx: mpsc::Receiver<Result<EngineCoreOutputs>>,
+async fn run_dispatcher<P: EngineProtocol>(
+    mut out_rx: mpsc::Receiver<Result<EngineBatch<P::Output>>>,
     mut abort_rx: mpsc::UnboundedReceiver<(EngineId, String)>,
-    inner: Arc<ClientInner>,
+    inner: Arc<ClientInner<P>>,
 ) {
     loop {
         tokio::select! {
             output = out_rx.recv() => {
                 match output {
-                    Some(Ok(EngineCoreOutputs::RequestBatch(batch))) => {
-                        if let Some(stats) = batch.scheduler_stats {
-                            inner.load.lock().insert(batch.engine_index, *stats);
+                    Some(Ok(batch)) => {
+                        if let Some(load) = batch.load {
+                            inner.load.lock().insert(batch.engine_index, load);
                         }
                         let mut registry = inner.registry.lock();
                         for output in batch.outputs {
                             registry.route(output);
                         }
-                        if let Some(finished) = &batch.finished_requests {
-                            registry.remove_all(finished);
-                        }
+                        registry.remove_all(&batch.finished_request_ids);
                     }
-                    // DP control / utility outputs are out of scope for now.
-                    Some(Ok(_)) => {}
                     Some(Err(error)) => {
                         if matches!(error, Error::EngineCoreDead | Error::Transport(_)) {
                             warn!(%error, "engine transport failed; failing all in-flight requests");
@@ -349,23 +355,23 @@ async fn run_dispatcher(
 
 /// Stream of outputs for one submitted request. Dropping it before the terminal
 /// output aborts the request on the engine.
-pub struct EngineCoreStream {
+pub struct RequestStream<P: EngineProtocol> {
     request_id: String,
     engine_id: EngineId,
-    receiver: OutputReceiver,
+    receiver: OutputReceiver<P::Output>,
     abort_tx: mpsc::UnboundedSender<(EngineId, String)>,
     finished: bool,
 }
 
-impl EngineCoreStream {
+impl<P: EngineProtocol> RequestStream<P> {
     /// The request id this stream tracks.
     pub fn request_id(&self) -> &str {
         &self.request_id
     }
 }
 
-impl Stream for EngineCoreStream {
-    type Item = Result<EngineCoreOutput>;
+impl<P: EngineProtocol> Stream for RequestStream<P> {
+    type Item = Result<P::Output>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -395,7 +401,7 @@ impl Stream for EngineCoreStream {
     }
 }
 
-impl Drop for EngineCoreStream {
+impl<P: EngineProtocol> Drop for RequestStream<P> {
     fn drop(&mut self) {
         if !self.finished {
             // Best-effort auto-abort; the dispatcher sends the Abort frame.
@@ -416,8 +422,12 @@ mod tests {
     use crate::{
         codec::{decode_msgpack, encode_msgpack},
         mock_engine::{connect_to_frontend, default_ready_response, IpcNamespace, MockEngine},
-        protocol::vllm::output::{
-            EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, RequestBatchOutputs,
+        protocol::vllm::{
+            output::{
+                EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, RequestBatchOutputs,
+            },
+            request::EngineCoreRequest,
+            stats::SchedulerStats,
         },
         transport::{connect_handshake, ENGINE_CORE_DEAD_SENTINEL},
     };
@@ -455,7 +465,7 @@ mod tests {
         )
     }
 
-    fn batch(engine_index: u32, output: EngineCoreOutput) -> Vec<bytes::Bytes> {
+    fn batch(engine_index: u32, output: EngineCoreOutput) -> Vec<Bytes> {
         let finished = output.finish_reason.map(|_| {
             let mut set = std::collections::BTreeSet::new();
             set.insert(output.request_id.clone());
@@ -467,7 +477,7 @@ mod tests {
             finished_requests: finished,
             ..RequestBatchOutputs::default()
         });
-        vec![bytes::Bytes::from(encode_msgpack(&outputs).unwrap())]
+        vec![Bytes::from(encode_msgpack(&outputs).unwrap())]
     }
 
     #[tokio::test]
@@ -550,15 +560,15 @@ mod tests {
             ..Default::default()
         });
         engine
-            .send_output(vec![bytes::Bytes::from(encode_msgpack(&outputs).unwrap())])
+            .send_output(vec![Bytes::from(encode_msgpack(&outputs).unwrap())])
             .await
             .unwrap();
 
         // Drain the stream so the batch is processed.
         while stream.next().await.is_some() {}
-        let stats = client.scheduler_stats(0).expect("load recorded");
-        assert_eq!(stats.num_running_reqs, 3);
-        assert_eq!(stats.num_waiting_reqs, 5);
+        let load = client.engine_load(0).expect("load recorded");
+        assert_eq!(load.num_running, 3);
+        assert_eq!(load.num_waiting, 5);
     }
 
     #[tokio::test]
@@ -596,11 +606,109 @@ mod tests {
         engine.recv_request().await.unwrap();
 
         engine
-            .send_output(vec![bytes::Bytes::from_static(ENGINE_CORE_DEAD_SENTINEL)])
+            .send_output(vec![Bytes::from_static(ENGINE_CORE_DEAD_SENTINEL)])
             .await
             .unwrap();
 
         let result = stream.next().await.expect("an error item");
         assert!(matches!(result, Err(Error::Shared(_))));
+    }
+
+    /// The generic connector drives the TokenSpeed protocol over the same shared
+    /// transport: it frames a tagged `TokenizedGenerateReqInput` and streams
+    /// `BatchTokenIDOutSlim` batches back until a finish reason is seen.
+    #[tokio::test]
+    async fn tokenspeed_client_submits_and_streams() {
+        use crate::protocol::tokenspeed::{
+            output::BatchTokenIDOutSlim,
+            request::{TokenSpeedRequestType, TokenizedGenerateReqInput},
+            sampling::SamplingParams,
+        };
+
+        let ns = IpcNamespace::new().unwrap();
+        let (handshake, input, output) = (
+            ns.handshake_endpoint(),
+            ns.input_endpoint(),
+            ns.output_endpoint(),
+        );
+        std::mem::forget(ns);
+        let (transport, engine) = tokio::join!(
+            connect_handshake(
+                &handshake,
+                1,
+                "127.0.0.1",
+                Some(&input),
+                Some(&output),
+                TIMEOUT
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let client = TokenSpeedClient::new(transport.unwrap());
+        let mut engine = engine.unwrap();
+
+        let request = TokenizedGenerateReqInput {
+            rid: "ts-1".to_string(),
+            input_ids: vec![1, 2, 3],
+            sampling_params: SamplingParams {
+                max_new_tokens: Some(4),
+                ..SamplingParams::default()
+            },
+            stream: true,
+            ..TokenizedGenerateReqInput::default()
+        };
+        let mut stream = client.submit(request).await.unwrap();
+
+        // Engine sees the Add frame + the positional-array payload.
+        let frames = engine.recv_request().await.unwrap();
+        assert_eq!(
+            TokenSpeedRequestType::from_frame(frames[0].as_ref()),
+            Some(TokenSpeedRequestType::Add)
+        );
+        let received: TokenizedGenerateReqInput = decode_msgpack(frames[1].as_ref()).unwrap();
+        assert_eq!(received.rid, "ts-1");
+        assert_eq!(received.input_ids, vec![1, 2, 3]);
+
+        let chunk = BatchTokenIDOutSlim {
+            rids: vec!["ts-1".into()],
+            output_ids: vec![vec![10]],
+            finished_reasons: vec![String::new()],
+            prompt_tokens: vec![3],
+            completion_tokens: vec![1],
+            cached_tokens: vec![0],
+            output_token_logprobs_val: vec![vec![]],
+            output_token_logprobs_idx: vec![vec![]],
+        };
+        let done = BatchTokenIDOutSlim {
+            rids: vec!["ts-1".into()],
+            output_ids: vec![vec![11]],
+            finished_reasons: vec!["stop".into()],
+            prompt_tokens: vec![3],
+            completion_tokens: vec![2],
+            cached_tokens: vec![0],
+            output_token_logprobs_val: vec![vec![]],
+            output_token_logprobs_idx: vec![vec![]],
+        };
+        engine
+            .send_output(vec![Bytes::from(encode_msgpack(&chunk).unwrap())])
+            .await
+            .unwrap();
+        engine
+            .send_output(vec![Bytes::from(encode_msgpack(&done).unwrap())])
+            .await
+            .unwrap();
+
+        let first = stream.next().await.unwrap().unwrap();
+        assert_eq!(first.output_ids, vec![10]);
+        assert!(!first.finished());
+        let second = stream.next().await.unwrap().unwrap();
+        assert_eq!(second.output_ids, vec![11]);
+        assert_eq!(second.finish_reason.as_deref(), Some("stop"));
+        assert!(second.finished());
+        // Terminal output ends the stream.
+        assert!(stream.next().await.is_none());
     }
 }

--- a/crates/engine_zmq_client/src/lib.rs
+++ b/crates/engine_zmq_client/src/lib.rs
@@ -35,8 +35,11 @@ pub mod transport;
 #[cfg(any(test, feature = "mock-engine"))]
 pub mod mock_engine;
 
-pub use connector::{EngineCoreClient, EngineCoreStream};
+pub use connector::{
+    Client, EngineCoreClient, EngineCoreStream, RequestStream, TokenSpeedClient, TokenSpeedStream,
+};
 pub use error::{Error, Result};
+pub use protocol::{EngineBatch, EngineOutput, EngineProtocol};
 pub use transport::{
     connect_handshake, run_output_loop, send_message, ConnectedEngine, ConnectedTransport,
     EngineId, ENGINE_CORE_DEAD_SENTINEL,

--- a/crates/engine_zmq_client/src/mock_engine.rs
+++ b/crates/engine_zmq_client/src/mock_engine.rs
@@ -20,10 +20,12 @@ use zeromq::{
 
 use crate::{
     codec::{decode_msgpack, dtype::ModelDtype, encode_msgpack},
-    protocol::vllm::{
+    protocol::{
         handshake::{EngineCoreReadyResponse, HandshakeInitMessage, ReadyMessage},
-        output::EngineCoreOutputs,
-        request::{EngineCoreRequest, EngineCoreRequestType},
+        vllm::{
+            output::EngineCoreOutputs,
+            request::{EngineCoreRequest, EngineCoreRequestType},
+        },
     },
     transport::EngineId,
     Error, Result,

--- a/crates/engine_zmq_client/src/protocol/handshake.rs
+++ b/crates/engine_zmq_client/src/protocol/handshake.rs
@@ -3,6 +3,11 @@
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/handshake.rs.
 
+//! Startup-handshake messages shared by every engine family. The wire shapes
+//! originate from vLLM's EngineCore, but the handshake itself is engine-neutral:
+//! TokenSpeed speaks the same HELLO/INIT/READY protocol, so the transport uses
+//! these types for both.
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
@@ -82,9 +87,11 @@ pub struct EngineCoreReadyResponse {
     /// Scheduler cap on concurrently running sequences.
     #[serde(default)]
     pub max_num_seqs: u64,
-    /// Scheduler cap on batched tokens per step.
+    /// Scheduler cap on batched tokens per step. Signed because TokenSpeed
+    /// sends its `chunked_prefill_size` verbatim, where `-1` means "chunked
+    /// prefill disabled". SMG does not consume this value.
     #[serde(default)]
-    pub max_num_batched_tokens: u64,
+    pub max_num_batched_tokens: i64,
     /// Unique identifier for this server instance.
     #[serde(default)]
     pub instance_id: String,
@@ -166,5 +173,25 @@ mod tests {
         assert_eq!(resp.data_parallel_rank, 0);
         // Optional trailing field defaults when omitted.
         assert!(resp.kv_events_config.is_none());
+    }
+
+    #[test]
+    fn ready_response_decodes_negative_max_num_batched_tokens() {
+        // TokenSpeed sends chunked_prefill_size verbatim; -1 = disabled. The
+        // strict msgpack decoder must accept it (a u64 field would fail here).
+        let json = serde_json::json!({
+            "max_model_len": 4096u64,
+            "num_gpu_blocks": 1000u64,
+            "block_size": 16u64,
+            "dp_stats_address": serde_json::Value::Null,
+            "dtype": "bfloat16",
+            "vllm_version": "tokenspeed",
+            "world_size": 1u64,
+            "data_parallel_size": 1u64,
+            "max_num_batched_tokens": -1i64,
+        });
+        let bytes = rmp_serde::to_vec_named(&json).unwrap();
+        let resp: EngineCoreReadyResponse = decode_msgpack(&bytes).unwrap();
+        assert_eq!(resp.max_num_batched_tokens, -1);
     }
 }

--- a/crates/engine_zmq_client/src/protocol/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/mod.rs
@@ -1,6 +1,99 @@
 // SPDX-License-Identifier: Apache-2.0
 
-//! Per-engine wire protocol modules. vLLM's EngineCore protocol is first; the
-//! sglang-family msgpack protocol (issues #2003/#2006) will live alongside it.
+//! Per-engine wire protocol modules plus the engine-neutral seam the transport
+//! and connector are generic over.
+//!
+//! vLLM's EngineCore protocol and TokenSpeed's native msgpack protocol
+//! (issues #2003/#2006) live alongside each other. Both are msgpack-over-ZMQ
+//! with a single-byte request-type frame and share the same transport — only
+//! the message struct shapes differ, so the transport and connector are
+//! parameterized over the [`EngineProtocol`] trait and each engine family
+//! provides one implementation.
 
+use bytes::Bytes;
+
+use crate::Result;
+
+pub mod handshake;
+pub mod tokenspeed;
 pub mod vllm;
+
+/// Engine-neutral per-rank load signal. Each protocol maps its native scheduler
+/// stats into this shape (vLLM maps `SchedulerStats`; TokenSpeed carries none
+/// yet), so the connector and gateway consume one load type regardless of
+/// engine. Extend it as more engines report load (task #11).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct EngineLoad {
+    /// Requests currently in model-execution batches.
+    pub num_running: u64,
+    /// Requests waiting in the scheduler queue.
+    pub num_waiting: u64,
+    /// KV-cache usage ratio (`1.0` == 100%).
+    pub kv_cache_usage: f64,
+}
+
+/// A single per-request output decoded from one engine tick. Lets the
+/// engine-neutral connector route outputs to their request streams without
+/// knowing the concrete protocol payload.
+pub trait EngineOutput {
+    /// The request id this output belongs to (the registry routing key).
+    fn request_id(&self) -> &str;
+    /// Whether this output is terminal for the request.
+    fn finished(&self) -> bool;
+}
+
+/// One decoded engine tick: the per-request outputs plus the piggybacked load
+/// signal and any out-of-band finished ids. The connector consumes this shape
+/// for every protocol.
+pub struct EngineBatch<O> {
+    /// The DP rank / ZMQ index the batch came from.
+    pub engine_index: u32,
+    /// Per-request outputs produced in this tick.
+    pub outputs: Vec<O>,
+    /// Request ids the engine reported finished out-of-band.
+    pub finished_request_ids: Vec<String>,
+    /// Per-rank load signal, when the protocol carries it (`None` otherwise).
+    pub load: Option<EngineLoad>,
+}
+
+impl<O> Default for EngineBatch<O> {
+    fn default() -> Self {
+        Self {
+            engine_index: 0,
+            outputs: Vec::new(),
+            finished_request_ids: Vec::new(),
+            load: None,
+        }
+    }
+}
+
+/// A per-engine wire protocol spoken over the shared ZMQ transport.
+///
+/// The transport and connector are generic over this trait; each engine family
+/// (vLLM EngineCore, TokenSpeed) provides one zero-sized implementation. Only
+/// the struct shapes and framing differ — the request registry, streaming,
+/// auto-abort, and load tracking are shared.
+pub trait EngineProtocol: Send + Sync + 'static {
+    /// The typed add-request the connector submits.
+    type Request: Send + 'static;
+    /// The typed per-request output streamed back.
+    type Output: EngineOutput + Send + 'static;
+
+    /// The single-byte request-type frame prepended to an add-request.
+    fn add_frame() -> Bytes;
+    /// The single-byte request-type frame prepended to an abort.
+    fn abort_frame() -> Bytes;
+
+    /// The request's id (the registry routing key).
+    fn request_id(request: &Self::Request) -> &str;
+    /// SMG-pinned DP rank, if any (else the sole engine is used).
+    fn data_parallel_rank(request: &Self::Request) -> Option<u32>;
+    /// Reject fields this client cannot represent on the wire.
+    fn validate(request: &Self::Request) -> Result<()>;
+    /// Encode the add payload plus any aux tensor frames (empty on the text path).
+    fn encode_add(request: &Self::Request) -> Result<(Vec<u8>, Vec<Bytes>)>;
+    /// Encode the abort payload for one request id.
+    fn encode_abort(request_id: &str) -> Result<Vec<u8>>;
+    /// Decode one output message (frame 0 plus ordered aux frames) into a batch.
+    fn decode_batch(frames: &[Bytes]) -> Result<EngineBatch<Self::Output>>;
+}

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/mod.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! TokenSpeed wire protocol.
+//!
+//! Clean-room port of TokenSpeed's native engine-IPC messages
+//! (`runtime/engine/io_struct.py`). Every data-plane message is a Python
+//! `msgspec.Struct(tag=True, tag_field="_tag", kw_only=True, array_like=True)`:
+//! it rides the wire as a positional msgpack array whose element 0 is the
+//! class-name tag string, followed by the fields in declaration order. Field
+//! order is the wire contract — append only, never reorder. Decoders here
+//! validate the tag and skip trailing fields they do not model (TokenSpeed
+//! appends fields over time); the encoder emits the shortest valid prefix,
+//! since `msgspec` fills missing trailing fields from their defaults.
+//!
+//! Only the text-generation path is typed. Per TokenSpeed's `zmq_wire.py`, the
+//! request-type frame (a single raw byte ahead of the payload, so the receiver
+//! dispatches without decoding) is `ADD = 0x00` / `ABORT = 0x01`, and the
+//! abort payload is a plain msgpack `list[str]` of request ids, not a tagged
+//! struct.
+
+pub mod output;
+pub mod request;
+pub mod sampling;
+
+use bytes::Bytes;
+use serde::de::{Deserialize, Error as _, IgnoredAny, SeqAccess};
+
+use crate::{
+    codec::{decode_msgpack, encode_msgpack},
+    error::Result,
+    protocol::{
+        tokenspeed::{
+            output::{BatchTokenIDOutSlim, TokenSpeedOutput},
+            request::{TokenSpeedRequestType, TokenizedGenerateReqInput},
+        },
+        EngineBatch, EngineProtocol,
+    },
+};
+
+/// Read the next positional element, failing loudly when the array is shorter
+/// than the modeled prefix (every modeled field is required on decode).
+pub(crate) fn next_field<'de, A, T>(
+    seq: &mut A,
+    name: &'static str,
+) -> std::result::Result<T, A::Error>
+where
+    A: SeqAccess<'de>,
+    T: Deserialize<'de>,
+{
+    seq.next_element::<T>()?
+        .ok_or_else(|| A::Error::custom(format!("missing positional field `{name}`")))
+}
+
+/// Validate the msgspec tag string at element 0. A wrong tag means the payload
+/// is a different message type — fail loudly instead of misreading fields.
+pub(crate) fn expect_tag<'de, A>(
+    seq: &mut A,
+    expected: &'static str,
+) -> std::result::Result<(), A::Error>
+where
+    A: SeqAccess<'de>,
+{
+    let tag: String = next_field(seq, "_tag")?;
+    if tag != expected {
+        return Err(A::Error::custom(format!(
+            "wrong msgspec tag: expected `{expected}`, got `{tag}`"
+        )));
+    }
+    Ok(())
+}
+
+/// Drain positional elements beyond the modeled prefix. TokenSpeed appends new
+/// fields at the end of its structs, so unknown trailing elements are skipped
+/// rather than treated as a decode error.
+pub(crate) fn drain_trailing<'de, A>(seq: &mut A) -> std::result::Result<(), A::Error>
+where
+    A: SeqAccess<'de>,
+{
+    while seq.next_element::<IgnoredAny>()?.is_some() {}
+    Ok(())
+}
+
+/// The TokenSpeed engine protocol: drives [`TokenizedGenerateReqInput`] over
+/// the shared ZMQ transport and decodes [`BatchTokenIDOutSlim`] back.
+pub struct TokenSpeedProtocol;
+
+impl EngineProtocol for TokenSpeedProtocol {
+    type Request = TokenizedGenerateReqInput;
+    type Output = TokenSpeedOutput;
+
+    fn add_frame() -> Bytes {
+        TokenSpeedRequestType::Add.to_frame()
+    }
+
+    fn abort_frame() -> Bytes {
+        TokenSpeedRequestType::Abort.to_frame()
+    }
+
+    fn request_id(request: &Self::Request) -> &str {
+        &request.rid
+    }
+
+    fn data_parallel_rank(_request: &Self::Request) -> Option<u32> {
+        // The TokenSpeed generate request carries no DP-rank field, so requests
+        // route to the sole engine (single-engine ZMQ). DP fan-out is future work.
+        None
+    }
+
+    fn validate(_request: &Self::Request) -> Result<()> {
+        // The tokenized text path has no fields this client cannot represent.
+        Ok(())
+    }
+
+    fn encode_add(request: &Self::Request) -> Result<(Vec<u8>, Vec<Bytes>)> {
+        // Text path carries no aux tensor frames.
+        Ok((encode_msgpack(request)?, Vec::new()))
+    }
+
+    fn encode_abort(request_id: &str) -> Result<Vec<u8>> {
+        // The abort payload is a positional msgpack array of request-id strings,
+        // decoded by the engine's `decode_abort` (a `msgspec.msgpack.Decoder(
+        // list[str])`) into abort requests. A single-element array aborts one rid.
+        encode_msgpack(&[request_id.to_string()])
+    }
+
+    fn decode_batch(frames: &[Bytes]) -> Result<EngineBatch<Self::Output>> {
+        // Output messages are `[payload, aux...]`. The slim batch carries no
+        // tensor fields today, so aux frames are unexpected but not fatal.
+        if frames.len() > 1 {
+            tracing::debug!(
+                aux_frames = frames.len() - 1,
+                "ignoring aux frames on a TokenSpeed output (BatchTokenIDOutSlim \
+                 has no tensor fields)"
+            );
+        }
+        let payload = frames.first().map(AsRef::as_ref).unwrap_or_default();
+        let batch: BatchTokenIDOutSlim = decode_msgpack(payload)?;
+        let outputs = batch.into_outputs()?;
+        let finished_request_ids = outputs
+            .iter()
+            .filter(|output| output.finish_reason.is_some())
+            .map(|output| output.request_id.clone())
+            .collect();
+        Ok(EngineBatch {
+            // Single-engine ZMQ: TokenSpeed batches carry no engine index and
+            // no piggybacked scheduler load.
+            engine_index: 0,
+            outputs,
+            finished_request_ids,
+            load: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slim_batch() -> BatchTokenIDOutSlim {
+        BatchTokenIDOutSlim {
+            rids: vec!["a".into(), "b".into()],
+            output_ids: vec![vec![10], vec![20]],
+            finished_reasons: vec![String::new(), "stop".into()],
+            prompt_tokens: vec![3, 4],
+            completion_tokens: vec![1, 1],
+            cached_tokens: vec![0, 0],
+            output_token_logprobs_val: vec![vec![], vec![]],
+            output_token_logprobs_idx: vec![vec![], vec![]],
+        }
+    }
+
+    #[test]
+    fn decode_batch_maps_outputs_and_finished_ids() {
+        let frames = vec![Bytes::from(encode_msgpack(&slim_batch()).unwrap())];
+        let decoded = TokenSpeedProtocol::decode_batch(&frames).unwrap();
+        assert_eq!(decoded.outputs.len(), 2);
+        assert_eq!(decoded.finished_request_ids, vec!["b".to_string()]);
+        assert!(decoded.load.is_none());
+    }
+
+    #[test]
+    fn decode_batch_tolerates_aux_frames() {
+        // Slim outputs are single-frame in practice, but the decoder must not
+        // choke if the engine ever sends `[payload, aux...]`.
+        let frames = vec![
+            Bytes::from(encode_msgpack(&slim_batch()).unwrap()),
+            Bytes::from_static(b"opaque-aux-frame"),
+        ];
+        let decoded = TokenSpeedProtocol::decode_batch(&frames).unwrap();
+        assert_eq!(decoded.outputs.len(), 2);
+    }
+
+    #[test]
+    fn request_type_frames_match_wire_contract() {
+        assert_eq!(TokenSpeedProtocol::add_frame().as_ref(), b"\x00");
+        assert_eq!(TokenSpeedProtocol::abort_frame().as_ref(), b"\x01");
+    }
+
+    #[test]
+    fn encode_abort_frames_rid_as_positional_array() {
+        // The abort payload is a positional msgpack array of request-id strings,
+        // matching the engine's `decode_abort` (`Decoder(list[str])`).
+        let payload = TokenSpeedProtocol::encode_abort("req-1").unwrap();
+        let decoded: Vec<String> = decode_msgpack(&payload).unwrap();
+        assert_eq!(decoded, vec!["req-1".to_string()]);
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/output.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/output.rs
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// TokenSpeed per-step batched output — the native `BatchTokenIDOutSlim` from
+// `io_struct.py`, a tagged `msgspec.Struct(array_like=True)`: on the wire it is
+// a positional msgpack array with the class-name tag string as element 0.
+// **Field order is the wire contract** — do not reorder.
+
+use serde::{
+    de::{SeqAccess, Visitor},
+    ser::SerializeTuple,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+use crate::{
+    error::{Error, Result},
+    protocol::{
+        tokenspeed::{drain_trailing, expect_tag, next_field},
+        EngineOutput,
+    },
+};
+
+/// The msgspec tag for [`BatchTokenIDOutSlim`] (element 0 on the wire).
+pub const BATCH_TOKEN_ID_OUT_SLIM_TAG: &str = "BatchTokenIDOutSlim";
+
+/// A batch of per-request token outputs from one engine step. Mirrors Python
+/// `BatchTokenIDOutSlim`: the per-request slice of an engine step for a
+/// frontend that detokenizes itself.
+///
+/// Every field is a column indexed in parallel by request: `rids[i]` owns
+/// `output_ids[i]`, `finished_reasons[i]`, `prompt_tokens[i]`, etc. The two
+/// logprob columns are always present (length == `rids.len()`); the inner `Vec`
+/// is empty for a request that did not ask for logprobs.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct BatchTokenIDOutSlim {
+    /// Request ids, one per column.
+    pub rids: Vec<String>,
+    /// Newly generated token ids per request this step.
+    pub output_ids: Vec<Vec<u32>>,
+    /// Finish reason per request (`"stop"`, `"length"`, `"abort"`); an empty
+    /// string means "not finished".
+    pub finished_reasons: Vec<String>,
+    /// Prompt token count per request.
+    pub prompt_tokens: Vec<u32>,
+    /// Completion token count so far, per request.
+    pub completion_tokens: Vec<u32>,
+    /// Prefix-cache-hit token count per request.
+    pub cached_tokens: Vec<u32>,
+    /// Sampled-token logprob value per newly decoded token, per request. `f64`
+    /// matches the Python float encoding. Empty inner `Vec` when logprobs were
+    /// not requested.
+    pub output_token_logprobs_val: Vec<Vec<f64>>,
+    /// Token id each logprob in `output_token_logprobs_val` belongs to,
+    /// parallel to it per request. Empty inner `Vec` when logprobs were not
+    /// requested.
+    pub output_token_logprobs_idx: Vec<Vec<u32>>,
+}
+
+impl Serialize for BatchTokenIDOutSlim {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        let mut tuple = serializer.serialize_tuple(9)?;
+        tuple.serialize_element(BATCH_TOKEN_ID_OUT_SLIM_TAG)?;
+        tuple.serialize_element(&self.rids)?;
+        tuple.serialize_element(&self.output_ids)?;
+        tuple.serialize_element(&self.finished_reasons)?;
+        tuple.serialize_element(&self.prompt_tokens)?;
+        tuple.serialize_element(&self.completion_tokens)?;
+        tuple.serialize_element(&self.cached_tokens)?;
+        tuple.serialize_element(&self.output_token_logprobs_val)?;
+        tuple.serialize_element(&self.output_token_logprobs_idx)?;
+        tuple.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for BatchTokenIDOutSlim {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        struct BatchVisitor;
+
+        impl<'de> Visitor<'de> for BatchVisitor {
+            type Value = BatchTokenIDOutSlim;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "a tagged BatchTokenIDOutSlim positional array")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> std::result::Result<Self::Value, A::Error> {
+                expect_tag(&mut seq, BATCH_TOKEN_ID_OUT_SLIM_TAG)?;
+                let batch = BatchTokenIDOutSlim {
+                    rids: next_field(&mut seq, "rids")?,
+                    output_ids: next_field(&mut seq, "output_ids")?,
+                    finished_reasons: next_field(&mut seq, "finished_reasons")?,
+                    prompt_tokens: next_field(&mut seq, "prompt_tokens")?,
+                    completion_tokens: next_field(&mut seq, "completion_tokens")?,
+                    cached_tokens: next_field(&mut seq, "cached_tokens")?,
+                    output_token_logprobs_val: next_field(&mut seq, "output_token_logprobs_val")?,
+                    output_token_logprobs_idx: next_field(&mut seq, "output_token_logprobs_idx")?,
+                };
+                drain_trailing(&mut seq)?;
+                Ok(batch)
+            }
+        }
+
+        deserializer.deserialize_seq(BatchVisitor)
+    }
+}
+
+/// One request's slice of a [`BatchTokenIDOutSlim`], in the engine-neutral
+/// shape the connector routes to per-request streams.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct TokenSpeedOutput {
+    /// The request id this output belongs to.
+    pub request_id: String,
+    /// Newly generated token ids this step.
+    pub output_ids: Vec<u32>,
+    /// Finish reason; `None` while the request is still generating.
+    pub finish_reason: Option<String>,
+    /// Prompt token count.
+    pub prompt_tokens: u32,
+    /// Completion token count so far.
+    pub completion_tokens: u32,
+    /// Prefix-cache-hit token count.
+    pub cached_tokens: u32,
+    /// Sampled-token logprob value per decoded token this step. Empty when
+    /// logprobs were not requested.
+    pub output_logprobs_val: Vec<f64>,
+    /// Token id each logprob in `output_logprobs_val` belongs to. Empty when
+    /// logprobs were not requested.
+    pub output_logprobs_idx: Vec<u32>,
+}
+
+impl EngineOutput for TokenSpeedOutput {
+    fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    fn finished(&self) -> bool {
+        self.finish_reason.is_some()
+    }
+}
+
+impl BatchTokenIDOutSlim {
+    /// Split the parallel columns into one [`TokenSpeedOutput`] per request.
+    /// Errors if the columns are ragged (a length mismatch is a protocol bug).
+    pub fn into_outputs(self) -> Result<Vec<TokenSpeedOutput>> {
+        let n = self.rids.len();
+        let ragged = self.output_ids.len() != n
+            || self.finished_reasons.len() != n
+            || self.prompt_tokens.len() != n
+            || self.completion_tokens.len() != n
+            || self.cached_tokens.len() != n
+            || self.output_token_logprobs_val.len() != n
+            || self.output_token_logprobs_idx.len() != n;
+        if ragged {
+            return Err(Error::Decode {
+                target_type: "BatchTokenIDOutSlim",
+                message: format!(
+                    "ragged columns: rids={}, output_ids={}, finished_reasons={}, \
+                     prompt_tokens={}, completion_tokens={}, cached_tokens={}, \
+                     output_token_logprobs_val={}, output_token_logprobs_idx={}",
+                    n,
+                    self.output_ids.len(),
+                    self.finished_reasons.len(),
+                    self.prompt_tokens.len(),
+                    self.completion_tokens.len(),
+                    self.cached_tokens.len(),
+                    self.output_token_logprobs_val.len(),
+                    self.output_token_logprobs_idx.len(),
+                ),
+            });
+        }
+
+        let BatchTokenIDOutSlim {
+            rids,
+            output_ids,
+            finished_reasons,
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens,
+            output_token_logprobs_val,
+            output_token_logprobs_idx,
+        } = self;
+
+        Ok(rids
+            .into_iter()
+            .zip(output_ids)
+            .zip(finished_reasons)
+            .zip(prompt_tokens)
+            .zip(completion_tokens)
+            .zip(cached_tokens)
+            .zip(output_token_logprobs_val)
+            .zip(output_token_logprobs_idx)
+            .map(
+                |(
+                    ((((((rid, ids), reason), prompt), completion), cached), logprobs_val),
+                    logprobs_idx,
+                )| {
+                    TokenSpeedOutput {
+                        request_id: rid,
+                        output_ids: ids,
+                        // An empty finish-reason string means "still generating".
+                        finish_reason: (!reason.is_empty()).then_some(reason),
+                        prompt_tokens: prompt,
+                        completion_tokens: completion,
+                        cached_tokens: cached,
+                        output_logprobs_val: logprobs_val,
+                        output_logprobs_idx: logprobs_idx,
+                    }
+                },
+            )
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmpv::Value;
+
+    use super::*;
+    use crate::codec::{decode_msgpack, decode_value, encode_msgpack};
+
+    /// A slim output batch captured from the Python encoder: rids ["vec-1"],
+    /// output_ids [[10, 11]], finished_reasons ["length"], prompt 3 /
+    /// completion 2 / cached 1, logprobs [[-0.5, -0.25]] over tokens [[10, 11]].
+    const PYTHON_OUTPUT_VECTOR: &str =
+        "99b34261746368546f6b656e49444f7574536c696d91a57665632d3191920a0b91a66c656e\
+         6774689103910291019192cbbfe0000000000000cbbfd000000000000091920a0b";
+
+    fn python_output_bytes() -> Vec<u8> {
+        let hex: String = PYTHON_OUTPUT_VECTOR
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    fn vector_batch() -> BatchTokenIDOutSlim {
+        BatchTokenIDOutSlim {
+            rids: vec!["vec-1".into()],
+            output_ids: vec![vec![10, 11]],
+            finished_reasons: vec!["length".into()],
+            prompt_tokens: vec![3],
+            completion_tokens: vec![2],
+            cached_tokens: vec![1],
+            output_token_logprobs_val: vec![vec![-0.5, -0.25]],
+            output_token_logprobs_idx: vec![vec![10, 11]],
+        }
+    }
+
+    /// The pinned cross-language vector — the exact bytes the engine sends —
+    /// decodes into the full 9-element (tag + 8 columns) batch.
+    #[test]
+    fn python_output_vector_decodes() {
+        let decoded: BatchTokenIDOutSlim = decode_msgpack(&python_output_bytes()).unwrap();
+        assert_eq!(decoded, vector_batch());
+
+        let outputs = decoded.into_outputs().unwrap();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].request_id, "vec-1");
+        assert_eq!(outputs[0].output_ids, vec![10, 11]);
+        assert_eq!(outputs[0].finish_reason.as_deref(), Some("length"));
+        assert_eq!(outputs[0].prompt_tokens, 3);
+        assert_eq!(outputs[0].completion_tokens, 2);
+        assert_eq!(outputs[0].cached_tokens, 1);
+        assert_eq!(outputs[0].output_logprobs_val, vec![-0.5, -0.25]);
+        assert_eq!(outputs[0].output_logprobs_idx, vec![10, 11]);
+    }
+
+    /// The Rust encoder mirrors the Python encoding byte-for-byte, so the mock
+    /// engine emits exactly what a real engine would.
+    #[test]
+    fn encoder_matches_python_bytes() {
+        let encoded = encode_msgpack(&vector_batch()).unwrap();
+        assert_eq!(encoded, python_output_bytes());
+    }
+
+    #[test]
+    fn batch_output_serializes_as_tagged_nine_element_array() {
+        let encoded = encode_msgpack(&vector_batch()).unwrap();
+        let Value::Array(array) = decode_value(&encoded).unwrap() else {
+            panic!("expected positional array");
+        };
+        assert_eq!(array.len(), 9);
+        assert_eq!(array[0], Value::from(BATCH_TOKEN_ID_OUT_SLIM_TAG));
+        assert_eq!(array[1], Value::Array(vec![Value::from("vec-1")])); // rids
+        assert_eq!(array[3], Value::Array(vec![Value::from("length")])); // finished_reasons
+        assert_eq!(array[6], Value::Array(vec![Value::from(1)])); // cached_tokens
+    }
+
+    #[test]
+    fn decode_rejects_wrong_tag() {
+        // Re-tag the batch as some other message type: decode must fail loudly.
+        let mut bytes = python_output_bytes();
+        bytes[2] = b'X'; // "BatchTokenIDOutSlim" -> "XatchTokenIDOutSlim"
+        let error = decode_msgpack::<BatchTokenIDOutSlim>(&bytes).unwrap_err();
+        let rendered = error.to_string();
+        assert!(rendered.contains("wrong msgspec tag"), "{rendered}");
+    }
+
+    #[test]
+    fn decode_tolerates_appended_trailing_columns() {
+        // TokenSpeed appends new fields at the end; the decoder skips them.
+        let mut with_extra = match decode_value(&python_output_bytes()).unwrap() {
+            Value::Array(array) => array,
+            other => panic!("expected array, got {other:?}"),
+        };
+        with_extra.push(Value::Array(vec![Value::from(99)]));
+        let mut bytes = Vec::new();
+        rmpv::encode::write_value(&mut bytes, &Value::Array(with_extra)).unwrap();
+        let decoded: BatchTokenIDOutSlim = decode_msgpack(&bytes).unwrap();
+        assert_eq!(decoded, vector_batch());
+    }
+
+    #[test]
+    fn into_outputs_splits_columns_and_maps_finish() {
+        let batch = BatchTokenIDOutSlim {
+            rids: vec!["a".into(), "b".into()],
+            output_ids: vec![vec![10], vec![20, 21]],
+            finished_reasons: vec![String::new(), "stop".into()],
+            prompt_tokens: vec![3, 4],
+            completion_tokens: vec![1, 2],
+            cached_tokens: vec![0, 1],
+            output_token_logprobs_val: vec![vec![-0.5], vec![-1.0, -2.0]],
+            output_token_logprobs_idx: vec![vec![10], vec![20, 21]],
+        };
+        let outputs = batch.into_outputs().unwrap();
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].request_id, "a");
+        assert_eq!(outputs[0].output_ids, vec![10]);
+        assert!(!outputs[0].finished()); // empty reason -> still generating
+        assert_eq!(outputs[0].output_logprobs_val, vec![-0.5]);
+        assert_eq!(outputs[0].output_logprobs_idx, vec![10]);
+        assert_eq!(outputs[1].request_id, "b");
+        assert_eq!(outputs[1].finish_reason.as_deref(), Some("stop"));
+        assert!(outputs[1].finished());
+        assert_eq!(outputs[1].completion_tokens, 2);
+        assert_eq!(outputs[1].output_logprobs_val, vec![-1.0, -2.0]);
+        assert_eq!(outputs[1].output_logprobs_idx, vec![20, 21]);
+    }
+
+    #[test]
+    fn into_outputs_leaves_logprobs_empty_when_not_requested() {
+        let batch = BatchTokenIDOutSlim {
+            rids: vec!["a".into()],
+            output_ids: vec![vec![10]],
+            finished_reasons: vec![String::new()],
+            prompt_tokens: vec![3],
+            completion_tokens: vec![1],
+            cached_tokens: vec![0],
+            output_token_logprobs_val: vec![vec![]],
+            output_token_logprobs_idx: vec![vec![]],
+        };
+        let outputs = batch.into_outputs().unwrap();
+        assert!(outputs[0].output_logprobs_val.is_empty());
+        assert!(outputs[0].output_logprobs_idx.is_empty());
+    }
+
+    #[test]
+    fn into_outputs_rejects_ragged_columns() {
+        let batch = BatchTokenIDOutSlim {
+            rids: vec!["a".into(), "b".into()],
+            output_ids: vec![vec![10]],
+            finished_reasons: vec![String::new(), String::new()],
+            prompt_tokens: vec![3, 4],
+            completion_tokens: vec![1, 2],
+            cached_tokens: vec![0, 1],
+            output_token_logprobs_val: vec![vec![], vec![]],
+            output_token_logprobs_idx: vec![vec![], vec![]],
+        };
+        assert!(batch.into_outputs().is_err());
+    }
+
+    #[test]
+    fn into_outputs_rejects_ragged_logprob_columns() {
+        let batch = BatchTokenIDOutSlim {
+            rids: vec!["a".into(), "b".into()],
+            output_ids: vec![vec![10], vec![20]],
+            finished_reasons: vec![String::new(), String::new()],
+            prompt_tokens: vec![3, 4],
+            completion_tokens: vec![1, 1],
+            cached_tokens: vec![0, 0],
+            // Only one logprob column entry for two requests.
+            output_token_logprobs_val: vec![vec![]],
+            output_token_logprobs_idx: vec![vec![], vec![]],
+        };
+        assert!(batch.into_outputs().is_err());
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/request.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/request.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// TokenSpeed tokenized generate request — the native `TokenizedGenerateReqInput`
+// from `io_struct.py`, a tagged `msgspec.Struct(array_like=True)`: on the wire
+// it is a positional msgpack array with the class-name tag string as element 0.
+// **Field order is the wire contract** — do not reorder.
+
+use bytes::Bytes;
+use serde::{
+    de::{SeqAccess, Visitor},
+    ser::SerializeTuple,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+use crate::protocol::tokenspeed::{
+    drain_trailing, expect_tag, next_field, sampling::SamplingParams,
+};
+
+/// The msgspec tag for [`TokenizedGenerateReqInput`] (element 0 on the wire).
+pub const TOKENIZED_GENERATE_REQ_INPUT_TAG: &str = "TokenizedGenerateReqInput";
+
+/// Request types are single-byte protocol constants sent as a raw ZMQ frame
+/// ahead of the msgpack payload (TokenSpeed's `REQ_TYPE_ADD`/`REQ_TYPE_ABORT`),
+/// so the receiver can dispatch without decoding first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TokenSpeedRequestType {
+    Add = 0,
+    Abort = 1,
+}
+
+impl TokenSpeedRequestType {
+    /// Decode the single-byte request-type frame. `None` for unrecognized values.
+    pub fn from_frame(frame: &[u8]) -> Option<Self> {
+        let [value] = frame else {
+            return None;
+        };
+        match value {
+            0 => Some(Self::Add),
+            1 => Some(Self::Abort),
+            _ => None,
+        }
+    }
+
+    /// Encode as the single-byte frame used on the engine input socket.
+    pub fn to_frame(self) -> Bytes {
+        Bytes::from_static(match self {
+            Self::Add => b"\x00",
+            Self::Abort => b"\x01",
+        })
+    }
+}
+
+/// TokenSpeed tokenized generate request sent from frontend to engine.
+///
+/// Models the leading prefix of the Python class, through `stream` — the
+/// fields SMG sets, plus the neutral logprob carry-over values between them.
+/// The encoder emits exactly this 11-element array (tag + 10 fields); the
+/// engine's decoder fills every later field (`input_embeds`, `session_params`,
+/// multimodal payloads, ...) from its defaults, since msgspec tolerates
+/// missing trailing fields. The decoder here accepts full-length arrays and
+/// skips the unmodeled trailing fields.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TokenizedGenerateReqInput {
+    /// Request id (the routing/registry key).
+    pub rid: String,
+    /// In-process HTTP-worker return address; unused on this transport.
+    pub http_worker_ipc: Option<String>,
+    /// Original prompt text. `None` on the token-id path (SMG detokenizes
+    /// downstream of the engine, so only ids are sent).
+    pub input_text: Option<String>,
+    /// Pre-tokenized prompt token ids (SMG tokenizes upstream).
+    pub input_ids: Vec<u32>,
+    /// Sampling parameters (nested untagged positional array).
+    pub sampling_params: SamplingParams,
+    /// Whether to return the sampled token's logprob for this request.
+    pub return_logprob: bool,
+    /// Prompt-logprob start offset. Neutral `-1`: prompt logprobs are not
+    /// supported on this wire.
+    pub logprob_start_len: i32,
+    /// Output top-k logprob count. Neutral `0`: only the sampled token's
+    /// logprob is materialized.
+    pub top_logprobs_num: u32,
+    /// Token ids to report logprobs for. Neutral `None`: not supported.
+    pub token_ids_logprob: Option<Vec<u32>>,
+    /// Whether to stream outputs incrementally.
+    pub stream: bool,
+}
+
+impl Default for TokenizedGenerateReqInput {
+    fn default() -> Self {
+        Self {
+            rid: String::new(),
+            http_worker_ipc: None,
+            input_text: None,
+            input_ids: Vec::new(),
+            sampling_params: SamplingParams::default(),
+            return_logprob: false,
+            // Neutral logprob carry-over values, mirroring the engine's own
+            // input processor.
+            logprob_start_len: -1,
+            top_logprobs_num: 0,
+            token_ids_logprob: None,
+            stream: false,
+        }
+    }
+}
+
+impl Serialize for TokenizedGenerateReqInput {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut tuple = serializer.serialize_tuple(11)?;
+        tuple.serialize_element(TOKENIZED_GENERATE_REQ_INPUT_TAG)?;
+        tuple.serialize_element(&self.rid)?;
+        tuple.serialize_element(&self.http_worker_ipc)?;
+        tuple.serialize_element(&self.input_text)?;
+        tuple.serialize_element(&self.input_ids)?;
+        tuple.serialize_element(&self.sampling_params)?;
+        tuple.serialize_element(&self.return_logprob)?;
+        tuple.serialize_element(&self.logprob_start_len)?;
+        tuple.serialize_element(&self.top_logprobs_num)?;
+        tuple.serialize_element(&self.token_ids_logprob)?;
+        tuple.serialize_element(&self.stream)?;
+        tuple.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for TokenizedGenerateReqInput {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ReqVisitor;
+
+        impl<'de> Visitor<'de> for ReqVisitor {
+            type Value = TokenizedGenerateReqInput;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "a tagged TokenizedGenerateReqInput positional array")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                expect_tag(&mut seq, TOKENIZED_GENERATE_REQ_INPUT_TAG)?;
+                let request = TokenizedGenerateReqInput {
+                    rid: next_field(&mut seq, "rid")?,
+                    http_worker_ipc: next_field(&mut seq, "http_worker_ipc")?,
+                    input_text: next_field(&mut seq, "input_text")?,
+                    input_ids: next_field(&mut seq, "input_ids")?,
+                    sampling_params: next_field(&mut seq, "sampling_params")?,
+                    return_logprob: next_field(&mut seq, "return_logprob")?,
+                    logprob_start_len: next_field(&mut seq, "logprob_start_len")?,
+                    top_logprobs_num: next_field(&mut seq, "top_logprobs_num")?,
+                    token_ids_logprob: next_field(&mut seq, "token_ids_logprob")?,
+                    stream: next_field(&mut seq, "stream")?,
+                };
+                drain_trailing(&mut seq)?;
+                Ok(request)
+            }
+        }
+
+        deserializer.deserialize_seq(ReqVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmpv::Value;
+
+    use super::*;
+    use crate::{
+        codec::{decode_msgpack, decode_value, encode_msgpack},
+        protocol::tokenspeed::sampling::TOP_K_DISABLED,
+    };
+
+    /// A full-length (24-element) request array captured from the Python
+    /// encoder: rid "vec-1", input_ids [1, 2, 3], normalized SamplingParams
+    /// (temperature 0.5, top_p 0.9, top_k disabled, max_new_tokens 8,
+    /// stop_token_ids {2}, seed 42), return_logprob, stream.
+    const PYTHON_REQUEST_VECTOR: &str =
+        "dc0018b9546f6b656e697a656447656e6572617465526571496e707574a57665632d31c0c0\
+         93010203dc001d08c09102cb3fe0000000000000cb3feccccccccccccdce40000000cb0000\
+         000000000000cb0000000000000000cb0000000000000000cb3ff000000000000000c0c0c0\
+         c0c2c3c3c2c0c0c0c02ac0019000c3c3ff00c0c3c0c0c0c2cb0000000000000000c0c0c0c0\
+         c0c0c0c0";
+
+    fn python_request_bytes() -> Vec<u8> {
+        let hex: String = PYTHON_REQUEST_VECTOR
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect();
+        (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect()
+    }
+
+    /// The logical request behind [`PYTHON_REQUEST_VECTOR`], built through the
+    /// same normalization path SMG uses.
+    fn vector_request() -> TokenizedGenerateReqInput {
+        let mut sampling_params = SamplingParams {
+            max_new_tokens: Some(8),
+            stop_token_ids: Some(vec![2]),
+            temperature: 0.5,
+            top_p: 0.9,
+            seed: Some(42),
+            ..SamplingParams::default()
+        };
+        sampling_params.normalize();
+        TokenizedGenerateReqInput {
+            rid: "vec-1".to_string(),
+            input_ids: vec![1, 2, 3],
+            sampling_params,
+            return_logprob: true,
+            stream: true,
+            ..TokenizedGenerateReqInput::default()
+        }
+    }
+
+    #[test]
+    fn request_type_frames_roundtrip() {
+        for ty in [TokenSpeedRequestType::Add, TokenSpeedRequestType::Abort] {
+            assert_eq!(TokenSpeedRequestType::from_frame(&ty.to_frame()), Some(ty));
+        }
+        assert_eq!(TokenSpeedRequestType::Add.to_frame().as_ref(), b"\x00");
+        assert_eq!(TokenSpeedRequestType::Abort.to_frame().as_ref(), b"\x01");
+        assert_eq!(TokenSpeedRequestType::from_frame(b"\x09"), None);
+        assert_eq!(TokenSpeedRequestType::from_frame(b""), None);
+    }
+
+    /// The pinned cross-language vector decodes field-for-field: the Python
+    /// side emits all 24 elements, and the modeled 11-element prefix plus
+    /// trailing-field skip must recover every field SMG cares about.
+    #[test]
+    fn python_request_vector_decodes() {
+        let decoded: TokenizedGenerateReqInput = decode_msgpack(&python_request_bytes()).unwrap();
+        assert_eq!(decoded.rid, "vec-1");
+        assert_eq!(decoded.http_worker_ipc, None);
+        assert_eq!(decoded.input_text, None);
+        assert_eq!(decoded.input_ids, vec![1, 2, 3]);
+        assert!(decoded.return_logprob);
+        assert_eq!(decoded.logprob_start_len, -1);
+        assert_eq!(decoded.top_logprobs_num, 0);
+        assert_eq!(decoded.token_ids_logprob, None);
+        assert!(decoded.stream);
+
+        let sp = &decoded.sampling_params;
+        assert_eq!(sp.max_new_tokens, Some(8));
+        assert_eq!(sp.stop_token_ids, Some(vec![2]));
+        assert_eq!(sp.temperature, 0.5);
+        assert_eq!(sp.top_p, 0.9);
+        assert_eq!(sp.top_k, TOP_K_DISABLED);
+        assert_eq!(sp.seed, Some(42));
+        assert_eq!(sp.n, 1);
+        assert_eq!(sp.stop_strs, Vec::<String>::new());
+        assert!(sp.is_normalized);
+
+        // Full struct equality against the same logical request built in Rust.
+        assert_eq!(decoded, vector_request());
+    }
+
+    /// The encoder emits the shortest valid prefix: an 11-element array
+    /// (tag + fields through `stream`) that decodes back to the same request
+    /// the full-length Python vector decodes to. The nested sampling params
+    /// are always sent in full (29 elements), since `is_normalized` — the
+    /// last field — is always set.
+    #[test]
+    fn encoder_emits_tagged_prefix_through_stream() {
+        let request = vector_request();
+        let encoded = encode_msgpack(&request).unwrap();
+
+        let Value::Array(array) = decode_value(&encoded).unwrap() else {
+            panic!("expected positional array");
+        };
+        assert_eq!(array.len(), 11);
+        assert_eq!(array[0], Value::from(TOKENIZED_GENERATE_REQ_INPUT_TAG));
+        assert_eq!(array[1], Value::from("vec-1"));
+        let Value::Array(sampling) = &array[5] else {
+            panic!("expected nested sampling params array, got {:?}", array[5]);
+        };
+        assert_eq!(sampling.len(), 29);
+        assert_eq!(array[10], Value::from(true)); // stream
+
+        // Round-trip: the prefix encoding is semantically identical to the
+        // full-length Python encoding.
+        let roundtripped: TokenizedGenerateReqInput = decode_msgpack(&encoded).unwrap();
+        assert_eq!(roundtripped, request);
+        let from_vector: TokenizedGenerateReqInput =
+            decode_msgpack(&python_request_bytes()).unwrap();
+        assert_eq!(roundtripped, from_vector);
+    }
+
+    #[test]
+    fn decode_rejects_wrong_tag() {
+        let mut request_bytes = python_request_bytes();
+        // Corrupt one tag byte: "TokenizedGenerateReqInput" -> "TOkenized...".
+        request_bytes[5] = b'O';
+        let error = decode_msgpack::<TokenizedGenerateReqInput>(&request_bytes).unwrap_err();
+        let rendered = error.to_string();
+        assert!(rendered.contains("wrong msgspec tag"), "{rendered}");
+        assert!(rendered.contains("TokenizedGenerateReqInput"), "{rendered}");
+    }
+
+    #[test]
+    fn decode_rejects_truncated_prefix() {
+        // Missing modeled fields (here: everything after input_ids) must fail
+        // loudly, not silently default.
+        let truncated = Value::Array(vec![
+            Value::from(TOKENIZED_GENERATE_REQ_INPUT_TAG),
+            Value::from("r1"),
+            Value::Nil,
+            Value::Nil,
+            Value::Array(vec![Value::from(1)]),
+        ]);
+        let mut bytes = Vec::new();
+        rmpv::encode::write_value(&mut bytes, &truncated).unwrap();
+        let error = decode_msgpack::<TokenizedGenerateReqInput>(&bytes).unwrap_err();
+        assert!(
+            error.to_string().contains("missing positional field"),
+            "{error}"
+        );
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/sampling.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/sampling.rs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// TokenSpeed `SamplingParams` — a Python `msgspec.Struct(kw_only=True,
+// array_like=True)` (runtime/sampling/sampling_params.py), so it rides the
+// wire as an untagged positional msgpack array nested inside the tokenized
+// request. **Field order is the wire contract** — append only, never reorder.
+
+use std::collections::HashMap;
+
+use serde_tuple::{Deserialize_tuple, Serialize_tuple};
+
+use crate::codec::OpaqueValue;
+
+/// TokenSpeed's "top_k is disabled" sentinel (sample from the whole vocab).
+/// The engine rewrites the API convention `top_k = -1` to this value so
+/// downstream kernels always see a positive cutoff.
+pub const TOP_K_DISABLED: i32 = 1 << 30;
+
+/// TokenSpeed's greedy-sampling threshold: a temperature below this collapses
+/// to greedy (`temperature = 1.0`, `top_k = 1`) during normalization.
+const SAMPLING_EPS: f64 = 1e-6;
+
+/// Engine-facing sampling parameters for TokenSpeed text generation.
+///
+/// Mirrors the Python `SamplingParams` msgspec struct: all 29 fields, in
+/// declaration order, encoded as one positional msgpack array. The engine
+/// runs its `__post_init__` re-derivation only when `is_normalized` is false,
+/// so senders that emit the normalized form (see [`Self::normalize`]) must
+/// pre-resolve the derived fields — most notably the `top_k` sentinel.
+#[derive(Debug, Clone, PartialEq, Serialize_tuple, Deserialize_tuple)]
+pub struct SamplingParams {
+    /// Maximum number of tokens to generate. `None` means engine default.
+    pub max_new_tokens: Option<u32>,
+    /// API-input stop-string alias. SMG rejects stop strings upstream (the
+    /// gateway does not enforce them on this wire), so it is always `None`.
+    pub stop: Option<String>,
+    /// Token IDs that stop generation (a Python set; encoded as an array).
+    /// The normalized form uses `None` rather than an empty collection.
+    pub stop_token_ids: Option<Vec<u32>>,
+    /// Controls randomness. Below [`SAMPLING_EPS`] normalizes to greedy.
+    pub temperature: f64,
+    /// Cumulative probability threshold for nucleus sampling.
+    pub top_p: f64,
+    /// Maximum number of top tokens to consider. API convention `-1` means
+    /// all tokens; the normalized form carries [`TOP_K_DISABLED`] instead.
+    pub top_k: i32,
+    /// Minimum probability threshold for token sampling.
+    pub min_p: f64,
+    /// Frequency penalty applied by the sampler.
+    pub frequency_penalty: f64,
+    /// Presence penalty applied by the sampler.
+    pub presence_penalty: f64,
+    /// Repetition penalty applied by the sampler.
+    pub repetition_penalty: f64,
+    /// Minimum number of tokens to generate before EOS / stop handling.
+    pub min_new_tokens: u32,
+    /// Structured-output JSON schema. SMG rejects constraints upstream.
+    pub json_schema: Option<String>,
+    /// Structured-output regex. SMG rejects constraints upstream.
+    pub regex: Option<String>,
+    /// Structured-output EBNF grammar. SMG rejects constraints upstream.
+    pub ebnf: Option<String>,
+    /// Structured-output structural tag. SMG rejects constraints upstream.
+    pub structural_tag: Option<String>,
+    /// Ignore the EOS token and keep generating until another stop condition.
+    pub ignore_eos: bool,
+    /// Whether detokenization skips special tokens (engine-side default true).
+    pub skip_special_tokens: bool,
+    /// Whether detokenization inserts spaces between special tokens.
+    pub spaces_between_special_tokens: bool,
+    /// Whether stop sequences are kept in the output text.
+    pub no_stop_trim: bool,
+    /// Token budget for thinking phases. Not set by SMG.
+    pub thinking_budget: Option<u64>,
+    /// Free-form engine extension parameters. Not set by SMG.
+    pub custom_params: Option<OpaqueValue>,
+    /// Streaming flush interval override. Not set by SMG.
+    pub stream_interval: Option<u32>,
+    /// Per-token logit bias, keyed by stringified token id. SMG rejects
+    /// logit_bias upstream (no support on this backend).
+    pub logit_bias: Option<HashMap<String, f64>>,
+    /// Random seed. `None` lets the engine derive one from the rid so all
+    /// TP/DP ranks agree.
+    pub seed: Option<u64>,
+    /// Output-logprob mode: `None` = off, `0` = the sampled token's logprob.
+    /// The transport drives logprobs off the request's `return_logprob` flag,
+    /// so SMG leaves this `None`.
+    pub logprobs: Option<i32>,
+    /// OpenAI-compat fanout count, stored but never acted on by the engine
+    /// (the transport validates `n == 1`; SMG fans out n > 1 itself).
+    pub n: u32,
+    /// Normalized stop strings (always a list once normalized; `[]` here since
+    /// SMG never sends stop strings).
+    pub stop_strs: Vec<String>,
+    /// Longest stop string in tokens, resolved by `normalize()`.
+    pub stop_str_max_len: u32,
+    /// True once the derived fields are resolved; the engine's decode-time
+    /// `__post_init__` skips re-derivation when set.
+    pub is_normalized: bool,
+}
+
+impl Default for SamplingParams {
+    /// The Python class defaults (the API-input form, pre-normalization).
+    fn default() -> Self {
+        Self {
+            max_new_tokens: None,
+            stop: None,
+            stop_token_ids: None,
+            temperature: 1.0,
+            top_p: 1.0,
+            top_k: -1,
+            min_p: 0.0,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
+            repetition_penalty: 1.0,
+            min_new_tokens: 0,
+            json_schema: None,
+            regex: None,
+            ebnf: None,
+            structural_tag: None,
+            ignore_eos: false,
+            skip_special_tokens: true,
+            spaces_between_special_tokens: true,
+            no_stop_trim: false,
+            thinking_budget: None,
+            custom_params: None,
+            stream_interval: None,
+            logit_bias: None,
+            seed: None,
+            logprobs: None,
+            n: 1,
+            stop_strs: Vec::new(),
+            stop_str_max_len: 0,
+            is_normalized: false,
+        }
+    }
+}
+
+impl SamplingParams {
+    /// Resolve the derived fields the engine's `__post_init__` / `normalize()`
+    /// would otherwise compute, and mark the struct normalized so the engine
+    /// skips re-derivation on decode. Mirrors the Python semantics exactly:
+    /// empty `stop_token_ids` collapses to `None`, a near-zero temperature
+    /// collapses to greedy, and `top_k = -1` becomes [`TOP_K_DISABLED`].
+    pub fn normalize(&mut self) {
+        if self.is_normalized {
+            return;
+        }
+        if self.stop_token_ids.as_ref().is_some_and(Vec::is_empty) {
+            self.stop_token_ids = None;
+        }
+        if self.temperature < SAMPLING_EPS {
+            self.temperature = 1.0;
+            self.top_k = 1;
+        }
+        if self.top_k == -1 {
+            self.top_k = TOP_K_DISABLED;
+        }
+        // SMG never sends stop strings, so the normalized stop_strs is always
+        // the empty list with a zero max length.
+        self.stop_strs = Vec::new();
+        self.stop_str_max_len = 0;
+        self.is_normalized = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmpv::Value;
+
+    use super::*;
+    use crate::codec::{decode_msgpack, decode_value, encode_msgpack};
+
+    #[test]
+    fn sampling_params_roundtrip() {
+        let mut params = SamplingParams {
+            max_new_tokens: Some(128),
+            stop_token_ids: Some(vec![2, 3]),
+            temperature: 0.7,
+            top_p: 0.9,
+            top_k: 40,
+            min_p: 0.05,
+            frequency_penalty: 0.1,
+            presence_penalty: 0.2,
+            repetition_penalty: 1.1,
+            min_new_tokens: 1,
+            ignore_eos: true,
+            seed: Some(42),
+            ..SamplingParams::default()
+        };
+        params.normalize();
+        let encoded = encode_msgpack(&params).unwrap();
+        assert_eq!(decode_msgpack::<SamplingParams>(&encoded).unwrap(), params);
+    }
+
+    #[test]
+    fn sampling_params_serializes_as_29_element_array() {
+        let mut params = SamplingParams {
+            max_new_tokens: Some(16),
+            stop_token_ids: Some(vec![7]),
+            temperature: 0.5,
+            ..SamplingParams::default()
+        };
+        params.normalize();
+        let encoded = encode_msgpack(&params).unwrap();
+        let value = decode_value(&encoded).unwrap();
+        let array = match value {
+            Value::Array(array) => array,
+            other => panic!("expected array (msgspec array_like), got {other:?}"),
+        };
+
+        // 29-element positional array; spot-check the wire positions.
+        assert_eq!(array.len(), 29);
+        assert_eq!(array[0], Value::from(16)); // max_new_tokens
+        assert_eq!(array[2], Value::Array(vec![Value::from(7)])); // stop_token_ids
+        assert_eq!(array[3], Value::F64(0.5)); // temperature
+        assert_eq!(array[5], Value::from(TOP_K_DISABLED)); // top_k, normalized
+        assert_eq!(array[23], Value::Nil); // seed
+        assert_eq!(array[26], Value::Array(vec![])); // stop_strs
+        assert_eq!(array[28], Value::from(true)); // is_normalized
+    }
+
+    #[test]
+    fn normalize_resolves_derived_fields() {
+        // top_k = -1 (API "all tokens") becomes the engine sentinel.
+        let mut params = SamplingParams::default();
+        params.normalize();
+        assert_eq!(params.top_k, TOP_K_DISABLED);
+        assert!(params.is_normalized);
+
+        // Near-zero temperature collapses to greedy.
+        let mut params = SamplingParams {
+            temperature: 0.0,
+            ..SamplingParams::default()
+        };
+        params.normalize();
+        assert_eq!(params.temperature, 1.0);
+        assert_eq!(params.top_k, 1);
+
+        // Empty stop_token_ids collapses to None.
+        let mut params = SamplingParams {
+            stop_token_ids: Some(Vec::new()),
+            ..SamplingParams::default()
+        };
+        params.normalize();
+        assert_eq!(params.stop_token_ids, None);
+
+        // Normalizing twice is a no-op (mirrors the engine's guard).
+        let mut params = SamplingParams {
+            top_k: 40,
+            ..SamplingParams::default()
+        };
+        params.normalize();
+        params.normalize();
+        assert_eq!(params.top_k, 40);
+    }
+}

--- a/crates/engine_zmq_client/src/protocol/vllm/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/mod.rs
@@ -12,10 +12,106 @@
 //! for now — they serialize as `nil` on the text path and get strongly typed in
 //! the multimodal phase.
 
-pub mod handshake;
+// The startup handshake is engine-neutral (TokenSpeed speaks the same
+// protocol); re-exported here so existing `vllm::handshake` paths keep working.
+pub use crate::protocol::handshake;
 pub mod logprobs;
 pub mod lora;
 pub mod output;
 pub mod request;
 pub mod sampling;
 pub mod stats;
+
+use bytes::Bytes;
+
+use crate::{
+    codec::encode_msgpack,
+    error::Result,
+    protocol::{
+        vllm::{
+            output::{decode_engine_core_outputs, EngineCoreOutput, EngineCoreOutputs},
+            request::{EngineCoreRequest, EngineCoreRequestType},
+            stats::SchedulerStats,
+        },
+        EngineBatch, EngineLoad, EngineOutput, EngineProtocol,
+    },
+};
+
+/// Map vLLM's piggybacked scheduler stats onto the engine-neutral load signal.
+impl From<SchedulerStats> for EngineLoad {
+    fn from(stats: SchedulerStats) -> Self {
+        Self {
+            num_running: stats.num_running_reqs,
+            num_waiting: stats.num_waiting_reqs,
+            kv_cache_usage: stats.kv_cache_usage,
+        }
+    }
+}
+
+impl EngineOutput for EngineCoreOutput {
+    fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    fn finished(&self) -> bool {
+        EngineCoreOutput::finished(self)
+    }
+}
+
+/// The vLLM EngineCore protocol: drives [`EngineCoreRequest`] over the shared ZMQ
+/// transport and decodes [`EngineCoreOutputs`] back.
+pub struct VllmProtocol;
+
+impl EngineProtocol for VllmProtocol {
+    type Request = EngineCoreRequest;
+    type Output = EngineCoreOutput;
+
+    fn add_frame() -> Bytes {
+        EngineCoreRequestType::Add.to_frame()
+    }
+
+    fn abort_frame() -> Bytes {
+        EngineCoreRequestType::Abort.to_frame()
+    }
+
+    fn request_id(request: &Self::Request) -> &str {
+        &request.request_id
+    }
+
+    fn data_parallel_rank(request: &Self::Request) -> Option<u32> {
+        request.data_parallel_rank
+    }
+
+    fn validate(request: &Self::Request) -> Result<()> {
+        request.validate()
+    }
+
+    fn encode_add(request: &Self::Request) -> Result<(Vec<u8>, Vec<Bytes>)> {
+        // Text path carries no aux tensor frames.
+        Ok((encode_msgpack(request)?, Vec::new()))
+    }
+
+    fn encode_abort(request_id: &str) -> Result<Vec<u8>> {
+        encode_msgpack(&[request_id.to_string()])
+    }
+
+    fn decode_batch(frames: &[Bytes]) -> Result<EngineBatch<Self::Output>> {
+        // vLLM multiplexes request batches, utility RPCs, and DP control on one
+        // wire struct; only request batches carry per-request outputs (the
+        // others surface as an empty batch the dispatcher ignores).
+        match decode_engine_core_outputs(frames)? {
+            EngineCoreOutputs::RequestBatch(batch) => Ok(EngineBatch {
+                engine_index: batch.engine_index,
+                outputs: batch.outputs,
+                finished_request_ids: batch
+                    .finished_requests
+                    .map(|ids| ids.into_iter().collect())
+                    .unwrap_or_default(),
+                load: batch.scheduler_stats.map(|stats| EngineLoad::from(*stats)),
+            }),
+            EngineCoreOutputs::Utility(_) | EngineCoreOutputs::DpControl(_) => {
+                Ok(EngineBatch::default())
+            }
+        }
+    }
+}

--- a/crates/engine_zmq_client/src/transport.rs
+++ b/crates/engine_zmq_client/src/transport.rs
@@ -27,11 +27,11 @@ use zeromq::{
 use crate::{
     codec::{decode_msgpack, encode_msgpack},
     error::{Error, Result},
-    protocol::vllm::{
+    protocol::{
         handshake::{
             EngineCoreReadyResponse, HandshakeAddresses, HandshakeInitMessage, ReadyMessage,
         },
-        output::{decode_engine_core_outputs, EngineCoreOutputs},
+        EngineBatch, EngineProtocol,
     },
 };
 
@@ -426,13 +426,13 @@ pub async fn send_message(
     Ok(())
 }
 
-/// Receive engine outputs from the shared PULL socket, decode them, and forward
-/// them on `tx`. Terminates on the `ENGINE_CORE_DEAD` sentinel, a transport
-/// error, or when the receiver is dropped. Decode errors are forwarded but do
-/// not stop the loop.
-pub async fn run_output_loop(
+/// Receive engine outputs from the shared PULL socket, decode them with the
+/// engine's protocol `P`, and forward them on `tx`. Terminates on the
+/// `ENGINE_CORE_DEAD` sentinel, a transport error, or when the receiver is
+/// dropped. Decode errors are forwarded but do not stop the loop.
+pub async fn run_output_loop<P: EngineProtocol>(
     mut output_socket: PullSocket,
-    tx: mpsc::Sender<Result<EngineCoreOutputs>>,
+    tx: mpsc::Sender<Result<EngineBatch<P::Output>>>,
 ) {
     loop {
         let message = match output_socket.recv().await {
@@ -455,7 +455,7 @@ pub async fn run_output_loop(
             return;
         }
 
-        let decoded = match decode_engine_core_outputs(&frames) {
+        let decoded = match P::decode_batch(&frames) {
             Ok(decoded) => Ok(decoded),
             Err(error) => {
                 // Keep the loop running so a single bad message doesn't drop the
@@ -483,6 +483,7 @@ mod tests {
                 EngineCoreFinishReason, EngineCoreOutput, EngineCoreOutputs, RequestBatchOutputs,
             },
             request::{EngineCoreRequest, EngineCoreRequestType},
+            VllmProtocol,
         },
     };
 
@@ -578,7 +579,7 @@ mod tests {
             clippy::disallowed_methods,
             reason = "test output loop torn down when the test ends"
         )]
-        let _output_loop = tokio::spawn(run_output_loop(output_socket, out_tx));
+        let _output_loop = tokio::spawn(run_output_loop::<VllmProtocol>(output_socket, out_tx));
 
         let outputs = EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
             engine_index: 0,
@@ -596,12 +597,11 @@ mod tests {
             .await
             .unwrap();
 
-        let received = out_rx
+        let batch = out_rx
             .recv()
             .await
             .expect("output delivered")
             .expect("decoded ok");
-        let batch = received.as_request_batch().expect("request batch");
         assert_eq!(batch.outputs[0].new_token_ids, vec![100, 101]);
         assert_eq!(
             batch.outputs[0].finish_reason,
@@ -641,7 +641,10 @@ mod tests {
             clippy::disallowed_methods,
             reason = "test output loop torn down when the test ends"
         )]
-        let _output_loop = tokio::spawn(run_output_loop(transport.output_socket, out_tx));
+        let _output_loop = tokio::spawn(run_output_loop::<VllmProtocol>(
+            transport.output_socket,
+            out_tx,
+        ));
 
         engine
             .send_output(vec![Bytes::from_static(ENGINE_CORE_DEAD_SENTINEL)])

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -712,6 +712,14 @@ pub struct WorkerSpec {
     /// is used. Overrides the router-level `multimodal_shm_min_bytes`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub multimodal_shm_min_bytes: Option<usize>,
+
+    /// Handshake address the frontend BINDS for this worker's engine handshake.
+    /// Only meaningful for `connection_mode: zmq`; must be a `tcp://` address.
+    /// When unset, the frontend derives a deterministic port from the worker's
+    /// `ipc://` path instead — this override exists for engines that dial a
+    /// fixed, pre-agreed address rather than the derived one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zmq_handshake_address: Option<String>,
 }
 
 impl WorkerSpec {
@@ -744,6 +752,7 @@ impl WorkerSpec {
             load_monitor_interval_secs: None,
             multimodal_tensor_transport: None,
             multimodal_shm_min_bytes: None,
+            zmq_handshake_address: None,
         }
     }
 }

--- a/crates/workflow/src/engine.rs
+++ b/crates/workflow/src/engine.rs
@@ -610,6 +610,31 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
                 && effective_waiting == 0
                 && pending_check.is_empty()
             {
+                // A step can finish in the gap between Phase 0's drain and Phase 1's
+                // tracker read: it removes itself from `running` and sends its
+                // completion in one lock scope, so Phase 1 sees running == 0 while
+                // the message is still queued in `rx` and its dependents were never
+                // added to `pending_check`. Re-drain before declaring deadlock;
+                // instant-completing steps (e.g. ZMQ connection detection) hit this
+                // window routinely.
+                let mut drained_completion = false;
+                while let Ok((step_id, result)) = rx.try_recv() {
+                    drained_completion = true;
+                    tracing::debug!(
+                        step_id = %step_id,
+                        result = ?result,
+                        "Step completed (deadlock-check drain)"
+                    );
+                    if matches!(result, StepResult::Success | StepResult::Skip) {
+                        for &dep_idx in definition.get_dependent_indices(&step_id) {
+                            pending_check.push_back(dep_idx);
+                        }
+                    }
+                }
+                if drained_completion {
+                    continue;
+                }
+
                 let failed_step = tracker.read().failed.iter().next().cloned();
                 // Use &'static str to avoid allocation in common error paths
                 let error_message: &'static str = if failed_step.is_some() {
@@ -668,11 +693,14 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
                                         "Step skipped due to run_if condition"
                                     );
 
-                                    // Update tracker and send skip signal
+                                    // Remove from running and send the skip signal in one
+                                    // lock scope so the deadlock re-drain never sees
+                                    // running == 0 with the completion still unsent.
                                     {
                                         let mut t = tracker.write();
                                         t.running.remove(&step_id);
                                         t.skipped.insert(step_id.clone());
+                                        let _ = tx.try_send((step_id.clone(), StepResult::Skip));
                                     }
 
                                     // Update state store
@@ -686,9 +714,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
                                             }
                                         })
                                         .await;
-
-                                    // Send skip signal
-                                    let _ = tx.try_send((step_id, StepResult::Skip));
                                     return;
                                 }
                             }
@@ -700,11 +725,14 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
                                     "Failed to get context for run_if evaluation, failing step"
                                 );
 
-                                // Update tracker
+                                // Remove from running and send the failure signal in one
+                                // lock scope so the deadlock re-drain never sees
+                                // running == 0 with the completion still unsent.
                                 {
                                     let mut t = tracker.write();
                                     t.running.remove(&step_id);
                                     t.failed.insert(step_id.clone());
+                                    let _ = tx.try_send((step_id.clone(), StepResult::Failure));
                                 }
 
                                 // Update state store
@@ -718,9 +746,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
                                         }
                                     })
                                     .await;
-
-                                // Send failure signal
-                                let _ = tx.try_send((step_id, StepResult::Failure));
                                 return;
                             }
                         }

--- a/crates/workflow/tests/workflow_test.rs
+++ b/crates/workflow/tests/workflow_test.rs
@@ -990,6 +990,109 @@ async fn test_run_if_context_based() {
     assert_eq!(executed_clone.load(Ordering::SeqCst), 1);
 }
 
+/// Regression test: instantly-skipped run_if steps feeding a dependent chain
+/// must not trigger a spurious "Workflow deadlocked" failure. The skip signal
+/// must be sent in the same tracker lock scope as the removal from `running`,
+/// otherwise the scheduler can observe running == 0 with the completion unsent.
+#[tokio::test]
+async fn test_run_if_skip_chain_no_spurious_deadlock() {
+    for i in 0..50 {
+        let engine: WorkflowEngine<TestWorkflowData> = WorkflowEngine::new();
+
+        let workflow = WorkflowDefinition::new(
+            "run_if_skip_chain_workflow",
+            "Run If Skip Chain Deadlock Regression",
+        )
+        .add_step(
+            StepDefinition::new("root", "Root", Arc::new(AlwaysSucceedStep)).run_if(|_ctx| false),
+        )
+        .add_step(
+            StepDefinition::new("mid", "Mid", Arc::new(AlwaysSucceedStep))
+                .depends_on(&["root"])
+                .run_if(|_ctx| false),
+        )
+        .add_step(
+            StepDefinition::new("leaf", "Leaf", Arc::new(AlwaysSucceedStep)).depends_on(&["mid"]),
+        );
+
+        let workflow_id = workflow.id.clone();
+        engine.register_workflow(workflow).unwrap();
+
+        let instance_id = engine
+            .start_workflow(workflow_id, TestWorkflowData::default())
+            .await
+            .unwrap();
+
+        let result = engine
+            .wait_for_completion(instance_id, "skip-chain", Duration::from_secs(5))
+            .await;
+        assert!(result.is_ok(), "iteration {i} failed: {result:?}");
+    }
+}
+
+/// A -> B(run_if=false) -> C: the chain completes with B skipped and C executed.
+#[tokio::test]
+async fn test_run_if_false_mid_chain_completes() {
+    use tokio::time::sleep;
+
+    let engine: WorkflowEngine<TestWorkflowData> = WorkflowEngine::new();
+
+    let executed = Arc::new(AtomicU32::new(0));
+    let executed_clone = Arc::clone(&executed);
+
+    struct TrackingStep {
+        counter: Arc<AtomicU32>,
+    }
+
+    #[async_trait::async_trait]
+    impl StepExecutor<TestWorkflowData> for TrackingStep {
+        async fn execute(
+            &self,
+            _context: &mut WorkflowContext<TestWorkflowData>,
+        ) -> WorkflowResult<StepResult> {
+            self.counter.fetch_add(1, Ordering::SeqCst);
+            Ok(StepResult::Success)
+        }
+    }
+
+    let workflow = WorkflowDefinition::new("run_if_mid_chain_workflow", "Run If Mid Chain Test")
+        .add_step(StepDefinition::new("a", "A", Arc::new(AlwaysSucceedStep)))
+        .add_step(
+            StepDefinition::new("b", "B", Arc::new(AlwaysSucceedStep))
+                .depends_on(&["a"])
+                .run_if(|_ctx| false),
+        )
+        .add_step(
+            StepDefinition::new("c", "C", Arc::new(TrackingStep { counter: executed }))
+                .depends_on(&["b"]),
+        );
+
+    let workflow_id = workflow.id.clone();
+    engine.register_workflow(workflow).unwrap();
+
+    let instance_id = engine
+        .start_workflow(workflow_id, TestWorkflowData::default())
+        .await
+        .unwrap();
+
+    // Poll instead of wait_for_completion so step states survive for inspection.
+    let mut state = engine.get_status(instance_id).await.unwrap();
+    for _ in 0..100 {
+        if state.status != WorkflowStatus::Running && state.status != WorkflowStatus::Pending {
+            break;
+        }
+        sleep(Duration::from_millis(50)).await;
+        state = engine.get_status(instance_id).await.unwrap();
+    }
+
+    assert_eq!(state.status, WorkflowStatus::Completed);
+    assert_eq!(
+        state.step_states.get(&StepId::new("b")).unwrap().status,
+        StepStatus::Skipped
+    );
+    assert_eq!(executed_clone.load(Ordering::SeqCst), 1);
+}
+
 #[tokio::test]
 async fn test_depends_on_any() {
     // DAG: A and B run in parallel, C waits for ANY (not both)

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -9,7 +9,7 @@ use super::{
     RetryConfig, RouterConfig, RoutingKeyOverrideConfig, RoutingMode, TenantApiKeyEntry,
     TokenizerCacheConfig, TraceConfig,
 };
-use crate::worker::ConnectionMode;
+use crate::worker::{ConnectionMode, RuntimeType};
 
 /// Builder for RouterConfig that wraps the config itself
 /// This eliminates field duplication and stays in sync automatically
@@ -146,6 +146,13 @@ impl RouterConfigBuilder {
     }
 
     // ==================== Connection ====================
+
+    /// Explicit runtime for startup workers over ZMQ (`None` keeps
+    /// auto-detection for HTTP/gRPC; see `RouterConfig::startup_worker_runtime_type`).
+    pub fn startup_worker_runtime_type(mut self, runtime: Option<RuntimeType>) -> Self {
+        self.config.startup_worker_runtime_type = runtime;
+        self
+    }
 
     pub fn connection_mode(mut self, mode: ConnectionMode) -> Self {
         self.config.connection_mode = mode;

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -9,7 +9,10 @@ pub use smg_data_connector::{
 };
 
 use super::{validation::ConfigValidator, ConfigResult};
-use crate::{tenant::DEFAULT_TENANT_HEADER_NAME, worker::ConnectionMode};
+use crate::{
+    tenant::DEFAULT_TENANT_HEADER_NAME,
+    worker::{ConnectionMode, RuntimeType},
+};
 
 /// Main router configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,6 +20,13 @@ pub struct RouterConfig {
     pub mode: RoutingMode,
     #[serde(default)]
     pub connection_mode: ConnectionMode,
+    /// Explicit runtime for the startup workers (`--worker-urls`), set from
+    /// `--backend` when the connection mode is ZMQ. The ZMQ handshake is shared
+    /// across engine runtimes, so the wire protocol cannot be probed and must
+    /// be declared up front; HTTP/gRPC workers keep auto-detection and ignore
+    /// this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_worker_runtime_type: Option<RuntimeType>,
     pub policy: PolicyConfig,
     /// Per-request sticky-routing override (honors `X-SMG-Routing-Key`).
     #[serde(default)]
@@ -826,6 +836,7 @@ impl Default for RouterConfig {
             health_check: HealthCheckConfig::default(),
             enable_igw: false,
             connection_mode: ConnectionMode::Http,
+            startup_worker_runtime_type: None,
             model_path: None,
             tokenizer_path: None,
             chat_template: None,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -18,7 +18,7 @@ use smg::{
     server::{self, ServerConfig},
     service_discovery::{ModelIdSource, ServiceDiscoveryConfig},
     version,
-    worker::ConnectionMode,
+    worker::{ConnectionMode, RuntimeType},
 };
 use smg_auth::{ApiKeyEntry, ControlPlaneAuthConfig, JwtConfig, Role};
 use smg_mesh::MeshServerConfig;
@@ -75,6 +75,8 @@ pub enum Backend {
     Vllm,
     #[value(name = "trtllm")]
     Trtllm,
+    #[value(name = "tokenspeed")]
+    Tokenspeed,
     #[value(name = "openai")]
     Openai,
     #[value(name = "anthropic")]
@@ -89,6 +91,7 @@ impl std::fmt::Display for Backend {
             Backend::Sglang => "sglang",
             Backend::Vllm => "vllm",
             Backend::Trtllm => "trtllm",
+            Backend::Tokenspeed => "tokenspeed",
             Backend::Openai => "openai",
             Backend::Anthropic => "anthropic",
             Backend::Gemini => "gemini",
@@ -1395,6 +1398,20 @@ impl CliArgs {
         }
         let connection_mode = Self::determine_connection_mode(&all_urls);
 
+        // `--backend` normally only steers the routing mode. Over ZMQ it
+        // additionally pins the startup workers' runtime: the shared EngineCore
+        // handshake carries no engine identity, so the wire protocol cannot be
+        // probed and must be declared. HTTP/gRPC keep auto-detection (None).
+        let startup_worker_runtime_type = if connection_mode == ConnectionMode::Zmq {
+            match self.backend {
+                Some(Backend::Vllm) => Some(RuntimeType::Vllm),
+                Some(Backend::Tokenspeed) => Some(RuntimeType::TokenSpeed),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         let history_backend = match self.history_backend.as_str() {
             "none" => HistoryBackend::None,
             "oracle" => HistoryBackend::Oracle,
@@ -1445,6 +1462,7 @@ impl CliArgs {
             .mode(mode)
             .policy(policy)
             .connection_mode(connection_mode)
+            .startup_worker_runtime_type(startup_worker_runtime_type)
             .host(&self.host)
             .port(self.port)
             .health_check_port(self.health_check_port)
@@ -1915,6 +1933,69 @@ mod tests {
 
         let server_config = cli.to_server_config(router_config).unwrap();
         assert_eq!(server_config.runtime_worker_threads, None);
+    }
+
+    /// Over ZMQ, `--backend` pins the startup workers' runtime (the shared
+    /// EngineCore handshake cannot be probed for a wire protocol). The pin must
+    /// reach `RouterConfig` and survive nesting into
+    /// `ServerConfig.router_config` — two-path config-plumbing guard.
+    #[test]
+    fn zmq_backend_pins_startup_worker_runtime_in_both_configs() {
+        let cli = cli_args_from(&[
+            "--backend",
+            "tokenspeed",
+            "--worker-urls",
+            "ipc:///tmp/smg-zmq/engine-0",
+        ]);
+
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.connection_mode, ConnectionMode::Zmq);
+        assert_eq!(
+            router_config.startup_worker_runtime_type,
+            Some(RuntimeType::TokenSpeed),
+            "--backend tokenspeed must pin the ZMQ startup worker runtime"
+        );
+
+        let server_config = cli.to_server_config(router_config).unwrap();
+        assert_eq!(
+            server_config.router_config.startup_worker_runtime_type,
+            Some(RuntimeType::TokenSpeed),
+            "the runtime pin must survive into ServerConfig via to_server_config"
+        );
+    }
+
+    /// The runtime pin only disambiguates the ZMQ wire protocol: gRPC (and
+    /// HTTP) workers keep backend auto-detection even when `--backend` names an
+    /// engine, and a ZMQ deployment without `--backend` stays unpinned
+    /// (detect_backend's vLLM default applies).
+    #[test]
+    fn startup_worker_runtime_stays_unpinned_off_the_zmq_path() {
+        let grpc = cli_args_from(&[
+            "--backend",
+            "tokenspeed",
+            "--worker-urls",
+            "grpc://localhost:30001",
+        ]);
+        let router_config = grpc.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.connection_mode, ConnectionMode::Grpc);
+        assert_eq!(router_config.startup_worker_runtime_type, None);
+
+        let zmq_no_backend = cli_args_from(&["--worker-urls", "ipc:///tmp/smg-zmq/engine-0"]);
+        let router_config = zmq_no_backend.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.connection_mode, ConnectionMode::Zmq);
+        assert_eq!(router_config.startup_worker_runtime_type, None);
+
+        let zmq_vllm = cli_args_from(&[
+            "--backend",
+            "vllm",
+            "--worker-urls",
+            "ipc:///tmp/smg-zmq/engine-0",
+        ]);
+        let router_config = zmq_vllm.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(
+            router_config.startup_worker_runtime_type,
+            Some(RuntimeType::Vllm)
+        );
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/backend_client.rs
+++ b/model_gateway/src/routers/grpc/backend_client.rs
@@ -2,7 +2,8 @@
 //!
 //! A worker's backend is reached either via gRPC (the [`GrpcClient`] multiplexer
 //! over SGLang/vLLM/TRT-LLM/MLX/TokenSpeed) or via a direct ZMQ connection to a
-//! same-host vLLM EngineCore ([`ZmqEngineClient`]). `BackendClient` keeps those
+//! same-host engine — vLLM EngineCore or TokenSpeed ([`ZmqEngineClient`]).
+//! `BackendClient` keeps those
 //! first-class siblings — `GrpcClient` stays pure gRPC — while the execution
 //! pipeline (which works against [`ProtoStream`]/[`ProtoGenerateRequest`]) is
 //! shared unchanged.
@@ -24,7 +25,8 @@ use crate::routers::grpc::{
     zmq_client::ZmqEngineClient,
 };
 
-/// A backend connection: gRPC (any engine) or direct ZMQ (vLLM EngineCore).
+/// A backend connection: gRPC (any engine) or direct ZMQ (vLLM EngineCore or
+/// TokenSpeed).
 #[derive(Clone)]
 pub enum BackendClient {
     Grpc(GrpcClient),
@@ -36,8 +38,7 @@ impl BackendClient {
     pub fn runtime_type(&self) -> crate::worker::RuntimeType {
         match self {
             Self::Grpc(client) => client.runtime_type(),
-            // ZMQ is the vLLM engine over a different transport.
-            Self::Zmq(_) => crate::worker::RuntimeType::Vllm,
+            Self::Zmq(client) => client.runtime(),
         }
     }
 

--- a/model_gateway/src/routers/grpc/common/stages/encode.rs
+++ b/model_gateway/src/routers/grpc/common/stages/encode.rs
@@ -345,8 +345,8 @@ fn prepare_tokenspeed_items(
 }
 
 /// Display name of the engine runtime behind a client, for diagnostics. Keyed on
-/// the runtime, not the transport: a ZMQ worker is a vLLM engine reached over
-/// `ipc://`, so it reports "vLLM" like any other vLLM worker.
+/// the runtime, not the transport: a ZMQ worker reports its engine runtime
+/// (vLLM or TokenSpeed) the same as a gRPC worker for that engine.
 fn backend_name(client: &BackendClient) -> &'static str {
     match client.runtime_type() {
         RuntimeType::Sglang => "SGLang",

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -2,8 +2,8 @@
 //
 // ZMQ backend adapter (gateway glue): presents the vLLM engine surface (the same
 // proto request/response types as `VllmEngineClient`) but speaks ZMQ directly to
-// a same-host vLLM EngineCore via `engine-zmq-client`, bypassing the gRPC Python
-// servicer.
+// a same-host engine (vLLM EngineCore or TokenSpeed) via `engine-zmq-client`,
+// bypassing the gRPC Python servicer.
 //
 // This bridges the gateway's proto request-execution pipeline to the raw ZMQ
 // transport, so it lives with the router (which owns `GrpcClient`/`ProtoStream`),
@@ -20,23 +20,48 @@ use std::{
 
 use engine_zmq_client::{
     connect_handshake,
-    connector::{EngineCoreClient, EngineCoreStream},
-    protocol::vllm::{
-        output::{EngineCoreFinishReason, EngineCoreOutput, StopReason},
-        request::EngineCoreRequest,
-        sampling::EngineCoreSamplingParams,
+    connector::{EngineCoreClient, EngineCoreStream, TokenSpeedClient, TokenSpeedStream},
+    protocol::{
+        tokenspeed::{
+            output::TokenSpeedOutput, request::TokenizedGenerateReqInput,
+            sampling::SamplingParams as TokenSpeedSamplingParams,
+        },
+        vllm::{
+            output::{EngineCoreFinishReason, EngineCoreOutput, StopReason},
+            request::EngineCoreRequest,
+            sampling::EngineCoreSamplingParams,
+        },
+        EngineLoad,
     },
+    ConnectedEngine,
 };
-use futures::StreamExt;
+use futures::{stream::SelectAll, Stream, StreamExt};
 use openai_protocol::worker::{SchedulerLoadSnapshot, WorkerLoadResponse};
 use smg_grpc_client::vllm_proto as vllm;
 
-/// Direct ZMQ connection to a same-host vLLM EngineCore, presented behind the
-/// vLLM gRPC client surface.
+use crate::worker::RuntimeType;
+
+/// Loopback host for the same-host ZMQ transport (TCP handshake and local
+/// binds). Shared with the worker-side socket derivation.
+pub(crate) const ZMQ_LOOPBACK_HOST: &str = "127.0.0.1";
+
+/// The engine protocol a ZMQ backend speaks. Both share the transport and
+/// handshake; only the request/output struct shapes and the translation to/from
+/// SMG proto differ.
+#[derive(Clone)]
+enum ZmqBackend {
+    /// vLLM EngineCore.
+    Vllm(Arc<EngineCoreClient>),
+    /// TokenSpeed.
+    TokenSpeed(Arc<TokenSpeedClient>),
+}
+
+/// Direct ZMQ connection to a same-host engine (vLLM EngineCore or TokenSpeed),
+/// presented behind the vLLM gRPC client surface.
 #[derive(Clone)]
 pub struct ZmqEngineClient {
-    inner: Arc<EngineCoreClient>,
-    /// Model id advertised for metadata (EngineCore does not report it on the
+    backend: ZmqBackend,
+    /// Model id advertised for metadata (the engine does not report it on the
     /// wire; it is configured at worker registration).
     model_id: String,
 }
@@ -47,49 +72,133 @@ impl ZmqEngineClient {
     ///
     /// `input_address`/`output_address` are the `ipc://` data-plane endpoints the
     /// engines connect to (chosen by SMG). `engine_count` is the number of DP
-    /// ranks to await.
+    /// ranks to await. `runtime` selects the wire protocol spoken over the shared
+    /// transport (vLLM EngineCore vs TokenSpeed).
     pub async fn connect(
         handshake_address: &str,
         input_address: &str,
         output_address: &str,
         engine_count: usize,
         model_id: String,
+        runtime: RuntimeType,
         timeout: Duration,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        // Single-engine scope for TokenSpeed: its wire carries no DP-rank routing
+        // yet (`data_parallel_rank` is always `None`), so more than one engine
+        // would silently send all traffic to engine 0. Reject it loudly until
+        // DP>1 lands. The engine count is known here (the handshake awaits it).
+        if matches!(runtime, RuntimeType::TokenSpeed) && engine_count > 1 {
+            return Err(format!(
+                "TokenSpeed ZMQ backend supports a single engine only (got \
+                 engine_count={engine_count}); DP>1 is not yet supported"
+            )
+            .into());
+        }
+        // No silent fallback: any other runtime has no ZMQ engine adapter.
+        // Reject before the handshake — no such engine ever dials in, so the
+        // handshake would just block for the full timeout.
+        if !matches!(
+            runtime,
+            RuntimeType::Vllm | RuntimeType::TokenSpeed | RuntimeType::Unspecified
+        ) {
+            return Err(format!(
+                "ZMQ direct backend has no engine implementation for runtime \
+                 {runtime}; only vllm and tokenspeed are supported"
+            )
+            .into());
+        }
+
         let transport = connect_handshake(
             handshake_address,
             engine_count,
-            "127.0.0.1",
+            ZMQ_LOOPBACK_HOST,
             Some(input_address),
             Some(output_address),
             timeout,
         )
         .await?;
-        Ok(Self {
-            inner: Arc::new(EngineCoreClient::new(transport)),
-            model_id,
-        })
+        let backend = match runtime {
+            RuntimeType::TokenSpeed => {
+                ZmqBackend::TokenSpeed(Arc::new(TokenSpeedClient::new(transport)))
+            }
+            // vLLM EngineCore is the default ZMQ wire; an unspecified runtime maps
+            // to it for backward compatibility (see `detect_backend`). All other
+            // runtimes were rejected before the handshake.
+            _ => ZmqBackend::Vllm(Arc::new(EngineCoreClient::new(transport))),
+        };
+        Ok(Self { backend, model_id })
+    }
+
+    /// The engine runtime behind this connection (the wire protocol chosen at
+    /// connect time).
+    pub fn runtime(&self) -> RuntimeType {
+        match &self.backend {
+            ZmqBackend::Vllm(_) => RuntimeType::Vllm,
+            ZmqBackend::TokenSpeed(_) => RuntimeType::TokenSpeed,
+        }
+    }
+
+    /// The engines connected on the shared transport (same handshake for both
+    /// protocols).
+    fn engines(&self) -> &[ConnectedEngine] {
+        match &self.backend {
+            ZmqBackend::Vllm(client) => client.engines(),
+            ZmqBackend::TokenSpeed(client) => client.engines(),
+        }
     }
 
     /// Submit a generate request and return a stream of vLLM-proto responses.
+    /// The request is translated into the backend's wire protocol.
+    ///
+    /// Over gRPC the engine-side frontend (e.g. vLLM's AsyncLLM) fans `n` out
+    /// itself and multiplexes the choices onto one stream. The raw ZMQ wire has
+    /// no such frontend, so `n > 1` is fanned out HERE into `n` independent
+    /// single-sample engine requests (see [`fan_out_requests`]); their outputs
+    /// are merged back into one stream with each sub tagged via the proto
+    /// `index` field, exactly like the gRPC contract.
     pub async fn generate(
         &self,
         req: vllm::GenerateRequest,
     ) -> Result<ZmqGenerateStream, tonic::Status> {
-        let core_request = translate_request(req).map_err(tonic::Status::invalid_argument)?;
-        let stream = self.inner.submit(core_request).await.map_err(zmq_status)?;
-        Ok(ZmqGenerateStream::new(stream))
+        let subs = fan_out_requests(req);
+        // Sub-streams submitted before a mid-loop failure are dropped with the
+        // error, which auto-aborts their engine-side requests.
+        match &self.backend {
+            ZmqBackend::Vllm(client) => {
+                let mut streams = SelectAll::new();
+                for (index, sub) in subs.into_iter().enumerate() {
+                    let request =
+                        translate_request(sub).map_err(tonic::Status::invalid_argument)?;
+                    let stream = client.submit(request).await.map_err(zmq_status)?;
+                    streams.push(VllmGenerateStream::new(stream, index as u32));
+                }
+                Ok(ZmqGenerateStream::Vllm(streams))
+            }
+            ZmqBackend::TokenSpeed(client) => {
+                let mut streams = SelectAll::new();
+                for (index, sub) in subs.into_iter().enumerate() {
+                    let request = translate_request_tokenspeed(sub)
+                        .map_err(tonic::Status::invalid_argument)?;
+                    let stream = client.submit(request).await.map_err(zmq_status)?;
+                    streams.push(TokenSpeedGenerateStream::new(stream, index as u32));
+                }
+                Ok(ZmqGenerateStream::TokenSpeed(streams))
+            }
+        }
     }
 
     /// Local liveness: false once the connection observed `ENGINE_CORE_DEAD` or
     /// a transport failure. No RPC (the raw ZMQ wire has no health RPC).
     pub fn is_alive(&self) -> bool {
-        self.inner.is_alive()
+        match &self.backend {
+            ZmqBackend::Vllm(client) => client.is_alive(),
+            ZmqBackend::TokenSpeed(client) => client.is_alive(),
+        }
     }
 
     /// Health as an RPC-shaped response, derived from local liveness.
     pub fn health_check(&self) -> vllm::HealthCheckResponse {
-        let alive = self.inner.is_alive();
+        let alive = self.is_alive();
         vllm::HealthCheckResponse {
             healthy: alive,
             message: if alive {
@@ -100,21 +209,30 @@ impl ZmqEngineClient {
         }
     }
 
+    /// Latest per-rank load for one engine index, if the backend carries it.
+    /// vLLM piggybacks it on every batch; TokenSpeed does not (always `None`).
+    fn engine_load(&self, engine_index: u32) -> Option<EngineLoad> {
+        match &self.backend {
+            ZmqBackend::Vllm(client) => client.engine_load(engine_index),
+            ZmqBackend::TokenSpeed(client) => client.engine_load(engine_index),
+        }
+    }
+
     /// Per-rank load from the piggybacked `scheduler_stats` (SMG's DP routing
-    /// signal), in the same shape as the gRPC `GetLoads` response.
+    /// signal), in the same shape as the gRPC `GetLoads` response. TokenSpeed
+    /// carries no piggybacked load, so its response has no per-rank entries.
     pub fn get_loads(&self) -> WorkerLoadResponse {
         let loads: Vec<SchedulerLoadSnapshot> = self
-            .inner
             .engines()
             .iter()
             .filter_map(|engine| {
                 let dp_rank = engine.engine_id.engine_index()?;
-                let stats = self.inner.scheduler_stats(dp_rank)?;
+                let load = self.engine_load(dp_rank)?;
                 Some(SchedulerLoadSnapshot {
                     dp_rank: i32::try_from(dp_rank).unwrap_or(i32::MAX),
-                    num_running_reqs: i32::try_from(stats.num_running_reqs).unwrap_or(i32::MAX),
-                    num_waiting_reqs: i32::try_from(stats.num_waiting_reqs).unwrap_or(i32::MAX),
-                    token_usage: stats.kv_cache_usage,
+                    num_running_reqs: i32::try_from(load.num_running).unwrap_or(i32::MAX),
+                    num_waiting_reqs: i32::try_from(load.num_waiting).unwrap_or(i32::MAX),
+                    token_usage: load.kv_cache_usage,
                     ..Default::default()
                 })
             })
@@ -127,11 +245,10 @@ impl ZmqEngineClient {
     }
 
     /// Model info derived from the handshake `EngineCoreReadyResponse` plus the
-    /// configured model id (EngineCore does not report tokenizer/vocab metadata,
+    /// configured model id (the engine does not report tokenizer/vocab metadata,
     /// so those come from worker config).
     pub fn get_model_info(&self) -> vllm::GetModelInfoResponse {
         let max_context_length = self
-            .inner
             .engines()
             .first()
             .map(|e| e.ready_response.max_model_len)
@@ -149,48 +266,43 @@ impl ZmqEngineClient {
     /// Server info derived from the handshake response.
     pub fn get_server_info(&self) -> vllm::GetServerInfoResponse {
         let data_parallel_size = self
-            .inner
             .engines()
             .first()
             .map(|e| e.ready_response.data_parallel_size)
             .unwrap_or(1);
+        let server_type = match &self.backend {
+            ZmqBackend::Vllm(_) => "vllm",
+            ZmqBackend::TokenSpeed(_) => "tokenspeed",
+        };
         vllm::GetServerInfoResponse {
             data_parallel_size: i32::try_from(data_parallel_size).unwrap_or(i32::MAX),
-            server_type: "vllm".to_string(),
+            server_type: server_type.to_string(),
             ..Default::default()
         }
     }
 }
 
-/// Streaming generate output, mapping each `EngineCoreOutput` to a vLLM-proto
-/// `GenerateResponse` (chunks until the terminal output, then a complete). The
-/// underlying [`EngineCoreStream`] auto-aborts on drop, so no explicit abort or
-/// `mark_completed` is required.
-pub struct ZmqGenerateStream {
-    inner: EngineCoreStream,
-    output_ids: Vec<u32>,
-    completion_tokens: u32,
-    prompt_tokens: u32,
-    cached_tokens: u32,
+/// Streaming generate output over ZMQ, presented as vLLM-proto
+/// `GenerateResponse`. One sub-stream per fanned-out engine request (n>1);
+/// they are polled together and yield as ready (interleaved), each tagging its
+/// responses with its choice `index`. The merged stream ends when every sub
+/// has delivered its terminal `Complete`. Dropping it before that aborts all
+/// still-running engine-side sub-requests, so no explicit abort or
+/// `mark_completed` is required. Which variant is active is fixed by the
+/// backend protocol chosen at connect time.
+pub enum ZmqGenerateStream {
+    /// vLLM EngineCore outputs.
+    Vllm(SelectAll<VllmGenerateStream>),
+    /// TokenSpeed outputs.
+    TokenSpeed(SelectAll<TokenSpeedGenerateStream>),
 }
 
 impl ZmqGenerateStream {
-    fn new(inner: EngineCoreStream) -> Self {
-        Self {
-            inner,
-            output_ids: Vec::new(),
-            completion_tokens: 0,
-            prompt_tokens: 0,
-            cached_tokens: 0,
-        }
-    }
-
     /// Next vLLM-proto response, or `None` when the stream ends.
     pub async fn next(&mut self) -> Option<Result<vllm::GenerateResponse, tonic::Status>> {
-        match self.inner.next().await {
-            Some(Ok(output)) => Some(Ok(self.map_output(output))),
-            Some(Err(error)) => Some(Err(zmq_status(error))),
-            None => None,
+        match self {
+            Self::Vllm(streams) => streams.next().await,
+            Self::TokenSpeed(streams) => streams.next().await,
         }
     }
 
@@ -198,33 +310,271 @@ impl ZmqGenerateStream {
     /// mark. Present for parity with the tonic abort-on-drop streams.
     #[expect(
         clippy::unused_self,
-        reason = "receiver kept for API parity with the tonic streams"
+        reason = "kept for API parity with the tonic abort-on-drop streams"
     )]
     pub fn mark_completed(&mut self) {}
+}
 
-    fn map_output(&mut self, output: EngineCoreOutput) -> vllm::GenerateResponse {
-        if let Some(stats) = &output.prefill_stats {
-            self.prompt_tokens = stats.num_prompt_tokens;
-            self.cached_tokens = stats.num_cached_tokens;
+/// Accumulated per-request token counts shared by both stream mappers.
+#[derive(Default)]
+struct StreamState {
+    output_ids: Vec<u32>,
+    completion_tokens: u32,
+    prompt_tokens: u32,
+    cached_tokens: u32,
+    /// Cumulative sampled-token logprobs across ticks. The proto contract is
+    /// incremental per streaming chunk but cumulative on the terminal
+    /// `Complete`, so accumulate here and drain into `Complete`.
+    output_logprobs_val: Vec<f32>,
+    output_logprobs_idx: Vec<u32>,
+}
+
+impl StreamState {
+    /// Cumulative sampled-token logprobs for the terminal `Complete`, drained
+    /// from the accumulated state (`None` when logprobs were not requested).
+    fn take_complete_logprobs(&mut self) -> Option<vllm::OutputLogProbs> {
+        (!self.output_logprobs_val.is_empty()).then(|| vllm::OutputLogProbs {
+            token_logprobs: std::mem::take(&mut self.output_logprobs_val),
+            token_ids: std::mem::take(&mut self.output_logprobs_idx),
+            ..Default::default()
+        })
+    }
+}
+
+/// Streaming generate output for one vLLM EngineCore sub-request, mapping each
+/// `EngineCoreOutput` to a vLLM-proto `GenerateResponse` (chunks until the
+/// terminal output, then a complete), tagged with this sub's choice `index`.
+pub struct VllmGenerateStream {
+    inner: EngineCoreStream,
+    state: StreamState,
+    /// Choice index stamped on every chunk/complete (0 for n=1; the fan-out
+    /// position for n>1) — the proto field the pipeline demuxes choices by.
+    index: u32,
+    /// Terminal `Complete` held back when the finish tick also carried new
+    /// tokens: streaming frontends decode text/logprobs from chunks only, so
+    /// the tick's delta goes out as a `Chunk` first.
+    pending: Option<vllm::GenerateResponse>,
+}
+
+impl VllmGenerateStream {
+    fn new(inner: EngineCoreStream, index: u32) -> Self {
+        Self {
+            inner,
+            state: StreamState::default(),
+            index,
+            pending: None,
         }
-        self.completion_tokens += output.new_token_ids.len() as u32;
-        self.output_ids.extend(output.new_token_ids.iter().copied());
+    }
+
+    fn map_output(
+        &mut self,
+        output: EngineCoreOutput,
+    ) -> Result<vllm::GenerateResponse, tonic::Status> {
+        let state = &mut self.state;
+        if let Some(stats) = &output.prefill_stats {
+            state.prompt_tokens = stats.num_prompt_tokens;
+            state.cached_tokens = stats.num_cached_tokens;
+        }
+        let token_ids = output.new_token_ids;
+        state.completion_tokens += token_ids.len() as u32;
+        state.output_ids.extend(token_ids.iter().copied());
+
+        // Sampled-token logprobs (entry 0 per position), if requested. Chunks
+        // carry this tick's increment; the terminal `Complete` carries the
+        // cumulative set, so accumulate into `state` and drain it on finish.
+        let mut tick_logprobs_val = Vec::new();
+        let mut tick_logprobs_idx = Vec::new();
+        if let Some(logprobs) = &output.new_logprobs {
+            let decoded = logprobs.as_direct().ok_or_else(|| {
+                // The protocol layer resolves wire logprobs during decode, so
+                // an unresolved payload here is a protocol bug — fail loudly.
+                tonic::Status::internal("unresolved wire logprobs in engine output")
+            })?;
+            for position in &decoded.positions {
+                if let Some(sampled) = position.entries.first() {
+                    tick_logprobs_val.push(sampled.logprob);
+                    tick_logprobs_idx.push(sampled.token_id);
+                }
+            }
+        }
+        let chunk_logprobs = (!tick_logprobs_val.is_empty()).then(|| vllm::OutputLogProbs {
+            token_logprobs: tick_logprobs_val.clone(),
+            token_ids: tick_logprobs_idx.clone(),
+            ..Default::default()
+        });
+        state.output_logprobs_val.extend(tick_logprobs_val);
+        state.output_logprobs_idx.extend(tick_logprobs_idx);
 
         let response = match output.finish_reason {
-            Some(reason) => vllm::generate_response::Response::Complete(vllm::GenerateComplete {
-                output_ids: std::mem::take(&mut self.output_ids),
-                finish_reason: finish_reason_str(reason).to_string(),
-                prompt_tokens: self.prompt_tokens,
-                completion_tokens: self.completion_tokens,
-                cached_tokens: self.cached_tokens,
-                matched_stop: output.stop_reason.map(map_matched_stop),
+            Some(reason) => {
+                let complete = vllm::GenerateResponse {
+                    response: Some(vllm::generate_response::Response::Complete(
+                        vllm::GenerateComplete {
+                            output_ids: std::mem::take(&mut state.output_ids),
+                            finish_reason: finish_reason_str(reason).to_string(),
+                            prompt_tokens: state.prompt_tokens,
+                            completion_tokens: state.completion_tokens,
+                            cached_tokens: state.cached_tokens,
+                            matched_stop: output.stop_reason.map(map_matched_stop),
+                            output_logprobs: state.take_complete_logprobs(),
+                            index: self.index,
+                            ..Default::default()
+                        },
+                    )),
+                };
+                if token_ids.is_empty() {
+                    return Ok(complete);
+                }
+                // The finish tick carried new tokens: emit them as a `Chunk`
+                // first and hold the `Complete` for the next poll.
+                let chunk = vllm::generate_response::Response::Chunk(vllm::GenerateStreamChunk {
+                    token_ids,
+                    prompt_tokens: state.prompt_tokens,
+                    completion_tokens: state.completion_tokens,
+                    cached_tokens: state.cached_tokens,
+                    output_logprobs: chunk_logprobs,
+                    index: self.index,
+                    ..Default::default()
+                });
+                self.pending = Some(complete);
+                chunk
+            }
+            None => vllm::generate_response::Response::Chunk(vllm::GenerateStreamChunk {
+                token_ids,
+                prompt_tokens: state.prompt_tokens,
+                completion_tokens: state.completion_tokens,
+                cached_tokens: state.cached_tokens,
+                output_logprobs: chunk_logprobs,
+                index: self.index,
                 ..Default::default()
             }),
+        };
+        Ok(vllm::GenerateResponse {
+            response: Some(response),
+        })
+    }
+}
+
+impl Stream for VllmGenerateStream {
+    type Item = Result<vllm::GenerateResponse, tonic::Status>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::task::Poll;
+        let this = self.get_mut();
+        if let Some(pending) = this.pending.take() {
+            return Poll::Ready(Some(Ok(pending)));
+        }
+        match std::pin::Pin::new(&mut this.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(output))) => Poll::Ready(Some(this.map_output(output))),
+            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(zmq_status(error)))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Streaming generate output for one TokenSpeed sub-request, mapping each
+/// `TokenSpeedOutput` to a vLLM-proto `GenerateResponse`, tagged with this
+/// sub's choice `index`.
+pub struct TokenSpeedGenerateStream {
+    inner: TokenSpeedStream,
+    state: StreamState,
+    /// Choice index stamped on every chunk/complete (0 for n=1; the fan-out
+    /// position for n>1) — the proto field the pipeline demuxes choices by.
+    index: u32,
+    /// Terminal `Complete` held back when the finish tick also carried new
+    /// tokens: streaming frontends decode text/logprobs from chunks only, so
+    /// the tick's delta goes out as a `Chunk` first.
+    pending: Option<vllm::GenerateResponse>,
+}
+
+impl TokenSpeedGenerateStream {
+    fn new(inner: TokenSpeedStream, index: u32) -> Self {
+        Self {
+            inner,
+            state: StreamState::default(),
+            index,
+            pending: None,
+        }
+    }
+
+    fn map_output(&mut self, output: TokenSpeedOutput) -> vllm::GenerateResponse {
+        let state = &mut self.state;
+        // TokenSpeed reports per-request token counts directly (cumulative for
+        // completions), rather than vLLM's per-output prefill-stats deltas.
+        if output.prompt_tokens > 0 {
+            state.prompt_tokens = output.prompt_tokens;
+        }
+        if output.cached_tokens > 0 {
+            state.cached_tokens = output.cached_tokens;
+        }
+        state.completion_tokens = output.completion_tokens;
+        state.output_ids.extend(output.output_ids.iter().copied());
+
+        // Sampled-token logprobs, if requested. The proto column is `float`, so
+        // downcast the wire's `f64` values. Chunks carry this tick's increment;
+        // the terminal `Complete` carries the cumulative set, so accumulate
+        // into `state` and drain it on finish.
+        let chunk_logprobs =
+            (!output.output_logprobs_val.is_empty()).then(|| vllm::OutputLogProbs {
+                token_logprobs: output
+                    .output_logprobs_val
+                    .iter()
+                    .map(|&lp| lp as f32)
+                    .collect(),
+                token_ids: output.output_logprobs_idx.clone(),
+                ..Default::default()
+            });
+        state
+            .output_logprobs_val
+            .extend(output.output_logprobs_val.iter().map(|&lp| lp as f32));
+        state
+            .output_logprobs_idx
+            .extend(output.output_logprobs_idx.iter().copied());
+
+        let response = match output.finish_reason {
+            Some(reason) => {
+                let complete = vllm::GenerateResponse {
+                    response: Some(vllm::generate_response::Response::Complete(
+                        vllm::GenerateComplete {
+                            output_ids: std::mem::take(&mut state.output_ids),
+                            finish_reason: normalize_finish_reason(&reason).to_string(),
+                            prompt_tokens: state.prompt_tokens,
+                            completion_tokens: state.completion_tokens,
+                            cached_tokens: state.cached_tokens,
+                            output_logprobs: state.take_complete_logprobs(),
+                            index: self.index,
+                            ..Default::default()
+                        },
+                    )),
+                };
+                if output.output_ids.is_empty() {
+                    return complete;
+                }
+                // The finish tick carried new tokens: emit them as a `Chunk`
+                // first and hold the `Complete` for the next poll.
+                let chunk = vllm::generate_response::Response::Chunk(vllm::GenerateStreamChunk {
+                    token_ids: output.output_ids,
+                    prompt_tokens: state.prompt_tokens,
+                    completion_tokens: state.completion_tokens,
+                    cached_tokens: state.cached_tokens,
+                    output_logprobs: chunk_logprobs,
+                    index: self.index,
+                    ..Default::default()
+                });
+                self.pending = Some(complete);
+                chunk
+            }
             None => vllm::generate_response::Response::Chunk(vllm::GenerateStreamChunk {
-                token_ids: output.new_token_ids,
-                prompt_tokens: self.prompt_tokens,
-                completion_tokens: self.completion_tokens,
-                cached_tokens: self.cached_tokens,
+                token_ids: output.output_ids,
+                prompt_tokens: state.prompt_tokens,
+                completion_tokens: state.completion_tokens,
+                cached_tokens: state.cached_tokens,
+                output_logprobs: chunk_logprobs,
+                index: self.index,
                 ..Default::default()
             }),
         };
@@ -232,6 +582,191 @@ impl ZmqGenerateStream {
             response: Some(response),
         }
     }
+}
+
+impl Stream for TokenSpeedGenerateStream {
+    type Item = Result<vllm::GenerateResponse, tonic::Status>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        use std::task::Poll;
+        let this = self.get_mut();
+        if let Some(pending) = this.pending.take() {
+            return Poll::Ready(Some(Ok(pending)));
+        }
+        match std::pin::Pin::new(&mut this.inner).poll_next(cx) {
+            Poll::Ready(Some(Ok(output))) => Poll::Ready(Some(Ok(this.map_output(output)))),
+            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(zmq_status(error)))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Split an `n > 1` generate request into `n` independent single-sample wire
+/// requests (an `n <= 1` request passes through untouched).
+///
+/// - Rids: sub `i` is `"{request_id}-{i}"` — engine-side rids must be unique,
+///   and the pipeline's request id is already unique per request, so the
+///   suffixed forms are too. Dropping the merged stream aborts every sub.
+/// - Seeds: with no explicit seed each sub keeps `None` — the engine seeds each
+///   rid independently, so the samples differ. An explicit seed becomes
+///   `seed + i` per sub: a fixed seed with identical params would otherwise
+///   make all n samples identical, and deriving distinct per-sample seeds from
+///   the request seed is the established engine convention (each of the n
+///   sequences gets its own sampler state for exactly this reason) while
+///   staying deterministic for repeat runs.
+/// - Usage: every sub reports the full `prompt_tokens` on its `Complete` (the
+///   subs share one prompt), matching the gRPC engines' n>1 contract — the
+///   pipeline de-duplicates (max per prompt), so nothing is counted n times.
+fn fan_out_requests(req: vllm::GenerateRequest) -> Vec<vllm::GenerateRequest> {
+    let n = req.sampling_params.as_ref().map_or(1, |sp| sp.n.max(1));
+    if n <= 1 {
+        return vec![req];
+    }
+    (0..n)
+        .map(|i| {
+            let mut sub = req.clone();
+            sub.request_id = format!("{}-{i}", req.request_id);
+            if let Some(sp) = sub.sampling_params.as_mut() {
+                sp.n = 1;
+                sp.seed = sp.seed.map(|seed| seed.wrapping_add(i as i32));
+            }
+            sub
+        })
+        .collect()
+}
+
+/// Translate a vLLM-proto generate request into a TokenSpeed
+/// `TokenizedGenerateReqInput`. ZMQ mode requires pre-tokenized input (SMG
+/// tokenizes upstream).
+fn translate_request_tokenspeed(
+    req: vllm::GenerateRequest,
+) -> Result<TokenizedGenerateReqInput, String> {
+    let input_ids = match req.input {
+        Some(vllm::generate_request::Input::Tokenized(tokenized)) => tokenized.input_ids,
+        Some(vllm::generate_request::Input::Text(_)) => {
+            return Err("ZMQ mode requires pre-tokenized input (TokenizedInput)".to_string());
+        }
+        None => {
+            return Err("ZMQ mode requires pre-tokenized input; no input provided".to_string());
+        }
+    };
+    let stream = req.stream;
+    // Single-engine TokenSpeed: a pinned DP rank other than 0 cannot be honored.
+    if req.data_parallel_rank.is_some_and(|rank| rank != 0) {
+        return Err(format!(
+            "invalid data_parallel_rank {:?}: the TokenSpeed ZMQ backend is single-engine",
+            req.data_parallel_rank
+        ));
+    }
+    // TokenSpeed returns only the single sampled-token logprob per token
+    // (`top_logprobs_num = 0` on its wire) and no prompt logprobs. The vLLM
+    // sampling `logprobs` field is a count: the chat frontend maps a bare
+    // `logprobs: true` to `1` and `top_logprobs = k` to `k`, so a count above 1
+    // (or `-1` = "all") is a top-k request that cannot be honored — reject it
+    // rather than silently return fewer. Counts of 0 or 1 are the plain
+    // sampled-token logprob and are wired end-to-end. Note the flip side: at
+    // this proto boundary a chat `top_logprobs: 1` is indistinguishable from a
+    // bare `logprobs: true` (both arrive as count 1), so it is accepted and its
+    // `top_logprobs` list simply stays empty.
+    if let Some(sp) = req.sampling_params.as_ref() {
+        if sp.logprobs.is_some_and(|n| !(0..=1).contains(&n)) {
+            return Err(
+                "top_logprobs are not supported over the TokenSpeed ZMQ backend".to_string(),
+            );
+        }
+        if sp.prompt_logprobs.is_some() {
+            return Err(
+                "prompt logprobs are not supported over the TokenSpeed ZMQ backend".to_string(),
+            );
+        }
+        // The response_format / forced-tool-choice constraint oneof is not
+        // translated onto the TokenSpeed structured-output fields yet; dropping
+        // it would return unconstrained text.
+        if sp.constraint.is_some() {
+            return Err(
+                "structured output constraints are not supported over the ZMQ backend yet"
+                    .to_string(),
+            );
+        }
+        // The TokenSpeed wire has no per-sample demux; n>1 is fanned out into
+        // single-sample sub-requests by `generate` before translation.
+        // Stop strings are not forwarded: the direct ZMQ path sends token ids
+        // only (the engine-side transport normalizes without a tokenizer) and
+        // the gateway's stop decoder does not enforce them, so they would be
+        // ignored and the request would run to max_tokens.
+        if !sp.stop.is_empty() {
+            return Err(
+                "stop strings are not supported over the TokenSpeed ZMQ backend yet; \
+                 use stop_token_ids"
+                    .to_string(),
+            );
+        }
+        // logit_bias is not translated onto the TokenSpeed wire either.
+        if !sp.logit_bias.is_empty() {
+            return Err("logit_bias is not supported over the TokenSpeed ZMQ backend".to_string());
+        }
+    }
+    let return_logprob = req
+        .sampling_params
+        .as_ref()
+        .is_some_and(|sp| sp.logprobs.is_some());
+    Ok(TokenizedGenerateReqInput {
+        rid: req.request_id,
+        input_ids,
+        sampling_params: req
+            .sampling_params
+            .map(translate_sampling_tokenspeed)
+            .unwrap_or_else(|| {
+                let mut params = TokenSpeedSamplingParams::default();
+                params.normalize();
+                params
+            }),
+        return_logprob,
+        stream,
+        // Every other field keeps its neutral default (the fields after
+        // `stream` are not even emitted; the engine fills them from defaults).
+        ..TokenizedGenerateReqInput::default()
+    })
+}
+
+/// Map vLLM-proto sampling params onto TokenSpeed's native `SamplingParams`,
+/// in the normalized form: the engine skips its decode-time re-derivation once
+/// `is_normalized` is set, so [`TokenSpeedSamplingParams::normalize`] resolves
+/// the derived fields (top_k sentinel, greedy collapse) before encoding.
+fn translate_sampling_tokenspeed(sp: vllm::SamplingParams) -> TokenSpeedSamplingParams {
+    let mut params = TokenSpeedSamplingParams {
+        max_new_tokens: sp.max_tokens,
+        stop_token_ids: (!sp.stop_token_ids.is_empty()).then_some(sp.stop_token_ids),
+        temperature: f64::from(sp.temperature.unwrap_or(1.0)),
+        top_p: f64::from(sp.top_p),
+        // vLLM proto uses `0` for "all tokens"; TokenSpeed's API form is `-1`
+        // (`normalize` resolves it to the engine's disabled sentinel).
+        top_k: if sp.top_k == 0 {
+            -1
+        } else {
+            i32::try_from(sp.top_k).unwrap_or(-1)
+        },
+        min_p: f64::from(sp.min_p),
+        frequency_penalty: f64::from(sp.frequency_penalty),
+        presence_penalty: f64::from(sp.presence_penalty),
+        repetition_penalty: f64::from(sp.repetition_penalty),
+        min_new_tokens: sp.min_tokens,
+        ignore_eos: sp.ignore_eos,
+        // A negative seed is a "no seed" sentinel; drop it rather than wrap
+        // (the engine then derives a per-rid seed).
+        seed: sp.seed.and_then(|seed| u64::try_from(seed).ok()),
+        // Proto `0` means unspecified; TokenSpeed expects at least one sample.
+        // The engine stores n without acting on it — n>1 is fanned out before
+        // translation, so this is always 1 on the wire.
+        n: sp.n.max(1),
+        ..TokenSpeedSamplingParams::default()
+    };
+    params.normalize();
+    params
 }
 
 /// Translate a vLLM-proto generate request into an `EngineCoreRequest`. ZMQ mode
@@ -250,6 +785,24 @@ fn translate_request(req: vllm::GenerateRequest) -> Result<EngineCoreRequest, St
         .data_parallel_rank
         .map(|rank| u32::try_from(rank).map_err(|_| format!("invalid data_parallel_rank: {rank}")))
         .transpose()?;
+    if let Some(sp) = req.sampling_params.as_ref() {
+        // The response_format / forced-tool-choice constraint oneof is not
+        // translated onto the EngineCore wire yet; dropping it would return
+        // unconstrained text.
+        if sp.constraint.is_some() {
+            return Err(
+                "structured output constraints are not supported over the ZMQ backend yet"
+                    .to_string(),
+            );
+        }
+        // n is not carried on the EngineCore wire; n>1 is fanned out into
+        // single-sample sub-requests by `generate` before translation.
+        // The ZMQ renderer path has no prompt-logprob merge, so the engine's
+        // prompt logprobs would be computed and then dropped.
+        if sp.prompt_logprobs.is_some() {
+            return Err("prompt logprobs are not supported over the ZMQ backend".to_string());
+        }
+    }
     Ok(EngineCoreRequest {
         request_id: req.request_id,
         prompt_token_ids,
@@ -292,7 +845,8 @@ fn translate_sampling(sp: vllm::SamplingParams) -> EngineCoreSamplingParams {
         stop_token_ids: sp.stop_token_ids,
         seed: sp.seed.map(i64::from),
         logprobs: sp.logprobs,
-        prompt_logprobs: sp.prompt_logprobs,
+        // prompt_logprobs is rejected in `translate_request` (no renderer
+        // support on the ZMQ path), so it is never forwarded.
         logit_bias,
         ..EngineCoreSamplingParams::default()
     }
@@ -314,6 +868,27 @@ fn finish_reason_str(reason: EngineCoreFinishReason) -> &'static str {
     }
 }
 
+/// Normalize a TokenSpeed wire finish-reason string into the canonical set the
+/// gateway's response layer exact-matches (`stop`, `length`, `abort`, `error`) —
+/// the same set the vLLM path emits via [`finish_reason_str`]. TokenSpeed emits
+/// `stop`/`length`/`abort`; an unknown value falls back to `stop` with a warning
+/// so a non-canonical string never mis-renders downstream.
+fn normalize_finish_reason(reason: &str) -> &'static str {
+    match reason {
+        "stop" => "stop",
+        "length" => "length",
+        "abort" => "abort",
+        "error" => "error",
+        other => {
+            tracing::warn!(
+                finish_reason = other,
+                "unknown TokenSpeed finish_reason; defaulting to \"stop\""
+            );
+            "stop"
+        }
+    }
+}
+
 fn now_secs() -> f64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -332,7 +907,10 @@ fn zmq_status(error: engine_zmq_client::Error) -> tonic::Status {
 mod tests {
     use engine_zmq_client::{
         mock_engine::{connect_to_frontend, default_ready_response, EngineInbound},
-        protocol::vllm::output::{EngineCoreOutputs, RequestBatchOutputs},
+        protocol::vllm::{
+            logprobs::{Logprobs, MaybeWireLogprobs, PositionLogprobs, TokenLogprob},
+            output::{EngineCoreOutputs, RequestBatchOutputs},
+        },
         EngineId,
     };
 
@@ -341,14 +919,27 @@ mod tests {
     fn batch(
         request_id: &str,
         token: u32,
+        logprob: Option<f32>,
         finish: Option<EngineCoreFinishReason>,
     ) -> EngineCoreOutputs {
         let finished = finish.map(|_| std::collections::BTreeSet::from([request_id.to_string()]));
+        let new_logprobs = logprob.map(|lp| {
+            MaybeWireLogprobs::Direct(Logprobs {
+                positions: vec![PositionLogprobs {
+                    entries: vec![TokenLogprob {
+                        token_id: token,
+                        logprob: lp,
+                        rank: 1,
+                    }],
+                }],
+            })
+        });
         EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
             engine_index: 0,
             outputs: vec![EngineCoreOutput {
                 request_id: request_id.to_string(),
                 new_token_ids: vec![token],
+                new_logprobs,
                 finish_reason: finish,
                 ..Default::default()
             }],
@@ -372,6 +963,7 @@ mod tests {
                 &output,
                 1,
                 "m".to_string(),
+                RuntimeType::Vllm,
                 Duration::from_secs(10)
             ),
             connect_to_frontend(
@@ -397,9 +989,17 @@ mod tests {
             assert_eq!(request.request_id, "r1");
             assert_eq!(request.prompt_token_ids, Some(vec![1, 2, 3]));
             assert_eq!(request.sampling_params.as_ref().unwrap().max_tokens, 2);
-            output.send_outputs(&batch("r1", 10, None)).await.unwrap();
             output
-                .send_outputs(&batch("r1", 11, Some(EngineCoreFinishReason::Length)))
+                .send_outputs(&batch("r1", 10, Some(-0.5), None))
+                .await
+                .unwrap();
+            output
+                .send_outputs(&batch(
+                    "r1",
+                    11,
+                    Some(-1.25),
+                    Some(EngineCoreFinishReason::Length),
+                ))
                 .await
                 .unwrap();
         });
@@ -414,6 +1014,7 @@ mod tests {
             )),
             sampling_params: Some(vllm::SamplingParams {
                 max_tokens: Some(2),
+                logprobs: Some(1),
                 ..Default::default()
             }),
             stream: true,
@@ -425,19 +1026,191 @@ mod tests {
         match first.response {
             Some(vllm::generate_response::Response::Chunk(chunk)) => {
                 assert_eq!(chunk.token_ids, vec![10]);
+                let logprobs = chunk.output_logprobs.expect("chunk logprobs");
+                assert_eq!(logprobs.token_logprobs, vec![-0.5]);
+                assert_eq!(logprobs.token_ids, vec![10]);
             }
             other => panic!("expected chunk, got {other:?}"),
         }
-        let second = stream
+        // The finish tick carried a new token, so its delta is emitted as a
+        // chunk before the (cumulative) terminal complete.
+        let second = stream.next().await.expect("chunk item").expect("chunk ok");
+        match second.response {
+            Some(vllm::generate_response::Response::Chunk(chunk)) => {
+                assert_eq!(chunk.token_ids, vec![11]);
+                let logprobs = chunk.output_logprobs.expect("chunk logprobs");
+                assert_eq!(logprobs.token_logprobs, vec![-1.25]);
+                assert_eq!(logprobs.token_ids, vec![11]);
+            }
+            other => panic!("expected chunk, got {other:?}"),
+        }
+        let third = stream
             .next()
             .await
             .expect("complete item")
             .expect("complete ok");
-        match second.response {
+        match third.response {
             Some(vllm::generate_response::Response::Complete(complete)) => {
                 assert_eq!(complete.output_ids, vec![10, 11]);
                 assert_eq!(complete.finish_reason, "length");
                 assert_eq!(complete.completion_tokens, 2);
+                let logprobs = complete.output_logprobs.expect("complete logprobs");
+                assert_eq!(logprobs.token_logprobs, vec![-0.5, -1.25]);
+                assert_eq!(logprobs.token_ids, vec![10, 11]);
+            }
+            other => panic!("expected complete, got {other:?}"),
+        }
+        assert!(stream.next().await.is_none());
+
+        engine_task.await.unwrap();
+    }
+
+    /// End-to-end over ipc:// for a TokenSpeed backend: the adapter frames a
+    /// tagged `TokenizedGenerateReqInput`, and maps `BatchTokenIDOutSlim`
+    /// batches back to vLLM-proto responses. The mock engine speaks the shared
+    /// transport with raw frames (it decodes/encodes the TokenSpeed structs
+    /// directly).
+    #[tokio::test]
+    async fn generate_e2e_translates_and_streams_tokenspeed() {
+        use engine_zmq_client::{
+            codec::{decode_msgpack, encode_msgpack},
+            protocol::tokenspeed::{
+                output::BatchTokenIDOutSlim,
+                request::{TokenSpeedRequestType, TokenizedGenerateReqInput},
+            },
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let ep = |name: &str| format!("ipc://{}", dir.path().join(name).display());
+        let (handshake, input, output) = (ep("hs.sock"), ep("in.sock"), ep("out.sock"));
+
+        let (client, engine) = tokio::join!(
+            ZmqEngineClient::connect(
+                &handshake,
+                &input,
+                &output,
+                1,
+                "m".to_string(),
+                RuntimeType::TokenSpeed,
+                Duration::from_secs(10)
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let client = client.expect("adapter connect");
+        let engine = engine.expect("mock engine");
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "engine task ends after responding"
+        )]
+        let engine_task = tokio::spawn(async move {
+            let (mut input, mut output) = engine.split();
+            let frames = input.recv_frames().await.unwrap();
+            assert_eq!(
+                TokenSpeedRequestType::from_frame(frames[0].as_ref()),
+                Some(TokenSpeedRequestType::Add)
+            );
+            let request: TokenizedGenerateReqInput = decode_msgpack(frames[1].as_ref()).unwrap();
+            assert_eq!(request.rid, "r1");
+            assert_eq!(request.input_ids, vec![1, 2, 3]);
+            assert_eq!(request.sampling_params.max_new_tokens, Some(2));
+            // The adapter always emits the normalized sampling form.
+            assert!(request.sampling_params.is_normalized);
+            // A plain sampled-token logprob request (logprobs=1) sets the flag.
+            assert!(request.return_logprob);
+
+            let chunk = BatchTokenIDOutSlim {
+                rids: vec!["r1".into()],
+                output_ids: vec![vec![10]],
+                finished_reasons: vec![String::new()],
+                prompt_tokens: vec![3],
+                completion_tokens: vec![1],
+                cached_tokens: vec![0],
+                output_token_logprobs_val: vec![vec![-0.5]],
+                output_token_logprobs_idx: vec![vec![10]],
+            };
+            let done = BatchTokenIDOutSlim {
+                rids: vec!["r1".into()],
+                output_ids: vec![vec![11]],
+                finished_reasons: vec!["length".into()],
+                prompt_tokens: vec![3],
+                completion_tokens: vec![2],
+                cached_tokens: vec![0],
+                output_token_logprobs_val: vec![vec![-1.25]],
+                output_token_logprobs_idx: vec![vec![11]],
+            };
+            output
+                .send_frames(vec![bytes::Bytes::from(encode_msgpack(&chunk).unwrap())])
+                .await
+                .unwrap();
+            output
+                .send_frames(vec![bytes::Bytes::from(encode_msgpack(&done).unwrap())])
+                .await
+                .unwrap();
+        });
+
+        let req = vllm::GenerateRequest {
+            request_id: "r1".to_string(),
+            input: Some(vllm::generate_request::Input::Tokenized(
+                vllm::TokenizedInput {
+                    original_text: String::new(),
+                    input_ids: vec![1, 2, 3],
+                },
+            )),
+            sampling_params: Some(vllm::SamplingParams {
+                max_tokens: Some(2),
+                // Plain sampled-token logprob (count 1); must be wired through.
+                logprobs: Some(1),
+                ..Default::default()
+            }),
+            stream: true,
+            ..Default::default()
+        };
+        let mut stream = client.generate(req).await.expect("generate");
+
+        let first = stream.next().await.expect("chunk item").expect("chunk ok");
+        match first.response {
+            Some(vllm::generate_response::Response::Chunk(chunk)) => {
+                assert_eq!(chunk.token_ids, vec![10]);
+                assert_eq!(chunk.prompt_tokens, 3);
+                let logprobs = chunk.output_logprobs.expect("chunk logprobs");
+                assert_eq!(logprobs.token_logprobs, vec![-0.5]);
+                assert_eq!(logprobs.token_ids, vec![10]);
+            }
+            other => panic!("expected chunk, got {other:?}"),
+        }
+        // The finish tick carried a new token, so its delta is emitted as a
+        // chunk before the (cumulative) terminal complete.
+        let second = stream.next().await.expect("chunk item").expect("chunk ok");
+        match second.response {
+            Some(vllm::generate_response::Response::Chunk(chunk)) => {
+                assert_eq!(chunk.token_ids, vec![11]);
+                let logprobs = chunk.output_logprobs.expect("chunk logprobs");
+                assert_eq!(logprobs.token_logprobs, vec![-1.25]);
+                assert_eq!(logprobs.token_ids, vec![11]);
+            }
+            other => panic!("expected chunk, got {other:?}"),
+        }
+        let third = stream
+            .next()
+            .await
+            .expect("complete item")
+            .expect("complete ok");
+        match third.response {
+            Some(vllm::generate_response::Response::Complete(complete)) => {
+                assert_eq!(complete.output_ids, vec![10, 11]);
+                assert_eq!(complete.finish_reason, "length");
+                assert_eq!(complete.completion_tokens, 2);
+                // Chunks carry the tick's incremental logprobs; the terminal
+                // `Complete` carries the cumulative set, parallel to `output_ids`
+                // (the non-streaming renderer reads only the `Complete`).
+                let logprobs = complete.output_logprobs.expect("complete logprobs");
+                assert_eq!(logprobs.token_logprobs, vec![-0.5, -1.25]);
+                assert_eq!(logprobs.token_ids, vec![10, 11]);
             }
             other => panic!("expected complete, got {other:?}"),
         }
@@ -454,5 +1227,479 @@ mod tests {
             "stop"
         );
         assert_eq!(finish_reason_str(EngineCoreFinishReason::Abort), "abort");
+    }
+
+    #[test]
+    fn tokenspeed_sampling_maps_top_k_sentinel_and_seed() {
+        use engine_zmq_client::protocol::tokenspeed::sampling::TOP_K_DISABLED;
+
+        // Proto top_k=0 ("all tokens") normalizes to the engine's disabled
+        // sentinel; negative seed dropped; n floored to 1.
+        let mapped = translate_sampling_tokenspeed(vllm::SamplingParams {
+            top_k: 0,
+            n: 0,
+            seed: Some(-1),
+            max_tokens: Some(8),
+            ..Default::default()
+        });
+        assert_eq!(mapped.top_k, TOP_K_DISABLED);
+        assert_eq!(mapped.n, 1);
+        assert_eq!(mapped.seed, None);
+        assert_eq!(mapped.max_new_tokens, Some(8));
+        // The wire form is always normalized (the engine skips re-derivation).
+        assert!(mapped.is_normalized);
+
+        let mapped = translate_sampling_tokenspeed(vllm::SamplingParams {
+            top_k: 40,
+            seed: Some(7),
+            ..Default::default()
+        });
+        assert_eq!(mapped.top_k, 40);
+        assert_eq!(mapped.seed, Some(7));
+
+        // A near-zero temperature collapses to greedy on the wire.
+        let mapped = translate_sampling_tokenspeed(vllm::SamplingParams {
+            temperature: Some(0.0),
+            ..Default::default()
+        });
+        assert_eq!(mapped.temperature, 1.0);
+        assert_eq!(mapped.top_k, 1);
+
+        // Empty stop_token_ids ride as None (the normalized encoding).
+        let mapped = translate_sampling_tokenspeed(vllm::SamplingParams::default());
+        assert_eq!(mapped.stop_token_ids, None);
+    }
+
+    fn tokenized_req(sampling: vllm::SamplingParams) -> vllm::GenerateRequest {
+        vllm::GenerateRequest {
+            request_id: "r1".to_string(),
+            input: Some(vllm::generate_request::Input::Tokenized(
+                vllm::TokenizedInput {
+                    original_text: String::new(),
+                    input_ids: vec![1, 2, 3],
+                },
+            )),
+            sampling_params: Some(sampling),
+            stream: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn tokenspeed_plain_logprobs_set_return_logprob() {
+        // Counts 0 and 1 are the plain sampled-token case; both accepted.
+        for count in [0, 1] {
+            let req = translate_request_tokenspeed(tokenized_req(vllm::SamplingParams {
+                logprobs: Some(count),
+                ..Default::default()
+            }))
+            .expect("plain logprobs accepted");
+            assert!(req.return_logprob);
+        }
+
+        // No logprobs -> the flag stays false.
+        let req = translate_request_tokenspeed(tokenized_req(vllm::SamplingParams::default()))
+            .expect("no logprobs accepted");
+        assert!(!req.return_logprob);
+    }
+
+    #[test]
+    fn tokenspeed_rejects_top_k_and_prompt_logprobs() {
+        // Top-k (count > 1) cannot be honored.
+        assert!(
+            translate_request_tokenspeed(tokenized_req(vllm::SamplingParams {
+                logprobs: Some(5),
+                ..Default::default()
+            }))
+            .is_err()
+        );
+        // "all" (count -1) cannot be honored.
+        assert!(
+            translate_request_tokenspeed(tokenized_req(vllm::SamplingParams {
+                logprobs: Some(-1),
+                ..Default::default()
+            }))
+            .is_err()
+        );
+        // Prompt logprobs cannot be produced.
+        assert!(
+            translate_request_tokenspeed(tokenized_req(vllm::SamplingParams {
+                prompt_logprobs: Some(1),
+                ..Default::default()
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn tokenspeed_rejects_unsupported_sampling_features() {
+        // Structured-output constraints have no TokenSpeed wire slot.
+        let err = translate_request_tokenspeed(tokenized_req(vllm::SamplingParams {
+            constraint: Some(vllm::sampling_params::Constraint::JsonObject(true)),
+            ..Default::default()
+        }))
+        .expect_err("constraint rejected");
+        assert!(err.contains("structured output"), "{err}");
+
+        // Stop strings have no wire slot and are not enforced by the gateway.
+        let err = translate_request_tokenspeed(tokenized_req(vllm::SamplingParams {
+            stop: vec!["</s>".to_string()],
+            ..Default::default()
+        }))
+        .expect_err("stop strings rejected");
+        assert!(err.contains("stop_token_ids"), "{err}");
+
+        // logit_bias has no wire slot.
+        let err = translate_request_tokenspeed(tokenized_req(vllm::SamplingParams {
+            logit_bias: HashMap::from([(7, 1.0)]),
+            ..Default::default()
+        }))
+        .expect_err("logit_bias rejected");
+        assert!(err.contains("logit_bias"), "{err}");
+    }
+
+    #[test]
+    fn tokenspeed_rejects_nonzero_dp_rank() {
+        // Single-engine backend: only rank 0 (or none) is valid.
+        let mut req = tokenized_req(vllm::SamplingParams::default());
+        req.data_parallel_rank = Some(1);
+        assert!(translate_request_tokenspeed(req).is_err());
+
+        let mut req = tokenized_req(vllm::SamplingParams::default());
+        req.data_parallel_rank = Some(0);
+        assert!(translate_request_tokenspeed(req).is_ok());
+    }
+
+    #[test]
+    fn vllm_rejects_unsupported_sampling_features() {
+        // Structured-output constraints are not translated onto the wire.
+        let err = translate_request(tokenized_req(vllm::SamplingParams {
+            constraint: Some(vllm::sampling_params::Constraint::JsonObject(true)),
+            ..Default::default()
+        }))
+        .expect_err("constraint rejected");
+        assert!(err.contains("structured output"), "{err}");
+
+        // Prompt logprobs have no renderer merge on the ZMQ path.
+        let err = translate_request(tokenized_req(vllm::SamplingParams {
+            prompt_logprobs: Some(1),
+            ..Default::default()
+        }))
+        .expect_err("prompt logprobs rejected");
+        assert!(err.contains("prompt logprobs"), "{err}");
+    }
+
+    /// n=3 fans out into 3 single-sample wire requests with unique sub-rids.
+    /// An explicit seed derives per-sub seeds (`seed + i`) so the samples
+    /// differ deterministically; no seed stays `None` per sub (the engine
+    /// seeds each rid independently).
+    #[test]
+    fn fan_out_splits_n_into_single_sample_requests() {
+        let mut req = tokenized_req(vllm::SamplingParams {
+            n: 3,
+            seed: Some(7),
+            ..Default::default()
+        });
+        req.request_id = "r1".to_string();
+
+        let subs = fan_out_requests(req);
+        assert_eq!(subs.len(), 3);
+        let rids: Vec<&str> = subs.iter().map(|sub| sub.request_id.as_str()).collect();
+        assert_eq!(rids, vec!["r1-0", "r1-1", "r1-2"]);
+        for (i, sub) in subs.iter().enumerate() {
+            let sp = sub.sampling_params.as_ref().unwrap();
+            assert_eq!(sp.n, 1);
+            assert_eq!(sp.seed, Some(7 + i as i32));
+            // Everything else is shared verbatim.
+            assert_eq!(
+                sub.input,
+                Some(vllm::generate_request::Input::Tokenized(
+                    vllm::TokenizedInput {
+                        original_text: String::new(),
+                        input_ids: vec![1, 2, 3],
+                    }
+                ))
+            );
+        }
+
+        // No explicit seed: every sub keeps None.
+        let subs = fan_out_requests(tokenized_req(vllm::SamplingParams {
+            n: 2,
+            ..Default::default()
+        }));
+        assert!(subs
+            .iter()
+            .all(|sub| sub.sampling_params.as_ref().unwrap().seed.is_none()));
+
+        // n<=1 passes through untouched (rid keeps its original form).
+        let single = fan_out_requests(tokenized_req(vllm::SamplingParams::default()));
+        assert_eq!(single.len(), 1);
+        assert_eq!(single[0].request_id, "r1");
+    }
+
+    /// n=2 over a vLLM EngineCore: two engine-side requests with distinct
+    /// sub-rids, and the merged stream yields two `Complete`s tagged with the
+    /// proto `index` (0 and 1) the pipeline demuxes choices by.
+    #[tokio::test]
+    async fn generate_e2e_fans_out_n2_vllm() {
+        let dir = tempfile::tempdir().unwrap();
+        let ep = |name: &str| format!("ipc://{}", dir.path().join(name).display());
+        let (handshake, input, output) = (ep("hs.sock"), ep("in.sock"), ep("out.sock"));
+
+        let (client, engine) = tokio::join!(
+            ZmqEngineClient::connect(
+                &handshake,
+                &input,
+                &output,
+                1,
+                "m".to_string(),
+                RuntimeType::Vllm,
+                Duration::from_secs(10)
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let client = client.expect("adapter connect");
+        let engine = engine.expect("mock engine");
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "engine task ends after responding"
+        )]
+        let engine_task = tokio::spawn(async move {
+            let (mut input, mut output) = engine.split();
+            let mut rids = Vec::new();
+            for _ in 0..2 {
+                let request = match input.recv().await.unwrap() {
+                    EngineInbound::Add(request) => request,
+                    other => panic!("expected Add, got {other:?}"),
+                };
+                // Each sub is a single-sample request with a derived seed.
+                let sp = request.sampling_params.as_ref().unwrap();
+                assert_eq!(sp.max_tokens, 4);
+                rids.push((request.request_id.clone(), sp.seed));
+            }
+            assert_eq!(
+                rids,
+                vec![("r1-0".to_string(), Some(5)), ("r1-1".to_string(), Some(6))],
+                "sub-rids must be unique and seeds derived per sub"
+            );
+            output
+                .send_outputs(&batch("r1-0", 10, None, Some(EngineCoreFinishReason::Stop)))
+                .await
+                .unwrap();
+            output
+                .send_outputs(&batch("r1-1", 11, None, Some(EngineCoreFinishReason::Stop)))
+                .await
+                .unwrap();
+        });
+
+        let mut req = tokenized_req(vllm::SamplingParams {
+            n: 2,
+            seed: Some(5),
+            max_tokens: Some(4),
+            ..Default::default()
+        });
+        req.request_id = "r1".to_string();
+        let mut stream = client.generate(req).await.expect("generate");
+
+        let mut completes = Vec::new();
+        while let Some(item) = stream.next().await {
+            match item.expect("stream item").response {
+                Some(vllm::generate_response::Response::Complete(complete)) => {
+                    completes.push(complete);
+                }
+                Some(vllm::generate_response::Response::Chunk(_)) | None => {}
+            }
+        }
+        completes.sort_by_key(|complete| complete.index);
+        assert_eq!(completes.len(), 2, "one Complete per fanned-out sub");
+        assert_eq!(completes[0].index, 0);
+        assert_eq!(completes[0].output_ids, vec![10]);
+        assert_eq!(completes[1].index, 1);
+        assert_eq!(completes[1].output_ids, vec![11]);
+
+        engine_task.await.unwrap();
+    }
+
+    /// n=2 over TokenSpeed: two engine-side requests with distinct sub-rids
+    /// (delivered in one wire batch), two indexed `Complete`s, and the shared
+    /// prompt reported in full on each (the pipeline de-duplicates via max, so
+    /// prompt tokens are not counted n times).
+    #[tokio::test]
+    async fn generate_e2e_fans_out_n2_tokenspeed() {
+        use engine_zmq_client::{
+            codec::{decode_msgpack, encode_msgpack},
+            protocol::tokenspeed::{
+                output::BatchTokenIDOutSlim,
+                request::{TokenSpeedRequestType, TokenizedGenerateReqInput},
+            },
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let ep = |name: &str| format!("ipc://{}", dir.path().join(name).display());
+        let (handshake, input, output) = (ep("hs.sock"), ep("in.sock"), ep("out.sock"));
+
+        let (client, engine) = tokio::join!(
+            ZmqEngineClient::connect(
+                &handshake,
+                &input,
+                &output,
+                1,
+                "m".to_string(),
+                RuntimeType::TokenSpeed,
+                Duration::from_secs(10)
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let client = client.expect("adapter connect");
+        let engine = engine.expect("mock engine");
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "engine task ends after responding"
+        )]
+        let engine_task = tokio::spawn(async move {
+            let (mut input, mut output) = engine.split();
+            let mut rids = Vec::new();
+            for _ in 0..2 {
+                let frames = input.recv_frames().await.unwrap();
+                assert_eq!(
+                    TokenSpeedRequestType::from_frame(frames[0].as_ref()),
+                    Some(TokenSpeedRequestType::Add)
+                );
+                let request: TokenizedGenerateReqInput =
+                    decode_msgpack(frames[1].as_ref()).unwrap();
+                assert_eq!(request.sampling_params.n, 1);
+                rids.push((request.rid.clone(), request.sampling_params.seed));
+            }
+            assert_eq!(
+                rids,
+                vec![("r1-0".to_string(), Some(5)), ("r1-1".to_string(), Some(6))],
+                "sub-rids must be unique and seeds derived per sub"
+            );
+            // Both subs finish in one wire batch (the batch demux fans them
+            // back out to their sub-streams).
+            let done = BatchTokenIDOutSlim {
+                rids: vec!["r1-0".into(), "r1-1".into()],
+                output_ids: vec![vec![10], vec![11]],
+                finished_reasons: vec!["stop".into(), "stop".into()],
+                prompt_tokens: vec![3, 3],
+                completion_tokens: vec![1, 1],
+                cached_tokens: vec![0, 0],
+                output_token_logprobs_val: vec![vec![], vec![]],
+                output_token_logprobs_idx: vec![vec![], vec![]],
+            };
+            output
+                .send_frames(vec![bytes::Bytes::from(encode_msgpack(&done).unwrap())])
+                .await
+                .unwrap();
+        });
+
+        let mut req = tokenized_req(vllm::SamplingParams {
+            n: 2,
+            seed: Some(5),
+            ..Default::default()
+        });
+        req.request_id = "r1".to_string();
+        let mut stream = client.generate(req).await.expect("generate");
+
+        let mut completes = Vec::new();
+        while let Some(item) = stream.next().await {
+            match item.expect("stream item").response {
+                Some(vllm::generate_response::Response::Complete(complete)) => {
+                    completes.push(complete);
+                }
+                Some(vllm::generate_response::Response::Chunk(_)) | None => {}
+            }
+        }
+        completes.sort_by_key(|complete| complete.index);
+        assert_eq!(completes.len(), 2, "one Complete per fanned-out sub");
+        assert_eq!(completes[0].index, 0);
+        assert_eq!(completes[0].output_ids, vec![10]);
+        assert_eq!(completes[1].index, 1);
+        assert_eq!(completes[1].output_ids, vec![11]);
+        // Each sub reports the full shared prompt; the pipeline maxes, so
+        // usage is not double-counted.
+        assert!(completes.iter().all(|complete| complete.prompt_tokens == 3));
+
+        engine_task.await.unwrap();
+    }
+
+    /// Dropping the merged stream before completion aborts EVERY fanned-out
+    /// engine-side sub-request, not just one.
+    #[tokio::test]
+    async fn dropping_fanned_out_stream_aborts_all_subs() {
+        let dir = tempfile::tempdir().unwrap();
+        let ep = |name: &str| format!("ipc://{}", dir.path().join(name).display());
+        let (handshake, input, output) = (ep("hs.sock"), ep("in.sock"), ep("out.sock"));
+
+        let (client, engine) = tokio::join!(
+            ZmqEngineClient::connect(
+                &handshake,
+                &input,
+                &output,
+                1,
+                "m".to_string(),
+                RuntimeType::Vllm,
+                Duration::from_secs(10)
+            ),
+            connect_to_frontend(
+                &handshake,
+                EngineId::from_engine_index(0),
+                default_ready_response()
+            ),
+        );
+        let client = client.expect("adapter connect");
+        let engine = engine.expect("mock engine");
+        let (mut engine_input, _engine_output) = engine.split();
+
+        let stream = client
+            .generate(tokenized_req(vllm::SamplingParams {
+                n: 2,
+                ..Default::default()
+            }))
+            .await
+            .expect("generate");
+
+        // Consume both Adds first so the drop-triggered aborts are the next
+        // inbound messages.
+        for _ in 0..2 {
+            match engine_input.recv().await.unwrap() {
+                EngineInbound::Add(_) => {}
+                other => panic!("expected Add, got {other:?}"),
+            }
+        }
+
+        drop(stream); // unfinished -> every sub auto-aborts
+
+        let mut aborted = std::collections::BTreeSet::new();
+        while aborted.len() < 2 {
+            match engine_input.recv().await.unwrap() {
+                EngineInbound::Abort(rids) => aborted.extend(rids),
+                other => panic!("expected Abort, got {other:?}"),
+            }
+        }
+        assert_eq!(
+            aborted,
+            std::collections::BTreeSet::from(["r1-0".to_string(), "r1-1".to_string()])
+        );
+    }
+
+    #[test]
+    fn tokenspeed_finish_reason_normalizes() {
+        assert_eq!(normalize_finish_reason("stop"), "stop");
+        assert_eq!(normalize_finish_reason("length"), "length");
+        assert_eq!(normalize_finish_reason("abort"), "abort");
+        assert_eq!(normalize_finish_reason("error"), "error");
+        // An unknown wire value falls back to "stop".
+        assert_eq!(normalize_finish_reason("garbage"), "stop");
     }
 }

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -114,6 +114,13 @@ impl BasicWorkerBuilder {
         self
     }
 
+    /// Set the explicit ZMQ handshake bind address (replaces the address
+    /// derived from the ipc:// worker URL). Only meaningful for ZMQ workers.
+    pub fn zmq_handshake_address(mut self, address: impl Into<String>) -> Self {
+        self.spec.zmq_handshake_address = Some(address.into());
+        self
+    }
+
     /// Set labels for worker identification
     pub fn labels(mut self, labels: HashMap<String, String>) -> Self {
         self.spec.labels = labels;
@@ -356,6 +363,20 @@ mod tests {
 
     use super::*;
     use crate::worker::worker::Worker;
+
+    #[test]
+    fn zmq_handshake_address_reaches_the_built_spec() {
+        // The connect path reads the override from the built worker's spec, so
+        // dropping it here would silently fall back to the derived address.
+        let worker = BasicWorkerBuilder::new("ipc:///tmp/w.ipc")
+            .connection_mode(ConnectionMode::Zmq)
+            .zmq_handshake_address("tcp://127.0.0.1:30500")
+            .build();
+        assert_eq!(
+            worker.metadata().spec.zmq_handshake_address.as_deref(),
+            Some("tcp://127.0.0.1:30500")
+        );
+    }
 
     #[test]
     fn test_basic_worker_builder_minimal() {

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -26,7 +26,11 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
         common::header_utils::extract_routing_key,
-        grpc::{backend_client::BackendClient, client::GrpcClient, zmq_client::ZmqEngineClient},
+        grpc::{
+            backend_client::BackendClient,
+            client::GrpcClient,
+            zmq_client::{ZmqEngineClient, ZMQ_LOOPBACK_HOST},
+        },
     },
 };
 
@@ -46,10 +50,6 @@ const PROFILE_HTTP_TIMEOUT: Duration = Duration::from_secs(630);
 /// the engine loads the model and profiles KV cache between INIT and READY.
 const ZMQ_CONNECT_TIMEOUT: Duration = Duration::from_secs(600);
 
-/// Loopback host for the TCP handshake. ZMQ direct connections are same-host
-/// only, so the handshake never leaves loopback.
-const ZMQ_HANDSHAKE_HOST: &str = "127.0.0.1";
-
 /// Derive a deterministic TCP handshake port from the ipc data-plane path.
 ///
 /// vLLM's headless engine dials a *TCP* handshake (`--data-parallel-address` +
@@ -57,6 +57,9 @@ const ZMQ_HANDSHAKE_HOST: &str = "127.0.0.1";
 /// URL lets the operator compute the same `--data-parallel-rpc-port` without a
 /// side channel. FNV-1a keeps it stable across processes and builds. Mapped
 /// into 20000..=29999 to avoid well-known and typical ephemeral ranges.
+///
+/// `_zmq_handshake_port` in `bindings/python/src/smg/serve.py` mirrors this
+/// function — keep them in sync.
 fn derive_handshake_port(path: &str) -> u16 {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for b in path.as_bytes() {
@@ -77,15 +80,39 @@ fn derive_handshake_port(path: &str) -> u16 {
 /// and hands them to the engine during the handshake INIT). The operator gives a
 /// single `ipc://<path>` base; SMG binds the ipc input/output at
 /// `<path>-in.sock` / `-out.sock` and derives the TCP handshake port from the
-/// path. Returns `(handshake, input, output)`.
-fn zmq_socket_addresses(base_url: &str) -> WorkerResult<(String, String, String)> {
+/// path. A `WorkerSpec.zmq_handshake_address` override replaces the derived
+/// handshake address verbatim (it must be `tcp://`), for engines that dial a
+/// fixed, pre-agreed address — e.g. TokenSpeed's default dial target is
+/// `tcp://127.0.0.1:30500` (its `--data-parallel-address`/
+/// `--data-parallel-rpc-port` defaults, outside the derived 20000..=29999
+/// band), so setting the override to that value pairs a bare
+/// `ts serve --headless` with a manually registered worker.
+/// Returns `(handshake, input, output)`.
+fn zmq_socket_addresses(
+    base_url: &str,
+    handshake_override: Option<&str>,
+) -> WorkerResult<(String, String, String)> {
     let path = base_url
         .strip_prefix("ipc://")
         .ok_or_else(|| WorkerError::ConnectionFailed {
             url: base_url.to_string(),
             reason: "ZMQ worker URL must be ipc://<path>".to_string(),
         })?;
-    let handshake = format!("tcp://{ZMQ_HANDSHAKE_HOST}:{}", derive_handshake_port(path));
+    let handshake = match handshake_override {
+        Some(address) => {
+            if !address.starts_with("tcp://") {
+                return Err(WorkerError::ConnectionFailed {
+                    url: base_url.to_string(),
+                    reason: format!(
+                        "zmq_handshake_address must be a tcp:// address \
+                         (the engine dials a TCP handshake), got '{address}'"
+                    ),
+                });
+            }
+            address.to_string()
+        }
+        None => format!("tcp://{ZMQ_LOOPBACK_HOST}:{}", derive_handshake_port(path)),
+    };
     let input = format!("ipc://{path}-in.sock");
     let output = format!("ipc://{path}-out.sock");
     Ok((handshake, input, output))
@@ -161,8 +188,11 @@ async fn ensure_ipc_socket_dir(base_url: &str) -> WorkerResult<()> {
 async fn connect_zmq_backend(
     base_url: String,
     model_id: String,
+    runtime: RuntimeType,
+    handshake_override: Option<String>,
 ) -> WorkerResult<Arc<BackendClient>> {
-    let (handshake, input, output) = zmq_socket_addresses(&base_url)?;
+    let (handshake, input, output) =
+        zmq_socket_addresses(&base_url, handshake_override.as_deref())?;
     ensure_ipc_socket_dir(&base_url).await?;
     tracing::info!("Binding ZMQ client for worker {base_url} (handshake={handshake})");
     match ZmqEngineClient::connect(
@@ -171,6 +201,7 @@ async fn connect_zmq_backend(
         &output,
         1,
         model_id,
+        runtime,
         ZMQ_CONNECT_TIMEOUT,
     )
     .await
@@ -1430,9 +1461,13 @@ impl Worker for BasicWorker {
                 // wire (see create_worker).
                 let base_url = self.metadata.base_url().to_string();
                 let model_id = self.metadata.model_id().to_string();
+                let runtime = self.metadata.spec.runtime_type;
+                let handshake_override = self.metadata.spec.zmq_handshake_address.clone();
                 let cell = self.backend_client.load_full();
                 let client = cell
-                    .get_or_try_init(|| connect_zmq_backend(base_url, model_id))
+                    .get_or_try_init(|| {
+                        connect_zmq_backend(base_url, model_id, runtime, handshake_override)
+                    })
                     .await?;
                 Ok(Some(Arc::clone(client)))
             }
@@ -1520,6 +1555,8 @@ impl Worker for BasicWorker {
             let base_url = self.metadata.base_url().to_string();
             let model_id = self.metadata.model_id().to_string();
             let url = self.metadata.spec.url.clone();
+            let runtime = self.metadata.spec.runtime_type;
+            let handshake_override = self.metadata.spec.zmq_handshake_address.clone();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "detached one-shot handshake driver; the OnceCell dedupes with the request path and the guard self-clears on failure to allow a retry"
@@ -1527,7 +1564,9 @@ impl Worker for BasicWorker {
             // Detached: dropping the handle at scope end leaves the task running.
             let _handle = tokio::spawn(async move {
                 if let Err(e) = cell
-                    .get_or_try_init(|| connect_zmq_backend(base_url, model_id))
+                    .get_or_try_init(|| {
+                        connect_zmq_backend(base_url, model_id, runtime, handshake_override)
+                    })
                     .await
                 {
                     tracing::warn!(
@@ -1708,6 +1747,56 @@ mod tests {
         assert_eq!(WorkerType::Regular.to_string(), "regular");
         assert_eq!(WorkerType::Prefill.to_string(), "prefill");
         assert_eq!(WorkerType::Decode.to_string(), "decode");
+    }
+
+    #[test]
+    fn derive_handshake_port_matches_pinned_vectors() {
+        // Fixed vectors shared with `_zmq_handshake_port` in
+        // bindings/python/src/smg/serve.py — a change on either side breaks the
+        // engine/router port agreement, so these must stay in sync.
+        assert_eq!(derive_handshake_port("/tmp/smg-zmq/ts0.ipc"), 25152);
+        assert_eq!(derive_handshake_port("/tmp/smg-zmq/engine-31000"), 22714);
+        // Range invariant: every path maps into 20000..=29999.
+        for p in ["", "a", "/x/y/z.ipc", "very/long/path/with/segments.sock"] {
+            let port = derive_handshake_port(p);
+            assert!(
+                (20000..=29999).contains(&port),
+                "port {port} out of band for {p:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn zmq_socket_addresses_derive_handshake_by_default() {
+        let (handshake, input, output) =
+            zmq_socket_addresses("ipc:///tmp/smg-zmq/ts0.ipc", None).unwrap();
+        assert_eq!(handshake, "tcp://127.0.0.1:25152");
+        assert_eq!(input, "ipc:///tmp/smg-zmq/ts0.ipc-in.sock");
+        assert_eq!(output, "ipc:///tmp/smg-zmq/ts0.ipc-out.sock");
+    }
+
+    #[test]
+    fn zmq_socket_addresses_honor_handshake_override() {
+        // TokenSpeed's default dial target — outside the derived band; the
+        // override must be bound verbatim while the data plane stays derived.
+        let (handshake, input, output) =
+            zmq_socket_addresses("ipc:///tmp/smg-zmq/ts0.ipc", Some("tcp://127.0.0.1:30500"))
+                .unwrap();
+        assert_eq!(handshake, "tcp://127.0.0.1:30500");
+        assert_eq!(input, "ipc:///tmp/smg-zmq/ts0.ipc-in.sock");
+        assert_eq!(output, "ipc:///tmp/smg-zmq/ts0.ipc-out.sock");
+    }
+
+    #[test]
+    fn zmq_socket_addresses_reject_non_tcp_override() {
+        // The engine dials a TCP handshake; a non-tcp override is a config
+        // error and must fail loudly rather than bind something unexpected.
+        let err = zmq_socket_addresses("ipc:///tmp/smg-zmq/ts0.ipc", Some("ipc:///tmp/hs.sock"))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("tcp://"),
+            "error must name the required scheme: {err}"
+        );
     }
 
     #[test]
@@ -2652,37 +2741,6 @@ mod tests {
         assert!(worker.has_models_discovered());
     }
 
-    /// Pinned FNV-1a vectors. serve.py's `_zmq_handshake_port` derives the same
-    /// value from the same `ipc://` path so the launcher can pass a matching
-    /// `--data-parallel-rpc-port` without a side channel — if this changes, that
-    /// mirror must change in lockstep or the engine and router pick different
-    /// handshake ports and never connect.
-    #[test]
-    fn derive_handshake_port_matches_pinned_vectors() {
-        assert_eq!(derive_handshake_port("/tmp/smg-zmq/ts0.ipc"), 25152);
-        assert_eq!(derive_handshake_port("/tmp/smg-zmq/ts1.ipc"), 22735);
-        assert_eq!(derive_handshake_port("ts0.ipc"), 23912);
-        // Range invariant: every path maps into 20000..=29999.
-        for p in ["", "a", "/x/y/z.ipc", "very/long/path/with/segments.sock"] {
-            let port = derive_handshake_port(p);
-            assert!(
-                (20000..=29999).contains(&port),
-                "port {port} out of band for {p:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn zmq_socket_addresses_split_handshake_tcp_from_ipc_data_plane() {
-        let (handshake, input, output) =
-            zmq_socket_addresses("ipc:///tmp/smg-zmq/ts0.ipc").unwrap();
-        assert_eq!(handshake, "tcp://127.0.0.1:25152");
-        assert_eq!(input, "ipc:///tmp/smg-zmq/ts0.ipc-in.sock");
-        assert_eq!(output, "ipc:///tmp/smg-zmq/ts0.ipc-out.sock");
-        // A non-ipc base URL has no data-plane topology and must be rejected.
-        assert!(zmq_socket_addresses("tcp://127.0.0.1:5000").is_err());
-    }
-
     #[tokio::test]
     async fn ensure_ipc_socket_dir_creates_a_private_owner_only_dir() {
         let base = tempfile::tempdir().unwrap();
@@ -2740,6 +2798,7 @@ mod tests {
                 &output,
                 1,
                 "m".to_string(),
+                RuntimeType::Vllm,
                 Duration::from_secs(10)
             ),
             connect_to_frontend(

--- a/model_gateway/src/workflow/job_queue.rs
+++ b/model_gateway/src/workflow/job_queue.rs
@@ -565,6 +565,13 @@ impl JobQueue {
                     spec.worker_type = proto_worker_type;
                     spec.api_key.clone_from(&api_key);
                     spec.bootstrap_port = bootstrap_port;
+                    // ZMQ startup workers carry the runtime pinned by
+                    // `--backend` (the shared handshake cannot be probed for a
+                    // wire protocol); `None` — HTTP/gRPC or no `--backend` —
+                    // keeps auto-detection in detect_backend.
+                    if let Some(runtime) = router_config.startup_worker_runtime_type {
+                        spec.runtime_type = runtime;
+                    }
                     // Health config is resolved at worker build time from router
                     // defaults + per-worker overrides (spec.health). No need to
                     // set spec.health here since these workers have no overrides.

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -110,6 +110,29 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
             RuntimeType::Sglang
         };
 
+        validate_zmq_handshake_override(config, *connection_mode).map_err(|message| {
+            WorkflowError::StepFailed {
+                step_id: StepId::new("create_worker"),
+                message,
+            }
+        })?;
+
+        // Only vLLM EngineCore and TokenSpeed speak the ZMQ direct-backend wire.
+        // Fail registration here rather than letting the connect-time rejection
+        // strand the worker in Pending.
+        if *connection_mode == ConnectionMode::Zmq
+            && !matches!(runtime_type, RuntimeType::Vllm | RuntimeType::TokenSpeed)
+        {
+            return Err(WorkflowError::StepFailed {
+                step_id: StepId::new("create_worker"),
+                message: format!(
+                    "ZMQ worker {} has unsupported runtime {}: only vllm and tokenspeed \
+                     are supported over the ZMQ direct backend",
+                    config.url, runtime_type
+                ),
+            });
+        }
+
         // Normalize URL
         let url = normalize_url(&config.url, *connection_mode);
 
@@ -189,6 +212,9 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
                 }
                 if let Some(ref e) = kv_engine_id {
                     builder = builder.kv_engine_id(e);
+                }
+                if let Some(ref address) = config.zmq_handshake_address {
+                    builder = builder.zmq_handshake_address(address.clone());
                 }
 
                 // Builder sets initial status: Pending if health-checked, Ready if not.
@@ -348,6 +374,23 @@ fn infer_non_generation_type(labels: &HashMap<String, String>) -> ModelType {
     ModelType::EMBEDDINGS
 }
 
+/// `zmq_handshake_address` only steers the ZMQ handshake bind; on any other
+/// connection mode it would be silently ignored, so reject the registration
+/// loudly instead.
+fn validate_zmq_handshake_override(
+    config: &WorkerSpec,
+    connection_mode: ConnectionMode,
+) -> Result<(), String> {
+    if config.zmq_handshake_address.is_some() && connection_mode != ConnectionMode::Zmq {
+        return Err(format!(
+            "worker {} sets zmq_handshake_address but its connection mode is \
+             {connection_mode:?}: the field is only meaningful for ZMQ workers",
+            config.url
+        ));
+    }
+    Ok(())
+}
+
 fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
     if url.starts_with("http://")
         || url.starts_with("https://")
@@ -422,6 +465,23 @@ mod tests {
         assert_eq!(
             normalize_url("localhost:30001", ConnectionMode::Grpc),
             "grpc://localhost:30001"
+        );
+    }
+
+    #[test]
+    fn zmq_handshake_override_is_rejected_off_the_zmq_path() {
+        let mut spec = WorkerSpec::new("http://worker:8080");
+        spec.zmq_handshake_address = Some("tcp://127.0.0.1:30500".to_string());
+
+        for mode in [ConnectionMode::Http, ConnectionMode::Grpc] {
+            let err = validate_zmq_handshake_override(&spec, mode)
+                .expect_err("non-ZMQ workers must reject the handshake override");
+            assert!(err.contains("zmq_handshake_address"), "{err}");
+        }
+        // On the ZMQ path the override is legitimate; unset is always fine.
+        assert!(validate_zmq_handshake_override(&spec, ConnectionMode::Zmq).is_ok());
+        assert!(
+            validate_zmq_handshake_override(&WorkerSpec::new("x"), ConnectionMode::Http).is_ok()
         );
     }
 

--- a/model_gateway/src/workflow/steps/local/detect_backend.rs
+++ b/model_gateway/src/workflow/steps/local/detect_backend.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use reqwest::Client;
-use tracing::debug;
+use tracing::{debug, warn};
 use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use super::discover_metadata::ModelsResponse;
@@ -285,8 +285,21 @@ impl StepExecutor<WorkerWorkflowData> for DetectBackendStep {
                     step_id: wfaas::StepId::new("detect_backend"),
                     message: format!("gRPC backend detection failed for {}: {}", config.url, e),
                 })?,
-            // A ZMQ EngineCore is always vLLM; there is nothing to probe.
-            ConnectionMode::Zmq => "vllm".to_string(),
+            // A ZMQ EngineCore handshake is shared across engine runtimes, so the
+            // runtime cannot be probed here. An explicit `runtime_type` (vllm,
+            // sglang, tokenspeed, ...) is honored by the early return above; only a
+            // worker that left it unspecified reaches this default of vLLM.
+            ConnectionMode::Zmq => {
+                warn!(
+                    worker = %config.url,
+                    "runtime_type unspecified for ZMQ worker; defaulting to vLLM \
+                     EngineCore. A TokenSpeed engine must declare its runtime to \
+                     speak the correct wire protocol: `--backend tokenspeed` for \
+                     startup --worker-urls workers, or an explicit runtime_type \
+                     on the worker API spec / YAML worker config."
+                );
+                "vllm".to_string()
+            }
         };
 
         debug!(

--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -373,9 +373,11 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverMetadataStep {
                     .await
                     .map(|(labels, rt)| (labels, Some(rt)))
             }
-            // EngineCore does not report model/tokenizer metadata over ZMQ; it is
-            // configured at worker registration. The runtime is always vLLM.
-            ConnectionMode::Zmq => Ok((HashMap::new(), Some("vllm".to_string()))),
+            // An EngineCore worker does not report model/tokenizer metadata over
+            // ZMQ; it is configured at worker registration. Return `None` for the
+            // runtime so the explicitly configured / detected runtime is preserved
+            // (the handshake is shared across engines, so it cannot be probed here).
+            ConnectionMode::Zmq => Ok((HashMap::new(), None)),
         }
         .unwrap_or_else(|e| {
             warn!("Failed to fetch metadata for {}: {}", config.url, e);


### PR DESCRIPTION
## Description

### Problem

The ZMQ direct-backend path (#2000, built on #2015) speaks only vLLM's EngineCore protocol. TokenSpeed (and later sglang) engines need the same same-host `ipc://` fast path, but the crate's transport, connector, and gateway adapter all hard-assumed the vLLM wire format — and several workflow steps hard-assumed "ZMQ worker ⇒ vLLM".

### Solution

Make the ZMQ stack engine-neutral and add TokenSpeed as the second protocol:

- `engine-zmq-client`: a new `EngineProtocol` trait seams the shared transport/connector (handshake, ROUTER/DEALER identity framing, output loop, abort-on-drop) away from the per-engine wire structs. `VllmProtocol` keeps the existing behavior; `TokenSpeedProtocol` adds the sglang-family msgpack tuples (`WireTokenizedGenerateReq` 5-tuple, `WireSamplingParams` 13-tuple, `WireBatchTokenIDOut` 8-tuple with sampled-token logprob columns). Handshake structs move to a neutral `protocol/handshake.rs` (re-exported for compatibility). A neutral `EngineLoad` replaces the vLLM-specific stats type in the shared seam.
- Gateway adapter (`zmq_client.rs`): `ZmqEngineClient` selects the protocol from the worker's explicit `runtime_type` (`tokenspeed` vs `vllm`; anything else is rejected before the handshake and at registration). Streams map both protocols to the existing vLLM-proto pipeline — chunks carry incremental tokens/logprobs, the terminal `Complete` carries the cumulative set, and a finish-tick's tokens are emitted as a chunk first so streaming never loses the last token.
- No silent narrowing: requests the wire cannot honor fail loudly with `invalid_argument` instead of degrading — structured-output constraints, `n>1`, top-k/prompt logprobs, stop strings (TokenSpeed), `logit_bias` (TokenSpeed), nonzero `data_parallel_rank`. Sampled-token logprobs are wired end-to-end on both ZMQ protocols.
- Runtime plumbing: `detect_backend`/`discover_metadata` no longer force ZMQ workers to vLLM — an explicitly configured `runtime_type` survives to the built worker (unspecified still defaults to vLLM with a warning). `BackendClient::runtime_type()` reports the actual ZMQ backend runtime.
- `wfaas` fix: the DAG scheduler could fail a workflow with a spurious "Workflow deadlocked" when a step completed between the completion-drain and the tracker read (instant-completing ZMQ detection steps hit this routinely). The deadlock branch now re-drains the completion channel before failing, and the `run_if` paths send their completion inside the tracker lock scope. Regression tests included.
- `smg serve`: per-user ZMQ socket dir (`SMG_ZMQ_SOCKET_DIR` override), FNV handshake-port derivation pinned by conformance vectors against the Python mirror.

### Changes

- `crates/engine_zmq_client`: `protocol/mod.rs` (EngineProtocol/EngineOutput/EngineBatch/EngineLoad), `protocol/tokenspeed/{mod,request,sampling,output}.rs`, `protocol/handshake.rs`, generic `connector.rs`/`transport.rs`, `EngineCoreReadyResponse.max_num_batched_tokens` widened to `i64` (TokenSpeed sends `-1` = disabled).
- `model_gateway`: `routers/grpc/zmq_client.rs` (ZmqBackend enum, per-protocol translate/map with loud rejection boundary, logprob accumulation), `routers/grpc/backend_client.rs` (runtime passthrough), `worker/worker.rs` (runtime param on connect), `workflow/steps/local/{detect_backend,discover_metadata,create_worker}.rs` (runtime preservation + ZMQ runtime validation).
- `crates/workflow`: deadlock-detector re-drain + `run_if` in-lock completion send + regression tests.
- `bindings/python/src/smg/serve.py`: per-user socket dir.

### Test Plan

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo +nightly fmt --all -- --check` clean; `engine-zmq-client` (incl. mock-engine e2e for both protocols), `wfaas`, and `smg` zmq_client suites green.
- Cross-language contract: Python `msgspec`-encoded fixtures decode in the Rust codec and vice versa (field order, arity, float64 logprob columns).
- Live e2e on GB300: real TokenSpeed engine (Qwen3-0.6B, branch `lightseekorg/tokenspeed#feat/zmq-msgpack`) registered via `POST /workers {"url":"ipc://...","connection_mode":"zmq","runtime_type":"tokenspeed"}` — chat (content + reasoning_content), completions, sampled-token logprobs (`--enable-output-logprobs`), top-k/prompt-logprob rejections, and repeated worker registration with zero workflow-deadlock failures. The existing vLLM ZMQ path re-validated unchanged.

Follow-ups: engine-side handshake retry, DP>1 (coordinator/wave, task tracked), legacy `/v1/completions` logprobs rendering (pre-existing gap for all backends).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
