### PR TITLE
feat(router): add worker startup delay and drive startup poll cadence

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -378,7 +378,6 @@ struct Router {
     worker_urls: Vec<String>,
     policy: PolicyType,
     worker_startup_timeout_secs: u64,
-    worker_startup_delay: u64,
     worker_startup_check_interval: u64,
     load_monitor_interval: u64,
     cache_threshold: f32,
@@ -494,6 +493,7 @@ struct Router {
     multimodal_tensor_transport: Option<String>,
     multimodal_shm_min_bytes: Option<usize>,
     model_aliases: HashMap<String, String>,
+    worker_startup_delay: u64,
 }
 
 impl Router {
@@ -869,7 +869,6 @@ impl Router {
         host = String::from("0.0.0.0"),
         port = 3001,
         worker_startup_timeout_secs = 600,
-        worker_startup_delay = 0,
         worker_startup_check_interval = 30,
         load_monitor_interval = 10,
         cache_threshold = 0.3,
@@ -986,6 +985,7 @@ impl Router {
         multimodal_tensor_transport = None,
         multimodal_shm_min_bytes = None,
         model_aliases = HashMap::new(),
+        worker_startup_delay = 0,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -998,7 +998,6 @@ impl Router {
         host: String,
         port: u16,
         worker_startup_timeout_secs: u64,
-        worker_startup_delay: u64,
         worker_startup_check_interval: u64,
         load_monitor_interval: u64,
         cache_threshold: f32,
@@ -1114,6 +1113,7 @@ impl Router {
         multimodal_tensor_transport: Option<String>,
         multimodal_shm_min_bytes: Option<usize>,
         model_aliases: HashMap<String, String>,
+        worker_startup_delay: u64,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1143,7 +1143,6 @@ impl Router {
             worker_urls,
             policy,
             worker_startup_timeout_secs,
-            worker_startup_delay,
             worker_startup_check_interval,
             load_monitor_interval,
             cache_threshold,
@@ -1256,6 +1255,7 @@ impl Router {
             multimodal_tensor_transport,
             multimodal_shm_min_bytes,
             model_aliases,
+            worker_startup_delay,
         })
     }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -378,6 +378,7 @@ struct Router {
     worker_urls: Vec<String>,
     policy: PolicyType,
     worker_startup_timeout_secs: u64,
+    worker_startup_delay: u64,
     worker_startup_check_interval: u64,
     load_monitor_interval: u64,
     cache_threshold: f32,
@@ -769,6 +770,7 @@ impl Router {
             .max_payload_size(self.max_payload_size)
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
+            .worker_startup_delay_secs(self.worker_startup_delay)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
             .load_monitor_interval_secs(self.load_monitor_interval)
             .max_concurrent_requests(self.max_concurrent_requests)
@@ -867,6 +869,7 @@ impl Router {
         host = String::from("0.0.0.0"),
         port = 3001,
         worker_startup_timeout_secs = 600,
+        worker_startup_delay = 0,
         worker_startup_check_interval = 30,
         load_monitor_interval = 10,
         cache_threshold = 0.3,
@@ -995,6 +998,7 @@ impl Router {
         host: String,
         port: u16,
         worker_startup_timeout_secs: u64,
+        worker_startup_delay: u64,
         worker_startup_check_interval: u64,
         load_monitor_interval: u64,
         cache_threshold: f32,
@@ -1139,6 +1143,7 @@ impl Router {
             worker_urls,
             policy,
             worker_startup_timeout_secs,
+            worker_startup_delay,
             worker_startup_check_interval,
             load_monitor_interval,
             cache_threshold,

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -157,6 +157,9 @@ class Router:
         worker_startup_timeout_secs: Timeout in seconds for worker startup and
             registration. Large models can take significant time to load into GPU
             memory. Default: 1800 (30 minutes)
+        worker_startup_delay: Grace period in seconds before the first worker
+            startup check fires. Leaves the engine alone this long, then polls
+            every worker_startup_check_interval. Default: 0
         worker_startup_check_interval: Interval in seconds between checks for worker
             initialization. Default: 10
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -54,6 +54,7 @@ class RouterArgs:
     prefill_policy: str | None = None  # Specific policy for prefill nodes in PD mode
     decode_policy: str | None = None  # Specific policy for decode nodes in PD mode
     worker_startup_timeout_secs: int = 1800
+    worker_startup_delay: int = 0
     worker_startup_check_interval: int = 30
     load_monitor_interval: int = 10
     cache_threshold: float = 0.3
@@ -553,6 +554,12 @@ class RouterArgs:
                 "Timeout in seconds for worker startup and registration (default: 1800 / 30 minutes)."
                 " Large models can take significant time to load into GPU memory."
             ),
+        )
+        pd_group.add_argument(
+            f"--{prefix}worker-startup-delay",
+            type=int,
+            default=RouterArgs.worker_startup_delay,
+            help="Grace period in seconds before the first worker startup check (default: 0)",
         )
         pd_group.add_argument(
             f"--{prefix}worker-startup-check-interval",

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -54,7 +54,6 @@ class RouterArgs:
     prefill_policy: str | None = None  # Specific policy for prefill nodes in PD mode
     decode_policy: str | None = None  # Specific policy for decode nodes in PD mode
     worker_startup_timeout_secs: int = 1800
-    worker_startup_delay: int = 0
     worker_startup_check_interval: int = 30
     load_monitor_interval: int = 10
     cache_threshold: float = 0.3
@@ -203,6 +202,7 @@ class RouterArgs:
     mesh_peer_urls: list[str] = dataclasses.field(default_factory=list)
     # Append new fields here to preserve positional callers.
     model_aliases: dict[str, str] = dataclasses.field(default_factory=dict)
+    worker_startup_delay: int = 0
 
     @staticmethod
     def add_cli_args(

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -206,6 +206,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn worker_startup_delay_secs(mut self, delay: u64) -> Self {
+        self.config.worker_startup_delay_secs = delay;
+        self
+    }
+
     pub fn worker_startup_check_interval_secs(mut self, interval: u64) -> Self {
         self.config.worker_startup_check_interval_secs = interval;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -46,6 +46,11 @@ pub struct RouterConfig {
     pub max_payload_size: usize,
     pub request_timeout_secs: u64,
     pub worker_startup_timeout_secs: u64,
+    /// Grace period before the first worker-startup check fires. The engine is
+    /// left alone for this long, then polled every
+    /// `worker_startup_check_interval_secs`.
+    #[serde(default)]
+    pub worker_startup_delay_secs: u64,
     pub worker_startup_check_interval_secs: u64,
     #[serde(default = "default_load_monitor_interval_secs")]
     pub load_monitor_interval_secs: u64,
@@ -800,6 +805,7 @@ impl Default for RouterConfig {
             max_payload_size: 536_870_912,     // 512MB
             request_timeout_secs: 1800,        // 30 minutes
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
+            worker_startup_delay_secs: 0,
             worker_startup_check_interval_secs: 30,
             load_monitor_interval_secs: 10,
             engine_metrics: false,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -306,6 +306,10 @@ struct CliArgs {
     #[arg(long, default_value_t = 1800, help_heading = "PD Disaggregation")]
     worker_startup_timeout_secs: u64,
 
+    /// Grace period in seconds before the first worker startup check
+    #[arg(long, default_value_t = 0, help_heading = "PD Disaggregation")]
+    worker_startup_delay: u64,
+
     /// Interval in seconds between worker startup checks
     #[arg(long, default_value_t = 30, help_heading = "PD Disaggregation")]
     worker_startup_check_interval: u64,
@@ -1470,6 +1474,7 @@ impl CliArgs {
             .max_payload_size(self.max_payload_size)
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
+            .worker_startup_delay_secs(self.worker_startup_delay)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
             .load_monitor_interval_secs(self.load_monitor_interval)
             .engine_metrics(self.engine_metrics)

--- a/model_gateway/src/workflow/steps/mod.rs
+++ b/model_gateway/src/workflow/steps/mod.rs
@@ -67,39 +67,41 @@ pub fn create_worker_registration_workflow(
     router_config: &RouterConfig,
 ) -> WorkflowDefinition<WorkerWorkflowData> {
     let detect_timeout = Duration::from_secs(router_config.worker_startup_timeout_secs);
+    let startup_delay = Duration::from_secs(router_config.worker_startup_delay_secs);
+    let check_interval = Duration::from_secs(router_config.worker_startup_check_interval_secs);
 
-    // Reserve 10% of the startup timeout for workflow overhead (step transitions, etc.).
-    // The remaining budget is split into retry attempts: a base number of attempts for
-    // the first ATTEMPTS_THRESHOLD seconds, plus one extra attempt per SECS_PER_EXTRA
-    // seconds beyond that.
+    // Startup detection polls the starting engine every
+    // `worker_startup_check_interval_secs` until `worker_startup_timeout_secs`
+    // elapses. Derive the retry attempt budget from that cadence (reserving
+    // 10% of the timeout for workflow overhead like step transitions) so the
+    // two knobs stay consistent: total wait ≈ max_attempts × check_interval ≈
+    // worker_startup_timeout_secs. A floor keeps a very short timeout retrying
+    // a few times.
     const EFFECTIVE_TIMEOUT_FACTOR: f64 = 0.9;
-    const ATTEMPTS_THRESHOLD_SECS: f64 = 10.0;
-    const BASE_ATTEMPTS: u32 = 5;
-    const SECS_PER_EXTRA_ATTEMPT: f64 = 5.0;
     const MIN_ATTEMPTS: u32 = 3;
 
-    let timeout_secs = detect_timeout.as_secs() as f64;
-    let effective_timeout = timeout_secs * EFFECTIVE_TIMEOUT_FACTOR;
-    let max_attempts = if effective_timeout > ATTEMPTS_THRESHOLD_SECS {
-        (BASE_ATTEMPTS
-            + ((effective_timeout - ATTEMPTS_THRESHOLD_SECS) / SECS_PER_EXTRA_ATTEMPT).ceil()
-                as u32)
-            .max(MIN_ATTEMPTS)
-    } else {
-        MIN_ATTEMPTS
-    };
+    let interval_secs = (check_interval.as_secs() as f64).max(1.0);
+    let effective_timeout = detect_timeout.as_secs() as f64 * EFFECTIVE_TIMEOUT_FACTOR;
+    let max_attempts = ((effective_timeout / interval_secs).ceil() as u32).max(MIN_ATTEMPTS);
+
+    // Step 0: Classify worker type (Local vs External). This is the entry step,
+    // so it carries the one-time startup grace period: leave the engine alone
+    // for `worker_startup_delay_secs` before the first probe, then let the
+    // downstream steps poll at the startup cadence.
+    let mut classify_worker_type = StepDefinition::new(
+        "classify_worker_type",
+        "Classify Worker Type",
+        Arc::new(ClassifyWorkerTypeStep),
+    )
+    .with_timeout(Duration::from_secs(10))
+    .with_failure_action(FailureAction::FailWorkflow);
+    if !startup_delay.is_zero() {
+        classify_worker_type = classify_worker_type.with_delay(startup_delay);
+    }
 
     WorkflowDefinition::new("worker_registration", "Worker Registration")
         // Step 0: Classify worker type (Local vs External)
-        .add_step(
-            StepDefinition::new(
-                "classify_worker_type",
-                "Classify Worker Type",
-                Arc::new(ClassifyWorkerTypeStep),
-            )
-            .with_timeout(Duration::from_secs(10))
-            .with_failure_action(FailureAction::FailWorkflow),
-        )
+        .add_step(classify_worker_type)
         // === LOCAL BRANCH ===
         // Step 1: Detect connection mode (HTTP vs gRPC)
         .add_step(
@@ -110,10 +112,8 @@ pub fn create_worker_registration_workflow(
             )
             .with_retry(RetryPolicy {
                 max_attempts,
-                backoff: BackoffStrategy::Linear {
-                    increment: Duration::from_secs(1),
-                    max: Duration::from_secs(5),
-                },
+                // Poll the starting engine at the configured startup cadence.
+                backoff: BackoffStrategy::Fixed(check_interval),
             })
             .with_timeout(detect_timeout)
             .with_failure_action(FailureAction::FailWorkflow)
@@ -294,5 +294,87 @@ pub fn create_worker_workflow_data(
         final_labels: std::collections::HashMap::new(),
         app_context: Some(app_context),
         actual_workers: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RouterConfig;
+
+    fn config_with(timeout_secs: u64, check_interval_secs: u64) -> RouterConfig {
+        RouterConfig::builder()
+            .regular_mode(vec!["http://worker:8000".to_string()])
+            .random_policy()
+            .worker_startup_timeout_secs(timeout_secs)
+            .worker_startup_check_interval_secs(check_interval_secs)
+            .build_unchecked()
+    }
+
+    fn detect_step(config: &RouterConfig) -> RetryPolicy {
+        create_worker_registration_workflow(config)
+            .steps
+            .iter()
+            .find(|s| s.id.to_string() == "detect_connection_mode")
+            .expect("detect_connection_mode step present")
+            .retry_policy
+            .clone()
+            .expect("detect_connection_mode has a retry policy")
+    }
+
+    fn startup_delay(config: &RouterConfig) -> Option<Duration> {
+        create_worker_registration_workflow(config)
+            .steps
+            .iter()
+            .find(|s| s.id.to_string() == "classify_worker_type")
+            .expect("classify_worker_type step present")
+            .delay
+    }
+
+    #[test]
+    fn startup_check_interval_drives_detect_poll_cadence() {
+        let retry = detect_step(&config_with(1800, 30));
+        // The dead knob now drives the retry cadence: poll every 30s.
+        match retry.backoff {
+            BackoffStrategy::Fixed(d) => assert_eq!(d, Duration::from_secs(30)),
+            other => panic!("expected Fixed(check_interval), got {other:?}"),
+        }
+        // Attempts span the timeout budget at that cadence:
+        // ceil(1800 * 0.9 / 30) = 54.
+        assert_eq!(retry.max_attempts, 54);
+    }
+
+    #[test]
+    fn startup_attempts_scale_with_check_interval() {
+        // Halving the interval doubles the attempt budget for the same timeout.
+        let coarse = detect_step(&config_with(1800, 60));
+        let fine = detect_step(&config_with(1800, 30));
+        assert_eq!(coarse.max_attempts, 27);
+        assert_eq!(fine.max_attempts, 54);
+    }
+
+    #[test]
+    fn startup_attempts_have_a_floor_for_tiny_timeouts() {
+        // A 1s timeout at a 30s cadence still retries MIN_ATTEMPTS (3) times
+        // instead of giving up after a single probe.
+        let retry = detect_step(&config_with(1, 30));
+        assert_eq!(retry.max_attempts, 3);
+    }
+
+    #[test]
+    fn startup_delay_defers_first_probe() {
+        // The delay knob becomes a one-time wait on the entry step, before any
+        // engine probing begins.
+        let mut config = config_with(1800, 30);
+        config.worker_startup_delay_secs = 120;
+        assert_eq!(startup_delay(&config), Some(Duration::from_secs(120)));
+    }
+
+    #[test]
+    fn zero_startup_delay_leaves_probe_immediate() {
+        // Default (0) preserves the immediate-check behavior: no delay is set.
+        let config = config_with(1800, 30);
+        assert_eq!(config.worker_startup_delay_secs, 0);
+        assert_eq!(startup_delay(&config), None);
     }
 }


### PR DESCRIPTION
## Description

### Problem

The worker-registration workflow had no way to defer probing a freshly launched engine, and `worker_startup_check_interval_secs` was dead config — accepted and validated but never read by any loop. As a result:

- A cold engine gets probed immediately on registration, before it has had any chance to boot.
- The startup poll cadence was hardcoded rather than honoring the configured `worker_startup_check_interval_secs`.
- There was no clear separation between *startup* cadence and *steady-state* health cadence, so the two concerns were easy to conflate.

### Solution

Define three distinct knobs, each mapping to a specific phase of the worker lifecycle:

| Knob | Phase | Behavior |
|------|-------|----------|
| `worker_startup_delay_secs` (**new**, default `0`) | before first probe | one-time grace period — leave a booting engine alone this long before any probing begins |
| `worker_startup_check_interval_secs` (default `30`) | during startup | poll cadence while the registration workflow waits for the engine |
| `health_check.check_interval_secs` (default `60`) | steady-state | health-loop cadence after startup passes (**untouched**) |

- The startup delay is applied as a one-time `with_delay` on the entry step (`classify_worker_type`) of the registration workflow — the first step to touch the engine. Applied only when non-zero, so the default (`0`) preserves the existing immediate-probe behavior byte-for-byte.
- `worker_startup_check_interval_secs` now drives the startup detection retry cadence (`Fixed` backoff), with the retry attempt budget derived from that interval and `worker_startup_timeout_secs` so total startup wait stays consistent with the configured timeout (with a small floor so a very short timeout still retries a few times).

## Changes

- **`config/types.rs`**: new `worker_startup_delay_secs: u64` field (`#[serde(default)]`, default `0`).
- **`config/builder.rs`**: `worker_startup_delay_secs(...)` builder method.
- **`main.rs`**: `--worker-startup-delay` CLI arg (default `0`).
- **`workflow/steps/mod.rs`**: apply the startup delay via `with_delay` on the entry step (only when non-zero); wire `worker_startup_check_interval_secs` into the startup detection `Fixed` backoff and derive `max_attempts` from interval + timeout.
- **Python bindings** (`bindings/python/src/lib.rs`, `router_args.py`, `router.py`): expose `worker_startup_delay` across the constructor, `RouterArgs`, the `--worker-startup-delay` argparse flag, and docstrings — keeping CLI/Python parity.

## Test Plan

New unit tests in `workflow::steps`:

- `startup_delay_defers_first_probe` — a non-zero `worker_startup_delay_secs` sets a one-time delay on the entry step.
- `zero_startup_delay_leaves_probe_immediate` — the default (`0`) sets no delay, preserving immediate-probe behavior.
- `startup_check_interval_drives_detect_poll_cadence` — the detection step polls on `Fixed(check_interval)`.
- `startup_attempts_scale_with_check_interval` — halving the interval doubles the attempt budget for the same timeout.
- `startup_attempts_have_a_floor_for_tiny_timeouts` — a tiny timeout still retries a minimum number of times.

```
cargo test -p smg --lib -- startup      # 12 passed
cargo test -p smg --lib config::        # 118 passed
cargo build -p smg                      # green
cargo build -p smg-python               # green
PYTHONPATH=src python3 -m pytest tests/test_arg_parser.py   # 33 passed (from_cli_args maps the new field automatically)
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>