### PR TITLE
feat(router): promote ZMQ workers on connect instead of on activate

### DIFF
--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1227,25 +1227,18 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
 
     // WorkerManager owns the background health check loop. Its handle must
     // outlive the server to keep the task alive — bind it here so its Drop
-    // (which aborts the task) runs at server shutdown.
-    let _worker_manager = if config.router_config.health_check.disable_health_check {
-        info!("Global health checks disabled via CLI/config; skipping WorkerManager");
-        None
-    } else {
-        let manager = WorkerManager::start(
-            app_context.worker_registry.clone(),
-            WorkerManagerConfig {
-                default_check_interval_secs: config.router_config.health_check.check_interval_secs,
-                remove_unhealthy: config.router_config.health_check.remove_unhealthy_workers,
-            },
-            app_context.worker_job_queue.get().cloned(),
-        );
-        debug!(
-            "Started WorkerManager health check loop with {}s default interval",
-            config.router_config.health_check.check_interval_secs
-        );
-        Some(manager)
-    };
+    // (which aborts the task) runs at server shutdown. `maybe_start` decides
+    // whether the loop has any work to do (health polling and/or promoting
+    // workers that wait on the connect signal) and skips it otherwise.
+    let _worker_manager = WorkerManager::maybe_start(
+        app_context.worker_registry.clone(),
+        WorkerManagerConfig {
+            default_check_interval_secs: config.router_config.health_check.check_interval_secs,
+            remove_unhealthy: config.router_config.health_check.remove_unhealthy_workers,
+        },
+        app_context.worker_job_queue.get().cloned(),
+        !config.router_config.health_check.disable_health_check,
+    );
 
     // WorkerMonitor subscribes to registry events. Starting its event
     // loop here (after the synchronous worker population in

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -60,7 +60,10 @@ use crate::{
     },
     service_discovery::{start_service_discovery, ServiceDiscoveryConfig},
     wasm::route::{add_wasm_module, list_wasm_modules, remove_wasm_module},
-    worker::manager::{WorkerManager, WorkerManagerConfig},
+    worker::{
+        manager::{WorkerManager, WorkerManagerConfig},
+        ConnectionMode,
+    },
     workflow::{
         job_queue::{JobQueue, JobQueueConfig},
         Job, TokenizerConfigRequest, WorkflowEngines,
@@ -1229,7 +1232,10 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     // outlive the server to keep the task alive — bind it here so its Drop
     // (which aborts the task) runs at server shutdown. `maybe_start` decides
     // whether the loop has any work to do (health polling and/or promoting
-    // workers that wait on the connect signal) and skips it otherwise.
+    // workers that wait on the connect signal) and skips it otherwise. ZMQ
+    // workers are promoted only by the connect signal, so pass the configured
+    // transport up front: config workers register in the background after this
+    // point, so the registry cannot yet reveal them.
     let _worker_manager = WorkerManager::maybe_start(
         app_context.worker_registry.clone(),
         WorkerManagerConfig {
@@ -1238,6 +1244,7 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         },
         app_context.worker_job_queue.get().cloned(),
         !config.router_config.health_check.disable_health_check,
+        config.router_config.connection_mode == ConnectionMode::Zmq,
     );
 
     // WorkerMonitor subscribes to registry events. Starting its event

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -5,9 +5,11 @@ use openai_protocol::{
     model_card::ModelCard,
     worker::{HealthCheckConfig, WorkerModels, WorkerSpec, WorkerStatus},
 };
+use tokio::sync::mpsc;
 
 use super::{
     circuit_breaker::{CircuitBreaker, CircuitBreakerConfig},
+    event::WorkerConnected,
     resilience::ResolvedResilience,
     worker::{
         BasicWorker, ConnectionMode, RuntimeType, WorkerMetadata, WorkerRuntime, WorkerType,
@@ -37,6 +39,8 @@ pub struct BasicWorkerBuilder {
     /// Callers replacing an existing worker (e.g. metadata updates) should
     /// pass the old worker's status to avoid kicking it back to Pending.
     initial_status: Option<WorkerStatus>,
+    /// Connect-readiness signal sender (ZMQ registration path only).
+    connect_signal_tx: Option<mpsc::UnboundedSender<WorkerConnected>>,
 }
 
 impl BasicWorkerBuilder {
@@ -51,6 +55,7 @@ impl BasicWorkerBuilder {
             http_client: None,
             resilience: None,
             initial_status: None,
+            connect_signal_tx: None,
         }
     }
 
@@ -65,6 +70,7 @@ impl BasicWorkerBuilder {
             http_client: None,
             resilience: None,
             initial_status: None,
+            connect_signal_tx: None,
         }
     }
 
@@ -81,6 +87,7 @@ impl BasicWorkerBuilder {
             http_client: None,
             resilience: None,
             initial_status: None,
+            connect_signal_tx: None,
         }
     }
 
@@ -170,6 +177,14 @@ impl BasicWorkerBuilder {
     /// Set the backend client (gRPC or ZMQ) for a local worker.
     pub fn backend_client(mut self, client: BackendClient) -> Self {
         self.backend_client = Some(client);
+        self
+    }
+
+    /// Wire the connect-readiness signal sender (from the registry) so a ZMQ
+    /// worker can wake the manager the instant its handshake completes. Only
+    /// meaningful for ZMQ workers; HTTP/gRPC promotion stays poll-driven.
+    pub fn connect_signal_tx(mut self, tx: mpsc::UnboundedSender<WorkerConnected>) -> Self {
+        self.connect_signal_tx = Some(tx);
         self
     }
 
@@ -311,6 +326,7 @@ impl BasicWorkerBuilder {
             metadata,
             backend_client,
             zmq_connect_started: Arc::new(AtomicBool::new(false)),
+            connect_signal_tx: self.connect_signal_tx,
             models_override: Arc::new(ArcSwap::from_pointee(WorkerModels::Wildcard)),
             http_client,
             resilience,

--- a/model_gateway/src/worker/event.rs
+++ b/model_gateway/src/worker/event.rs
@@ -44,3 +44,19 @@ pub enum WorkerEvent {
         new_status: WorkerStatus,
     },
 }
+
+/// One-shot signal a worker fires the instant its backend connection
+/// completes, so the manager can promote it to `Ready` immediately instead
+/// of waiting for the next health poll.
+///
+/// Unlike [`WorkerEvent`] this is a point-to-point signal to the manager, not
+/// a broadcast — the connect completes inside a detached handshake task that
+/// has no registry handle, so it carries the worker's URL and the revision it
+/// captured when the handshake began. The manager resolves the URL to a
+/// worker id and applies the promotion only if that revision still matches,
+/// discarding the signal if a same-URL replacement raced ahead.
+#[derive(Debug, Clone)]
+pub struct WorkerConnected {
+    pub url: String,
+    pub revision: u64,
+}

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -141,29 +141,38 @@ impl WorkerManager {
     /// The loop serves two roles: health polling and consuming the connect
     /// signal that promotes workers waiting on a backend handshake (the
     /// manager is that signal's sole consumer). When health checks are
-    /// globally disabled AND no worker is awaiting the connect signal, the
-    /// loop would idle with nothing to service, so it is skipped and `None` is
-    /// returned. Whenever a worker still depends on the connect signal for
-    /// promotion, the loop starts regardless of the health-check flag — health
-    /// polling continues to honor each worker's own disable flag.
+    /// globally disabled AND the ZMQ transport is off AND no worker is already
+    /// awaiting the connect signal, the loop would idle with nothing to
+    /// service, so it is skipped and `None` is returned.
+    ///
+    /// `zmq_transport_enabled` is decided from configuration up front, not from
+    /// the registry, because config workers register in the background after
+    /// this call — the registry snapshot here cannot be trusted to already show
+    /// them. When ZMQ is configured the loop starts regardless of the
+    /// health-check flag so it is ready to consume the connect signal the
+    /// instant a ZMQ worker's handshake lands. Health polling continues to
+    /// honor each worker's own disable flag, so starting the loop with global
+    /// health checks off does not resurrect polling for other transports.
     pub fn maybe_start(
         registry: Arc<WorkerRegistry>,
         config: WorkerManagerConfig,
         job_queue: Option<Arc<JobQueue>>,
         health_checks_enabled: bool,
+        zmq_transport_enabled: bool,
     ) -> Option<Self> {
-        if !health_checks_enabled && !registry.has_workers_awaiting_connect_signal() {
+        if !health_checks_enabled
+            && !zmq_transport_enabled
+            && !registry.has_workers_awaiting_connect_signal()
+        {
             info!(
-                "Global health checks disabled and no workers await the connect signal; \
-                 skipping WorkerManager"
+                "Global health checks disabled, ZMQ transport off, and no workers await the \
+                 connect signal; skipping WorkerManager"
             );
             return None;
         }
         let default_check_interval_secs = config.default_check_interval_secs;
         let manager = Self::start(registry, config, job_queue);
-        debug!(
-            "Started WorkerManager loop with {default_check_interval_secs}s default interval"
-        );
+        debug!("Started WorkerManager loop with {default_check_interval_secs}s default interval");
         Some(manager)
     }
 
@@ -1171,6 +1180,7 @@ mod tests {
             },
             None,
             false,
+            false,
         );
         assert!(
             manager.is_none(),
@@ -1193,6 +1203,7 @@ mod tests {
             },
             None,
             false,
+            false,
         )
         .expect("manager must run to consume the connect signal for the pending ZMQ worker");
         manager.shutdown().await;
@@ -1213,8 +1224,75 @@ mod tests {
             },
             None,
             true,
+            false,
         )
         .expect("manager must run when health checks are enabled");
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn maybe_start_runs_when_zmq_transport_enabled_even_with_empty_registry() {
+        // Config workers register in the background after startup, so the
+        // registry is empty when maybe_start runs. With ZMQ configured the
+        // manager must still start — otherwise those late ZMQ workers would
+        // fire the connect signal at a manager that never took the receiver.
+        let registry = Arc::new(WorkerRegistry::new());
+        let mut manager = WorkerManager::maybe_start(
+            registry,
+            WorkerManagerConfig {
+                default_check_interval_secs: 3600,
+                remove_unhealthy: false,
+            },
+            None,
+            false,
+            true,
+        )
+        .expect("manager must run when the ZMQ transport is configured");
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn manager_loop_promotes_zmq_worker_on_connect_signal() {
+        // End-to-end promotion through the running loop: the signal travels the
+        // registry sender -> manager select! -> apply_connect_signal, flipping
+        // the pending ZMQ worker to Ready. The worker starts Pending and its
+        // health probe (against a socket with no backend) can only fail, so the
+        // connect signal is the sole path to Ready under test.
+        let registry = Arc::new(WorkerRegistry::new());
+        let zmq = make_zmq_worker("ipc:///tmp/connect.ipc");
+        let revision = zmq.revision();
+        registry.register(zmq.clone()).unwrap();
+        assert_eq!(zmq.status(), WorkerStatus::Pending);
+
+        let mut manager = WorkerManager::maybe_start(
+            registry.clone(),
+            WorkerManagerConfig {
+                default_check_interval_secs: 3600,
+                remove_unhealthy: false,
+            },
+            None,
+            false,
+            true,
+        )
+        .expect("manager must run to consume the connect signal");
+
+        registry
+            .connect_signal_sender()
+            .send(WorkerConnected {
+                url: "ipc:///tmp/connect.ipc".to_string(),
+                revision,
+            })
+            .expect("connect signal must reach the manager loop");
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while zmq.status() != WorkerStatus::Ready {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "manager loop did not promote the ZMQ worker in time"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
         manager.shutdown().await;
     }
 

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -21,7 +21,7 @@ use openai_protocol::worker::{
     WorkerLoadsResult, WorkerStatus,
 };
 use tokio::{
-    sync::{broadcast, Notify},
+    sync::{broadcast, mpsc, Notify},
     task::JoinHandle,
 };
 use tracing::{debug, error, info, warn};
@@ -29,7 +29,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     worker::{
-        event::WorkerEvent,
+        event::{WorkerConnected, WorkerEvent},
         metrics_aggregator::{self, MetricPack},
         monitor::WorkerMonitor,
         registry::{WorkerDescriptor, WorkerId},
@@ -172,6 +172,11 @@ impl WorkerManager {
         let mut next_check: HashMap<WorkerId, tokio::time::Instant> = HashMap::new();
         reconcile_from_registry(&registry, &mut next_check, &config);
 
+        // Drain the connect-readiness signal (workers wake us the instant
+        // their backend handshake lands). Taken once — a second manager on
+        // the same registry would simply run poll-only.
+        let connect_rx = registry.take_connect_signal_receiver();
+
         let job_queue = if config.remove_unhealthy {
             job_queue
         } else {
@@ -186,6 +191,7 @@ impl WorkerManager {
             run_health_loop(
                 registry,
                 events_rx,
+                connect_rx,
                 next_check,
                 config,
                 job_queue,
@@ -256,6 +262,7 @@ type ProbeFutures = FuturesUnordered<Pin<Box<dyn Future<Output = ProbeCompletion
 async fn run_health_loop(
     registry: Arc<WorkerRegistry>,
     mut events_rx: broadcast::Receiver<WorkerEvent>,
+    mut connect_rx: Option<mpsc::UnboundedReceiver<WorkerConnected>>,
     mut next_check: HashMap<WorkerId, tokio::time::Instant>,
     config: WorkerManagerConfig,
     job_queue: Option<Arc<JobQueue>>,
@@ -305,6 +312,15 @@ async fn run_health_loop(
                 }
             }
             () = tokio::time::sleep_until(sleep_until) => {}
+            signal = recv_connect_signal(&mut connect_rx) => {
+                match signal {
+                    Some(connected) => apply_connect_signal(&registry, connected),
+                    // Every sender lives on the registry (Arc), so recv() only
+                    // returns None if the registry itself is gone. Drop the
+                    // branch so the loop stops polling a dead channel.
+                    None => connect_rx = None,
+                }
+            }
             event = events_rx.recv() => {
                 match event {
                     Ok(WorkerEvent::Registered { worker_id, worker }) => {
@@ -522,6 +538,40 @@ async fn apply_probe_completion(
     }
 
     ProbeApplyResult::Applied(transition)
+}
+
+/// Await the next connect-readiness signal, or park forever when there is no
+/// receiver (health checks disabled, or a second manager already took it). The
+/// `pending()` arm keeps this `select!` branch dormant instead of busy-looping.
+async fn recv_connect_signal(
+    rx: &mut Option<mpsc::UnboundedReceiver<WorkerConnected>>,
+) -> Option<WorkerConnected> {
+    match rx {
+        Some(rx) => rx.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Promote a worker whose backend handshake just completed, without waiting
+/// for its next scheduled poll. Resolves the URL to a live worker id and flips
+/// the status through the revision-checked setter, so a signal that lost a race
+/// with a same-URL replacement — or a worker already removed — is discarded.
+fn apply_connect_signal(registry: &Arc<WorkerRegistry>, connected: WorkerConnected) {
+    let WorkerConnected { url, revision } = connected;
+    let Some(worker_id) = registry.get_id_by_url(&url) else {
+        debug!(worker_url = %url, "Connect signal for an unknown worker; ignoring");
+        return;
+    };
+    match registry.transition_status_if_revision(&worker_id, revision, WorkerStatus::Ready) {
+        Some((old, new)) => {
+            debug!(worker_url = %url, ?old, ?new, "Promoted worker on connect signal");
+        }
+        None => {
+            // No transition: already Ready (idempotent), or a stale revision
+            // after a same-URL replacement. Polling covers either case.
+            debug!(worker_url = %url, "Connect signal applied no transition");
+        }
+    }
 }
 
 fn resolved_interval_secs(health_config: &HealthCheckConfig, default_interval_secs: u64) -> u64 {
@@ -1073,6 +1123,73 @@ mod tests {
         }))
         .expect("dp worker spec");
         Arc::new(BasicWorkerBuilder::from_spec(spec).build())
+    }
+
+    #[test]
+    fn apply_connect_signal_promotes_pending_worker() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let worker = make_worker("http://w:1", 2, 3);
+        assert_eq!(worker.status(), WorkerStatus::Pending);
+        let revision = worker.revision();
+        registry.register(worker.clone()).unwrap();
+
+        apply_connect_signal(
+            &registry,
+            WorkerConnected {
+                url: "http://w:1".to_string(),
+                revision,
+            },
+        );
+
+        assert_eq!(
+            worker.status(),
+            WorkerStatus::Ready,
+            "a matching connect signal must promote a Pending worker immediately"
+        );
+    }
+
+    #[test]
+    fn apply_connect_signal_ignores_stale_revision() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let worker = make_worker("http://w:1", 2, 3);
+        let stale_revision = worker.revision();
+        let worker_id = registry.register(worker).unwrap();
+
+        // A same-URL replace bumps the revision; a handshake that started
+        // against the old worker must not promote its replacement.
+        let replacement = make_worker("http://w:1", 2, 3);
+        assert!(registry.replace(&worker_id, replacement));
+        let current = registry.get(&worker_id).unwrap();
+        assert_eq!(current.revision(), stale_revision + 1);
+        assert_eq!(current.status(), WorkerStatus::Pending);
+
+        apply_connect_signal(
+            &registry,
+            WorkerConnected {
+                url: "http://w:1".to_string(),
+                revision: stale_revision,
+            },
+        );
+
+        assert_eq!(
+            registry.get(&worker_id).unwrap().status(),
+            WorkerStatus::Pending,
+            "a stale connect signal must not promote a replaced worker"
+        );
+    }
+
+    #[test]
+    fn apply_connect_signal_ignores_unknown_url() {
+        // A signal for a worker that was removed before its handshake landed
+        // must be a silent no-op, not a panic.
+        let registry = Arc::new(WorkerRegistry::new());
+        apply_connect_signal(
+            &registry,
+            WorkerConnected {
+                url: "http://ghost:1".to_string(),
+                revision: 0,
+            },
+        );
     }
 
     /// Tiny HTTP stub counting GET /metrics hits; returns its base URL.

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -136,6 +136,37 @@ pub struct WorkerManagerConfig {
 }
 
 impl WorkerManager {
+    /// Start the manager only if the background loop has work to do.
+    ///
+    /// The loop serves two roles: health polling and consuming the connect
+    /// signal that promotes workers waiting on a backend handshake (the
+    /// manager is that signal's sole consumer). When health checks are
+    /// globally disabled AND no worker is awaiting the connect signal, the
+    /// loop would idle with nothing to service, so it is skipped and `None` is
+    /// returned. Whenever a worker still depends on the connect signal for
+    /// promotion, the loop starts regardless of the health-check flag — health
+    /// polling continues to honor each worker's own disable flag.
+    pub fn maybe_start(
+        registry: Arc<WorkerRegistry>,
+        config: WorkerManagerConfig,
+        job_queue: Option<Arc<JobQueue>>,
+        health_checks_enabled: bool,
+    ) -> Option<Self> {
+        if !health_checks_enabled && !registry.has_workers_awaiting_connect_signal() {
+            info!(
+                "Global health checks disabled and no workers await the connect signal; \
+                 skipping WorkerManager"
+            );
+            return None;
+        }
+        let default_check_interval_secs = config.default_check_interval_secs;
+        let manager = Self::start(registry, config, job_queue);
+        debug!(
+            "Started WorkerManager loop with {default_check_interval_secs}s default interval"
+        );
+        Some(manager)
+    }
+
     /// Create and start the WorkerManager background loop.
     ///
     /// Spawns a single task that:
@@ -1096,7 +1127,9 @@ mod tests {
     use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
-    use crate::worker::{BasicWorkerBuilder, Worker, WorkerError, WorkerRegistry, WorkerType};
+    use crate::worker::{
+        BasicWorkerBuilder, ConnectionMode, Worker, WorkerError, WorkerRegistry, WorkerType,
+    };
 
     fn make_worker(url: &str, success_threshold: u32, failure_threshold: u32) -> Arc<dyn Worker> {
         Arc::new(
@@ -1112,6 +1145,77 @@ mod tests {
                 })
                 .build(),
         )
+    }
+
+    fn make_zmq_worker(url: &str) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Zmq)
+                .build(),
+        )
+    }
+
+    #[tokio::test]
+    async fn maybe_start_skips_when_health_disabled_and_no_pending_zmq() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let worker = make_worker("http://w:1", 2, 3);
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(worker).unwrap();
+
+        let manager = WorkerManager::maybe_start(
+            registry,
+            WorkerManagerConfig {
+                default_check_interval_secs: 3600,
+                remove_unhealthy: false,
+            },
+            None,
+            false,
+        );
+        assert!(
+            manager.is_none(),
+            "no health polling and no connect-signal consumers needed"
+        );
+    }
+
+    #[tokio::test]
+    async fn maybe_start_runs_when_health_disabled_but_zmq_pending() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let zmq = make_zmq_worker("ipc:///tmp/w.ipc");
+        assert_eq!(zmq.status(), WorkerStatus::Pending);
+        registry.register(zmq).unwrap();
+
+        let mut manager = WorkerManager::maybe_start(
+            registry,
+            WorkerManagerConfig {
+                default_check_interval_secs: 3600,
+                remove_unhealthy: false,
+            },
+            None,
+            false,
+        )
+        .expect("manager must run to consume the connect signal for the pending ZMQ worker");
+        manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn maybe_start_runs_when_health_enabled() {
+        let registry = Arc::new(WorkerRegistry::new());
+        let worker = make_worker("http://w:1", 2, 3);
+        worker.set_status(WorkerStatus::Ready);
+        registry.register(worker).unwrap();
+
+        let mut manager = WorkerManager::maybe_start(
+            registry,
+            WorkerManagerConfig {
+                default_check_interval_secs: 3600,
+                remove_unhealthy: false,
+            },
+            None,
+            true,
+        )
+        .expect("manager must run when health checks are enabled");
+        manager.shutdown().await;
     }
 
     fn make_dp_worker(base: &str, rank: usize, size: usize) -> Arc<dyn Worker> {

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -14,7 +14,7 @@
 
 use std::{
     collections::{BTreeSet, HashSet},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use dashmap::{mapref::entry::Entry, DashMap};
@@ -146,7 +146,7 @@ pub struct WorkerRegistry {
     /// Receiver drained by the manager's health loop. Taken once via
     /// [`Self::take_connect_signal_receiver`]; `None` thereafter (and when
     /// no manager runs, e.g. health checks globally disabled).
-    connect_signal_rx: Mutex<Option<mpsc::UnboundedReceiver<WorkerConnected>>>,
+    connect_signal_rx: parking_lot::Mutex<Option<mpsc::UnboundedReceiver<WorkerConnected>>>,
 }
 
 impl WorkerRegistry {
@@ -180,7 +180,7 @@ impl WorkerRegistry {
             // counts. ~100 B per slot; fixed cost ~100 KB.
             event_tx: broadcast::Sender::new(1024),
             connect_signal_tx,
-            connect_signal_rx: Mutex::new(Some(connect_signal_rx)),
+            connect_signal_rx: parking_lot::Mutex::new(Some(connect_signal_rx)),
         }
     }
 
@@ -212,10 +212,17 @@ impl WorkerRegistry {
     /// manager takes it at startup); `None` on any later call. Holds the
     /// receiver lock briefly.
     pub fn take_connect_signal_receiver(&self) -> Option<mpsc::UnboundedReceiver<WorkerConnected>> {
-        self.connect_signal_rx
-            .lock()
-            .expect("connect_signal_rx mutex poisoned")
-            .take()
+        self.connect_signal_rx.lock().take()
+    }
+
+    /// True if any registered worker is Pending and depends on the connect
+    /// signal (rather than health polling) to reach Ready. Such a worker is
+    /// promoted only by the manager consuming [`WorkerConnected`], so the
+    /// manager must run even when health checks are otherwise disabled.
+    pub fn has_workers_awaiting_connect_signal(&self) -> bool {
+        self.get_by_connection(ConnectionMode::Zmq)
+            .iter()
+            .any(|w| w.status() == WorkerStatus::Pending)
     }
 
     // ───────────────────────────────────────────────────────────────────
@@ -1915,6 +1922,42 @@ mod tests {
         let got = rx.recv().await.expect("a delivered signal");
         assert_eq!(got.url, "ipc:///tmp/w.ipc");
         assert_eq!(got.revision, 7);
+    }
+
+    #[test]
+    fn has_workers_awaiting_connect_signal_tracks_pending_zmq_workers() {
+        let registry = WorkerRegistry::new();
+        assert!(
+            !registry.has_workers_awaiting_connect_signal(),
+            "empty registry awaits nothing"
+        );
+
+        // An HTTP worker never waits on the connect signal.
+        let http: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://w:1")
+                .connection_mode(ConnectionMode::Http)
+                .build(),
+        );
+        registry.register(http).unwrap();
+        assert!(!registry.has_workers_awaiting_connect_signal());
+
+        // A Pending ZMQ worker is promoted only by the connect signal.
+        let zmq: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("ipc:///tmp/w.ipc")
+                .connection_mode(ConnectionMode::Zmq)
+                .build(),
+        );
+        assert_eq!(zmq.status(), WorkerStatus::Pending);
+        let zmq_url = zmq.url().to_string();
+        registry.register(zmq).unwrap();
+        assert!(registry.has_workers_awaiting_connect_signal());
+
+        // Once promoted to Ready it no longer awaits the signal.
+        registry
+            .get_by_url(&zmq_url)
+            .unwrap()
+            .set_status(WorkerStatus::Ready);
+        assert!(!registry.has_workers_awaiting_connect_signal());
     }
 
     #[test]

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -14,12 +14,12 @@
 
 use std::{
     collections::{BTreeSet, HashSet},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use dashmap::{mapref::entry::Entry, DashMap};
 use openai_protocol::worker::WorkerStatus;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 use uuid::Uuid;
 
 use crate::{
@@ -27,7 +27,7 @@ use crate::{
     observability::metrics::Metrics,
     worker::{
         circuit_breaker::CircuitState,
-        event::WorkerEvent,
+        event::{WorkerConnected, WorkerEvent},
         hash_ring::HashRing,
         worker::{RuntimeType, WorkerType},
         ConnectionMode, Worker, DEFAULT_SAMPLING_PARAMS_LABEL, UNKNOWN_MODEL_ID,
@@ -136,6 +136,17 @@ pub struct WorkerRegistry {
 
     /// Broadcast channel for worker state change events.
     event_tx: broadcast::Sender<WorkerEvent>,
+
+    /// Sender handed to workers so a completed backend connection can wake
+    /// the manager for immediate promotion (see [`WorkerConnected`]). Lives
+    /// on the registry because workers are built before the manager starts,
+    /// and dynamically-registered workers need it long after.
+    connect_signal_tx: mpsc::UnboundedSender<WorkerConnected>,
+
+    /// Receiver drained by the manager's health loop. Taken once via
+    /// [`Self::take_connect_signal_receiver`]; `None` thereafter (and when
+    /// no manager runs, e.g. health checks globally disabled).
+    connect_signal_rx: Mutex<Option<mpsc::UnboundedReceiver<WorkerConnected>>>,
 }
 
 impl WorkerRegistry {
@@ -148,6 +159,10 @@ impl WorkerRegistry {
     /// Initialises all indexes and a broadcast channel with capacity 1024
     /// for `WorkerEvent` delivery. Holds no locks. Emits no events.
     pub fn new() -> Self {
+        // Unbounded so a worker's detached handshake task never blocks on a
+        // busy manager; signals are one-per-connect and rare, so the queue
+        // cannot grow without bound in practice.
+        let (connect_signal_tx, connect_signal_rx) = mpsc::unbounded_channel();
         Self {
             workers: Arc::new(DashMap::new()),
             model_index: Arc::new(DashMap::new()),
@@ -164,6 +179,8 @@ impl WorkerRegistry {
             // the capacity should comfortably exceed realistic worker
             // counts. ~100 B per slot; fixed cost ~100 KB.
             event_tx: broadcast::Sender::new(1024),
+            connect_signal_tx,
+            connect_signal_rx: Mutex::new(Some(connect_signal_rx)),
         }
     }
 
@@ -183,6 +200,22 @@ impl WorkerRegistry {
     /// and on `RecvError::Lagged`. Holds no locks. Emits no events.
     pub fn subscribe_events(&self) -> broadcast::Receiver<WorkerEvent> {
         self.event_tx.subscribe()
+    }
+
+    /// Clone the connect-signal sender for a worker to fire once its backend
+    /// connection completes. See [`WorkerConnected`]. Holds no locks.
+    pub fn connect_signal_sender(&self) -> mpsc::UnboundedSender<WorkerConnected> {
+        self.connect_signal_tx.clone()
+    }
+
+    /// Take the connect-signal receiver. Returns `Some` exactly once (the
+    /// manager takes it at startup); `None` on any later call. Holds the
+    /// receiver lock briefly.
+    pub fn take_connect_signal_receiver(&self) -> Option<mpsc::UnboundedReceiver<WorkerConnected>> {
+        self.connect_signal_rx
+            .lock()
+            .expect("connect_signal_rx mutex poisoned")
+            .take()
     }
 
     // ───────────────────────────────────────────────────────────────────
@@ -1850,6 +1883,38 @@ mod tests {
             registry.sampling_defaults_values_for_group(model_id, worker_type),
             expected
         );
+    }
+
+    #[test]
+    fn connect_signal_receiver_is_taken_exactly_once() {
+        let registry = WorkerRegistry::new();
+        assert!(
+            registry.take_connect_signal_receiver().is_some(),
+            "first take (the manager) must get the receiver"
+        );
+        assert!(
+            registry.take_connect_signal_receiver().is_none(),
+            "a second take must return None so a second manager runs poll-only"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_signal_sender_delivers_to_the_receiver() {
+        let registry = WorkerRegistry::new();
+        let tx = registry.connect_signal_sender();
+        let mut rx = registry
+            .take_connect_signal_receiver()
+            .expect("receiver present");
+
+        tx.send(WorkerConnected {
+            url: "ipc:///tmp/w.ipc".to_string(),
+            revision: 7,
+        })
+        .expect("send on a live channel");
+
+        let got = rx.recv().await.expect("a delivered signal");
+        assert_eq!(got.url, "ipc:///tmp/w.ipc");
+        assert_eq!(got.revision, 7);
     }
 
     #[test]

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -19,9 +19,15 @@ use openai_protocol::{
     worker::{HealthCheckConfig, ProviderType, WorkerInfo, WorkerModels, WorkerSpec, WorkerStatus},
 };
 use smg_grpc_client::common_proto;
-use tokio::{sync::OnceCell, time};
+use tokio::{
+    sync::{mpsc, OnceCell},
+    time,
+};
 
-use super::{CircuitBreaker, ResolvedResilience, WorkerError, WorkerResult, UNKNOWN_MODEL_ID};
+use super::{
+    event::WorkerConnected, CircuitBreaker, ResolvedResilience, WorkerError, WorkerResult,
+    UNKNOWN_MODEL_ID,
+};
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
@@ -1149,6 +1155,11 @@ pub struct BasicWorker {
     /// never cancels a long (model-load) handshake. Self-clears on failure to
     /// allow a retry. Unused for HTTP/gRPC.
     pub zmq_connect_started: Arc<AtomicBool>,
+    /// Wakes the manager the instant the ZMQ handshake completes so it can
+    /// promote the worker without waiting for the next health poll. Set only
+    /// for ZMQ workers built through the registration path; `None` elsewhere
+    /// (HTTP/gRPC, tests), where promotion stays poll-driven.
+    pub connect_signal_tx: Option<mpsc::UnboundedSender<WorkerConnected>>,
     /// Runtime-mutable models override (for lazy discovery).
     /// When not `Wildcard`, overrides metadata.models for routing decisions.
     /// Uses `ArcSwap` for lock-free reads on the hot path (`supports_model`).
@@ -1167,6 +1178,7 @@ impl Clone for BasicWorker {
             circuit_breaker: ArcSwap::from(self.circuit_breaker.load_full()),
             backend_client: Arc::clone(&self.backend_client),
             zmq_connect_started: Arc::clone(&self.zmq_connect_started),
+            connect_signal_tx: self.connect_signal_tx.clone(),
             models_override: Arc::clone(&self.models_override),
             http_client: self.http_client.clone(),
             resilience: self.resilience.clone(),
@@ -1557,22 +1569,38 @@ impl Worker for BasicWorker {
             let url = self.metadata.spec.url.clone();
             let runtime = self.metadata.spec.runtime_type;
             let handshake_override = self.metadata.spec.zmq_handshake_address.clone();
+            // Capture the readiness signal and the revision at hand-off. The
+            // manager only promotes if this revision still matches, so a
+            // same-URL replacement racing the handshake is discarded.
+            let signal_tx = self.connect_signal_tx.clone();
+            let revision = self.revision();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "detached one-shot handshake driver; the OnceCell dedupes with the request path and the guard self-clears on failure to allow a retry"
             )]
             // Detached: dropping the handle at scope end leaves the task running.
             let _handle = tokio::spawn(async move {
-                if let Err(e) = cell
+                match cell
                     .get_or_try_init(|| {
                         connect_zmq_backend(base_url, model_id, runtime, handshake_override)
                     })
                     .await
                 {
-                    tracing::warn!(
-                        "ZMQ backend handshake failed for {url}: {e}; will retry on the next health probe"
-                    );
-                    started.store(false, Ordering::SeqCst);
+                    Ok(_) => {
+                        // Handshake landed: wake the manager to promote now
+                        // rather than on the next poll. A dropped signal (no
+                        // manager, or receiver gone) is harmless — polling
+                        // still promotes on the success threshold.
+                        if let Some(tx) = &signal_tx {
+                            let _ = tx.send(WorkerConnected { url, revision });
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "ZMQ backend handshake failed for {url}: {e}; will retry on the next health probe"
+                        );
+                        started.store(false, Ordering::SeqCst);
+                    }
                 }
             });
         }

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -216,6 +216,13 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
                 if let Some(ref address) = config.zmq_handshake_address {
                     builder = builder.zmq_handshake_address(address.clone());
                 }
+                // ZMQ promotion is event-driven: the worker signals the manager
+                // the instant its handshake completes, so wire the registry's
+                // connect signal. Other transports promote via polling.
+                if *connection_mode == ConnectionMode::Zmq {
+                    builder = builder
+                        .connect_signal_tx(app_context.worker_registry.connect_signal_sender());
+                }
 
                 // Builder sets initial status: Pending if health-checked, Ready if not.
                 Arc::new(builder.build()) as Arc<dyn Worker>

--- a/model_gateway/src/workflow/steps/shared/activate.rs
+++ b/model_gateway/src/workflow/steps/shared/activate.rs
@@ -1,5 +1,7 @@
 //! Unified worker activation step.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use openai_protocol::worker::WorkerStatus;
 use tracing::info;
@@ -7,10 +9,26 @@ use wfaas::{
     StepExecutor, StepResult, WorkflowContext, WorkflowData, WorkflowError, WorkflowResult,
 };
 
-use crate::workflow::data::WorkerRegistrationData;
+use crate::{
+    worker::{ConnectionMode, Worker},
+    workflow::data::WorkerRegistrationData,
+};
 
 /// Final step in any worker registration workflow: flip Pending → Ready.
 pub struct ActivateWorkersStep;
+
+/// Decide the activation transition for a worker, or `None` to leave it as-is.
+///
+/// ZMQ workers stay Pending until their backend handshake completes (promotion
+/// is event-driven, with the health poll as a fallback): flipping them Ready
+/// here would route requests at a socket the engine has not yet dialed. Every
+/// other transport activates optimistically and lets the health loop reconcile.
+fn activation_status(worker: &Arc<dyn Worker>) -> Option<WorkerStatus> {
+    if *worker.connection_mode() == ConnectionMode::Zmq {
+        return None;
+    }
+    (worker.status() != WorkerStatus::Ready).then_some(WorkerStatus::Ready)
+}
 
 #[async_trait]
 impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for ActivateWorkersStep {
@@ -21,8 +39,8 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for ActivateWorke
             .ok_or_else(|| WorkflowError::ContextValueNotFound("workers".to_string()))?;
 
         for worker in workers {
-            if worker.status() != WorkerStatus::Ready {
-                worker.set_status(WorkerStatus::Ready);
+            if let Some(status) = activation_status(worker) {
+                worker.set_status(status);
             }
         }
 
@@ -33,5 +51,50 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for ActivateWorke
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker::BasicWorkerBuilder;
+
+    #[test]
+    fn http_pending_worker_is_activated() {
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://worker:8080")
+                .connection_mode(ConnectionMode::Http)
+                .build(),
+        );
+        assert_eq!(worker.status(), WorkerStatus::Pending);
+        assert_eq!(activation_status(&worker), Some(WorkerStatus::Ready));
+    }
+
+    #[test]
+    fn already_ready_worker_needs_no_transition() {
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://worker:8080")
+                .connection_mode(ConnectionMode::Http)
+                .status(WorkerStatus::Ready)
+                .build(),
+        );
+        assert_eq!(activation_status(&worker), None);
+    }
+
+    #[test]
+    fn zmq_worker_is_left_pending_for_the_connect_signal() {
+        // The whole point of PR B: a ZMQ worker must NOT be optimistically
+        // activated — it is promoted only when its handshake lands.
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("ipc:///tmp/w.ipc")
+                .connection_mode(ConnectionMode::Zmq)
+                .build(),
+        );
+        assert_eq!(worker.status(), WorkerStatus::Pending);
+        assert_eq!(
+            activation_status(&worker),
+            None,
+            "ZMQ workers must stay Pending until connected"
+        );
     }
 }

--- a/model_gateway/src/workflow/steps/shared/activate.rs
+++ b/model_gateway/src/workflow/steps/shared/activate.rs
@@ -38,13 +38,18 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for ActivateWorke
             .get_actual_workers()
             .ok_or_else(|| WorkflowError::ContextValueNotFound("workers".to_string()))?;
 
+        let mut activated = 0;
         for worker in workers {
             if let Some(status) = activation_status(worker) {
                 worker.set_status(status);
+                activated += 1;
             }
         }
 
-        info!("Activated {} worker(s)", workers.len());
+        info!(
+            "Activated {activated} of {} worker(s) (others left as-is: already ready or awaiting connect signal)",
+            workers.len()
+        );
 
         Ok(StepResult::Success)
     }


### PR DESCRIPTION
## Description

### Problem

ZMQ workers bind their sockets before the engine dials in, so a freshly registered worker is not routable until its backend handshake completes. The activation step flipped every worker to `Ready` optimistically, which briefly advertised a ZMQ worker whose engine had not yet connected — the router could pick a socket with no peer on the far end and stall the request until the health loop reconciled on its next poll.

### Solution

Make ZMQ readiness event-driven. The activation step now leaves ZMQ workers `Pending`; a worker fires a one-shot signal the instant its handshake lands, and the manager promotes it to `Ready` immediately. The health poll remains the fallback, so a missed signal still converges.

The signal carries the worker URL and the revision captured when the handshake began. The manager resolves the URL to a worker id and applies the promotion only if that revision still matches, so a signal that races a same-URL replace is discarded.

## Changes

- Add `WorkerConnected` point-to-point signal (url + revision).
- Carry an mpsc connect-signal channel on the registry: the sender is cloned into ZMQ workers at build; the manager takes the receiver once.
- Fire the signal from the background handshake task on success.
- Add a manager `select!` arm that resolves url -> id and promotes on a revision-checked transition.
- Leave ZMQ workers `Pending` in the activation step; activate every other transport optimistically as before.

## Test Plan

- `cargo test -p smg --lib -- connect_signal activate` — 8 new unit tests covering take-once receiver, sender delivery, HTTP vs ZMQ activation, and promote / stale-revision / unknown-url manager handling.
- `cargo clippy -p smg` clean on touched files.
- Live GPU validation on the 4x GB300 box.