### PR TITLE
test(zmq): direct-backend e2e tests and CI lanes

### DIFF
--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -54,6 +54,11 @@ on:
         type: string
         default: "nixl"
         description: "KV transfer backend for vLLM PD workers: nixl or mooncake"
+      connection_mode:
+        required: false
+        type: string
+        default: ""
+        description: "Wire override for local backends: zmq runs the local cases over ZMQ"
 
 jobs:
   run:
@@ -66,6 +71,7 @@ jobs:
       E2E_RUNTIME: ${{ inputs.engine }}
       E2E_GPU_TIER: ${{ inputs.gpu_tier }}
       E2E_VLLM_KV_BACKEND: ${{ inputs.vllm_kv_backend }}
+      E2E_CONNECTION_MODE: ${{ inputs.connection_mode }}
       ROUTER_LOCAL_MODEL_PATH: /models
     steps:
       - name: Checkout code
@@ -165,6 +171,12 @@ jobs:
           SUFFIX=""
           if [ "${{ inputs.engine }}" = "vllm" ]; then
             SUFFIX="-${{ inputs.vllm_kv_backend }}"
+          fi
+          # gRPC and ZMQ chat legs share engine/GPU/test-dir and differ only by
+          # wire mode; fold it in so their log artifacts don't collide.
+          MODE="${{ inputs.connection_mode }}"
+          if [ -n "$MODE" ]; then
+            SUFFIX="${SUFFIX}-${MODE}"
           fi
           ARTIFACT="e2e-worker-logs-${{ inputs.engine }}-gpu${{ inputs.gpu_tier }}-${LABEL}${SUFFIX}"
           bash scripts/ci_dump_worker_logs.sh e2e-logs "$ARTIFACT"

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -543,6 +543,45 @@ jobs:
       test_dirs: ${{ matrix.test_dirs || 'e2e_test/chat_completions' }}
     secrets: inherit
 
+  e2e-1gpu-chat-zmq:
+    name: e2e-1gpu-chat-zmq (${{ matrix.engine }})
+    needs: [build-wheel, detect-changes]
+    if: >-
+      always()
+      && !cancelled()
+      && needs.build-wheel.result == 'success'
+      && (github.event_name != 'pull_request'
+          || (needs.detect-changes.result == 'success'
+              && (needs.detect-changes.outputs.common == 'true'
+                  || needs.detect-changes.outputs.chat-completions == 'true')))
+    # Same single-worker chat suite as e2e-1gpu-chat, driven over the ZMQ
+    # direct-backend wire. The collection hook deselects the gRPC-only
+    # families (PD, EPD, multi-worker) for a ZMQ lane, so this covers the
+    # local cases only.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The ZMQ lane restarts the engine per model group (66-90s of
+          # load+warmup each); the suite needs more headroom than the gRPC
+          # lane, whose pool amortizes worker bring-up.
+          - engine: vllm
+            timeout: 46
+            test_timeout: 40
+          - engine: tokenspeed
+            timeout: 50
+            test_timeout: 40
+    uses: ./.github/workflows/e2e-gpu-job.yml
+    with:
+      engine: ${{ matrix.engine }}
+      gpu_tier: "1"
+      runner: 1-gpu-h100
+      timeout: ${{ matrix.timeout }}
+      test_timeout: ${{ matrix.test_timeout }}
+      test_dirs: e2e_test/chat_completions
+      connection_mode: zmq
+    secrets: inherit
+
   e2e-1gpu-completions:
     name: e2e-1gpu-completions (${{ matrix.engine }})
     needs: [build-wheel, detect-changes]
@@ -1049,7 +1088,7 @@ jobs:
           path: benchmark_go_bindings/
 
   finish:
-    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-vendor, go-unit-tests, go-bindings-e2e]
+    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-chat-zmq, e2e-1gpu-completions, e2e-1gpu-embeddings, e2e-1gpu-gateway, e2e-1gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-4gpu-epd, e2e-vendor, go-unit-tests, go-bindings-e2e]
     if: always()
     runs-on: k8s-runner-cpu
     permissions: {}
@@ -1064,6 +1103,7 @@ jobs:
                 "${{ needs.unit-tests.result }}" == "failure" || \
                 "${{ needs.benchmarks.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-chat.result }}" == "failure" || \
+                "${{ needs.e2e-1gpu-chat-zmq.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-completions.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-embeddings.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-gateway.result }}" == "failure" || \

--- a/e2e_test/fixtures/test_connection_mode_validation.py
+++ b/e2e_test/fixtures/test_connection_mode_validation.py
@@ -1,0 +1,34 @@
+"""Unit tests for connection-mode/engine validation (no GPU)."""
+
+from __future__ import annotations
+
+import pytest
+from infra.constants import ConnectionMode, Runtime
+
+# setup_backend pulls in the cloud SDKs; skip if the env lacks them.
+setup_backend = pytest.importorskip("fixtures.setup_backend")
+
+
+@pytest.mark.parametrize("engine", [Runtime.VLLM.value, Runtime.TOKENSPEED.value])
+def test_zmq_allowed_for_capable_engines(engine):
+    # Does not raise.
+    setup_backend._validate_connection_mode(ConnectionMode.ZMQ, engine)
+
+
+@pytest.mark.parametrize(
+    "engine",
+    [Runtime.SGLANG.value, Runtime.TRTLLM.value, Runtime.MLX.value],
+)
+def test_zmq_rejected_for_incapable_engines(engine):
+    with pytest.raises(ValueError, match="ConnectionMode.ZMQ is only supported"):
+        setup_backend._validate_connection_mode(ConnectionMode.ZMQ, engine)
+
+
+@pytest.mark.parametrize("mode", [ConnectionMode.GRPC, ConnectionMode.HTTP])
+@pytest.mark.parametrize(
+    "engine",
+    [Runtime.SGLANG.value, Runtime.VLLM.value, Runtime.TOKENSPEED.value],
+)
+def test_non_zmq_modes_accept_any_engine(mode, engine):
+    # Non-ZMQ wires impose no engine restriction.
+    setup_backend._validate_connection_mode(mode, engine)

--- a/e2e_test/fixtures/test_hooks_zmq_filter.py
+++ b/e2e_test/fixtures/test_hooks_zmq_filter.py
@@ -1,0 +1,127 @@
+"""Unit tests for the ZMQ-lane collection filter (no GPU)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fixtures import hooks
+
+
+class _FakeItem:
+    """Minimal stand-in for a pytest ``Item`` for the collection helpers.
+
+    Exposes only what ``_filter_zmq_items`` / ``_zmq_dedup_key`` touch:
+    ``nodeid``, ``callspec.params``, ``cls`` (always None so marker resolution
+    falls back to ``get_closest_marker``), and a ``workers`` marker.
+    """
+
+    def __init__(self, nodeid, params=None, workers=None):
+        self.nodeid = nodeid
+        self.cls = None
+        self.callspec = SimpleNamespace(params=params) if params is not None else None
+        self._workers = workers
+
+    def get_closest_marker(self, name):
+        if name == "workers":
+            return self._workers
+        return None
+
+
+def _item(nodeid, setup_backend=None, extra_params=None, workers=None):
+    params = None
+    if setup_backend is not None or extra_params is not None:
+        params = {}
+        if setup_backend is not None:
+            params["setup_backend"] = setup_backend
+        if extra_params:
+            params.update(extra_params)
+    return _FakeItem(nodeid, params=params, workers=workers)
+
+
+def _workers_marker(**kwargs):
+    return pytest.mark.workers(**kwargs).mark
+
+
+# ---------------------------------------------------------------------------
+# _zmq_dedup_key
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_key_ignores_setup_backend_value():
+    grpc = _item("t.py::test_x[grpc]", setup_backend="grpc")
+    http = _item("t.py::test_x[http]", setup_backend="http")
+    assert hooks._zmq_dedup_key(grpc) == hooks._zmq_dedup_key(http)
+
+
+def test_dedup_key_keeps_other_params_apart():
+    a = _item("t.py::test_x[grpc-a]", setup_backend="grpc", extra_params={"api_client": "a"})
+    b = _item("t.py::test_x[grpc-b]", setup_backend="grpc", extra_params={"api_client": "b"})
+    assert hooks._zmq_dedup_key(a) != hooks._zmq_dedup_key(b)
+
+
+def test_dedup_key_splits_nodeid_at_bracket():
+    key, _others = hooks._zmq_dedup_key(_item("t.py::test_x[grpc]", setup_backend="grpc"))
+    assert key == "t.py::test_x"
+
+
+# ---------------------------------------------------------------------------
+# _filter_zmq_items
+# ---------------------------------------------------------------------------
+
+
+def test_grpc_http_twins_collapse_to_grpc():
+    grpc = _item("t.py::test_x[grpc]", setup_backend="grpc")
+    http = _item("t.py::test_x[http]", setup_backend="http")
+    kept, deselected = hooks._filter_zmq_items([grpc, http])
+    assert kept == [grpc]
+    assert deselected == [http]
+
+
+def test_http_only_case_is_retained():
+    http = _item("t.py::test_x[http]", setup_backend="http")
+    kept, deselected = hooks._filter_zmq_items([http])
+    assert kept == [http]
+    assert deselected == []
+
+
+def test_distinct_other_params_keep_both_wires():
+    # A grpc/http pair that differs on another param is NOT a twin.
+    grpc = _item("t.py::test_x[grpc-a]", setup_backend="grpc", extra_params={"api_client": "a"})
+    http = _item("t.py::test_x[http-b]", setup_backend="http", extra_params={"api_client": "b"})
+    kept, deselected = hooks._filter_zmq_items([grpc, http])
+    assert kept == [grpc, http]
+    assert deselected == []
+
+
+@pytest.mark.parametrize("param", ["pd_grpc", "epd_grpc", ("epd_grpc", (1, 1, 1)), ()])
+def test_non_local_wire_families_are_deselected(param):
+    item = _item("t.py::test_x[p]", setup_backend=param)
+    kept, deselected = hooks._filter_zmq_items([item])
+    assert kept == []
+    assert deselected == [item]
+
+
+def test_multi_worker_case_is_deselected():
+    item = _item("t.py::test_x[grpc]", setup_backend="grpc", workers=_workers_marker(count=2))
+    kept, deselected = hooks._filter_zmq_items([item])
+    assert kept == []
+    assert deselected == [item]
+
+
+def test_pd_worker_topology_is_deselected():
+    item = _item(
+        "t.py::test_x[grpc]",
+        setup_backend="grpc",
+        workers=_workers_marker(prefill=1, decode=1),
+    )
+    kept, deselected = hooks._filter_zmq_items([item])
+    assert kept == []
+    assert deselected == [item]
+
+
+def test_items_without_setup_backend_are_untouched():
+    item = _item("t.py::test_plain")  # no callspec / params
+    kept, deselected = hooks._filter_zmq_items([item])
+    assert kept == [item]
+    assert deselected == []

--- a/e2e_test/infra/test_connection_mode.py
+++ b/e2e_test/infra/test_connection_mode.py
@@ -1,0 +1,43 @@
+"""Unit tests for E2E connection-mode env parsing (no GPU)."""
+
+from __future__ import annotations
+
+import pytest
+from infra.constants import (
+    ENV_CONNECTION_MODE,
+    ConnectionMode,
+    get_connection_mode_override,
+)
+
+
+def test_unset_returns_none(monkeypatch):
+    monkeypatch.delenv(ENV_CONNECTION_MODE, raising=False)
+    assert get_connection_mode_override() is None
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("zmq", ConnectionMode.ZMQ),
+        ("ZMQ", ConnectionMode.ZMQ),
+        ("Grpc", ConnectionMode.GRPC),
+        ("  http  ", ConnectionMode.HTTP),
+    ],
+)
+def test_valid_values_are_case_insensitive(monkeypatch, value, expected):
+    monkeypatch.setenv(ENV_CONNECTION_MODE, value)
+    assert get_connection_mode_override() == expected
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_set_but_blank_returns_none(monkeypatch, value):
+    # The workflow always exports E2E_CONNECTION_MODE and leaves it empty for
+    # non-override lanes, so a blank value must mean "no override", not an error.
+    monkeypatch.setenv(ENV_CONNECTION_MODE, value)
+    assert get_connection_mode_override() is None
+
+
+def test_invalid_value_raises(monkeypatch):
+    monkeypatch.setenv(ENV_CONNECTION_MODE, "bogus")
+    with pytest.raises(ValueError, match="not a valid connection mode"):
+        get_connection_mode_override()

--- a/e2e_test/infra/test_zmq_cmd_builders.py
+++ b/e2e_test/infra/test_zmq_cmd_builders.py
@@ -1,0 +1,71 @@
+"""Unit tests for the ZMQ direct-backend command builders (no GPU)."""
+
+from __future__ import annotations
+
+import pytest
+from infra.constants import ConnectionMode
+from infra.worker import Worker
+
+_VLLM_MODEL = "meta-llama/Llama-3.2-1B-Instruct"
+_TS_MODEL = "Qwen/Qwen3.5-9B"
+
+
+@pytest.fixture
+def serve():
+    # The ZMQ builders delegate to smg.serve, so the wheel must be importable.
+    # Scoped to a fixture (not module import) so the gRPC test below still runs
+    # when the wheel is absent.
+    return pytest.importorskip("smg.serve")
+
+
+def _worker(engine, port=50111):
+    return Worker(
+        model_id=_TS_MODEL if engine == "tokenspeed" else _VLLM_MODEL,
+        engine=engine,
+        port=port,
+        gpu_ids=[0],
+        mode=ConnectionMode.ZMQ,
+    )
+
+
+def test_zmq_base_url_matches_serve_helper(serve):
+    w = _worker("vllm", port=50123)
+    assert w.base_url == serve._zmq_ipc_url(50123)
+    assert w.base_url.startswith("ipc://")
+
+
+def test_vllm_zmq_cmd_is_headless_with_derived_handshake_port(serve):
+    w = _worker("vllm")
+    cmd = w._build_vllm_zmq_cmd("/models/llama", 1, {"vllm_args": ["--max-model-len", "2048"]})
+    assert "serve" in cmd
+    assert "--headless" in cmd
+    assert "/models/llama" in cmd
+    # The engine dials the same tcp port SMG derives from the ipc path.
+    expected_port = serve._zmq_handshake_port(serve._zmq_ipc_url(w.port))
+    assert cmd[cmd.index("--data-parallel-rpc-port") + 1] == str(expected_port)
+    # Model-spec engine args ride through.
+    assert cmd[cmd.index("--max-model-len") + 1] == "2048"
+
+
+def test_tokenspeed_zmq_cmd_is_headless_with_derived_handshake_port(serve):
+    w = _worker("tokenspeed")
+    cmd = w._build_tokenspeed_zmq_cmd(
+        "/models/qwen", 1, {"tokenspeed_args": ["--attention-backend", "fa3"]}
+    )
+    assert "serve" in cmd
+    assert "--headless" in cmd
+    assert "/models/qwen" in cmd
+    expected_port = serve._zmq_handshake_port(serve._zmq_ipc_url(w.port))
+    assert cmd[cmd.index("--data-parallel-rpc-port") + 1] == str(expected_port)
+    assert cmd[cmd.index("--attention-backend") + 1] == "fa3"
+
+
+def test_grpc_worker_still_uses_grpc_url():
+    w = Worker(
+        model_id=_VLLM_MODEL,
+        engine="vllm",
+        port=50111,
+        gpu_ids=[0],
+        mode=ConnectionMode.GRPC,
+    )
+    assert w.base_url == "grpc://127.0.0.1:50111"


### PR DESCRIPTION
## Description

### Problem

The direct-ZMQ backend and its e2e harness are not covered by tests or run in CI,
so regressions in ZMQ dispatch, capability validation, or the headless command
builders would go undetected. Nothing has ever exercised the ZMQ wire end to end
on a GPU lane.

### Solution

Add unit tests for the ZMQ harness and wire the ZMQ lanes into CI: a `connection_mode`
input on the reusable GPU e2e job, and an `e2e-1gpu-chat-zmq` lane that runs the
existing single-worker chat suite over the ZMQ wire for both vLLM and TokenSpeed.

## Changes

- `e2e_test/infra/{test_connection_mode.py,test_zmq_cmd_builders.py}` —
  connection-mode parsing, engine-capability validation, headless command builders.
- `e2e_test/fixtures/{test_connection_mode_validation.py,test_hooks_zmq_filter.py}`
  — wire-family dedup/deselect hook coverage.
- `.github/workflows/e2e-gpu-job.yml` — `connection_mode` input, folded into the
  log-artifact name so the gRPC and ZMQ legs don't collide.
- `.github/workflows/pr-test-rust.yml` — the `e2e-1gpu-chat-zmq` lane, gated on the
  same change filters as the gRPC chat lane and added to `finish`.
- `scripts/ci_install_tokenspeed.sh` — pin bump to a TokenSpeed revision with the
  ZMQ entrypoint.

## Test Plan

- `pytest e2e_test/infra/test_connection_mode.py e2e_test/infra/test_zmq_cmd_builders.py
  e2e_test/fixtures/test_connection_mode_validation.py e2e_test/fixtures/test_hooks_zmq_filter.py`
  → 33 passed, 3 skipped (the 3 skips need the `smg` wheel installed, which CI has).
- The GPU e2e lane needs real hardware + models; it runs on this PR.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

---
Rebuilt on current `main`. The rest of the original 7-PR stack (core dispatch,
structured outputs, multimodal, EOS forwarding, harmony stop matcher, e2e infra)
has already landed in reworked form, so this is now a standalone tests+CI change.