### PR TITLE
chore: remove redundant SPDX license headers

### DIFF
--- a/crates/engine_zmq_client/examples/live_probe.rs
+++ b/crates/engine_zmq_client/examples/live_probe.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Live wire-validation probe: play the SMG frontend against a real headless
 // vLLM EngineCore over ZMQ. Binds the handshake/input/output sockets, drives the
 // handshake, submits one tokenized generate request, and prints the streamed

--- a/crates/engine_zmq_client/src/codec/dtype.rs
+++ b/crates/engine_zmq_client/src/codec/dtype.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Adapted from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/dtype.rs and protocol/logprobs/array.rs.
 

--- a/crates/engine_zmq_client/src/codec/mod.rs
+++ b/crates/engine_zmq_client/src/codec/mod.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Adapted from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/mod.rs.
 

--- a/crates/engine_zmq_client/src/codec/tensor.rs
+++ b/crates/engine_zmq_client/src/codec/tensor.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Adapted from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/tensor.rs and protocol/logprobs/array.rs.
 //

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // The connector: the frontend-side request/response layer over a
 // [`ConnectedTransport`]. Adapted from the Apache-2.0 reference
 // `vllm-engine-core-client` (vllm-project/vllm) client, scoped to SMG's needs:

--- a/crates/engine_zmq_client/src/error.rs
+++ b/crates/engine_zmq_client/src/error.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Error variants for the vLLM EngineCore protocol are adapted from the
 // Apache-2.0 reference `vllm-engine-core-client` (vllm-project/vllm,
 // rust/src/engine-core-client/src/error.rs). See crate root for provenance.

--- a/crates/engine_zmq_client/src/lib.rs
+++ b/crates/engine_zmq_client/src/lib.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-
 //! Engine-agnostic ZMQ transport + per-engine protocol modules for same-host
 //! SMG backend connections.
 //!

--- a/crates/engine_zmq_client/src/mock_engine.rs
+++ b/crates/engine_zmq_client/src/mock_engine.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Test-only mock engine, adapted from the Apache-2.0 reference
 // `vllm-engine-core-client` (vllm-project/vllm): mock_engine.rs + test_utils.rs.
 //

--- a/crates/engine_zmq_client/src/protocol/handshake.rs
+++ b/crates/engine_zmq_client/src/protocol/handshake.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/handshake.rs.
 

--- a/crates/engine_zmq_client/src/protocol/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/mod.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-
 //! Per-engine wire protocol modules plus the engine-neutral seam the transport
 //! and connector are generic over.
 //!

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/mod.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-
 //! TokenSpeed wire protocol.
 //!
 //! Clean-room port of TokenSpeed's native engine-IPC messages

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/output.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/output.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // TokenSpeed per-step batched output — the native `BatchTokenIDOutSlim` from
 // `io_struct.py`, a tagged `msgspec.Struct(array_like=True)`: on the wire it is
 // a positional msgpack array with the class-name tag string as element 0.

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/request.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/request.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // TokenSpeed tokenized generate request — the native `TokenizedGenerateReqInput`
 // from `io_struct.py`, a tagged `msgspec.Struct(array_like=True)`: on the wire
 // it is a positional msgpack array with the class-name tag string as element 0.

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/sampling.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/sampling.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // TokenSpeed `SamplingParams` — a Python `msgspec.Struct(kw_only=True,
 // array_like=True)` (runtime/sampling/sampling_params.py), so it rides the
 // wire as an untagged positional msgpack array nested inside the tokenized

--- a/crates/engine_zmq_client/src/protocol/vllm/logprobs.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/logprobs.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/logprobs.rs + protocol/logprobs/wire.rs.
 // The numpy-array decoders live in `crate::codec::tensor`.

--- a/crates/engine_zmq_client/src/protocol/vllm/lora.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/lora.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/lora.rs.
 

--- a/crates/engine_zmq_client/src/protocol/vllm/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/mod.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-
 //! vLLM EngineCore wire protocol.
 //!
 //! Clean-room port of vLLM's Apache-2.0 `vllm-engine-core-client`

--- a/crates/engine_zmq_client/src/protocol/vllm/output.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/output.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/output.rs.
 //

--- a/crates/engine_zmq_client/src/protocol/vllm/request.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/request.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/request.rs.
 //

--- a/crates/engine_zmq_client/src/protocol/vllm/sampling.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/sampling.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/sampling.rs.
 //

--- a/crates/engine_zmq_client/src/protocol/vllm/stats.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/stats.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/stats.rs.
 

--- a/crates/engine_zmq_client/src/transport.rs
+++ b/crates/engine_zmq_client/src/transport.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): transport.rs.
 //

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -1,5 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-//
 // ZMQ backend adapter (gateway glue): presents the vLLM engine surface (the same
 // proto request/response types as `VllmEngineClient`) but speaks ZMQ directly to
 // a same-host engine (vLLM EngineCore or TokenSpeed) via `engine-zmq-client`,


### PR DESCRIPTION
## Description

### Problem

Files under `crates/engine_zmq_client/` and `model_gateway/src/routers/grpc/zmq_client.rs`
carry a per-file `// SPDX-License-Identifier: Apache-2.0` header. These are
redundant: every crate's `Cargo.toml` already declares `license = "Apache-2.0"`
and the repo ships a root `LICENSE` file. They're also inconsistent with the
rest of the tree — no other source file carries one.

### Solution

Strip the redundant SPDX headers (23 files).

The NVIDIA proto (`crates/grpc_client/proto/trtllm_service.proto`) keeps its
header intentionally: it carries a third-party copyright notice
(`Copyright (c) 2024 NVIDIA CORPORATION`) that Apache-2.0 section 4 requires
preserving.

## Test Plan

Comment-only deletions; no behavior change.

- `cargo +nightly fmt --all -- --check` passes
- `cargo clippy -p engine-zmq-client --all-targets --all-features -- -D warnings` passes

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
