### PR TITLE
docs(bindings): correct worker_startup_check_interval default to 30

### DIFF
--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -161,7 +161,7 @@ class Router:
             startup check fires. Leaves the engine alone this long, then polls
             every worker_startup_check_interval. Default: 0
         worker_startup_check_interval: Interval in seconds between checks for worker
-            initialization. Default: 10
+            initialization. Default: 30
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to
             cached worker if the match rate exceeds threshold, otherwise routes to the
             worker with the smallest tree. Default: 0.5


### PR DESCRIPTION
## Description

### Problem

The `router.py` docstring for `worker_startup_check_interval` lists the default as `10`, but every configuration surface actually defaults this knob to `30` seconds:

- `RouterConfig` (`worker_startup_check_interval_secs: 30`) — the value the worker-registration workflow reads
- CLI `--worker-startup-check-interval` (`default_value_t = 30`)
- PyO3 binding (`worker_startup_check_interval = 30`)
- `RouterArgs` dataclass (`worker_startup_check_interval: int = 30`)

The stale docstring is misleading — a user reading it would expect a 6× tighter startup poll cadence than they actually get.

### Solution

Correct the docstring to `Default: 30` so it matches the real default. Documentation-only; no behavior change.

## Changes

- `bindings/python/src/smg/router.py`: docstring `Default: 10` → `Default: 30` for `worker_startup_check_interval`.

## Test Plan

Documentation-only change. No code paths affected; existing defaults verified against `RouterConfig`, the CLI arg, the PyO3 signature, and the `RouterArgs` dataclass (all `30`).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>