### PR TITLE
fix(rate-limit): honor zero token refill rate

### DIFF
--- a/deploy/helm/smg/templates/_helpers.tpl
+++ b/deploy/helm/smg/templates/_helpers.tpl
@@ -276,7 +276,7 @@ Called from the router Deployment template.
 - {{ .Values.history.oracle.password | quote }}
 {{- end }}
 {{- end }}
-{{- if gt (int .Values.auth.rateLimitTokensPerSecond) 0 }}
+{{- if ge (int .Values.auth.rateLimitTokensPerSecond) 0 }}
 - "--rate-limit-tokens-per-second"
 - {{ .Values.auth.rateLimitTokensPerSecond | quote }}
 {{- end }}

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -718,7 +718,7 @@ mod tests {
     #[tokio::test]
     async fn explicit_zero_rate_limit_disables_refill() {
         let config = RouterConfig {
-            max_concurrent_requests: 2,
+            max_concurrent_requests: 10,
             rate_limit_tokens_per_second: Some(0),
             ..RouterConfig::default()
         };
@@ -727,8 +727,10 @@ mod tests {
             .rate_limiter
             .expect("rate limiter should be enabled");
 
-        assert!(bucket.try_acquire(2.0).is_ok());
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(bucket.try_acquire(10.0).is_ok());
+        // The previous fallback used max_concurrent_requests as the refill
+        // rate, which would add more than one token during this wait.
+        tokio::time::sleep(Duration::from_millis(150)).await;
         assert!(bucket.try_acquire(1.0).is_err());
 
         bucket.return_tokens_sync(1.0);

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -497,7 +497,7 @@ impl AppContextBuilder {
             n => {
                 let rate_limit_tokens = config
                     .rate_limit_tokens_per_second
-                    .filter(|&t| t > 0)
+                    .filter(|&t| t >= 0)
                     .unwrap_or(n);
                 Some(Arc::new(TokenBucket::new(
                     n as usize,
@@ -714,6 +714,26 @@ impl Default for AppContextBuilder {
 mod tests {
     use super::*;
     use crate::config::types::PolicyConfig;
+
+    #[tokio::test]
+    async fn explicit_zero_rate_limit_disables_refill() {
+        let config = RouterConfig {
+            max_concurrent_requests: 2,
+            rate_limit_tokens_per_second: Some(0),
+            ..RouterConfig::default()
+        };
+        let bucket = AppContextBuilder::new()
+            .maybe_rate_limiter(&config)
+            .rate_limiter
+            .expect("rate limiter should be enabled");
+
+        assert!(bucket.try_acquire(2.0).is_ok());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(bucket.try_acquire(1.0).is_err());
+
+        bucket.return_tokens_sync(1.0);
+        assert!(bucket.try_acquire(1.0).is_ok());
+    }
 
     fn config_with_policy(policy: PolicyConfig) -> RouterConfig {
         RouterConfig {


### PR DESCRIPTION
## Description

### Problem

`rate_limit_tokens_per_second = 0` passes configuration validation and is supported by `TokenBucket` as a zero-refill concurrency limiter. However, startup filtered out zero and fell back to `max_concurrent_requests` as the refill rate. The Helm chart also omitted the CLI flag when the value was zero.

### Solution

Preserve explicit non-negative refill rates when constructing the token bucket, and render the Helm CLI argument for zero. Keep negative values filtered so unchecked configurations cannot be cast to an invalid `usize`.

## Changes

- Honor an explicit zero token refill rate in `AppContextBuilder`.
- Pass `auth.rateLimitTokensPerSecond: 0` through the Helm chart.
- Add a regression test proving that zero disables time-based refill while returned tokens remain reusable.

## Test Plan

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `helm lint deploy/helm/smg`
- Render the chart with `auth.rateLimitTokensPerSecond=0` and verify that `--rate-limit-tokens-per-second 0` is present.
- Render the chart with the default `-1` and verify that the rate-limit argument is absent.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
