### PR TITLE
test(discovery): kind-based real-cluster e2e for multi-port discovery

### DIFF
--- a/.github/workflows/e2e-kind-discovery.yml
+++ b/.github/workflows/e2e-kind-discovery.yml
@@ -1,0 +1,63 @@
+name: E2E Kind Discovery
+
+# Manual-only while runner Docker support (dind on the k8s runner pool) is
+# unconfirmed; GitHub-hosted ubuntu-latest works out of the box. Builds smg
+# in-job: pr-test-rust publishes no server binary artifact (and its
+# artifacts expire after a day), and its self-hosted runner image is not
+# glibc-matched to ubuntu-latest — sccache keeps rebuilds cheap instead.
+# Once dind on k8s-runner-cpu is confirmed, set the runner input and
+# artifact reuse becomes safe.
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner label (needs Docker for the kind node container)
+        required: false
+        default: ubuntu-latest
+
+env:
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  kind-discovery:
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          sccache-version: 'v0.10.0'
+
+      - name: Install kind and kubectl
+        run: |
+          curl -Lo kind "https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64"
+          chmod +x kind && sudo mv kind /usr/local/bin/
+          curl -Lo kubectl "https://dl.k8s.io/release/v1.33.0/bin/linux/amd64/kubectl"
+          chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
+      - name: Build smg and mock-worker
+        run: |
+          source "$HOME/.cargo/env"
+          cargo build -p smg -p mock-worker
+
+      - name: Build mock-worker and gateway images
+        run: |
+          docker build -t smg-mock-worker:e2e \
+            -f e2e_test/kind_discovery/Dockerfile.mock-worker target/debug
+          docker build -t smg-gateway:e2e \
+            -f e2e_test/kind_discovery/Dockerfile.smg target/debug
+          # Fail here (not as CrashLoopBackOff later) on any linkage problem.
+          docker run --rm smg-mock-worker:e2e --help >/dev/null 2>&1 || true
+          docker run --rm --entrypoint /usr/local/bin/smg smg-gateway:e2e --help >/dev/null
+
+      - name: Run discovery e2e
+        timeout-minutes: 30
+        run: |
+          pip install pytest requests
+          SMG_KIND_E2E=1 SMG_MOCK_IMAGE=smg-mock-worker:e2e \
+            SMG_GATEWAY_IMAGE=smg-gateway:e2e \
+            pytest e2e_test/kind_discovery \
+            --confcutdir e2e_test/kind_discovery -m kind -v

--- a/e2e_test/kind_discovery/Dockerfile.mock-worker
+++ b/e2e_test/kind_discovery/Dockerfile.mock-worker
@@ -1,0 +1,6 @@
+# Wraps the workspace mock-worker binary (built on the runner) for kind.
+# Base must glibc-match the build host (ubuntu-latest); build context is
+# target/debug.
+FROM ubuntu:24.04
+COPY mock-worker /usr/local/bin/mock-worker
+ENTRYPOINT ["/usr/local/bin/mock-worker"]

--- a/e2e_test/kind_discovery/Dockerfile.smg
+++ b/e2e_test/kind_discovery/Dockerfile.smg
@@ -1,0 +1,9 @@
+# Wraps the workspace smg binary (built on the runner) for in-cluster runs.
+# Base must glibc-match the build host (ubuntu-latest); build context is
+# target/debug. openssl: smg links the system libssl (non-vendored).
+FROM ubuntu:24.04
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY smg /usr/local/bin/smg
+ENTRYPOINT ["/usr/local/bin/smg"]

--- a/e2e_test/kind_discovery/burst.yaml
+++ b/e2e_test/kind_discovery/burst.yaml
@@ -1,0 +1,87 @@
+# Burst workload: three single-engine pods applied and deleted as a batch.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: burst-0
+  labels:
+    app: smg-kind-e2e
+  annotations:
+    smg.ai/worker-ports: "28091"
+spec:
+  hostNetwork: true
+  restartPolicy: Never
+  containers:
+    - name: engine
+      image: python:3.12-alpine
+      command: ["python", "/opt/mock/server.py", "28091"]
+      volumeMounts:
+        - name: script
+          mountPath: /opt/mock
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 28091
+        initialDelaySeconds: 1
+        periodSeconds: 2
+  volumes:
+    - name: script
+      configMap:
+        name: mock-engine-script
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: burst-1
+  labels:
+    app: smg-kind-e2e
+  annotations:
+    smg.ai/worker-ports: "28092"
+spec:
+  hostNetwork: true
+  restartPolicy: Never
+  containers:
+    - name: engine
+      image: python:3.12-alpine
+      command: ["python", "/opt/mock/server.py", "28092"]
+      volumeMounts:
+        - name: script
+          mountPath: /opt/mock
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 28092
+        initialDelaySeconds: 1
+        periodSeconds: 2
+  volumes:
+    - name: script
+      configMap:
+        name: mock-engine-script
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: burst-2
+  labels:
+    app: smg-kind-e2e
+  annotations:
+    smg.ai/worker-ports: "28093"
+spec:
+  hostNetwork: true
+  restartPolicy: Never
+  containers:
+    - name: engine
+      image: python:3.12-alpine
+      command: ["python", "/opt/mock/server.py", "28093"]
+      volumeMounts:
+        - name: script
+          mountPath: /opt/mock
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 28093
+        initialDelaySeconds: 1
+        periodSeconds: 2
+  volumes:
+    - name: script
+      configMap:
+        name: mock-engine-script

--- a/e2e_test/kind_discovery/conftest.py
+++ b/e2e_test/kind_discovery/conftest.py
@@ -1,0 +1,159 @@
+"""Fixtures for the kind-cluster service discovery e2e.
+
+The session owns one kind cluster and one smg process; tests drive the
+cluster with kubectl and assert through the gateway's /workers endpoint.
+Gated behind SMG_KIND_E2E=1 (and skipped when kind/kubectl are absent) so
+regular e2e sessions never attempt cluster creation. Linux only: the host
+must reach the kind node IP to probe hostNetwork worker ports.
+
+Run locally:
+    pip install -e e2e_test && cargo build -p smg && \
+        SMG_KIND_E2E=1 pytest e2e_test/kind_discovery -m kind
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+CLUSTER = "smg-discovery-e2e"
+SMG_PORT = 3009
+FALLBACK_PORT = 28090
+HERE = Path(__file__).parent
+
+
+def kubectl(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(["kubectl", *args], check=check, capture_output=True, text=True)
+
+
+class KindGateway:
+    """Handle on the smg process under test plus /workers assertions."""
+
+    def __init__(self, binary: Path):
+        self.binary = binary
+        self.base_url = f"http://127.0.0.1:{SMG_PORT}"
+        self.log_path = Path(tempfile.mkstemp(prefix="smg-kind-e2e-", suffix=".log")[1])
+        self.proc: subprocess.Popen | None = None
+
+    def start(self, extra_args: tuple[str, ...] = ()) -> None:
+        log = open(self.log_path, "a")
+        self.proc = subprocess.Popen(
+            [
+                str(self.binary),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(SMG_PORT),
+                "--service-discovery",
+                "--selector",
+                "app=smg-kind-e2e",
+                "--service-discovery-port",
+                str(FALLBACK_PORT),
+                "--service-discovery-namespace",
+                "default",
+                "--policy",
+                "round_robin",
+                *extra_args,
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+
+    def stop(self) -> None:
+        if self.proc and self.proc.poll() is None:
+            self.proc.kill()
+            self.proc.wait(timeout=10)
+
+    def restart(self, extra_args: tuple[str, ...] = ()) -> None:
+        self.stop()
+        self.start(extra_args)
+
+    def workers(self) -> list[dict]:
+        try:
+            payload = requests.get(f"{self.base_url}/workers", timeout=5).json()
+        except requests.RequestException:
+            return []
+        return payload.get("workers", payload if isinstance(payload, list) else [])
+
+    def worker_count(self) -> int:
+        return len(self.workers())
+
+    def pod_uid_of_port(self, port: int) -> str | None:
+        for worker in self.workers():
+            if worker.get("url", "").endswith(f":{port}"):
+                return worker.get("labels", {}).get("smg.ai/pod-uid")
+        return None
+
+    def wait_for_count(self, expect: int, what: str, timeout: float = 120.0) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            # A dead gateway must never satisfy an expected-zero count.
+            assert self.proc is not None and self.proc.poll() is None, (
+                f"smg process died while waiting for {what}"
+            )
+            if self.worker_count() == expect:
+                return
+            time.sleep(1)
+        raise AssertionError(f"timed out waiting for {what}; workers: {self.workers()}")
+
+    def log_contains(self, needle: str) -> bool:
+        return needle in self.log_path.read_text()
+
+
+@pytest.fixture(scope="session")
+def kind_cluster():
+    if os.environ.get("SMG_KIND_E2E") != "1":
+        pytest.skip("kind e2e disabled (set SMG_KIND_E2E=1)")
+    for tool in ("kind", "kubectl"):
+        if shutil.which(tool) is None:
+            pytest.skip(f"{tool} not installed")
+
+    subprocess.run(
+        ["kind", "create", "cluster", "--name", CLUSTER, "--wait", "120s"],
+        check=True,
+    )
+    try:
+        for image_env in ("SMG_MOCK_IMAGE", "SMG_GATEWAY_IMAGE"):
+            image = os.environ.get(image_env)
+            if image:
+                subprocess.run(
+                    ["kind", "load", "docker-image", image, "--name", CLUSTER],
+                    check=True,
+                )
+        kubectl("apply", "-f", str(HERE / "manifests.yaml"))
+        kubectl(
+            "wait",
+            "--for=condition=Ready",
+            "pod/multi-engine-0",
+            "pod/single-engine-0",
+            "--timeout=300s",
+        )
+        yield
+    finally:
+        subprocess.run(
+            ["kind", "delete", "cluster", "--name", CLUSTER],
+            check=False,
+            capture_output=True,
+        )
+
+
+@pytest.fixture(scope="session")
+def gateway(kind_cluster):
+    binary = Path(os.environ.get("SMG_BIN", "target/debug/smg")).resolve()
+    assert binary.exists(), f"smg binary not found at {binary} (cargo build -p smg first)"
+    gw = KindGateway(binary)
+    gw.start()
+    try:
+        yield gw
+    finally:
+        gw.stop()
+        print(f"\n=== smg log tail ({gw.log_path}) ===")
+        lines = gw.log_path.read_text().splitlines()
+        print("\n".join(lines[-40:]))

--- a/e2e_test/kind_discovery/in_cluster.yaml
+++ b/e2e_test/kind_discovery/in_cluster.yaml
@@ -1,0 +1,120 @@
+# Reference deployment for running smg with K8s service discovery
+# **inside** the cluster: the gateway authenticates via its ServiceAccount
+# (in-cluster config), needs exactly pods get/list/watch in the watched
+# namespace, and probes engine pods over the pod network — no hostNetwork.
+#
+# The engine Deployment is the canonical multi-server shape: every pod runs
+# four engines on 8080-8083 and lists them in the smg.ai/worker-ports
+# annotation; each pod IP contributes four workers.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: smg-discovery
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: smg-discovery
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: smg-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: smg-discovery
+subjects:
+  - kind: ServiceAccount
+    name: smg-discovery
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smg-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smg-gateway
+  template:
+    metadata:
+      labels:
+        app: smg-gateway
+    spec:
+      serviceAccountName: smg-discovery
+      containers:
+        - name: smg
+          image: smg-gateway:e2e
+          imagePullPolicy: Never
+          args:
+            - --host
+            - 0.0.0.0
+            - --port
+            - "3009"
+            - --service-discovery
+            - --selector
+            - app=engines-incluster
+            - --service-discovery-port
+            - "8080"
+            - --service-discovery-namespace
+            - default
+            - --policy
+            - round_robin
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3009
+            initialDelaySeconds: 1
+            periodSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smg-gateway
+spec:
+  selector:
+    app: smg-gateway
+  ports:
+    - port: 3009
+      targetPort: 3009
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: engines
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: engines-incluster
+  template:
+    metadata:
+      labels:
+        app: engines-incluster
+      annotations:
+        smg.ai/worker-ports: "8080,8081,8082,8083"
+    spec:
+      containers:
+        - name: engines
+          image: smg-mock-worker:e2e
+          imagePullPolicy: Never
+          args:
+            - --host
+            - 0.0.0.0
+            - --http-base-port
+            - "8080"
+            - --http-count
+            - "4"
+            - --model
+            - incluster-model
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 2

--- a/e2e_test/kind_discovery/manifests.yaml
+++ b/e2e_test/kind_discovery/manifests.yaml
@@ -1,0 +1,139 @@
+# Mock multi-engine workload for the kind discovery e2e.
+#
+# hostNetwork pods so the smg binary on the runner host can probe worker
+# ports at the pod IP (= the kind node's container IP, routable on Linux).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mock-engine-script
+data:
+  server.py: |
+    import http.server
+    import json
+    import sys
+    import threading
+
+    HEALTHY = {"value": True}
+
+    class EngineServer(http.server.ThreadingHTTPServer):
+        def __init__(self, addr, handler, engine_port):
+            self.engine_port = engine_port
+            super().__init__(addr, handler)
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        RESPONSES = {
+            "/model_info": {"model_path": "kind-e2e-model", "is_generation": True},
+            "/server_info": {"version": "kind-e2e"},
+        }
+
+        def _respond(self):
+            self.rfile.read(int(self.headers.get("Content-Length", 0) or 0))
+            path = self.path.split("?")[0]
+            if path == "/set_health":
+                HEALTHY["value"] = "state=up" in self.path
+                body, code = b'{"toggled":true}', 200
+            elif path == "/health":
+                body = json.dumps({"status": "ok" if HEALTHY["value"] else "down"}).encode()
+                code = 200 if HEALTHY["value"] else 503
+            elif path == "/v1/chat/completions":
+                completion = {
+                    "id": "cmpl-kind",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "kind-e2e-model",
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "served-by-%d" % self.server.engine_port,
+                        },
+                        "finish_reason": "stop",
+                    }],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+                body, code = json.dumps(completion).encode(), 200
+            elif path in self.RESPONSES:
+                body, code = json.dumps(self.RESPONSES[path]).encode(), 200
+            else:
+                # Unknown paths must 404: the gateway's metadata fetch relies
+                # on it to fall back between endpoint variants.
+                body, code = b'{}', 404
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        do_GET = _respond
+        do_POST = _respond
+
+        def log_message(self, *args):
+            pass
+
+    def serve(port):
+        EngineServer(("0.0.0.0", port), Handler, port).serve_forever()
+
+    ports = [int(p) for p in sys.argv[1:]]
+    for port in ports[1:]:
+        threading.Thread(target=serve, args=(port,), daemon=True).start()
+    serve(ports[0])
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: multi-engine-0
+  labels:
+    app: smg-kind-e2e
+  annotations:
+    smg.ai/worker-ports: "28080,28081,28082,28083"
+spec:
+  hostNetwork: true
+  restartPolicy: Never
+  containers:
+    - name: engines
+      image: python:3.12-alpine
+      command: ["python", "/opt/mock/server.py", "28080", "28081", "28082", "28083"]
+      volumeMounts:
+        - name: script
+          mountPath: /opt/mock
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 28080
+        initialDelaySeconds: 1
+        periodSeconds: 2
+  volumes:
+    - name: script
+      configMap:
+        name: mock-engine-script
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: single-engine-0
+  labels:
+    app: smg-kind-e2e
+spec:
+  hostNetwork: true
+  restartPolicy: Never
+  containers:
+    - name: engine
+      image: python:3.12-alpine
+      command: ["python", "/opt/mock/server.py", "28090"]
+      volumeMounts:
+        - name: script
+          mountPath: /opt/mock
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 28090
+        initialDelaySeconds: 1
+        periodSeconds: 2
+  volumes:
+    - name: script
+      configMap:
+        name: mock-engine-script

--- a/e2e_test/kind_discovery/test_in_cluster_journey.py
+++ b/e2e_test/kind_discovery/test_in_cluster_journey.py
@@ -1,0 +1,256 @@
+"""Operator-journey e2e: smg deployed **inside** the cluster.
+
+Everything here runs the way a user runs it: smg is a Deployment using
+in-cluster ServiceAccount auth with the minimal RBAC from in_cluster.yaml
+(the reference manifests), engines are a plain Deployment whose pods each
+run four servers on 8080-8083 over the pod network (no hostNetwork), and
+the cluster is driven with kubectl apply / scale / rollout restart.
+
+Beyond pass/fail invariants, each step records convergence timings into a
+cluster report printed at the end — the "what goes well / what doesn't"
+characterization for a real cluster.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+HERE = Path(__file__).parent
+FORWARD_PORT = 3109
+ENGINE_PORTS = (8080, 8081, 8082, 8083)
+
+needs_images = pytest.mark.skipif(
+    not (os.environ.get("SMG_MOCK_IMAGE") and os.environ.get("SMG_GATEWAY_IMAGE")),
+    reason="SMG_MOCK_IMAGE and SMG_GATEWAY_IMAGE not set",
+)
+
+
+def kubectl(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["kubectl", *args], check=True, capture_output=True, text=True)
+
+
+class InClusterGateway:
+    """Assertion helper talking to the in-cluster smg via port-forward."""
+
+    def __init__(self):
+        self.base_url = f"http://127.0.0.1:{FORWARD_PORT}"
+        self.report: list[tuple[str, float, str]] = []
+
+    def workers(self) -> list[dict]:
+        try:
+            payload = requests.get(f"{self.base_url}/workers", timeout=5).json()
+        except requests.RequestException:
+            return []
+        return payload.get("workers", payload if isinstance(payload, list) else [])
+
+    def worker_urls(self) -> set[str]:
+        return {w["url"] for w in self.workers()}
+
+    def wait_for_count(self, expect: int, what: str, timeout: float = 180.0) -> float:
+        """Wait for exactly `expect` workers; returns elapsed seconds."""
+        start = time.monotonic()
+        deadline = start + timeout
+        while time.monotonic() < deadline:
+            if len(self.workers()) == expect:
+                elapsed = time.monotonic() - start
+                self.report.append((what, elapsed, f"converged to {expect}"))
+                return elapsed
+            time.sleep(1)
+        raise AssertionError(f"timed out waiting for {what}; workers: {sorted(self.worker_urls())}")
+
+    def print_report(self) -> None:
+        print("\n=== IN-CLUSTER JOURNEY REPORT (what the cluster observed) ===")
+        for what, elapsed, note in self.report:
+            print(f"  {elapsed:7.1f}s  {what}  [{note}]")
+
+
+def engine_pod_ips(label: str = "app=engines-incluster") -> set[str]:
+    out = kubectl("get", "pods", "-l", label, "-o", "json").stdout
+    return {
+        item["status"]["podIP"]
+        for item in json.loads(out)["items"]
+        if item["metadata"].get("deletionTimestamp") is None and item["status"].get("podIP")
+    }
+
+
+def expected_urls(pod_ips: set[str]) -> set[str]:
+    return {f"http://{ip}:{port}" for ip in pod_ips for port in ENGINE_PORTS}
+
+
+@pytest.fixture(scope="class")
+def incluster(kind_cluster):
+    kubectl("apply", "-f", str(HERE / "in_cluster.yaml"))
+    kubectl("rollout", "status", "deployment/smg-gateway", "--timeout=180s")
+    kubectl("rollout", "status", "deployment/engines", "--timeout=180s")
+
+    forward = subprocess.Popen(
+        ["kubectl", "port-forward", "svc/smg-gateway", f"{FORWARD_PORT}:3009"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    gw = InClusterGateway()
+    deadline = time.monotonic() + 30
+    while True:
+        try:
+            requests.get(f"{gw.base_url}/health", timeout=2)
+            break
+        except requests.RequestException:
+            assert time.monotonic() < deadline, "port-forward never became ready"
+            time.sleep(1)
+    try:
+        yield gw
+    finally:
+        gw.print_report()
+        forward.kill()
+        subprocess.run(
+            ["kubectl", "delete", "-f", str(HERE / "in_cluster.yaml"), "--wait=false"],
+            check=False,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["kubectl", "delete", "deployment", "engines-typo", "--wait=false"],
+            check=False,
+            capture_output=True,
+        )
+
+
+@pytest.mark.kind
+@needs_images
+class TestInClusterUserJourney:
+    def test_deploy_registers_every_engine_of_every_pod(self, incluster):
+        incluster.wait_for_count(8, "initial deploy (2 pods x 4 engines)")
+        assert incluster.worker_urls() == expected_urls(engine_pod_ips())
+
+        # In-cluster data plane: a request through the gateway reaches a
+        # discovered engine over the pod network.
+        response = requests.post(
+            f"{incluster.base_url}/v1/chat/completions",
+            json={
+                "model": "incluster-model",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            timeout=15,
+        )
+        assert response.status_code == 200, response.text
+
+    def test_scale_up_and_down_like_an_operator(self, incluster):
+        kubectl("scale", "deployment/engines", "--replicas=4")
+        kubectl("rollout", "status", "deployment/engines", "--timeout=180s")
+        incluster.wait_for_count(16, "scale 2 -> 4 replicas")
+        assert incluster.worker_urls() == expected_urls(engine_pod_ips())
+
+        kubectl("scale", "deployment/engines", "--replicas=1")
+        incluster.wait_for_count(4, "scale 4 -> 1 replicas")
+        assert incluster.worker_urls() == expected_urls(engine_pod_ips())
+
+    def test_rollout_restart_swaps_fleet_without_stale_workers(self, incluster):
+        kubectl("scale", "deployment/engines", "--replicas=3")
+        kubectl("rollout", "status", "deployment/engines", "--timeout=180s")
+        incluster.wait_for_count(12, "pre-rollout fleet of 3")
+        old_ips = engine_pod_ips()
+
+        start = time.monotonic()
+        floor = 12
+        kubectl("rollout", "restart", "deployment/engines")
+        while True:
+            floor = min(floor, len(incluster.workers()))
+            status = subprocess.run(
+                ["kubectl", "rollout", "status", "deployment/engines", "--timeout=1s"],
+                capture_output=True,
+                text=True,
+            )
+            if status.returncode == 0:
+                break
+            assert time.monotonic() - start < 300, "rollout never completed"
+
+        incluster.wait_for_count(12, "post-rollout convergence")
+        new_ips = engine_pod_ips()
+        assert incluster.worker_urls() == expected_urls(new_ips)
+        assert not (expected_urls(old_ips - new_ips) & incluster.worker_urls()), (
+            "stale workers survived the rollout"
+        )
+        incluster.report.append(
+            ("rollout restart capacity floor", float(floor), "min workers during roll (of 12)")
+        )
+
+    def test_misconfigured_deployment_falls_back_and_is_diagnosable(self, incluster):
+        manifest = """
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: engines-typo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: engines-incluster
+      variant: typo
+  template:
+    metadata:
+      labels:
+        app: engines-incluster
+        variant: typo
+      annotations:
+        smg.ai/worker-ports: "80eight0,8081"
+    spec:
+      containers:
+        - name: engines
+          image: smg-mock-worker:e2e
+          imagePullPolicy: Never
+          args: ["--host", "0.0.0.0", "--http-base-port", "8080", "--http-count", "4"]
+          readinessProbe:
+            httpGet: { path: /health, port: 8080 }
+            initialDelaySeconds: 1
+            periodSeconds: 2
+"""
+        subprocess.run(
+            ["kubectl", "apply", "-f", "-"],
+            input=manifest,
+            text=True,
+            check=True,
+            capture_output=True,
+        )
+        kubectl("rollout", "status", "deployment/engines-typo", "--timeout=180s")
+
+        # The invalid annotation must fall back to the single configured
+        # port — the typo pod contributes exactly one worker, not four and
+        # not zero, regardless of the healthy fleet's current size.
+        typo_ips = engine_pod_ips("app=engines-incluster,variant=typo")
+        assert typo_ips, "typo pod never got an IP"
+        expected = expected_urls(engine_pod_ips()) - {
+            f"http://{ip}:{port}" for ip in typo_ips for port in ENGINE_PORTS[1:]
+        }
+        self._wait_for_urls(incluster, expected, "typo deployment falls back to one worker")
+
+        # The operator must be able to see why from the gateway's own logs.
+        logs = kubectl("logs", "deployment/smg-gateway").stdout
+        assert "invalid smg.ai/worker-ports annotation" in logs, (
+            "misconfiguration is not diagnosable from gateway logs"
+        )
+
+        kubectl("delete", "deployment", "engines-typo", "--wait=true")
+        self._wait_for_urls(
+            incluster,
+            expected_urls(engine_pod_ips()),
+            "typo deployment removed",
+        )
+
+    @staticmethod
+    def _wait_for_urls(incluster, expected: set[str], what: str, timeout: float = 120.0) -> None:
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
+            if incluster.worker_urls() == expected:
+                incluster.report.append((what, time.monotonic() - start, f"{len(expected)} urls"))
+                return
+            time.sleep(1)
+        raise AssertionError(
+            f"timed out waiting for {what}; expected {sorted(expected)}, "
+            f"got {sorted(incluster.worker_urls())}"
+        )

--- a/e2e_test/kind_discovery/test_kind_discovery.py
+++ b/e2e_test/kind_discovery/test_kind_discovery.py
@@ -1,0 +1,409 @@
+"""Real-cluster service discovery e2e against a kind cluster.
+
+Covers the behaviors the fake-API-server integration tests cannot: real
+API-server watches and RBAC scoping, kubelet-driven readiness conditions,
+kubectl-applied mutations, and actual graceful/force deletion semantics.
+Tests run in definition order and each converges the cluster back to the
+5-worker baseline (4 annotated multi-engine ports + 1 fallback), except
+the final teardown test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).parent
+
+
+def kubectl(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["kubectl", *args], check=True, capture_output=True, text=True)
+
+
+DECOY_MANIFEST = """
+apiVersion: v1
+kind: Pod
+metadata:
+  name: decoy-0
+  namespace: decoy
+  labels:
+    app: smg-kind-e2e
+  annotations:
+    smg.ai/worker-ports: "28777"
+spec:
+  restartPolicy: Never
+  containers:
+    - name: sleeper
+      image: python:3.12-alpine
+      command: ["sleep", "3600"]
+"""
+
+
+def toggle_engine_health(pod: str, probe_port: int, state: str) -> None:
+    kubectl(
+        "exec",
+        pod,
+        "--",
+        "python",
+        "-c",
+        "import urllib.request; urllib.request.urlopen("
+        f"'http://127.0.0.1:{probe_port}/set_health?state={state}')",
+    )
+
+
+@pytest.mark.kind
+class TestKindDiscovery:
+    def test_initial_registration_and_ownership_labels(self, gateway):
+        gateway.wait_for_count(5, "initial registration (4 annotated + 1 fallback)")
+        workers = gateway.workers()
+        assert all(w.get("labels", {}).get("smg.ai/pod-uid") for w in workers)
+        multi = [
+            w for w in workers if w.get("labels", {}).get("smg.ai/pod-name") == "multi-engine-0"
+        ]
+        assert len(multi) == 4
+
+    def test_burst_batch_apply_and_delete(self, gateway):
+        kubectl("apply", "-f", str(HERE / "burst.yaml"))
+        kubectl(
+            "wait",
+            "--for=condition=Ready",
+            "pod/burst-0",
+            "pod/burst-1",
+            "pod/burst-2",
+            "--timeout=180s",
+        )
+        gateway.wait_for_count(8, "burst registration")
+        kubectl("delete", "-f", str(HERE / "burst.yaml"), "--wait=false")
+        gateway.wait_for_count(5, "burst removal")
+
+    def test_namespace_scoping_ignores_foreign_pod(self, gateway):
+        kubectl("create", "namespace", "decoy")
+        subprocess.run(
+            ["kubectl", "apply", "-f", "-"],
+            input=DECOY_MANIFEST,
+            text=True,
+            check=True,
+            capture_output=True,
+        )
+        kubectl(
+            "wait",
+            "--for=condition=Ready",
+            "pod/decoy-0",
+            "-n",
+            "decoy",
+            "--timeout=180s",
+        )
+        time.sleep(10)
+        assert not gateway.log_contains("28777"), (
+            "namespace scoping violated: discovery touched the decoy pod's port"
+        )
+        assert gateway.worker_count() == 5
+
+    def test_annotation_edit_reconciles_port_set(self, gateway):
+        kubectl(
+            "annotate",
+            "pod",
+            "multi-engine-0",
+            "smg.ai/worker-ports=28080,28081",
+            "--overwrite",
+        )
+        gateway.wait_for_count(3, "workers removed for dropped ports")
+        kubectl(
+            "annotate",
+            "pod",
+            "multi-engine-0",
+            "smg.ai/worker-ports=28080,28081,28082,28083",
+            "--overwrite",
+        )
+        gateway.wait_for_count(5, "workers restored for re-added ports")
+
+    def test_readiness_flip_keeps_workers(self, gateway):
+        toggle_engine_health("multi-engine-0", 28080, "down")
+        kubectl(
+            "wait",
+            "--for=condition=Ready=false",
+            "pod/multi-engine-0",
+            "--timeout=60s",
+        )
+        for _ in range(3):
+            time.sleep(2)
+            assert gateway.worker_count() == 5, "unready pod lost workers"
+        toggle_engine_health("multi-engine-0", 28080, "up")
+        kubectl(
+            "wait",
+            "--for=condition=Ready",
+            "pod/multi-engine-0",
+            "--timeout=60s",
+        )
+        gateway.wait_for_count(5, "workers intact after readiness recovery")
+
+    def test_gateway_restart_rebuilds_registry(self, gateway):
+        gateway.restart()
+        gateway.wait_for_count(5, "registry rebuilt from live cluster after restart")
+
+    def test_pod_recreation_changes_ownership_uid(self, gateway):
+        old_uid = gateway.pod_uid_of_port(28090)
+        assert old_uid, "missing uid label before recreation"
+        kubectl("delete", "pod", "single-engine-0", "--wait=true")
+        gateway.wait_for_count(4, "removal of deleted pod's worker")
+        kubectl("apply", "-f", str(HERE / "manifests.yaml"))
+        kubectl(
+            "wait",
+            "--for=condition=Ready",
+            "pod/single-engine-0",
+            "--timeout=180s",
+        )
+        gateway.wait_for_count(5, "re-registration after recreation")
+        new_uid = gateway.pod_uid_of_port(28090)
+        assert new_uid and new_uid != old_uid, (
+            f"recreated pod kept stale uid label (old={old_uid} new={new_uid})"
+        )
+
+    def test_completions_route_to_discovered_workers(self, gateway):
+        import requests
+
+        gateway.wait_for_count(5, "baseline before data-plane check")
+        # Health promotion lags registration; wait for the first 200 before
+        # asserting fan-out.
+        deadline = time.monotonic() + 60
+        while True:
+            probe = requests.post(
+                f"{gateway.base_url}/v1/chat/completions",
+                json={
+                    "model": "kind-e2e-model",
+                    "messages": [{"role": "user", "content": "warmup"}],
+                },
+                timeout=10,
+            )
+            if probe.status_code == 200:
+                break
+            assert time.monotonic() < deadline, f"no worker became routable: {probe.text}"
+            time.sleep(1)
+        served_by: set[str] = set()
+        for i in range(10):
+            response = requests.post(
+                f"{gateway.base_url}/v1/chat/completions",
+                json={
+                    "model": "kind-e2e-model",
+                    "messages": [{"role": "user", "content": f"probe {i}"}],
+                },
+                timeout=10,
+            )
+            assert response.status_code == 200, response.text
+            content = response.json()["choices"][0]["message"]["content"]
+            assert content.startswith("served-by-"), content
+            served_by.add(content)
+        # Round-robin over the discovered fleet: several distinct engines
+        # (pod ports) must actually serve traffic.
+        assert len(served_by) >= 2, f"traffic pinned to one engine: {served_by}"
+
+    def test_graceful_then_force_delete(self, gateway):
+        kubectl("delete", "pod", "single-engine-0", "--wait=false")
+        gateway.wait_for_count(4, "removal after graceful delete")
+        kubectl(
+            "delete",
+            "pod",
+            "multi-engine-0",
+            "--grace-period=0",
+            "--force",
+        )
+        gateway.wait_for_count(0, "removal after force delete")
+
+
+# ========== mock-worker fleet scenarios (need SMG_MOCK_IMAGE) ==========
+
+MOCK_IMAGE = os.environ.get("SMG_MOCK_IMAGE")
+needs_mock_image = pytest.mark.skipif(
+    not MOCK_IMAGE, reason="SMG_MOCK_IMAGE not set (build Dockerfile.mock-worker)"
+)
+
+
+def mock_worker_pod(
+    name: str,
+    args: list[str],
+    annotations: dict[str, str],
+    probe_port: int,
+    probe_kind: str = "http",
+    extra_labels: dict[str, str] | None = None,
+) -> str:
+    labels = {"app": "smg-kind-e2e", **(extra_labels or {})}
+    label_lines = "\n".join(f"    {k}: {v}" for k, v in labels.items())
+    annotation_lines = "\n".join(f'    {k}: "{v}"' for k, v in annotations.items())
+    if probe_kind == "http":
+        probe = f"httpGet: {{ path: /health, port: {probe_port} }}"
+    else:
+        probe = f"tcpSocket: {{ port: {probe_port} }}"
+    arg_list = ", ".join(f'"{a}"' for a in args)
+    return f"""
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {name}
+  labels:
+{label_lines}
+  annotations:
+{annotation_lines}
+spec:
+  hostNetwork: true
+  restartPolicy: Never
+  containers:
+    - name: engines
+      image: {MOCK_IMAGE}
+      imagePullPolicy: Never
+      args: [{arg_list}]
+      readinessProbe:
+        {probe}
+        initialDelaySeconds: 1
+        periodSeconds: 2
+  volumes: []
+"""
+
+
+def apply_manifest(manifest: str) -> None:
+    subprocess.run(
+        ["kubectl", "apply", "-f", "-"],
+        input=manifest,
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.mark.kind
+@needs_mock_image
+class TestKindMockWorkerFleet:
+    """Scale and protocol-mix scenarios on the real mock-worker binary."""
+
+    SCALE_PORTS = [29000 + i for i in range(40)]
+
+    def test_forty_engine_pod_registers_and_unwinds(self, gateway):
+        gateway.wait_for_count(0, "clean slate before fleet scenarios")
+        apply_manifest(
+            mock_worker_pod(
+                "fleet-0",
+                [
+                    "--host",
+                    "0.0.0.0",
+                    "--http-base-port",
+                    "29000",
+                    "--http-count",
+                    "40",
+                    "--model",
+                    "kind-e2e-model",
+                ],
+                {"smg.ai/worker-ports": ",".join(str(p) for p in self.SCALE_PORTS)},
+                probe_port=29000,
+            )
+        )
+        kubectl("wait", "--for=condition=Ready", "pod/fleet-0", "--timeout=180s")
+        gateway.wait_for_count(40, "forty workers from one pod", timeout=180)
+        urls = {w["url"].rsplit(":", 1)[-1] for w in gateway.workers()}
+        assert urls == {str(p) for p in self.SCALE_PORTS}
+        kubectl("delete", "pod", "fleet-0", "--grace-period=0", "--force")
+        gateway.wait_for_count(0, "fleet unwound", timeout=180)
+
+    def test_grpc_workers_register_with_grpc_mode(self, gateway):
+        apply_manifest(
+            mock_worker_pod(
+                "grpc-0",
+                [
+                    "--host",
+                    "0.0.0.0",
+                    "--grpc-base-port",
+                    "29500",
+                    "--grpc-count",
+                    "2",
+                    "--model",
+                    "kind-e2e-model",
+                ],
+                {"smg.ai/worker-ports": "29500,29501"},
+                probe_port=29500,
+                probe_kind="tcp",
+            )
+        )
+        kubectl("wait", "--for=condition=Ready", "pod/grpc-0", "--timeout=180s")
+        gateway.wait_for_count(2, "grpc workers registered", timeout=120)
+        for worker in gateway.workers():
+            assert worker.get("connection_mode") == "grpc", worker
+        kubectl("delete", "pod", "grpc-0", "--grace-period=0", "--force")
+        gateway.wait_for_count(0, "grpc pod unwound")
+
+
+@pytest.mark.kind
+@needs_mock_image
+class TestKindPDDisaggregation:
+    """PD prefill/decode mix with per-engine bootstrap alignment."""
+
+    def test_pd_mix_with_aligned_bootstrap_ports(self, gateway):
+        apply_manifest(
+            mock_worker_pod(
+                "prefill-0",
+                [
+                    "--host",
+                    "0.0.0.0",
+                    "--http-base-port",
+                    "29600",
+                    "--http-count",
+                    "2",
+                    "--model",
+                    "kind-e2e-model",
+                ],
+                {
+                    "smg.ai/worker-ports": "29600,29601",
+                    "sglang.ai/bootstrap-port": "29700,29701",
+                },
+                probe_port=29600,
+                extra_labels={"role": "prefill"},
+            )
+        )
+        apply_manifest(
+            mock_worker_pod(
+                "decode-0",
+                [
+                    "--host",
+                    "0.0.0.0",
+                    "--http-base-port",
+                    "29610",
+                    "--http-count",
+                    "2",
+                    "--model",
+                    "kind-e2e-model",
+                ],
+                {"smg.ai/worker-ports": "29610,29611"},
+                probe_port=29610,
+                extra_labels={"role": "decode"},
+            )
+        )
+        kubectl("wait", "--for=condition=Ready", "pod/prefill-0", "pod/decode-0", "--timeout=180s")
+
+        gateway.restart(
+            (
+                "--pd-disaggregation",
+                "--prefill-selector",
+                "app=smg-kind-e2e",
+                "--prefill-selector",
+                "role=prefill",
+                "--decode-selector",
+                "app=smg-kind-e2e",
+                "--decode-selector",
+                "role=decode",
+            )
+        )
+        gateway.wait_for_count(4, "PD fleet registered", timeout=120)
+
+        by_port = {w["url"].rsplit(":", 1)[-1]: w for w in gateway.workers()}
+        assert by_port["29600"]["worker_type"] == "prefill"
+        assert by_port["29601"]["worker_type"] == "prefill"
+        assert by_port["29610"]["worker_type"] == "decode"
+        assert by_port["29611"]["worker_type"] == "decode"
+        # Aligned bootstrap list: each prefill engine gets its own port.
+        assert by_port["29600"].get("bootstrap_port") == 29700
+        assert by_port["29601"].get("bootstrap_port") == 29701
+        assert "bootstrap_port" not in by_port["29610"]
+
+        kubectl("delete", "pod", "prefill-0", "decode-0", "--grace-period=0", "--force")
+        gateway.wait_for_count(0, "PD fleet unwound")

--- a/e2e_test/pyproject.toml
+++ b/e2e_test/pyproject.toml
@@ -43,6 +43,7 @@ markers = [
   "e2e: mark test as end-to-end test requiring GPU workers",
   "slow: mark test as slow-running",
   "external: mark test as dependent on external third-party services (run with -m external)",
+  "kind: mark test as requiring a local kind cluster (run with SMG_KIND_E2E=1)",
 ]
 addopts = "-v -s"
 # Explicitly disable live log to avoid "---- live log ----" dividers


### PR DESCRIPTION
Stacked on #2062 (which stacks on #2061).

## Description

Real-cluster coverage for the layers the fake-API-server tests can't reach: RBAC/kubeconfig auth, real watch bookmarks and relists, kubelet readiness transitions, and actual graceful/force deletion semantics.

- `e2e_test/kind_discovery/manifests.yaml` — two **hostNetwork** pods on a kind node: `multi-engine-0` runs four HTTP engine servers from one container (the exact multiple-servers-per-pod deployment shape) listed in `smg.ai/worker-ports: "28080,28081,28082,28083"`; `single-engine-0` has no annotation and exercises the `--service-discovery-port` fallback. The mock engine is a stdlib-only python script shipped via ConfigMap — no image builds.
- `e2e_test/kind_discovery/run.sh` — creates the cluster, waits for readiness, starts the `smg` binary on the runner host against the kind kubeconfig, then asserts via `GET /workers`: **5 workers** (4 + 1 fallback), all carrying `smg.ai/pod-uid`, exactly 4 labeled `smg.ai/pod-name=multi-engine-0`; graceful `kubectl delete` → 4 workers; `--grace-period=0 --force` → 0. Dumps the smg log tail and pod state on failure; always tears the cluster down.
- `.github/workflows/e2e-kind-discovery.yml` — **workflow_dispatch only** with a `runner` input defaulting to `ubuntu-latest` (GitHub-hosted has Docker, so this runs today); flip the input to the self-hosted pool once dind availability there is confirmed. Not a merge gate.

hostNetwork is what makes the host-side smg able to probe worker ports at the pod IP (= node container IP, routable on Linux runners) — and it also mirrors the real multi-engine GPU-pod deployment pattern.

## Validation

Runtime validation needs a Linux Docker host, so this is dispatch-validated on CI rather than locally (local Docker daemon unavailable, and macOS cannot route to kind node IPs regardless). Locally verified: `bash -n` on the script, workflow + manifest YAML parse, and the embedded multi-port engine server executed standalone — all four ports served `/health` and `/get_model_info` correctly. The full discovery pipeline itself is already covered end-to-end by the deterministic fake-API-server tests in #2062; this PR adds the real-cluster plumbing on top.

Suggested first run: `gh workflow run e2e-kind-discovery.yml` once this merges (or dispatch from this branch).