### PR TITLE
fix(docker): harden ffmpeg download with retries and a mirror fallback

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,8 +24,15 @@ RUN apt update -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt clean
 
+# The sha256 pin makes any mirror integrity-safe; OSUOSL is independent
+# infrastructure for when ffmpeg.org is unreachable.
 RUN mkdir -p /tmp/ffmpeg \
-    && curl -fsSL "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" -o /tmp/ffmpeg.tar.xz \
+    && { curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 --connect-timeout 30 \
+            --max-time 120 --retry-max-time 300 \
+            "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz" -o /tmp/ffmpeg.tar.xz \
+        || curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 --connect-timeout 30 \
+            --max-time 120 --retry-max-time 300 \
+            "https://ftp.osuosl.org/pub/blfs/conglomeration/ffmpeg/ffmpeg-${FFMPEG_VERSION}.tar.xz" -o /tmp/ffmpeg.tar.xz; } \
     && echo "${FFMPEG_SHA256}  /tmp/ffmpeg.tar.xz" | sha256sum -c - \
     && tar -C /tmp/ffmpeg --strip-components=1 -xJf /tmp/ffmpeg.tar.xz \
     && cd /tmp/ffmpeg \


### PR DESCRIPTION
## Description

Last night's [Nightly Docker Build](https://github.com/smg-project/smg/actions/runs/31084492872) failed with:

```
curl: (28) Failed to connect to ffmpeg.org port 443 after 133555 ms: Couldn't connect to server
```

ffmpeg.org was unreachable from the runner. Because the GHA layer cache is churned by the Rust jobs (10 GB repo cap), the ffmpeg source layer rebuilds on most nightlies for both arches — so a third-party outage can fail the nightly at all. This PR narrows that exposure:

- `curl --retry 5 --retry-all-errors --retry-delay 10 --connect-timeout 30` on the primary fetch (rides out transient blips), and
- a fallback fetch from the OSUOSL mirror (`ftp.osuosl.org/pub/blfs/conglomeration/ffmpeg/`) — fully independent infrastructure. The existing sha256 pin makes any mirror integrity-safe.

Caveat noted for future version bumps: the BLFS mirror can lag brand-new ffmpeg releases; the primary is tried first, so the worst case there is today's status quo.

For a structural end to third-party fetches in the nightly path, the follow-up would be a monthly-built ffmpeg base image on ghcr — out of scope here.

## Test Plan

- OSUOSL artifact downloaded in full and verified byte-identical to the pin: `sha256sum -c` → OK (11.4 MB)
- The exact fallback construct executed under `sh` with a dead primary URL: retries exhaust → mirror fetch → `sha256 OK`
- Stalled-transfer scenario (per review): an accept-then-stall server → each attempt aborts at the `--max-time` bound with 0 bytes → bounded retries exhaust → mirror fetch → `sha256 OK`; worst case is ~5 min per URL instead of an unbounded hang
- Docker layer semantics unchanged otherwise (same ARG pins, same build steps); pre-commit clean
