### PR TITLE
feat(zmq): synthesize Harmony stop strings for the direct backend (5/7)

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/mod.rs
+++ b/model_gateway/src/routers/grpc/harmony/mod.rs
@@ -35,6 +35,7 @@ pub(crate) mod parser;
 pub(crate) mod processor;
 pub(crate) mod responses;
 pub(crate) mod stages;
+pub(crate) mod stop;
 pub(crate) mod streaming;
 pub(crate) mod types;
 

--- a/model_gateway/src/routers/grpc/harmony/processor.rs
+++ b/model_gateway/src/routers/grpc/harmony/processor.rs
@@ -16,6 +16,7 @@ use tracing::error;
 
 use super::{
     builder::{convert_harmony_logprobs, try_harmony_encoding},
+    stop::TextStopScanner,
     HarmonyParserAdapter,
 };
 use crate::routers::{
@@ -39,11 +40,16 @@ impl HarmonyResponseProcessor {
     }
 
     /// Process a non-streaming Harmony chat response
+    ///
+    /// `router_stop_strings` is non-empty only when the router must enforce
+    /// string `stop` sequences itself (direct-ZMQ backends: the engine sees
+    /// token ids only).
     pub async fn process_non_streaming_chat_response(
         &self,
         execution_result: ExecutionResult,
         chat_request: Arc<ChatCompletionRequest>,
         dispatch: DispatchMetadata,
+        router_stop_strings: &[String],
     ) -> Result<ChatCompletionResponse, Response> {
         let request_logprobs = chat_request.logprobs;
 
@@ -103,15 +109,46 @@ impl HarmonyResponseProcessor {
                 None
             };
 
+            let mut analysis = parsed.analysis;
+            let mut final_text = parsed.final_text;
+            let mut tool_calls = parsed.commentary;
+            let mut finish_reason = parsed.finish_reason;
+            let mut matched_stop = matched_stop;
+
+            // Router-enforced string stops: scan channel text in emission
+            // order (analysis before final), truncate after the first match
+            // (retaining the stop as suffix, like the token-forwarding gRPC
+            // path), and drop everything generated past it.
+            if !router_stop_strings.is_empty() {
+                let mut scanner = TextStopScanner::new(router_stop_strings.to_vec());
+                if let Some(text) = analysis.take() {
+                    let (out, stopped) = scanner.scan_complete(&text);
+                    analysis = (!out.is_empty()).then_some(out);
+                    if stopped {
+                        final_text.clear();
+                        tool_calls = None;
+                    }
+                }
+                if scanner.matched().is_none() && !final_text.is_empty() {
+                    let (out, stopped) = scanner.scan_complete(&final_text);
+                    final_text = out;
+                    if stopped {
+                        tool_calls = None;
+                    }
+                }
+                if let Some(stop) = scanner.matched() {
+                    finish_reason = "stop".to_string();
+                    matched_stop = Some(serde_json::Value::String(stop.to_string()));
+                }
+            }
+
             // Build response message (assistant)
             let message = ChatCompletionMessage {
                 role: "assistant".to_string(),
-                content: (!parsed.final_text.is_empty()).then_some(parsed.final_text),
-                tool_calls: parsed.commentary,
-                reasoning_content: parsed.analysis,
+                content: (!final_text.is_empty()).then_some(final_text),
+                tool_calls,
+                reasoning_content: analysis,
             };
-
-            let finish_reason = parsed.finish_reason;
 
             // Accumulate reasoning tokens across all responses
             total_reasoning_tokens += parsed.reasoning_token_count;

--- a/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -12,11 +12,37 @@ use crate::{
         error,
         grpc::{
             common::stages::PipelineStage,
-            context::{FinalResponse, RequestContext, RequestType},
+            context::{ClientSelection, FinalResponse, RequestContext, RequestType},
         },
     },
     worker::AttachedBody,
 };
+
+/// String `stop` sequences the ROUTER must enforce: only for direct-ZMQ
+/// backends, where the engine receives token ids and never sees the strings.
+/// Empty for gRPC backends (the engine matches stops itself).
+fn router_stop_strings(ctx: &RequestContext) -> Vec<String> {
+    let is_zmq = ctx
+        .state
+        .clients
+        .as_ref()
+        .is_some_and(|clients| match clients {
+            ClientSelection::Single { client } => client.is_zmq(),
+            ClientSelection::Disaggregated { decode, .. } => decode.is_zmq(),
+        });
+    if !is_zmq {
+        return Vec::new();
+    }
+    match &ctx.input.request_type {
+        RequestType::Chat(_) => ctx
+            .chat_request_arc()
+            .stop
+            .as_ref()
+            .map(|stop| stop.to_vec())
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
 
 /// Harmony Response Processing stage: Parse and format Harmony responses
 ///
@@ -80,6 +106,7 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                             execution_result,
                             ctx.chat_request_arc(),
                             dispatch,
+                            router_stop_strings(ctx),
                         );
 
                     // Attach load guards to response body for proper RAII lifecycle
@@ -93,9 +120,15 @@ impl PipelineStage for HarmonyResponseProcessingStage {
 
                 // For non-streaming, delegate to Harmony response processor to build ChatCompletionResponse
                 let chat_request = ctx.chat_request_arc();
+                let stops = router_stop_strings(ctx);
                 let response = self
                     .processor
-                    .process_non_streaming_chat_response(execution_result, chat_request, dispatch)
+                    .process_non_streaming_chat_response(
+                        execution_result,
+                        chat_request,
+                        dispatch,
+                        &stops,
+                    )
                     .await?;
 
                 ctx.state.response.final_response = Some(FinalResponse::Chat(response));

--- a/model_gateway/src/routers/grpc/harmony/stop.rs
+++ b/model_gateway/src/routers/grpc/harmony/stop.rs
@@ -1,0 +1,163 @@
+//! Incremental stop-string scanning for harmony channel text.
+//!
+//! The direct-ZMQ engine receives token ids only and cannot match string
+//! `stop` sequences; the regular pipeline covers this with the router-side
+//! `StopSequenceDecoder`, but harmony emits channel-parsed text rather than
+//! raw tokens, so stops are matched here on the decoded text instead. The
+//! matched stop stays in the output as its suffix, mirroring what the
+//! token-forwarding gRPC path yields for harmony models.
+
+/// Result of feeding text through the scanner.
+pub(crate) struct StopScan {
+    /// Text safe to emit: everything up to and including a match, or the
+    /// prefix that cannot be part of a future match.
+    pub emit: String,
+    /// A stop sequence completed inside this push.
+    pub stopped: bool,
+}
+
+pub(crate) struct TextStopScanner {
+    stops: Vec<String>,
+    /// Tail held back because it could still grow into a match.
+    pending: String,
+    matched: Option<String>,
+}
+
+impl TextStopScanner {
+    pub fn new(stops: Vec<String>) -> Self {
+        Self {
+            stops,
+            pending: String::new(),
+            matched: None,
+        }
+    }
+
+    pub fn matched(&self) -> Option<&str> {
+        self.matched.as_deref()
+    }
+
+    /// Feed a text delta. Once a stop has matched, further pushes emit nothing.
+    pub fn push(&mut self, text: &str) -> StopScan {
+        if self.matched.is_some() {
+            return StopScan {
+                emit: String::new(),
+                stopped: true,
+            };
+        }
+        self.pending.push_str(text);
+
+        // Earliest match across all stops wins; ties prefer the longer stop.
+        let mut best: Option<(usize, &str)> = None;
+        for stop in &self.stops {
+            if let Some(at) = self.pending.find(stop.as_str()) {
+                let better = match best {
+                    None => true,
+                    Some((best_at, best_stop)) => {
+                        at < best_at || (at == best_at && stop.len() > best_stop.len())
+                    }
+                };
+                if better {
+                    best = Some((at, stop));
+                }
+            }
+        }
+        if let Some((at, stop)) = best {
+            let emit = self.pending[..at + stop.len()].to_string();
+            self.matched = Some(stop.to_string());
+            self.pending.clear();
+            return StopScan {
+                emit,
+                stopped: true,
+            };
+        }
+
+        // Hold back the longest suffix that is a prefix of some stop; emit the
+        // rest (it can never become part of a match).
+        let max_hold = (self.stops.iter().map(String::len).max())
+            .unwrap_or(1)
+            .saturating_sub(1);
+        let mut hold = 0;
+        for len in (1..=max_hold.min(self.pending.len())).rev() {
+            let Some(start) = self.pending.len().checked_sub(len) else {
+                continue;
+            };
+            if !self.pending.is_char_boundary(start) {
+                continue;
+            }
+            let tail = &self.pending[start..];
+            if self.stops.iter().any(|s| s.starts_with(tail)) {
+                hold = len;
+                break;
+            }
+        }
+        let emit = self.pending[..self.pending.len() - hold].to_string();
+        self.pending.drain(..self.pending.len() - hold);
+        StopScan {
+            emit,
+            stopped: false,
+        }
+    }
+
+    /// Emit whatever is still held back (end of stream, no match).
+    pub fn flush(&mut self) -> String {
+        std::mem::take(&mut self.pending)
+    }
+
+    /// Scan a complete text: returns the (possibly truncated) text and whether
+    /// a stop matched inside it.
+    pub fn scan_complete(&mut self, text: &str) -> (String, bool) {
+        let scan = self.push(text);
+        let mut out = scan.emit;
+        if !scan.stopped {
+            out.push_str(&self.flush());
+        }
+        (out, scan.stopped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn complete_scan_truncates_after_first_match() {
+        let mut scanner = TextStopScanner::new(vec![",".to_string()]);
+        let (out, stopped) = scanner.scan_complete("1, 2, 3");
+        assert_eq!(out, "1,");
+        assert!(stopped);
+        assert_eq!(scanner.matched(), Some(","));
+    }
+
+    #[test]
+    fn streaming_holds_back_partial_matches() {
+        let mut scanner = TextStopScanner::new(vec!["STOP".to_string()]);
+        let scan = scanner.push("abc ST");
+        assert_eq!(scan.emit, "abc ");
+        assert!(!scan.stopped);
+        let scan = scanner.push("OP tail");
+        assert_eq!(scan.emit, "STOP");
+        assert!(scan.stopped);
+        // Post-match pushes are swallowed.
+        let scan = scanner.push("more");
+        assert_eq!(scan.emit, "");
+        assert!(scan.stopped);
+    }
+
+    #[test]
+    fn flush_releases_unmatched_tail() {
+        let mut scanner = TextStopScanner::new(vec!["END".to_string()]);
+        let scan = scanner.push("value EN");
+        assert_eq!(scan.emit, "value ");
+        assert_eq!(scanner.flush(), "EN");
+        assert_eq!(scanner.matched(), None);
+    }
+
+    #[test]
+    fn earliest_match_wins_across_stops() {
+        let mut scanner = TextStopScanner::new(vec!["zz".to_string(), "b".to_string()]);
+        let (out, stopped) = scanner.scan_complete("abzz");
+        assert_eq!(out, "ab");
+        assert!(stopped);
+        assert_eq!(scanner.matched(), Some("b"));
+    }
+}

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -27,6 +27,7 @@ use tracing::{debug, error};
 use super::{
     builder::{convert_harmony_logprobs, try_harmony_encoding},
     processor::ResponsesIterationResult,
+    stop::TextStopScanner,
     types::HarmonyChannelDelta,
     HarmonyParserAdapter,
 };
@@ -100,11 +101,15 @@ impl HarmonyStreamingProcessor {
         clippy::disallowed_methods,
         reason = "streaming tasks are fire-and-forget by design; client disconnect terminates them"
     )]
+    /// `router_stop_strings` is non-empty only when the router must enforce
+    /// string `stop` sequences itself (direct-ZMQ backends: the engine sees
+    /// token ids only).
     pub fn process_streaming_chat_response(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
         chat_request: Arc<ChatCompletionRequest>,
         dispatch: context::DispatchMetadata,
+        router_stop_strings: Vec<String>,
     ) -> Response {
         // Create SSE channel
         let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
@@ -113,8 +118,14 @@ impl HarmonyStreamingProcessor {
         match execution_result {
             context::ExecutionResult::Single { stream } => {
                 tokio::spawn(async move {
-                    let result =
-                        Self::process_single_stream(stream, dispatch, chat_request, &tx).await;
+                    let result = Self::process_single_stream(
+                        stream,
+                        dispatch,
+                        chat_request,
+                        &tx,
+                        router_stop_strings,
+                    )
+                    .await;
 
                     if let Err(e) = result {
                         error!("Harmony streaming error: {}", e);
@@ -137,6 +148,7 @@ impl HarmonyStreamingProcessor {
                         dispatch,
                         chat_request,
                         &tx,
+                        router_stop_strings,
                     )
                     .await;
 
@@ -179,6 +191,7 @@ impl HarmonyStreamingProcessor {
         dispatch: context::DispatchMetadata,
         original_request: Arc<ChatCompletionRequest>,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        router_stop_strings: Vec<String>,
     ) -> Result<(), String> {
         let mut prompt_tokens = HashMap::new();
         let mut cached_tokens = HashMap::new();
@@ -189,6 +202,7 @@ impl HarmonyStreamingProcessor {
             tx,
             &mut prompt_tokens,
             &mut cached_tokens,
+            &router_stop_strings,
         )
         .await
     }
@@ -200,6 +214,7 @@ impl HarmonyStreamingProcessor {
         dispatch: context::DispatchMetadata,
         original_request: Arc<ChatCompletionRequest>,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        router_stop_strings: Vec<String>,
     ) -> Result<(), String> {
         // Phase 1: Process prefill stream (collect metadata)
         let mut prompt_tokens: HashMap<u32, u32> = HashMap::new();
@@ -222,6 +237,7 @@ impl HarmonyStreamingProcessor {
             tx,
             &mut prompt_tokens,
             &mut cached_tokens,
+            &router_stop_strings,
         )
         .await?;
 
@@ -244,6 +260,7 @@ impl HarmonyStreamingProcessor {
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
         prompt_tokens: &mut HashMap<u32, u32>,
         cached_tokens: &mut HashMap<u32, u32>,
+        router_stop_strings: &[String],
     ) -> Result<(), String> {
         // Timing for metrics
         let start_time = Instant::now();
@@ -253,6 +270,12 @@ impl HarmonyStreamingProcessor {
         let mut parsers: HashMap<u32, HarmonyParserAdapter> = HashMap::new();
         let mut is_firsts: HashMap<u32, bool> = HashMap::new();
         let mut matched_stops: HashMap<u32, Option<serde_json::Value>> = HashMap::new();
+        // Router-enforced string stops (direct-ZMQ): per-index, per-channel
+        // scanners. Once an index stops, its further deltas are swallowed and
+        // the engine's own Complete is not re-emitted.
+        let mut analysis_scanners: HashMap<u32, TextStopScanner> = HashMap::new();
+        let mut final_scanners: HashMap<u32, TextStopScanner> = HashMap::new();
+        let mut router_stopped: std::collections::HashSet<u32> = std::collections::HashSet::new();
         let mut completion_tokens = CompletionTokenTracker::new();
         // Reusable SSE encoder shared across every chunk emitted for this stream.
         let mut encoder = SseEncoder::new();
@@ -303,21 +326,76 @@ impl HarmonyStreamingProcessor {
                         .map_err(|e| format!("Parse error: {e}"))?;
 
                     // Emit SSE event if there's a delta
-                    if let Some(delta) = delta_result {
-                        let is_first = is_firsts.get(&index).copied().unwrap_or(false);
-                        Self::emit_chunk_delta(
-                            &delta,
-                            index,
-                            is_first,
-                            dispatch,
-                            original_request,
-                            tx,
-                            &mut encoder,
-                            chunk_logprobs,
-                        )?;
+                    if let Some(mut delta) = delta_result {
+                        if router_stopped.contains(&index) {
+                            continue;
+                        }
+                        let mut stop_matched: Option<String> = None;
+                        if !router_stop_strings.is_empty() {
+                            if let Some(text) = delta.analysis_delta.take() {
+                                let scanner = analysis_scanners.entry(index).or_insert_with(|| {
+                                    TextStopScanner::new(router_stop_strings.to_vec())
+                                });
+                                let scan = scanner.push(&text);
+                                delta.analysis_delta = (!scan.emit.is_empty()).then_some(scan.emit);
+                                if scan.stopped {
+                                    stop_matched = scanner.matched().map(str::to_string);
+                                    delta.final_delta = None;
+                                    delta.commentary_delta = None;
+                                }
+                            }
+                            if stop_matched.is_none() {
+                                if let Some(text) = delta.final_delta.take() {
+                                    let scanner =
+                                        final_scanners.entry(index).or_insert_with(|| {
+                                            TextStopScanner::new(router_stop_strings.to_vec())
+                                        });
+                                    let scan = scanner.push(&text);
+                                    delta.final_delta =
+                                        (!scan.emit.is_empty()).then_some(scan.emit);
+                                    if scan.stopped {
+                                        stop_matched = scanner.matched().map(str::to_string);
+                                        delta.commentary_delta = None;
+                                    }
+                                }
+                            }
+                        }
 
-                        if is_first {
-                            is_firsts.insert(index, false);
+                        let has_payload = delta.analysis_delta.is_some()
+                            || delta.final_delta.is_some()
+                            || delta.commentary_delta.is_some();
+                        let is_first = is_firsts.get(&index).copied().unwrap_or(false);
+                        if has_payload || is_first {
+                            Self::emit_chunk_delta(
+                                &delta,
+                                index,
+                                is_first,
+                                dispatch,
+                                original_request,
+                                tx,
+                                &mut encoder,
+                                chunk_logprobs,
+                            )?;
+
+                            if is_first {
+                                is_firsts.insert(index, false);
+                            }
+                        }
+
+                        // A router-side stop fired: emit the final chunk now
+                        // and swallow the rest of this index's stream (the
+                        // engine keeps generating until its own limits).
+                        if let Some(stop) = stop_matched {
+                            Self::emit_final_chunk(
+                                index,
+                                "stop",
+                                Some(&serde_json::Value::String(stop)),
+                                dispatch,
+                                original_request,
+                                tx,
+                                &mut encoder,
+                            )?;
+                            router_stopped.insert(index);
                         }
                     }
                 }
@@ -340,6 +418,37 @@ impl HarmonyStreamingProcessor {
 
                         let final_output =
                             parser.finalize(complete_wrapper.finish_reason().to_string());
+
+                        // A router-side stop already closed this choice.
+                        if router_stopped.contains(&index) {
+                            continue;
+                        }
+
+                        // Release scanner-held text that never became a match.
+                        let flushed = HarmonyChannelDelta {
+                            analysis_delta: analysis_scanners
+                                .get_mut(&index)
+                                .map(TextStopScanner::flush)
+                                .filter(|s| !s.is_empty()),
+                            commentary_delta: None,
+                            final_delta: final_scanners
+                                .get_mut(&index)
+                                .map(TextStopScanner::flush)
+                                .filter(|s| !s.is_empty()),
+                            is_final: false,
+                        };
+                        if flushed.analysis_delta.is_some() || flushed.final_delta.is_some() {
+                            Self::emit_chunk_delta(
+                                &flushed,
+                                index,
+                                false,
+                                dispatch,
+                                original_request,
+                                tx,
+                                &mut encoder,
+                                None,
+                            )?;
+                        }
 
                         Self::emit_final_chunk(
                             index,


### PR DESCRIPTION
## Description

### Problem

The Harmony response path does not honor router-side string stops over a
direct-ZMQ engine. Because the engine only sees token ids, Harmony responses can
over-generate past a requested stop string that the token-only backend cannot
match.

### Solution

Add a Harmony stop-string matcher and apply it on both the streaming and
non-streaming Harmony paths, using the same `is_zmq` backend signal to decide when
the router must own string-stop matching.

## Changes

- `model_gateway/src/routers/grpc/harmony/stop.rs` (new) — Harmony stop-string
  matcher.
- `model_gateway/.../harmony/mod.rs` — expose the `stop` module.
- `model_gateway/.../harmony/processor.rs` — thread resolved stops into
  non-streaming chat response processing.
- `model_gateway/.../harmony/stages/response_processing.rs` — compute
  `router_stop_strings(ctx)` from `client.is_zmq()`.
- `model_gateway/.../harmony/streaming.rs` — apply the matcher on the streaming
  path.

## Test Plan

- `cargo +nightly fmt -- --check` and `cargo clippy --all-features` clean.
- `cargo test` unit coverage for the Harmony stop-string matcher.
- e2e (top of stack) exercises Harmony stop behavior over ZMQ.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

---
**Stack** (split of the oversized #2041, merge bottom-up): 01-core-dispatch →
02-structured-outputs → 03-multimodal → 04-eos-forwarding →
**05-harmony-stop-matcher (this PR)** → 06-e2e-infra → 07-e2e-tests. Review/merge
after its parent `zmq/04-eos-forwarding`.
