### PR TITLE
ci: push nightly Docker images to the repo owner's GHCR namespace

### DIFF
--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -40,12 +40,14 @@ jobs:
 
       - name: Compute image tags
         id: tags
+        env:
+          OWNER: ${{ github.repository_owner }}
         run: |
           SUFFIX="$(date -u +%Y%m%d)-${GITHUB_SHA::7}"
           {
             echo "list<<EOF"
-            echo "ghcr.io/lightseekorg/smg:nightly"
-            echo "ghcr.io/lightseekorg/smg:nightly-${SUFFIX}"
+            echo "ghcr.io/${OWNER}/smg:nightly"
+            echo "ghcr.io/${OWNER}/smg:nightly-${SUFFIX}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/crates/engine_zmq_client/Cargo.toml
+++ b/crates/engine_zmq_client/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Engine-agnostic ZMQ transport + per-engine protocol modules for same-host SMG backend connections"
 license = "Apache-2.0"
-repository = "https://github.com/lightseekorg/smg"
+repository = "https://github.com/smg-project/smg"
 
 # The vLLM EngineCore protocol module is a clean-room port of vLLM's Apache-2.0
 # `vllm-engine-core-client` crate (vllm-project/vllm, rust/src/engine-core-client).


### PR DESCRIPTION
Closes #2022

## Problem

`nightly-docker.yml` hardcoded `ghcr.io/lightseekorg/smg:nightly`. After the move to `smg-project`, the login step's `secrets.GITHUB_TOKEN` is scoped to `smg-project/smg` and has no write access to the `lightseekorg` package namespace, so the job builds for ~1h45m and then dies on push:

```
failed to push ghcr.io/lightseekorg/smg:nightly:
denied: permission_denied: The requested installation does not exist.
```

(run [30688451155](https://github.com/smg-project/smg/actions/runs/30688451155))

## Fix

Derive the namespace from `github.repository_owner` instead of hardcoding it, matching what `_build-engine-image.yml` and `release-helm.yml` already do — so this survives any future move.

Also fixes the stale `repository` URL in `crates/engine_zmq_client/Cargo.toml`, the one manifest still pointing at the old org.

## Note for consumers

Nightlies now publish to `ghcr.io/smg-project/smg:nightly`. Anyone pulling `ghcr.io/lightseekorg/smg:nightly` needs to switch; the old tag stops receiving updates.

Release images are untouched by this PR — `release-docker.yml` publishes to **Docker Hub** `lightseekorg/smg` via `DOCKERHUB_TOKEN`, which is a separate namespace decision (and depends on whether a `smg-project` Docker Hub org exists).