### PR TITLE
fix(deps): pin minijinja to 2.21.0

### DIFF
--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -32,8 +32,12 @@ aho-corasick = "1.1"
 base64 = "0.22"
 rustc-hash = "2"
 hf-hub = { version = "0.5.0", default-features = false, features = ["tokio", "rustls-tls"] }
-minijinja = { version = "2.21", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }
-minijinja-contrib = { version = "2.21", features = ["pycompat"] }
+# Pinned: 2.22.0 changed boolean rendering to Python style ("False"), which
+# alters rendered chat-template text. With no committed Cargo.lock, CI floats
+# to the newest release, so an unpinned minor bump broke every PR's
+# unit-tests lane. Bump deliberately, revalidating template output.
+minijinja = { version = "=2.21.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls", "preserve_order"] }
+minijinja-contrib = { version = "=2.21.0", features = ["pycompat"] }
 rayon = "1.12"
 tiktoken-rs = "0.12"
 tokenizers = "0.23.1"


### PR DESCRIPTION
## Description

### Problem

Every PR's `unit-tests` lane went red today with no code changes:

```
---- chat_template::tests::thinking_param_sets_template_key_and_explicit_wins ----
assertion `left == right` failed
  left: "False"
 right: "false"
```

Root cause: minijinja released 2.22.0, which renders booleans Python-style (`False`/`True`). Because `Cargo.lock` is gitignored (#6438), CI resolves dependencies fresh on every run and silently floated from 2.21.0 to 2.22.0. The failure reproduces on unrelated dependabot branches and feature branches alike; locally it passes only because cached resolutions still hold 2.21.0.

Beyond the test, the rendering change alters actual chat-template output for any template that interpolates a boolean (e.g. `{{ enable_thinking }}`), so floating into it silently is a prompt-affecting behavior change, not just a test break.

### Solution

Pin `minijinja` and `minijinja-contrib` to `=2.21.0` until the bump is taken deliberately with template output revalidated.

### Note for maintainers

This class of breakage (any patch/minor release of any dependency turning CI red repo-wide) is a direct consequence of not committing `Cargo.lock`. Worth reconsidering #6438 separately — a committed lockfile makes CI reproducible and turns dependency bumps into reviewable diffs.

## Test Plan

- Fresh worktree with no lockfile: `cargo tree` resolves `minijinja v2.21.0` exactly.
- `cargo test --manifest-path crates/tokenizer/Cargo.toml --lib thinking_param` passes on the fresh resolution (the exact test that fails on 2.22.0).