### PR TITLE
feat(zmq): structured outputs over the direct ZMQ backend (2/7)

### DIFF
--- a/crates/engine_zmq_client/src/error.rs
+++ b/crates/engine_zmq_client/src/error.rs
@@ -51,6 +51,8 @@ pub enum Error {
         context: &'static str,
         field: &'static str,
     },
+    #[error("invalid structured outputs params: {message}")]
+    InvalidStructuredOutputsParams { message: String },
     #[error("request `{request_id}` is already in flight")]
     DuplicateRequestId { request_id: String },
     #[error("data parallel rank {rank} is out of range for {num_engines} engine(s)")]

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/sampling.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/sampling.rs
@@ -52,13 +52,14 @@ pub struct SamplingParams {
     pub repetition_penalty: f64,
     /// Minimum number of tokens to generate before EOS / stop handling.
     pub min_new_tokens: u32,
-    /// Structured-output JSON schema. SMG rejects constraints upstream.
+    /// Structured-output JSON schema. Set from the request's `constraint`;
+    /// at most one of these four structured-output fields is populated.
     pub json_schema: Option<String>,
-    /// Structured-output regex. SMG rejects constraints upstream.
+    /// Structured-output regex. Set from the request's `constraint`.
     pub regex: Option<String>,
-    /// Structured-output EBNF grammar. SMG rejects constraints upstream.
+    /// Structured-output EBNF grammar. Set from the request's `constraint`.
     pub ebnf: Option<String>,
-    /// Structured-output structural tag. SMG rejects constraints upstream.
+    /// Structured-output structural tag. Set from the request's `constraint`.
     pub structural_tag: Option<String>,
     /// Ignore the EOS token and keep generating until another stop condition.
     pub ignore_eos: bool,

--- a/crates/engine_zmq_client/src/protocol/vllm/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/mod.rs
@@ -5,10 +5,10 @@
 //! shapes, field order, and `array_like` positional-tuple encoding are the wire
 //! contract with Python `EngineCoreProc` — do not reorder fields.
 //!
-//! Text generation is typed fully. Multimodal features, structured outputs
-//! (guided decoding), and pooling params are carried as [`crate::codec::OpaqueValue`]
-//! for now — they serialize as `nil` on the text path and get strongly typed in
-//! the multimodal phase.
+//! Text generation and structured outputs (guided decoding) are typed fully.
+//! Multimodal features and pooling params are carried as
+//! [`crate::codec::OpaqueValue`] for now — they serialize as `nil` on the text
+//! path and get strongly typed in the multimodal phase.
 
 // The startup handshake is engine-neutral (TokenSpeed speaks the same
 // protocol); re-exported here so existing `vllm::handshake` paths keep working.
@@ -19,6 +19,7 @@ pub mod output;
 pub mod request;
 pub mod sampling;
 pub mod stats;
+pub mod structured_outputs;
 
 use bytes::Bytes;
 

--- a/crates/engine_zmq_client/src/protocol/vllm/sampling.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/sampling.rs
@@ -1,15 +1,12 @@
 // Ported from the Apache-2.0 reference `vllm-engine-core-client`
 // (vllm-project/vllm): protocol/sampling.rs.
-//
-// `structured_outputs` (guided decoding) is carried as OpaqueValue for now; it
-// serializes as `nil` when absent and gets strongly typed in a later phase.
 
 use std::collections::{BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 use serde_default::DefaultFromSerde;
 
-use crate::codec::OpaqueValue;
+use super::structured_outputs::StructuredOutputsParams;
 
 fn default_top_p() -> f32 {
     1.0
@@ -113,9 +110,9 @@ pub struct EngineCoreSamplingParams {
     /// Tokenized bad words to avoid during generation.
     #[serde(rename = "_bad_words_token_ids")]
     pub bad_words_token_ids: Option<Vec<Vec<u32>>>,
-    /// Structured outputs (guided decoding). Carried untyped for now; `nil` on
-    /// the text path.
-    pub structured_outputs: Option<OpaqueValue>,
+    /// Structured outputs (guided decoding). `None` (serialized `nil`) on the
+    /// unconstrained text path.
+    pub structured_outputs: Option<StructuredOutputsParams>,
     /// Specific token IDs for which log probabilities should be returned at each
     /// position, in addition to the sampled/scored token.
     pub logprob_token_ids: Option<Vec<u32>>,

--- a/crates/engine_zmq_client/src/protocol/vllm/structured_outputs.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/structured_outputs.rs
@@ -1,0 +1,334 @@
+// Ported from the Apache-2.0 reference `vllm-engine-core-client`
+// (vllm-project/vllm): protocol/structured_outputs.rs.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+
+use crate::error::{Error, Result};
+
+/// Structured-output backend selected for EngineCore grammar compilation.
+///
+/// Python stores this in `StructuredOutputsParams._backend` after request
+/// validation. This client selects the backend per constraint: structural
+/// tags require xgrammar (the triggered-tags format is not understood by
+/// guidance's legacy structures/triggers parser); everything else lowers to
+/// guidance. Peer-supplied `_backend` values are ignored.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StructuredOutputBackend {
+    Xgrammar,
+    #[default]
+    Guidance,
+    Outlines,
+    LmFormatEnforcer,
+}
+
+/// The single structured-output constraint selected for a request.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StructuredOutputConstraint {
+    /// JSON schema (as a dict/object or JSON string) constraining the output.
+    Json(Value),
+    /// Regular expression the output must match.
+    Regex(String),
+    /// List of allowed output strings (the model must produce one of these).
+    Choice(Vec<String>),
+    /// Context-free grammar (in EBNF-like notation) the output must conform to.
+    Grammar(String),
+    /// Output must be valid JSON (free-form, no schema).
+    JsonObject,
+    /// Structural tag configuration (JSON-encoded string).
+    StructuralTag(String),
+}
+
+/// Additional structured-output options that do not select the constraint mode.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StructuredOutputOptions {
+    /// Disable any additional whitespace in guided JSON output.
+    pub disable_any_whitespace: bool,
+    /// Disable `additionalProperties` in JSON schema output.
+    pub disable_additional_properties: bool,
+    /// Custom whitespace pattern for guided JSON output.
+    pub whitespace_pattern: Option<String>,
+}
+
+/// Parameters for configuring structured outputs (guided decoding).
+///
+/// This is the semantic Rust representation: exactly one constraint mode is
+/// always selected. The Python/msgpack product-shaped representation is kept in
+/// the private wire type below and used only at serde boundaries.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StructuredOutputsParams {
+    pub constraint: StructuredOutputConstraint,
+    pub options: StructuredOutputOptions,
+    /// Structured-output backend, mirroring Python's internal `_backend`.
+    ///
+    /// Peer-supplied values are ignored during deserialization. This matches the
+    /// Python request boundary, where `_backend` is set by validation rather
+    /// than accepted as a request-level backend selector.
+    pub backend: StructuredOutputBackend,
+}
+
+impl StructuredOutputsParams {
+    pub fn json(json: Value) -> Self {
+        Self::from_constraint(StructuredOutputConstraint::Json(json))
+    }
+
+    pub fn regex(regex: impl Into<String>) -> Self {
+        Self::from_constraint(StructuredOutputConstraint::Regex(regex.into()))
+    }
+
+    pub fn choice(choice: Vec<String>) -> Self {
+        Self::from_constraint(StructuredOutputConstraint::Choice(choice))
+    }
+
+    pub fn grammar(grammar: impl Into<String>) -> Self {
+        Self::from_constraint(StructuredOutputConstraint::Grammar(grammar.into()))
+    }
+
+    pub fn json_object() -> Self {
+        Self::from_constraint(StructuredOutputConstraint::JsonObject)
+    }
+
+    pub fn structural_tag(structural_tag: impl Into<String>) -> Self {
+        Self::from_constraint(StructuredOutputConstraint::StructuralTag(
+            structural_tag.into(),
+        ))
+    }
+
+    fn from_constraint(constraint: StructuredOutputConstraint) -> Self {
+        // Structural tags use the triggered-tags format that only xgrammar
+        // compiles; guidance's parser expects the legacy structures/triggers
+        // shape and fails the request at grammar build.
+        let backend = match &constraint {
+            StructuredOutputConstraint::StructuralTag(_) => StructuredOutputBackend::Xgrammar,
+            _ => StructuredOutputBackend::default(),
+        };
+        Self {
+            constraint,
+            options: StructuredOutputOptions::default(),
+            backend,
+        }
+    }
+}
+
+/// `true` when a boolean is `false`; used to drop default-`false` flags from the
+/// serialized map to match the sparse `omit_defaults` wire shape. Takes `&bool`
+/// because serde's `skip_serializing_if` requires a by-reference predicate.
+#[expect(clippy::trivially_copy_pass_by_ref)]
+fn is_false(v: &bool) -> bool {
+    !*v
+}
+
+/// Wire-compatible structured-output payload used by Python engine-core.
+///
+/// Python models `StructuredOutputsParams` as a product-shaped dataclass with
+/// several optional constraint fields, then validates that exactly one of those
+/// fields is present. This client exposes [`StructuredOutputsParams`] as an
+/// enum-backed domain type instead, while using this private wire type for
+/// ser/de.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+struct WireStructuredOutputsParams {
+    json: Option<Value>,
+    regex: Option<String>,
+    choice: Option<Vec<String>>,
+    grammar: Option<String>,
+    json_object: Option<bool>,
+    #[serde(skip_serializing_if = "is_false")]
+    disable_any_whitespace: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    disable_additional_properties: bool,
+    whitespace_pattern: Option<String>,
+    structural_tag: Option<String>,
+    #[serde(
+        default,
+        rename = "_backend",
+        deserialize_with = "serde_with::rust::deserialize_ignore_any"
+    )]
+    backend: StructuredOutputBackend,
+}
+
+impl TryFrom<WireStructuredOutputsParams> for StructuredOutputsParams {
+    type Error = Error;
+
+    fn try_from(raw: WireStructuredOutputsParams) -> Result<Self> {
+        use StructuredOutputConstraint::*;
+
+        let mut constraint = None;
+
+        macro_rules! insert_constraint {
+            ($name:literal, $value:expr) => {
+                if let Some(value) = $value {
+                    if let Some((existing, _)) = constraint {
+                        return Err(Error::InvalidStructuredOutputsParams {
+                            message: format!(
+                                "multiple structured output constraints specified: {existing}, {}",
+                                $name
+                            ),
+                        });
+                    }
+                    constraint = Some(($name, value));
+                }
+            };
+        }
+
+        insert_constraint!("json", raw.json.map(Json));
+        insert_constraint!("regex", raw.regex.map(Regex));
+        insert_constraint!("choice", raw.choice.map(Choice));
+        insert_constraint!("grammar", raw.grammar.map(Grammar));
+        match raw.json_object {
+            Some(true) => {
+                insert_constraint!("json_object", Some(JsonObject));
+            }
+            Some(false) => {
+                return Err(Error::InvalidStructuredOutputsParams {
+                    message: "structured_outputs.json_object must be true if set; omit structured_outputs to disable structured outputs".to_string(),
+                });
+            }
+            None => {}
+        }
+        insert_constraint!("structural_tag", raw.structural_tag.map(StructuralTag));
+
+        Ok(Self {
+            constraint: constraint.map(|(_, c)| c).ok_or_else(|| {
+                Error::InvalidStructuredOutputsParams {
+                    message: "missing structured output constraint".to_string(),
+                }
+            })?,
+            options: StructuredOutputOptions {
+                disable_any_whitespace: raw.disable_any_whitespace,
+                disable_additional_properties: raw.disable_additional_properties,
+                whitespace_pattern: raw.whitespace_pattern,
+            },
+            backend: raw.backend,
+        })
+    }
+}
+
+impl From<StructuredOutputsParams> for WireStructuredOutputsParams {
+    fn from(params: StructuredOutputsParams) -> Self {
+        let mut raw = Self {
+            disable_any_whitespace: params.options.disable_any_whitespace,
+            disable_additional_properties: params.options.disable_additional_properties,
+            whitespace_pattern: params.options.whitespace_pattern,
+            backend: params.backend,
+            ..Self::default()
+        };
+
+        match params.constraint {
+            StructuredOutputConstraint::Json(json) => raw.json = Some(json),
+            StructuredOutputConstraint::Regex(regex) => raw.regex = Some(regex),
+            StructuredOutputConstraint::Choice(choice) => raw.choice = Some(choice),
+            StructuredOutputConstraint::Grammar(grammar) => raw.grammar = Some(grammar),
+            StructuredOutputConstraint::JsonObject => raw.json_object = Some(true),
+            StructuredOutputConstraint::StructuralTag(structural_tag) => {
+                raw.structural_tag = Some(structural_tag);
+            }
+        }
+
+        raw
+    }
+}
+
+impl Serialize for StructuredOutputsParams {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        WireStructuredOutputsParams::from(self.clone()).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for StructuredOutputsParams {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        WireStructuredOutputsParams::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn structured_outputs_backend_ignores_deserialized_value() {
+        let params: StructuredOutputsParams = serde_json::from_value(serde_json::json!({
+            "json_object": true,
+            "_backend": "xgrammar",
+        }))
+        .unwrap();
+
+        assert_eq!(params.backend, StructuredOutputBackend::Guidance);
+        assert_eq!(params.constraint, StructuredOutputConstraint::JsonObject);
+
+        let value = serde_json::to_value(params).unwrap();
+        assert_eq!(value["_backend"], "guidance");
+    }
+
+    #[test]
+    fn structural_tag_selects_xgrammar_backend() {
+        // The triggered-tags format only compiles under xgrammar; guidance's
+        // legacy parser fails the request at grammar build.
+        let params = StructuredOutputsParams::structural_tag(r#"{"format":{}}"#);
+        assert_eq!(params.backend, StructuredOutputBackend::Xgrammar);
+
+        let value = serde_json::to_value(params).unwrap();
+        assert_eq!(value["_backend"], "xgrammar");
+        assert_eq!(value["structural_tag"], r#"{"format":{}}"#);
+    }
+
+    #[test]
+    fn structured_outputs_rejects_missing_constraint() {
+        let error =
+            serde_json::from_value::<StructuredOutputsParams>(serde_json::json!({})).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("missing structured output constraint"));
+    }
+
+    #[test]
+    fn structured_outputs_rejects_multiple_constraints() {
+        let error = serde_json::from_value::<StructuredOutputsParams>(serde_json::json!({
+            "json": {"type": "object"},
+            "regex": ".*",
+        }))
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("multiple structured output constraints specified: json, regex"));
+    }
+
+    #[test]
+    fn structured_outputs_rejects_json_object_false() {
+        let error = serde_json::from_value::<StructuredOutputsParams>(serde_json::json!({
+            "json_object": false,
+        }))
+        .unwrap_err();
+
+        assert!(error.to_string().contains("json_object must be true"));
+    }
+
+    #[test]
+    fn structured_outputs_serializes_through_raw_shape() {
+        let params = StructuredOutputsParams {
+            constraint: StructuredOutputConstraint::StructuralTag(
+                r#"{"type":"structural_tag"}"#.to_string(),
+            ),
+            options: StructuredOutputOptions::default(),
+            backend: StructuredOutputBackend::Xgrammar,
+        };
+
+        let value = serde_json::to_value(params).unwrap();
+
+        assert_eq!(value["structural_tag"], r#"{"type":"structural_tag"}"#);
+        assert_eq!(value["_backend"], "xgrammar");
+        assert!(value.get("json").is_none());
+    }
+}

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -28,6 +28,7 @@ use engine_zmq_client::{
             output::{EngineCoreFinishReason, EngineCoreOutput, StopReason},
             request::EngineCoreRequest,
             sampling::EngineCoreSamplingParams,
+            structured_outputs::StructuredOutputsParams,
         },
         EngineLoad,
     },
@@ -754,18 +755,6 @@ fn fan_out_tokenspeed_requests(
 fn translate_request_tokenspeed(
     req: tokenspeed_proto::GenerateRequest,
 ) -> Result<TokenizedGenerateReqInput, String> {
-    // The response_format / forced-tool-choice constraint oneof is not
-    // translated onto the TokenSpeed structured-output fields yet; dropping it
-    // would return unconstrained text.
-    if req
-        .sampling_params
-        .as_ref()
-        .is_some_and(|sp| sp.constraint.is_some())
-    {
-        return Err(
-            "structured output constraints are not supported over the ZMQ backend yet".to_string(),
-        );
-    }
     let input_ids = match req.tokenized {
         Some(tokenized) => tokenized.input_ids,
         None => {
@@ -834,8 +823,26 @@ fn translate_sampling_tokenspeed(sp: tokenspeed_proto::SamplingParams) -> TokenS
         n: sp.n.max(1),
         ..TokenSpeedSamplingParams::default()
     };
+    apply_tokenspeed_constraint(&mut params, sp.constraint);
     params.normalize();
     params
+}
+
+/// Map the proto structured-output `constraint` oneof onto the wire's dedicated
+/// fields. The oneof is single-valued, so at most one field is set; the rest
+/// stay `None`.
+fn apply_tokenspeed_constraint(
+    params: &mut TokenSpeedSamplingParams,
+    constraint: Option<tokenspeed_proto::sampling_params::Constraint>,
+) {
+    use tokenspeed_proto::sampling_params::Constraint;
+    match constraint {
+        Some(Constraint::JsonSchema(schema)) => params.json_schema = Some(schema),
+        Some(Constraint::Regex(regex)) => params.regex = Some(regex),
+        Some(Constraint::EbnfGrammar(grammar)) => params.ebnf = Some(grammar),
+        Some(Constraint::StructuralTag(tag)) => params.structural_tag = Some(tag),
+        None => {}
+    }
 }
 
 /// Translate a vLLM-proto generate request into an `EngineCoreRequest`. ZMQ mode
@@ -858,15 +865,6 @@ fn translate_request(
         .map(|rank| u32::try_from(rank).map_err(|_| format!("invalid data_parallel_rank: {rank}")))
         .transpose()?;
     if let Some(sp) = req.sampling_params.as_ref() {
-        // The response_format / forced-tool-choice constraint oneof is not
-        // translated onto the EngineCore wire yet; dropping it would return
-        // unconstrained text.
-        if sp.constraint.is_some() {
-            return Err(
-                "structured output constraints are not supported over the ZMQ backend yet"
-                    .to_string(),
-            );
-        }
         // n is not carried on the EngineCore wire; n>1 is fanned out into
         // single-sample sub-requests by `generate` before translation.
         // The ZMQ renderer path has no prompt-logprob merge, so the engine's
@@ -931,7 +929,30 @@ fn translate_sampling(
         // prompt_logprobs is rejected in `translate_request` (no renderer
         // support on the ZMQ path), so it is never forwarded.
         logit_bias,
+        structured_outputs: sp.constraint.and_then(translate_constraint),
         ..EngineCoreSamplingParams::default()
+    }
+}
+
+/// Map the proto `constraint` oneof onto typed structured-output params. The
+/// backend defaults to guidance engine-side; `json_object=false` selects no
+/// constraint (the caller opted out), so it maps to `None`.
+fn translate_constraint(
+    constraint: vllm::sampling_params::Constraint,
+) -> Option<StructuredOutputsParams> {
+    use vllm::sampling_params::Constraint;
+    match constraint {
+        Constraint::JsonSchema(schema) => Some(StructuredOutputsParams::json(
+            // The engine accepts a JSON schema object or a schema string; parse
+            // to preserve object shape, falling back to the raw string.
+            serde_json::from_str(&schema).unwrap_or(serde_json::Value::String(schema)),
+        )),
+        Constraint::Regex(regex) => Some(StructuredOutputsParams::regex(regex)),
+        Constraint::Grammar(grammar) => Some(StructuredOutputsParams::grammar(grammar)),
+        Constraint::StructuralTag(tag) => Some(StructuredOutputsParams::structural_tag(tag)),
+        Constraint::JsonObject(true) => Some(StructuredOutputsParams::json_object()),
+        Constraint::JsonObject(false) => None,
+        Constraint::Choice(choice) => Some(StructuredOutputsParams::choice(choice.choices)),
     }
 }
 
@@ -1562,6 +1583,48 @@ mod tests {
     }
 
     #[test]
+    fn tokenspeed_maps_structured_output_constraints() {
+        // The `constraint` oneof maps 1:1 onto the wire's dedicated fields; the
+        // oneof is single-valued, so the other three stay unset.
+        use tokenspeed_proto::sampling_params::Constraint;
+
+        let json = translate_sampling_tokenspeed(tokenspeed_proto::SamplingParams {
+            constraint: Some(Constraint::JsonSchema("{\"type\":\"object\"}".into())),
+            ..Default::default()
+        });
+        assert_eq!(json.json_schema.as_deref(), Some("{\"type\":\"object\"}"));
+        assert_eq!(json.regex, None);
+        assert_eq!(json.ebnf, None);
+        assert_eq!(json.structural_tag, None);
+
+        let regex = translate_sampling_tokenspeed(tokenspeed_proto::SamplingParams {
+            constraint: Some(Constraint::Regex("[0-9]+".into())),
+            ..Default::default()
+        });
+        assert_eq!(regex.regex.as_deref(), Some("[0-9]+"));
+        assert_eq!(regex.json_schema, None);
+
+        let ebnf = translate_sampling_tokenspeed(tokenspeed_proto::SamplingParams {
+            constraint: Some(Constraint::EbnfGrammar("root ::= \"a\"".into())),
+            ..Default::default()
+        });
+        assert_eq!(ebnf.ebnf.as_deref(), Some("root ::= \"a\""));
+
+        let tag = translate_sampling_tokenspeed(tokenspeed_proto::SamplingParams {
+            constraint: Some(Constraint::StructuralTag("<tag>".into())),
+            ..Default::default()
+        });
+        assert_eq!(tag.structural_tag.as_deref(), Some("<tag>"));
+
+        // No constraint leaves all four structured-output fields unset.
+        let none = translate_sampling_tokenspeed(tokenspeed_proto::SamplingParams::default());
+        assert_eq!(none.json_schema, None);
+        assert_eq!(none.regex, None);
+        assert_eq!(none.ebnf, None);
+        assert_eq!(none.structural_tag, None);
+    }
+
+    #[test]
     fn tokenspeed_forwards_stop_token_ids_and_drops_stop_strings() {
         // String stops are resolved upstream; any that reach here are dropped
         // (the token-only engine cannot match them) while stop token ids ride
@@ -1579,17 +1642,6 @@ mod tests {
 
     #[test]
     fn vllm_rejects_unsupported_sampling_features() {
-        // Structured-output constraints are not translated onto the wire.
-        let err = translate_request(
-            tokenized_req(vllm::SamplingParams {
-                constraint: Some(vllm::sampling_params::Constraint::JsonObject(true)),
-                ..Default::default()
-            }),
-            4096,
-        )
-        .expect_err("constraint rejected");
-        assert!(err.contains("structured output"), "{err}");
-
         // Prompt logprobs have no renderer merge on the ZMQ path.
         let err = translate_request(
             tokenized_req(vllm::SamplingParams {
@@ -1626,6 +1678,68 @@ mod tests {
             ),
             8,
         );
+    }
+
+    #[test]
+    fn vllm_translates_structured_output_constraints() {
+        use engine_zmq_client::protocol::vllm::structured_outputs::{
+            StructuredOutputBackend, StructuredOutputConstraint,
+        };
+
+        let translate = |constraint| {
+            translate_request(
+                tokenized_req(vllm::SamplingParams {
+                    constraint: Some(constraint),
+                    ..Default::default()
+                }),
+                4096,
+            )
+            .expect("constraint translated")
+            .sampling_params
+            .expect("sampling params present")
+            .structured_outputs
+        };
+
+        // Each constraint mode maps onto its typed counterpart, always lowering
+        // to the guidance backend engine-side.
+        let json_object = translate(vllm::sampling_params::Constraint::JsonObject(true))
+            .expect("json_object translated");
+        assert_eq!(
+            json_object.constraint,
+            StructuredOutputConstraint::JsonObject
+        );
+        assert_eq!(json_object.backend, StructuredOutputBackend::Guidance);
+
+        let regex = translate(vllm::sampling_params::Constraint::Regex("a.*".to_string()))
+            .expect("regex translated");
+        assert_eq!(
+            regex.constraint,
+            StructuredOutputConstraint::Regex("a.*".to_string())
+        );
+
+        let choice = translate(vllm::sampling_params::Constraint::Choice(
+            vllm::ChoiceConstraint {
+                choices: vec!["yes".to_string(), "no".to_string()],
+            },
+        ))
+        .expect("choice translated");
+        assert_eq!(
+            choice.constraint,
+            StructuredOutputConstraint::Choice(vec!["yes".to_string(), "no".to_string()])
+        );
+
+        // A JSON schema string is parsed to preserve object shape.
+        let json = translate(vllm::sampling_params::Constraint::JsonSchema(
+            r#"{"type":"object"}"#.to_string(),
+        ))
+        .expect("json schema translated");
+        assert_eq!(
+            json.constraint,
+            StructuredOutputConstraint::Json(serde_json::json!({"type": "object"}))
+        );
+
+        // json_object=false means the caller opted out: no constraint.
+        assert!(translate(vllm::sampling_params::Constraint::JsonObject(false)).is_none());
     }
 
     /// n=3 fans out into 3 single-sample wire requests with unique sub-rids.


### PR DESCRIPTION
## Description

### Problem

The text-only core (PR 1) carries structured-output (guided decoding) parameters
as a placeholder, so requests with `json` / `regex` / `choice` / `grammar` /
`json_object` / structural-tag constraints are not forwarded to a direct-ZMQ
engine.

### Solution

Type the structured-output params against the vLLM EngineCore wire shape and wire
them into the ZMQ request translation. The public API is an enum-backed domain
type (exactly one constraint mode) with a private product-shaped wire type used
only at serde boundaries; structural tags select the xgrammar backend since
guidance's legacy parser cannot compile the triggered-tags format.

## Changes

- `crates/engine_zmq_client/src/protocol/vllm/structured_outputs.rs` (new) —
  `StructuredOutputsParams` domain type, backend selection, and wire ser/de.
- `crates/engine_zmq_client/src/protocol/vllm/{mod,sampling}.rs` — expose the
  module and carry structured outputs through sampling translation.
- `model_gateway/src/routers/grpc/zmq_client.rs` — translate gRPC guided-decoding
  fields into `StructuredOutputsParams`.

## Test Plan

- `cargo +nightly fmt -- --check` and `cargo clippy --all-features` clean.
- `cargo test` unit coverage in `structured_outputs.rs`: backend-value ignore,
  structural-tag→xgrammar, missing/multiple/`json_object:false` constraint
  rejection, and raw-shape serialization.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

---
**Stack** (split of the oversized #2041, merge bottom-up): 01-core-dispatch →
**02-structured-outputs (this PR)** → 03-multimodal → 04-eos-forwarding →
05-harmony-stop-matcher → 06-e2e-infra → 07-e2e-tests. Review/merge after its
parent `zmq/01-core-dispatch`.
