### PR TITLE
refactor(zmq): clients finalize their own requests (no more stage-level transport probes)

### DIFF
--- a/model_gateway/src/routers/grpc/backend_client.rs
+++ b/model_gateway/src/routers/grpc/backend_client.rs
@@ -248,7 +248,7 @@ impl BackendClient {
                         )
                     })
                 }
-                _ => {
+                RuntimeType::Vllm => {
                     let vllm_mm = zmq_vllm_mm(options.multimodal_inputs)?;
                     finish_vllm_request(vllm_mm, |mm| {
                         VllmEngineClient::build_generate_request_from_chat(
@@ -261,6 +261,9 @@ impl BackendClient {
                         )
                     })
                 }
+                other => Err(format!(
+                    "ZMQ backend reports unsupported runtime {other:?}; expected vLLM or TokenSpeed"
+                )),
             },
         }
     }
@@ -293,7 +296,7 @@ impl BackendClient {
                         )
                     })
                 }
-                _ => {
+                RuntimeType::Vllm => {
                     let vllm_mm = zmq_vllm_mm(options.multimodal_inputs)?;
                     finish_vllm_request(vllm_mm, |mm| {
                         VllmEngineClient::build_generate_request_from_messages(
@@ -306,6 +309,9 @@ impl BackendClient {
                         )
                     })
                 }
+                other => Err(format!(
+                    "ZMQ backend reports unsupported runtime {other:?}; expected vLLM or TokenSpeed"
+                )),
             },
         }
     }
@@ -331,7 +337,7 @@ impl BackendClient {
                     )?;
                     Ok(ProtoGenerateRequest::TokenSpeed(Box::new(req)))
                 }
-                _ => {
+                RuntimeType::Vllm => {
                     let req = VllmEngineClient::build_generate_request_from_completion(
                         request_id,
                         body,
@@ -340,6 +346,9 @@ impl BackendClient {
                     )?;
                     Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
                 }
+                other => Err(format!(
+                    "ZMQ backend reports unsupported runtime {other:?}; expected vLLM or TokenSpeed"
+                )),
             },
         }
     }
@@ -365,7 +374,7 @@ impl BackendClient {
                     )?;
                     Ok(ProtoGenerateRequest::TokenSpeed(Box::new(req)))
                 }
-                _ => {
+                RuntimeType::Vllm => {
                     let req = VllmEngineClient::build_plain_generate_request(
                         request_id,
                         body,
@@ -374,6 +383,9 @@ impl BackendClient {
                     )?;
                     Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
                 }
+                other => Err(format!(
+                    "ZMQ backend reports unsupported runtime {other:?}; expected vLLM or TokenSpeed"
+                )),
             },
         }
     }

--- a/model_gateway/src/routers/grpc/backend_client.rs
+++ b/model_gateway/src/routers/grpc/backend_client.rs
@@ -70,11 +70,19 @@ impl BackendClient {
         tokenizer: Option<&std::sync::Arc<dyn llm_tokenizer::traits::Tokenizer>>,
     ) -> Vec<String> {
         let token_only_wire = self.is_zmq();
-        crate::routers::grpc::common::stages::helpers::resolve_string_stops(
+        let router_stops = crate::routers::grpc::common::stages::helpers::resolve_string_stops(
             request,
             tokenizer,
             token_only_wire,
-        )
+        );
+        if let Self::Zmq(client) = self {
+            // EngineCore has no tokenizer, so stopping at EOS is this
+            // frontend's job; TokenSpeed's scheduler stops at EOS itself.
+            if client.runtime() != RuntimeType::TokenSpeed {
+                crate::routers::grpc::zmq_client::fold_tokenizer_eos_backstop(request, tokenizer);
+            }
+        }
+        router_stops
     }
 
     /// Local liveness. gRPC has no cheap local flag (it uses a health RPC), so

--- a/model_gateway/src/routers/grpc/backend_client.rs
+++ b/model_gateway/src/routers/grpc/backend_client.rs
@@ -55,6 +55,28 @@ impl BackendClient {
         matches!(self, Self::Zmq(_))
     }
 
+    /// Finalize a built generate request for this backend's wire: resolve
+    /// string `stop`s the engine cannot match (token-only wires and SGLang's
+    /// `skip_tokenizer_init` workers) into `stop_token_ids`, folding in EOS
+    /// where the frontend owns stopping.
+    ///
+    /// Returns the router's residual obligation: the stop strings the engine
+    /// will never see, which response processing must trim from output text.
+    /// Empty when the engine matches stops server-side. This is the client's
+    /// own policy — callers need no transport knowledge.
+    pub fn finalize_generate_request(
+        &self,
+        request: &mut ProtoGenerateRequest,
+        tokenizer: Option<&std::sync::Arc<dyn llm_tokenizer::traits::Tokenizer>>,
+    ) -> Vec<String> {
+        let token_only_wire = self.is_zmq();
+        crate::routers::grpc::common::stages::helpers::resolve_string_stops(
+            request,
+            tokenizer,
+            token_only_wire,
+        )
+    }
+
     /// Local liveness. gRPC has no cheap local flag (it uses a health RPC), so
     /// this reports `true` for gRPC; ZMQ reflects its connection liveness.
     pub fn is_alive(&self) -> bool {

--- a/model_gateway/src/routers/grpc/backend_client.rs
+++ b/model_gateway/src/routers/grpc/backend_client.rs
@@ -22,11 +22,12 @@ use crate::{
         client::{
             GenerateRequestBuildOptions, GrpcClient, HealthCheckResponse, ModelInfo, ServerInfo,
         },
+        common::stages::helpers,
         proto_wrapper::{
             finish_tokenspeed_request, finish_vllm_request, ProtoEmbedComplete, ProtoEmbedRequest,
             ProtoGenerateRequest, ProtoStream,
         },
-        zmq_client::ZmqEngineClient,
+        zmq_client::{fold_tokenizer_eos_backstop, ZmqEngineClient},
         MultimodalData,
     },
     worker::RuntimeType,
@@ -70,16 +71,12 @@ impl BackendClient {
         tokenizer: Option<&std::sync::Arc<dyn llm_tokenizer::traits::Tokenizer>>,
     ) -> Vec<String> {
         let token_only_wire = self.is_zmq();
-        let router_stops = crate::routers::grpc::common::stages::helpers::resolve_string_stops(
-            request,
-            tokenizer,
-            token_only_wire,
-        );
+        let router_stops = helpers::resolve_string_stops(request, tokenizer, token_only_wire);
         if let Self::Zmq(client) = self {
             // EngineCore has no tokenizer, so stopping at EOS is this
             // frontend's job; TokenSpeed's scheduler stops at EOS itself.
             if client.runtime() != RuntimeType::TokenSpeed {
-                crate::routers::grpc::zmq_client::fold_tokenizer_eos_backstop(request, tokenizer);
+                fold_tokenizer_eos_backstop(request, tokenizer);
             }
         }
         router_stops

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -364,24 +364,29 @@ fn encode_single_token_stops(
 /// any single-token stop as a `stop_token_ids` entry for early stopping; the
 /// router-side decoder handles the rest. This is the single resolution point
 /// shared by SGLang gRPC and every ZMQ backend.
+///
+/// Returns the stop strings that were stripped — the router's residual
+/// obligation: the engine will never match these, so response processing must
+/// trim them from the output text. Empty when the engine matches server-side.
 pub(crate) fn resolve_string_stops(
     request: &mut ProtoGenerateRequest,
     tokenizer: Option<&Arc<dyn Tokenizer>>,
-    is_zmq: bool,
-) {
+    token_only_wire: bool,
+) -> Vec<String> {
     // SGLang always needs it; the vLLM and TokenSpeed protos only when talking
-    // to a ZMQ backend (which is the sole path either reaches token-only).
+    // to a token-only wire (direct-ZMQ, the sole path either reaches that way).
     match request {
         ProtoGenerateRequest::Sglang(req) => {
             if let Some(params) = req.sampling_params.as_mut() {
                 let stops = std::mem::take(&mut params.stop);
-                encode_single_token_stops(stops, &mut params.stop_token_ids, tokenizer);
+                encode_single_token_stops(stops.clone(), &mut params.stop_token_ids, tokenizer);
+                return stops;
             }
         }
-        ProtoGenerateRequest::Vllm(req) if is_zmq => {
+        ProtoGenerateRequest::Vllm(req) if token_only_wire => {
             if let Some(params) = req.sampling_params.as_mut() {
                 let stops = std::mem::take(&mut params.stop);
-                encode_single_token_stops(stops, &mut params.stop_token_ids, tokenizer);
+                encode_single_token_stops(stops.clone(), &mut params.stop_token_ids, tokenizer);
                 // The engine only stops at EOS when the frontend supplies the
                 // ids, and the connect-time model-dir resolution has nothing
                 // to read when the worker's model id is a repo id rather than
@@ -398,9 +403,10 @@ pub(crate) fn resolve_string_stops(
                         }
                     }
                 }
+                return stops;
             }
         }
-        ProtoGenerateRequest::TokenSpeed(req) if is_zmq => {
+        ProtoGenerateRequest::TokenSpeed(req) if token_only_wire => {
             // TokenSpeed over ZMQ receives token ids only, so its wire
             // translation drops raw `stop` strings; without this a single-token
             // user stop would never reach the engine as a `stop_token_ids`
@@ -409,11 +415,13 @@ pub(crate) fn resolve_string_stops(
             // stops at EOS itself, so its translation carries no frontend ids.
             if let Some(params) = req.sampling_params.as_mut() {
                 let stops = std::mem::take(&mut params.stop);
-                encode_single_token_stops(stops, &mut params.stop_token_ids, tokenizer);
+                encode_single_token_stops(stops.clone(), &mut params.stop_token_ids, tokenizer);
+                return stops;
             }
         }
         _ => {}
     }
+    Vec::new()
 }
 
 /// Inject PD bootstrap metadata for SGLang if needed.
@@ -772,6 +780,21 @@ mod stop_resolution_tests {
             vec![6],
             "only the single-token stop, no EOS fold"
         );
+    }
+
+    #[test]
+    fn resolution_returns_router_obligations() {
+        // Strings stripped for the engine come back as the router's trim duty.
+        let mut req = sglang_request(vec![".", "Hello world"], vec![]);
+        let obligations = resolve_string_stops(&mut req, Some(&mock_tokenizer()), false);
+        assert_eq!(
+            obligations,
+            vec![".".to_string(), "Hello world".to_string()]
+        );
+
+        // gRPC vLLM matches stops server-side: nothing left for the router.
+        let mut req = vllm_request(vec!["."], vec![]);
+        assert!(resolve_string_stops(&mut req, Some(&mock_tokenizer()), false).is_empty());
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -384,25 +384,12 @@ pub(crate) fn resolve_string_stops(
             }
         }
         ProtoGenerateRequest::Vllm(req) if token_only_wire => {
+            // EOS injection for the tokenizer-less EngineCore is the ZMQ
+            // client's own policy (zmq_client::fold_tokenizer_eos_backstop),
+            // not part of shared stop resolution.
             if let Some(params) = req.sampling_params.as_mut() {
                 let stops = std::mem::take(&mut params.stop);
                 encode_single_token_stops(stops.clone(), &mut params.stop_token_ids, tokenizer);
-                // The engine only stops at EOS when the frontend supplies the
-                // ids, and the connect-time model-dir resolution has nothing
-                // to read when the worker's model id is a repo id rather than
-                // a local path. The tokenizer carries the merged EOS set, so
-                // fold it into the stop tokens as the always-available
-                // backstop — without it an uncapped request generates to the
-                // full context window.
-                if !params.ignore_eos {
-                    if let Some(tokenizer) = tokenizer {
-                        for &id in tokenizer.eos_token_ids() {
-                            if !params.stop_token_ids.contains(&id) {
-                                params.stop_token_ids.push(id);
-                            }
-                        }
-                    }
-                }
                 return stops;
             }
         }
@@ -706,39 +693,14 @@ mod stop_resolution_tests {
         );
         assert!(params.stop_token_ids.is_empty());
 
-        // ZMQ vLLM (EngineCore sees token ids only) resolves like SGLang, and
-        // gains the tokenizer's EOS ids so generation always terminates.
+        // ZMQ vLLM (EngineCore sees token ids only) resolves like SGLang.
+        // EOS injection is the ZMQ client's own step, not stop resolution's
+        // (see zmq_client::fold_tokenizer_eos_backstop tests).
         let mut zmq = vllm_request(vec!["."], vec![]);
         resolve_string_stops(&mut zmq, Some(&mock_tokenizer()), true);
         let params = vllm_params(&zmq);
         assert!(params.stop.is_empty(), "ZMQ vLLM stop cleared");
-        assert_eq!(params.stop_token_ids, vec![6, 999]);
-    }
-
-    #[test]
-    fn vllm_zmq_appends_tokenizer_eos_ids() {
-        let mut req = vllm_request(vec![], vec![7]);
-        resolve_string_stops(&mut req, Some(&mock_tokenizer()), true);
-        assert_eq!(vllm_params(&req).stop_token_ids, vec![7, 999]);
-
-        // Already-present EOS ids are not duplicated.
-        let mut req = vllm_request(vec![], vec![999]);
-        resolve_string_stops(&mut req, Some(&mock_tokenizer()), true);
-        assert_eq!(vllm_params(&req).stop_token_ids, vec![999]);
-    }
-
-    #[test]
-    fn vllm_zmq_ignore_eos_skips_injection() {
-        let mut req = ProtoGenerateRequest::Vllm(Box::new(vllm_proto::GenerateRequest {
-            sampling_params: Some(vllm_proto::SamplingParams {
-                stop_token_ids: vec![7],
-                ignore_eos: true,
-                ..Default::default()
-            }),
-            ..Default::default()
-        }));
-        resolve_string_stops(&mut req, Some(&mock_tokenizer()), true);
-        assert_eq!(vllm_params(&req).stop_token_ids, vec![7]);
+        assert_eq!(params.stop_token_ids, vec![6]);
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -457,6 +457,12 @@ pub(crate) struct ResponseState {
     /// Stop sequence decoder
     pub stop_decoder: Option<StopSequenceDecoder>,
 
+    /// String stops the engine will never match, reported by
+    /// `BackendClient::finalize_generate_request` during request building.
+    /// Response processing must trim these from output text; empty when the
+    /// engine matches stops server-side.
+    pub router_stop_obligations: Vec<String>,
+
     /// Derived skip_special_tokens for streaming (set in preparation, read in response_processing).
     /// Stored here because PreparationOutput is consumed by request_building before
     /// response_processing runs.

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -396,7 +396,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 };
                 ProtoGenerateRequest::TokenSpeed(Box::new(req))
             }
-            BackendClient::Zmq(_) => {
+            BackendClient::Zmq(zmq_client) if zmq_client.runtime() == RuntimeType::Vllm => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = modified_request
@@ -442,6 +442,17 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                     }
                 };
                 ProtoGenerateRequest::Vllm(Box::new(req))
+            }
+            // connect() admits only vLLM/TokenSpeed runtimes over ZMQ; a client
+            // reporting anything else is a wiring bug, not a request to serve.
+            BackendClient::Zmq(zmq_client) => {
+                return Err(error::internal_error(
+                    "unsupported_zmq_runtime",
+                    format!(
+                        "ZMQ backend reports unsupported runtime {:?} for Harmony requests",
+                        zmq_client.runtime()
+                    ),
+                ));
             }
         };
 

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -500,6 +500,12 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             }
         }
 
+        // The client resolves string `stop`s its engine can't match and
+        // reports the router's residual trim obligation; harmony response
+        // processing scans channel text for exactly these strings.
+        ctx.state.response.router_stop_obligations = builder_client
+            .finalize_generate_request(&mut proto_request, ctx.tokenizer_arc().as_ref());
+
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {
                 helpers::maybe_inject_pd_metadata(&mut proto_request, workers);

--- a/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -12,36 +12,18 @@ use crate::{
         error,
         grpc::{
             common::stages::PipelineStage,
-            context::{ClientSelection, FinalResponse, RequestContext, RequestType},
+            context::{FinalResponse, RequestContext, RequestType},
         },
     },
     worker::AttachedBody,
 };
 
-/// String `stop` sequences the ROUTER must enforce: only for direct-ZMQ
-/// backends, where the engine receives token ids and never sees the strings.
-/// Empty for gRPC backends (the engine matches stops itself).
+/// String `stop` sequences the ROUTER must enforce, as reported by the
+/// backend client during request building (its residual obligation: strings
+/// the engine will never match). Empty for engines that match server-side —
+/// no transport inspection here.
 fn router_stop_strings(ctx: &RequestContext) -> Vec<String> {
-    let is_zmq = ctx
-        .state
-        .clients
-        .as_ref()
-        .is_some_and(|clients| match clients {
-            ClientSelection::Single { client } => client.is_zmq(),
-            ClientSelection::Disaggregated { decode, .. } => decode.is_zmq(),
-        });
-    if !is_zmq {
-        return Vec::new();
-    }
-    match &ctx.input.request_type {
-        RequestType::Chat(_) => ctx
-            .chat_request_arc()
-            .stop
-            .as_ref()
-            .map(|stop| stop.to_vec())
-            .unwrap_or_default(),
-        _ => Vec::new(),
-    }
+    ctx.state.response.router_stop_obligations.clone()
 }
 
 /// Harmony Response Processing stage: Parse and format Harmony responses

--- a/model_gateway/src/routers/grpc/multimodal/assemble.rs
+++ b/model_gateway/src/routers/grpc/multimodal/assemble.rs
@@ -112,7 +112,9 @@ async fn assemble_multimodal_data_impl(
             anyhow::bail!("MLX does not support multimodal inputs")
         }
         BackendClient::Zmq(client) => match client.runtime() {
-            RuntimeType::Vllm | RuntimeType::Unspecified => {
+            // connect() admits only vLLM/TokenSpeed runtimes over ZMQ, so no
+            // Unspecified fallback: anything else is a hard error below.
+            RuntimeType::Vllm => {
                 let batch = into_single_batch(intermediate, "vLLM")?;
                 let mut data = assemble_vllm(batch, workers)?;
                 // The ZMQ translate reads tensor bytes inline; this wire has no

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -147,12 +147,12 @@ impl PipelineStage for ChatRequestBuildingStage {
             ctx.state.workers.as_ref(),
         );
 
-        // Resolve string `stop` sequences for engines that can't match them
-        // server-side (SGLang skip_tokenizer_init, and every direct-ZMQ
-        // backend): drop the strings, convert single-token stops to
-        // stop_token_ids; the router-side StopSequenceDecoder trims the text.
-        let is_zmq = builder_client.is_zmq();
-        helpers::resolve_string_stops(&mut proto_request, ctx.tokenizer_arc().as_ref(), is_zmq);
+        // The client resolves string `stop`s its engine can't match and
+        // reports the router's residual trim obligation; no transport
+        // knowledge needed here. (Obligation wiring lands with the
+        // response-side convergence commit.)
+        let _router_stops = builder_client
+            .finalize_generate_request(&mut proto_request, ctx.tokenizer_arc().as_ref());
 
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -149,9 +149,8 @@ impl PipelineStage for ChatRequestBuildingStage {
 
         // The client resolves string `stop`s its engine can't match and
         // reports the router's residual trim obligation; no transport
-        // knowledge needed here. (Obligation wiring lands with the
-        // response-side convergence commit.)
-        let _router_stops = builder_client
+        // knowledge needed here.
+        ctx.state.response.router_stop_obligations = builder_client
             .finalize_generate_request(&mut proto_request, ctx.tokenizer_arc().as_ref());
 
         if self.inject_pd_metadata {

--- a/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
@@ -141,11 +141,9 @@ impl PipelineStage for CompletionRequestBuildingStage {
         let disaggregated = matches!(clients, ClientSelection::Disaggregated { .. });
         let request_type = &ctx.input.request_type;
         let workers = ctx.state.workers.as_ref();
-        // Resolve string `stop` sequences for engines that can't match them
-        // server-side (SGLang skip_tokenizer_init, and every direct-ZMQ
-        // backend): drop the strings, convert single-token stops to
-        // stop_token_ids; the router-side StopSequenceDecoder trims the text.
-        let is_zmq = builder_client.is_zmq();
+        // Each built request is finalized by the client below: it resolves
+        // string `stop`s its engine can't match and reports the router's
+        // residual trim obligation.
         let tokenizer = ctx.tokenizer_arc();
 
         let plan = match items.as_slice() {
@@ -169,7 +167,8 @@ impl PipelineStage for CompletionRequestBuildingStage {
                     request_type,
                     workers,
                 )?;
-                helpers::resolve_string_stops(&mut proto_request, tokenizer.as_ref(), is_zmq);
+                let _router_stops = builder_client
+                    .finalize_generate_request(&mut proto_request, tokenizer.as_ref());
                 ExecutionPlan::generate(self.plan_kind, proto_request)
             }
             batch_items => {
@@ -201,7 +200,8 @@ impl PipelineStage for CompletionRequestBuildingStage {
                         request_type,
                         workers,
                     )?;
-                    helpers::resolve_string_stops(&mut proto_request, tokenizer.as_ref(), is_zmq);
+                    let _router_stops = builder_client
+                        .finalize_generate_request(&mut proto_request, tokenizer.as_ref());
                     requests.push(proto_request);
                 }
                 ExecutionPlan::Batch {

--- a/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
@@ -167,7 +167,7 @@ impl PipelineStage for CompletionRequestBuildingStage {
                     request_type,
                     workers,
                 )?;
-                let _router_stops = builder_client
+                ctx.state.response.router_stop_obligations = builder_client
                     .finalize_generate_request(&mut proto_request, tokenizer.as_ref());
                 ExecutionPlan::generate(self.plan_kind, proto_request)
             }
@@ -200,7 +200,9 @@ impl PipelineStage for CompletionRequestBuildingStage {
                         request_type,
                         workers,
                     )?;
-                    let _router_stops = builder_client
+                    // Same CompletionRequest per prompt: every iteration
+                    // yields the same residual duty, so keep the last.
+                    ctx.state.response.router_stop_obligations = builder_client
                         .finalize_generate_request(&mut proto_request, tokenizer.as_ref());
                     requests.push(proto_request);
                 }

--- a/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -88,9 +88,8 @@ impl PipelineStage for GenerateRequestBuildingStage {
 
         // The client resolves string `stop`s its engine can't match and
         // reports the router's residual trim obligation; no transport
-        // knowledge needed here. (Obligation wiring lands with the
-        // response-side convergence commit.)
-        let _router_stops = builder_client
+        // knowledge needed here.
+        ctx.state.response.router_stop_obligations = builder_client
             .finalize_generate_request(&mut proto_request, ctx.tokenizer_arc().as_ref());
 
         if self.inject_pd_metadata {

--- a/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -86,12 +86,12 @@ impl PipelineStage for GenerateRequestBuildingStage {
             ctx.state.workers.as_ref(),
         );
 
-        // Resolve string `stop` sequences for engines that can't match them
-        // server-side (SGLang skip_tokenizer_init, and every direct-ZMQ
-        // backend): drop the strings, convert single-token stops to
-        // stop_token_ids; the router-side StopSequenceDecoder trims the text.
-        let is_zmq = builder_client.is_zmq();
-        helpers::resolve_string_stops(&mut proto_request, ctx.tokenizer_arc().as_ref(), is_zmq);
+        // The client resolves string `stop`s its engine can't match and
+        // reports the router's residual trim obligation; no transport
+        // knowledge needed here. (Obligation wiring lands with the
+        // response-side convergence commit.)
+        let _router_stops = builder_client
+            .finalize_generate_request(&mut proto_request, ctx.tokenizer_arc().as_ref());
 
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -150,9 +150,8 @@ impl PipelineStage for MessageRequestBuildingStage {
 
         // The client resolves string `stop`s its engine can't match and
         // reports the router's residual trim obligation; no transport
-        // knowledge needed here. (Obligation wiring lands with the
-        // response-side convergence commit.)
-        let _router_stops = builder_client
+        // knowledge needed here.
+        ctx.state.response.router_stop_obligations = builder_client
             .finalize_generate_request(&mut proto_request, ctx.tokenizer_arc().as_ref());
 
         if self.inject_pd_metadata {

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -148,12 +148,12 @@ impl PipelineStage for MessageRequestBuildingStage {
             ctx.state.workers.as_ref(),
         );
 
-        // Resolve string `stop` sequences for engines that can't match them
-        // server-side (SGLang skip_tokenizer_init, and every direct-ZMQ
-        // backend): drop the strings, convert single-token stops to
-        // stop_token_ids; the router-side StopSequenceDecoder trims the text.
-        let is_zmq = builder_client.is_zmq();
-        helpers::resolve_string_stops(&mut proto_request, ctx.tokenizer_arc().as_ref(), is_zmq);
+        // The client resolves string `stop`s its engine can't match and
+        // reports the router's residual trim obligation; no transport
+        // knowledge needed here. (Obligation wiring lands with the
+        // response-side convergence commit.)
+        let _router_stops = builder_client
+            .finalize_generate_request(&mut proto_request, ctx.tokenizer_arc().as_ref());
 
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -1167,6 +1167,7 @@ mod tests {
         },
         EngineId,
     };
+    use llm_tokenizer::mock::MockTokenizer;
 
     use super::*;
 
@@ -1191,7 +1192,7 @@ mod tests {
     #[test]
     fn eos_backstop_appends_tokenizer_ids_without_duplicates() {
         // MockTokenizer's EOS set is {999}.
-        let tokenizer: Arc<dyn Tokenizer> = Arc::new(llm_tokenizer::mock::MockTokenizer::new());
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
 
         let mut req = eos_request(vec![7], false);
         fold_tokenizer_eos_backstop(&mut req, Some(&tokenizer));
@@ -1205,7 +1206,7 @@ mod tests {
 
     #[test]
     fn eos_backstop_respects_ignore_eos() {
-        let tokenizer: Arc<dyn Tokenizer> = Arc::new(llm_tokenizer::mock::MockTokenizer::new());
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(MockTokenizer::new());
         let mut req = eos_request(vec![7], true);
         fold_tokenizer_eos_backstop(&mut req, Some(&tokenizer));
         assert_eq!(eos_stop_ids(&req), &[7]);

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -37,6 +37,7 @@ use engine_zmq_client::{
     ConnectedEngine,
 };
 use futures::{stream::SelectAll, Stream, StreamExt};
+use llm_tokenizer::traits::Tokenizer;
 use openai_protocol::worker::{SchedulerLoadSnapshot, WorkerLoadResponse};
 use smg_grpc_client::{tokenspeed_proto, vllm_proto as vllm};
 
@@ -124,6 +125,37 @@ fn eos_ids_from_value(value: Option<&serde_json::Value>) -> Vec<u32> {
         Some(serde_json::Value::Array(ids)) => ids.iter().filter_map(as_id).collect(),
         Some(id) => as_id(id).into_iter().collect(),
         None => Vec::new(),
+    }
+}
+
+/// Request-time EOS backstop for the tokenizer-less EngineCore.
+///
+/// EOS injection has exactly one owner — this file. The connect-time
+/// [`EosTokenIds`] model-dir resolution has nothing to read when the worker's
+/// model id is a repo id rather than a local path, so the tokenizer's merged
+/// EOS set is folded into `stop_token_ids` here as the always-available
+/// backstop; without it an uncapped request generates to the full context
+/// window. Not needed for TokenSpeed (its scheduler stops at EOS itself) —
+/// the caller gates on runtime.
+pub(crate) fn fold_tokenizer_eos_backstop(
+    request: &mut ProtoGenerateRequest,
+    tokenizer: Option<&Arc<dyn Tokenizer>>,
+) {
+    let ProtoGenerateRequest::Vllm(req) = request else {
+        return;
+    };
+    let Some(params) = req.sampling_params.as_mut() else {
+        return;
+    };
+    if params.ignore_eos {
+        return;
+    }
+    if let Some(tokenizer) = tokenizer {
+        for &id in tokenizer.eos_token_ids() {
+            if !params.stop_token_ids.contains(&id) {
+                params.stop_token_ids.push(id);
+            }
+        }
     }
 }
 
@@ -1137,6 +1169,47 @@ mod tests {
     };
 
     use super::*;
+
+    fn eos_request(stop_token_ids: Vec<u32>, ignore_eos: bool) -> ProtoGenerateRequest {
+        ProtoGenerateRequest::Vllm(Box::new(vllm::GenerateRequest {
+            sampling_params: Some(vllm::SamplingParams {
+                stop_token_ids,
+                ignore_eos,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+    }
+
+    fn eos_stop_ids(req: &ProtoGenerateRequest) -> &[u32] {
+        match req {
+            ProtoGenerateRequest::Vllm(r) => &r.sampling_params.as_ref().unwrap().stop_token_ids,
+            _ => panic!("expected vLLM request"),
+        }
+    }
+
+    #[test]
+    fn eos_backstop_appends_tokenizer_ids_without_duplicates() {
+        // MockTokenizer's EOS set is {999}.
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(llm_tokenizer::mock::MockTokenizer::new());
+
+        let mut req = eos_request(vec![7], false);
+        fold_tokenizer_eos_backstop(&mut req, Some(&tokenizer));
+        assert_eq!(eos_stop_ids(&req), &[7, 999]);
+
+        // Already-present EOS ids are not duplicated.
+        let mut req = eos_request(vec![999], false);
+        fold_tokenizer_eos_backstop(&mut req, Some(&tokenizer));
+        assert_eq!(eos_stop_ids(&req), &[999]);
+    }
+
+    #[test]
+    fn eos_backstop_respects_ignore_eos() {
+        let tokenizer: Arc<dyn Tokenizer> = Arc::new(llm_tokenizer::mock::MockTokenizer::new());
+        let mut req = eos_request(vec![7], true);
+        fold_tokenizer_eos_backstop(&mut req, Some(&tokenizer));
+        assert_eq!(eos_stop_ids(&req), &[7]);
+    }
 
     fn batch(
         request_id: &str,


### PR DESCRIPTION
## Motivation

Stacked on #2065. Phase 1 of the ZMQ architecture cleanup: the pipeline had one structural fact to model — vLLM EngineCore has no tokenizer — and it was being expressed as `is_zmq()` probes and catch-all runtime arms scattered across stages. This PR moves those decisions into the layer that already is the abstraction: `BackendClient`. No new types, tables, or layers.

## Modifications (one commit each, reviewable in order)

1. **Client-owned request finalization.** `BackendClient::finalize_generate_request` resolves string `stop`s its engine can't match (token-only wires, SGLang `skip_tokenizer_init`) and **returns the router's residual obligation** — the stop strings the engine will never see. All four regular request-building stages drop their `is_zmq()` probes.
2. **EOS has one owning file.** The request-time tokenizer backstop moves from the shared stage helper into `zmq_client::fold_tokenizer_eos_backstop`, next to the connect-time `EosTokenIds`. `resolve_string_stops` is now purely about stop strings.
3. **Harmony converges onto the obligations contract.** Harmony request building finalizes through the client like the regular stages; response processing reads the stored obligation instead of inspecting the client (`is_zmq` on the single/decode leg) — the last response-side transport probe is gone. Regular-pipeline response side intentionally unchanged: MLX's proto carries no string-stop field, so its trimming still rides the ungated decoder (noted in the commit message as future work).
4. **No silent vLLM defaulting.** The six `_ => vLLM` catch-alls (4× backend_client build matches, harmony's `Zmq(_)` arm, assemble's `Vllm | Unspecified`) become explicit `RuntimeType::Vllm` arms with hard errors for anything else — `connect()` already admits only vLLM/TokenSpeed, so this makes that contract visible at every dispatch point.

## Checklist

- [x] `cargo fmt` clean
- [x] `cargo test -p smg --lib`: 1435 passed (the single failure, `middleware::metrics::…interner`, fails identically on clean main under the full parallel suite — pre-existing flake, passes in isolation)