### PR TITLE
ci(bench): bound BFCL run time and fail A/B legs with an unscored arm

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -50,6 +50,10 @@ on:
         description: "Override reasoning parser for BOTH arms; empty = matrix defaults"
         required: false
         default: ""
+      run_timeout:
+        description: "Override per-arm `bfcl generate`/`evaluate` wall-clock cap in seconds (0 = uncapped); empty = matrix default"
+        required: false
+        default: ""
 
 concurrency:
   group: nightly-bfcl-${{ github.event_name }}-${{ github.ref }}
@@ -126,6 +130,13 @@ jobs:
           import json, os
           # max_model_len "auto": largest window that fits in GPU memory (capped at
           # native max). A fixed 32768 400'd on multi_turn_long_context (>32k prompts).
+          #
+          # run_timeout: per-arm wall-clock cap on `bfcl generate` (and `evaluate`),
+          # in seconds. Sized ~1.5-4x the observed healthy duration of each leg; a
+          # frontend that emits non-terminating garbage never hits a stop token, so
+          # every case runs to the generation cap and the leg would otherwise crawl
+          # until the 360m job limit and produce nothing at all. Sequential legs get
+          # half the budget: their two arms run one after the other in the same job.
           legs = [
               # H100 legs (TP=2 per arm, both arms concurrent: GPUs 0,1 + 2,3).
               {"name": "qwen3.6", "runner": "4-gpu-h100", "tp": 2,
@@ -134,6 +145,8 @@ jobs:
                "vllm_tool": "qwen3_xml", "vllm_reason": "qwen3",
                "smg_tool": "qwen_xml", "smg_reason": "qwen3",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
+               # Slowest healthy leg: 4441 cases took 4h02m per arm on 2026-08-05.
+               "run_timeout": "18000",
                "model_cache": "/models", "arm_mode": "concurrent", "max_model_len": "auto"},
               # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
               {"name": "gpt-oss", "runner": "4-gpu-h100", "tp": 2,
@@ -142,6 +155,7 @@ jobs:
                "vllm_tool": "openai", "vllm_reason": "",
                "smg_tool": "", "smg_reason": "",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
+               "run_timeout": "7200",  # healthy: 31m for both arms on 2026-08-05
                "model_cache": "/models", "arm_mode": "concurrent", "max_model_len": "auto"},
               # Blackwell legs (B200). Models pre-staged on NVMe at /raid/models/<id>.
               # Concurrent TP=4 per arm (0-3 + 4-7).
@@ -155,6 +169,9 @@ jobs:
                # kernel asserts fp8 kv-cache (else EngineCore dies at startup).
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
                "gpu_mem": "0.90", "startup_timeout": "2400", "model_cache": "/raid/models",
+               # No healthy baseline yet — every run so far has been the garbage-output
+               # failure that burns the whole 360m job.
+               "run_timeout": "14400",
                "arm_mode": "concurrent", "max_model_len": "auto"},
               {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
@@ -162,6 +179,7 @@ jobs:
                "vllm_tool": "minimax_m2", "vllm_reason": "minimax_m2",
                "smg_tool": "minimax_m2", "smg_reason": "minimax",
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
+               "run_timeout": "14400",
                "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "auto"},
               # Kimi-K2.6 int4 (~500GB) fits TP=4 half-node.
               {"name": "kimi-k2.6", "runner": "blackwell", "tp": 4,
@@ -172,6 +190,7 @@ jobs:
                "smg_reason": "kimi_thinking",  # K2.6 template prefills <think> (always-in-reasoning); kimi_k25 (always_in_reasoning=false) mis-splits reasoning -> SMG scored 0
                # Generous startup: 1T MoE at TP=4 needs minutes for load+compile+quant (420s timed out).
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
+               "run_timeout": "14400",
                "model_cache": "/raid/models", "arm_mode": "concurrent", "max_model_len": "auto"},
               # GLM-5.2-FP8 (~744GB) needs the whole 8-GPU node, so it runs SEQUENTIAL
               # (arm A then arm B; gpu_b unused) unlike the concurrent half-node legs.
@@ -184,6 +203,8 @@ jobs:
                "smg_tool": "glm47_moe", "smg_reason": "glm45",
                # FP8 load + DeepGEMM warmup on the largest leg: generous startup ceiling.
                "vllm_extra": "--trust-remote-code --kv-cache-dtype fp8_e4m3", "gpu_mem": "0.90", "startup_timeout": "3000",
+               # Sequential: both arms share the 360m job, healthy total 2h52m on 2026-08-05.
+               "run_timeout": "7200",
                "model_cache": "/raid/models", "arm_mode": "sequential", "max_model_len": "auto"},
           ]
           only = os.environ.get("ONLY", "")
@@ -269,6 +290,7 @@ jobs:
           GPU_B: ${{ matrix.gpu_b }}
           # Per-leg health-wait budget: big MoEs need minutes for load + compile + quant.
           BFCL_STARTUP_TIMEOUT: ${{ matrix.startup_timeout }}
+          RUN_TIMEOUT: ${{ github.event.inputs.run_timeout || matrix.run_timeout }}
           # Arm logs + pidfiles under RUNNER_TEMP (per-job, uploadable) not /tmp.
           BFCL_RUN_DIR: ${{ runner.temp }}/bfcl_run
         run: |
@@ -307,6 +329,20 @@ jobs:
           trap 'cleanup; exit 143' INT TERM
           BFCL="$(command -v bfcl)"
           ROOT="$RUNNER_TEMP/bfcl_ab"
+          # run_ab.py exit codes: 0 clean, 1 score regression (informational — this
+          # A/B is never a merge gate), 2 an arm timed out or scored nothing. Only 2
+          # fails the job: a "—" column is a broken run, not a passing one.
+          AB_RC=0
+          gate() {
+            local rc=0
+            "$@" || rc=$?
+            case "$rc" in
+              0) ;;
+              1) echo "::warning::BFCL A/B score regression beyond tolerance — see job summary" ;;
+              *) echo "::error::BFCL A/B incomplete (run_ab exit $rc): an arm timed out or produced no scores"
+                 AB_RC=$rc ;;
+            esac
+          }
           if [ "$ARM_MODE" = sequential ]; then
             # Whole node per arm (TP=8), one at a time: each model needs all 8 GPUs
             # for enough KV cache at the larger max_model_len. Score arm A, tear it
@@ -316,27 +352,27 @@ jobs:
             python scripts/bfcl/run_ab.py --score-arm "vllm=$A_URL" \
               --scores-out "$ROOT/scores_vllm.json" \
               --bfcl-model "$BFCL_MODEL_FC" --categories "$CATEGORIES" \
-              --bfcl "$BFCL" --project-root "$ROOT"
+              --bfcl "$BFCL" --project-root "$ROOT" --run-timeout "$RUN_TIMEOUT"
             bash scripts/bfcl/launch_arm.sh stop 9>&-
             B_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh b 9>&-)
             echo "arm B (smg): $B_URL"
             python scripts/bfcl/run_ab.py --score-arm "smg=$B_URL" \
               --scores-out "$ROOT/scores_smg.json" \
               --bfcl-model "$BFCL_MODEL_FC" --categories "$CATEGORIES" \
-              --bfcl "$BFCL" --project-root "$ROOT"
+              --bfcl "$BFCL" --project-root "$ROOT" --run-timeout "$RUN_TIMEOUT"
             bash scripts/bfcl/launch_arm.sh stop 9>&-
-            python scripts/bfcl/run_ab.py \
+            gate python scripts/bfcl/run_ab.py \
               --diff-baseline "$ROOT/scores_vllm.json" --diff-candidate "$ROOT/scores_smg.json" \
               --categories "$CATEGORIES" \
               --out "$RUNNER_TEMP/bfcl_ab.md" --json-out "$RUNNER_TEMP/bfcl_ab.json" \
-              --tolerance 0.02 || echo "BFCL_AB_REGRESSION=1" >> "$GITHUB_ENV"
+              --tolerance 0.02
           else
             # Concurrent: arm A (pure vLLM) on the first GPU half, arm B (SMG ->
             # vLLM gRPC) on the second; ports left unset so launch_arm.sh picks free.
             A_URL=$(BFCL_GPU="$GPU_A" bash scripts/bfcl/launch_arm.sh a 9>&-)
             B_URL=$(BFCL_GPU="$GPU_B" bash scripts/bfcl/launch_arm.sh b 9>&-)
             echo "arm A: $A_URL   arm B: $B_URL"
-            python scripts/bfcl/run_ab.py \
+            gate python scripts/bfcl/run_ab.py \
               --baseline  "vllm=$A_URL" \
               --candidate "smg=$B_URL" \
               --bfcl-model "$BFCL_MODEL_FC" \
@@ -345,8 +381,12 @@ jobs:
               --project-root "$ROOT" \
               --out "$RUNNER_TEMP/bfcl_ab.md" \
               --json-out "$RUNNER_TEMP/bfcl_ab.json" \
-              --tolerance 0.02 || echo "BFCL_AB_REGRESSION=1" >> "$GITHUB_ENV"
+              --run-timeout "$RUN_TIMEOUT" \
+              --tolerance 0.02
           fi
+          # Fail after the report is written, so Render summary / Upload results
+          # (both always()) still publish the partial table and transcripts.
+          [ "$AB_RC" -eq 0 ] || exit "$AB_RC"
       - name: Render summary
         if: always()
         run: |

--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -161,7 +161,8 @@ jobs:
               # Concurrent TP=4 per arm (0-3 + 4-7).
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
-               "model": "deepseek-ai/DeepSeek-V4-Flash-0731", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-0731-FC",
+               # Base V4-Flash: the -0731 refresh is not supported yet.
+               "model": "deepseek-ai/DeepSeek-V4-Flash", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-FC",
                "vllm_tool": "deepseek_v4", "vllm_reason": "deepseek_v4",
                "smg_tool": "deepseek_v4",
                "smg_reason": "deepseek_v31",  # TODO(confirm): no deepseek_v4 SMG reasoning parser yet
@@ -169,9 +170,8 @@ jobs:
                # kernel asserts fp8 kv-cache (else EngineCore dies at startup).
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
                "gpu_mem": "0.90", "startup_timeout": "2400", "model_cache": "/raid/models",
-               # No healthy baseline yet — every run so far has been the garbage-output
-               # failure that burns the whole 360m job.
-               "run_timeout": "14400",
+               # No healthy baseline yet; kept tight until the leg scores cleanly.
+               "run_timeout": "5400",
                "arm_mode": "concurrent", "max_model_len": "auto"},
               {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -333,6 +333,20 @@ jobs:
             # domain (worst case 3 domains/arm x 90m = 270m, under timeout-minutes:360).
             --request-timeout "$REQUEST_TIMEOUT" --run-timeout "$RUN_TIMEOUT"
           )
+          # run_ab.py exit codes: 0 clean, 1 score regression (informational — this
+          # A/B is never a merge gate), 2 an arm timed out or scored nothing. Only 2
+          # fails the job: a "—" column is a broken run, not a passing one.
+          AB_RC=0
+          gate() {
+            local rc=0
+            "$@" || rc=$?
+            case "$rc" in
+              0) ;;
+              1) echo "::warning::tau2 A/B score regression beyond tolerance — see job summary" ;;
+              *) echo "::error::tau2 A/B incomplete (run_ab exit $rc): an arm timed out or produced no scores"
+                 AB_RC=$rc ;;
+            esac
+          }
           if [ "$ARM_MODE" = sequential ]; then
             # Whole node per arm (TP=8), one at a time: score arm A, tear it down to
             # free the GPUs, score arm B, then diff the two saved score files.
@@ -346,24 +360,28 @@ jobs:
             python scripts/tau2/run_ab.py --score-arm "smg=$B_URL" \
               --scores-out "$RUNNER_TEMP/scores_smg.json" "${COMMON[@]}"
             bash scripts/tau2/launch_arms.sh stop 9>&-
-            python scripts/tau2/run_ab.py \
+            # --domains is required here too: it is the expected set the completeness
+            # gate checks against, so a domain neither arm scored is still caught.
+            gate python scripts/tau2/run_ab.py \
               --diff-baseline "$RUNNER_TEMP/scores_vllm.json" \
               --diff-candidate "$RUNNER_TEMP/scores_smg.json" \
+              --domains "$DOMAINS" \
               --num-trials "$NUM_TRIALS" --tolerance 0.02 \
-              --out "$RUNNER_TEMP/tau2_ab.md" --json-out "$RUNNER_TEMP/tau2_ab.json" \
-              || echo "TAU2_AB_REGRESSION=1" >> "$GITHUB_ENV"
+              --out "$RUNNER_TEMP/tau2_ab.md" --json-out "$RUNNER_TEMP/tau2_ab.json"
           else
             # Concurrent: arm A (pure vLLM) on the first GPU half, arm B (SMG ->
             # vLLM gRPC) on the second; ports left unset so launch_arms.sh picks free.
             A_URL=$(TAU2_GPU="$GPU_A" bash scripts/tau2/launch_arms.sh a 9>&-)
             B_URL=$(TAU2_GPU="$GPU_B" bash scripts/tau2/launch_arms.sh b 9>&-)
             echo "arm A: $A_URL   arm B: $B_URL"
-            python scripts/tau2/run_ab.py \
+            gate python scripts/tau2/run_ab.py \
               --baseline "vllm=$A_URL" --candidate "smg=$B_URL" "${COMMON[@]}" \
               --tolerance 0.02 \
-              --out "$RUNNER_TEMP/tau2_ab.md" --json-out "$RUNNER_TEMP/tau2_ab.json" \
-              || echo "TAU2_AB_REGRESSION=1" >> "$GITHUB_ENV"
+              --out "$RUNNER_TEMP/tau2_ab.md" --json-out "$RUNNER_TEMP/tau2_ab.json"
           fi
+          # Fail after the report is written, so Render summary / Upload results
+          # (both always()) still publish the partial table and transcripts.
+          [ "$AB_RC" -eq 0 ] || exit "$AB_RC"
       - name: Render summary
         if: always()
         run: |

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -59,9 +59,9 @@ on:
         required: false
         default: "300"
       run_timeout:
-        description: "Per-domain `tau2 run` wall-clock cap (s); 0 = off"
+        description: "Override per-domain `tau2 run` wall-clock cap (s), 0 = off; empty = matrix default"
         required: false
-        default: "5400"
+        default: ""
       vllm_tool_parser:
         description: "Override pure-vLLM --tool-call-parser; empty = matrix default"
         required: false
@@ -140,6 +140,9 @@ jobs:
           # capped at native max — multi-turn tau2 prompts can exceed a fixed 16k.
           # num_tasks: 0 = all (cheap H100 legs); 30/domain caps the heavy Blackwell
           # legs to bound GPU time + gpt-5.2 spend.
+          #
+          # run_timeout: per-DOMAIN `tau2 run` cap (s), so an arm's worst case is
+          # run_timeout x len(domains). 5400 is the default.
           legs = [
               # H100 legs (TP=2 per arm, both arms concurrent: GPUs 0,1 + 2,3).
               {"name": "qwen3.6", "runner": "4-gpu-h100", "tp": 2,
@@ -149,7 +152,7 @@ jobs:
                "smg_tool": "qwen_xml", "smg_reason": "qwen3",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
                "model_cache": "/models", "arm_mode": "concurrent",
-               "max_model_len": "auto", "num_tasks": 30},  # cap like Blackwell legs — dense 27B is slow; bounds runtime + skips the airline task-44 straggler
+               "max_model_len": "auto", "num_tasks": 30, "run_timeout": "5400"},  # cap like Blackwell legs — dense 27B is slow; bounds runtime + skips the airline task-44 straggler
               # gpt-oss SMG arm passes NO tool parser (smg_tool empty) -> harmony auto-detect.
               {"name": "gpt-oss", "runner": "4-gpu-h100", "tp": 2,
                "gpu_a": "0,1", "gpu_b": "2,3",
@@ -158,17 +161,20 @@ jobs:
                "smg_tool": "", "smg_reason": "",
                "vllm_extra": "", "gpu_mem": "0.85", "startup_timeout": "600",
                "model_cache": "/models", "arm_mode": "concurrent",
-               "max_model_len": "auto", "num_tasks": 0},
+               "max_model_len": "auto", "num_tasks": 0, "run_timeout": "5400"},
               # Blackwell legs (B200). Models pre-staged on NVMe at /raid/models/<id>.
               # Concurrent TP=4 per arm (0-3 + 4-7); num_tasks-capped.
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
-               "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
+               # Base V4-Flash: the -0731 refresh is not supported yet.
+               "model": "deepseek-ai/DeepSeek-V4-Flash",
                "vllm_tool": "deepseek_v4", "vllm_reason": "deepseek_v4",
                "smg_tool": "deepseek_v4", "smg_reason": "deepseek_v31",
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
                "gpu_mem": "0.90", "startup_timeout": "2400", "model_cache": "/raid/models",
-               "arm_mode": "concurrent", "max_model_len": "auto", "num_tasks": 30},
+               "arm_mode": "concurrent", "max_model_len": "auto", "num_tasks": 30,
+               # 20m/domain = ~1h/arm; both arms have hung on this leg before.
+               "run_timeout": "1200"},
               {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "MiniMaxAI/MiniMax-M2.7",
@@ -176,7 +182,7 @@ jobs:
                "smg_tool": "minimax_m2", "smg_reason": "minimax",
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
                "model_cache": "/raid/models", "arm_mode": "concurrent",
-               "max_model_len": "auto", "num_tasks": 30},
+               "max_model_len": "auto", "num_tasks": 30, "run_timeout": "5400"},
               {"name": "kimi-k2.6", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
                "model": "moonshotai/Kimi-K2.6",
@@ -184,7 +190,7 @@ jobs:
                "smg_tool": "kimik2", "smg_reason": "kimi_thinking",  # K2.6 template prefills <think> (always-in-reasoning); kimi_k25 is always_in_reasoning=false -> mis-splits reasoning
                "vllm_extra": "--trust-remote-code", "gpu_mem": "0.90", "startup_timeout": "2400",
                "model_cache": "/raid/models", "arm_mode": "concurrent",
-               "max_model_len": "auto", "num_tasks": 30},
+               "max_model_len": "auto", "num_tasks": 30, "run_timeout": "5400"},
               # GLM-5.2-FP8 (~744GB) needs the whole 8-GPU node, so it runs SEQUENTIAL
               # (arm A then arm B; gpu_b unused) unlike the concurrent half-node legs.
               {"name": "glm-5.2", "runner": "blackwell", "tp": 8,
@@ -194,7 +200,9 @@ jobs:
                "smg_tool": "glm47_moe", "smg_reason": "glm45",
                "vllm_extra": "--trust-remote-code --kv-cache-dtype fp8_e4m3",
                "gpu_mem": "0.90", "startup_timeout": "3000", "model_cache": "/raid/models",
-               "arm_mode": "sequential", "max_model_len": "auto", "num_tasks": 30},
+               "arm_mode": "sequential", "max_model_len": "auto", "num_tasks": 30,
+               # Sequential: both arms share the 360m job, so half the per-domain budget.
+               "run_timeout": "2700"},
           ]
           only = os.environ.get("ONLY", "")
           valid = [l["name"] for l in legs]
@@ -238,9 +246,9 @@ jobs:
       NUM_TASKS: ${{ github.event.inputs.num_tasks || (github.event_name == 'pull_request' && '3' || matrix.num_tasks) }}
       MAX_CONCURRENCY: ${{ github.event.inputs.max_concurrency || '16' }}
       # Fail-fast bounds (see COMMON below). Per-request cap 300s catches a single
-      # degenerate generation; per-domain cap 5400s (90m) bounds a wedged `tau2 run`.
+      # degenerate generation; the leg's per-domain cap bounds a wedged `tau2 run`.
       REQUEST_TIMEOUT: ${{ github.event.inputs.request_timeout || '300' }}
-      RUN_TIMEOUT: ${{ github.event.inputs.run_timeout || '5400' }}
+      RUN_TIMEOUT: ${{ github.event.inputs.run_timeout || matrix.run_timeout }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -64,7 +64,7 @@ Key env knobs for `launch_arm.sh`: `BFCL_GPU` (CUDA_VISIBLE_DEVICES, e.g. `0,1`)
 |---|---|---|---|---|
 | Qwen3.6-27B (`qwen3.6`) | `4-gpu-h100` | 2 | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
 | gpt-oss-120b (`gpt-oss`) | `4-gpu-h100` | 2 | `openai` / — | _(none — SMG auto-routes harmony)_ / — |
-| DeepSeek-V4-Flash-0731 (`deepseek-v4`) | `blackwell` | 4 | `deepseek_v4` / `deepseek_v4` (+`--tokenizer-mode deepseek_v4 --trust-remote-code`) | `deepseek_v4` / `deepseek_v31`† |
+| DeepSeek-V4-Flash (`deepseek-v4`) | `blackwell` | 4 | `deepseek_v4` / `deepseek_v4` (+`--tokenizer-mode deepseek_v4 --trust-remote-code`) | `deepseek_v4` / `deepseek_v31`† |
 | MiniMax-M2.7 (`minimax-m2.7`) | `blackwell` | 4 | `minimax_m2` / `minimax_m2` (+`--trust-remote-code`) | `minimax_m2` / `minimax` |
 | Kimi-K2.6 int4 (`kimi-k2.6`) | `blackwell` | 4 | `kimi_k2` / `kimi_k2` (+`--trust-remote-code`) | `kimik2` / `kimi_k25`† |
 
@@ -89,7 +89,7 @@ The nightly (`.github/workflows/nightly-bfcl.yml`) runs the A/B as a GitHub Acti
 matrix — one leg per model, `fail-fast: false`, each on its own runner:
 
 - `4-gpu-h100` — Qwen3.6-27B and gpt-oss-120b, TP=2 per arm (GPUs 0,1 + 2,3).
-- `blackwell` (B200) — DeepSeek-V4-Flash-0731, MiniMax-M2.7, Kimi-K2.6 int4, TP=4 per arm
+- `blackwell` (B200) — DeepSeek-V4-Flash, MiniMax-M2.7, Kimi-K2.6 int4, TP=4 per arm
   (GPUs 0-3 + 4-7).
 
 All legs use `max_model_len` **32768**: the `multi_turn` categories emit ~18k-token
@@ -107,7 +107,7 @@ Each leg sets `arm_mode`:
   saved score files. Flip a leg's `arm_mode` to enable it.
 
 Per the A/B's premise, model size is irrelevant — a smaller same-family checkpoint
-exercises the identical parser — so the matrix uses DeepSeek-V4-Flash-0731 and int4
+exercises the identical parser — so the matrix uses DeepSeek-V4-Flash and int4
 Kimi-K2.6 to validate the `deepseek_v4` / `kimi_k2` parsers without the full weights.
 
 `workflow_dispatch` can target one leg via the `only` input and override

--- a/scripts/bfcl/run_ab.py
+++ b/scripts/bfcl/run_ab.py
@@ -27,6 +27,9 @@ launch them. Example::
         --bfcl /home/keyang/bfcl-env/bin/bfcl \\
         --project-root /home/keyang/bfcl_ab \\
         --out /tmp/bfcl_ab.md --json-out /tmp/bfcl_ab.json
+
+Exit codes: ``0`` clean, ``1`` score regression beyond ``--tolerance``, ``2`` an
+arm did not finish (timed out or scored nothing), so there is nothing to compare.
 """
 
 from __future__ import annotations
@@ -35,11 +38,16 @@ import argparse
 import concurrent.futures
 import json
 import os
+import signal
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse
+
+EXIT_OK = 0
+EXIT_REGRESSION = 1
+EXIT_INCOMPLETE = 2
 
 
 @dataclass
@@ -53,6 +61,7 @@ class Arm:
     project_root: Path = field(default_factory=Path)
     scores: dict[str, float] = field(default_factory=dict)
     counts: dict[str, int] = field(default_factory=dict)  # per-category test-case count
+    timed_out: list[str] = field(default_factory=list)  # stages killed by --run-timeout
 
 
 def parse_arm(spec: str, project_root: Path) -> Arm:
@@ -81,8 +90,15 @@ def run_bfcl(
     num_threads: int,
     temperature: float,
     skip_generate: bool,
+    run_timeout: int = 0,
 ) -> None:
-    """Run ``bfcl generate`` + ``bfcl evaluate`` for one arm, in its own root."""
+    """Run ``bfcl generate`` + ``bfcl evaluate`` for one arm, in its own root.
+
+    ``run_timeout`` (0 = off) mirrors tau2's ``--run-timeout``. No BFCL analogue of
+    ``--request-timeout`` exists: the FC handler's ``openai.OpenAI`` client reads
+    ``api_key``/``base_url`` from the environment but not ``timeout``, and ``bfcl
+    generate`` exposes no passthrough, so 600s x 2 retries is the per-call ceiling.
+    """
     arm.project_root.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
     env["BFCL_PROJECT_ROOT"] = str(arm.project_root)
@@ -99,7 +115,7 @@ def run_bfcl(
 
     cats = ",".join(categories)
     if not skip_generate:
-        _run(
+        if not _run(
             [
                 bfcl,
                 "generate",
@@ -118,20 +134,42 @@ def run_bfcl(
             ],
             env,
             f"[{arm.name}] generate",
-        )
+            timeout=run_timeout,
+        ):
+            arm.timed_out.append("generate")
+    # Evaluate even after a killed generate: whatever completed is already on disk.
     _run(
         [bfcl, "evaluate", "--model", model, "--test-category", cats],
         env,
         f"[{arm.name}] evaluate",
+        timeout=run_timeout,
     )
     arm.scores, arm.counts = parse_scores(arm.project_root, model, categories)
 
 
-def _run(cmd: list[str], env: dict[str, str], label: str) -> None:
+def _run(cmd: list[str], env: dict[str, str], label: str, timeout: int = 0) -> bool:
+    """Run one bfcl subcommand; return False if it hit ``timeout`` (0 = no cap)."""
     print(f"\n=== {label}: {' '.join(cmd)}", flush=True)
-    proc = subprocess.run(cmd, env=env, check=False)
-    if proc.returncode != 0:
-        print(f"WARNING: {label} exited {proc.returncode}", file=sys.stderr)
+    # Own session so a timeout can SIGKILL the whole group: bfcl generate fans out
+    # over a thread pool and can sit blocked on a hung HTTP read.
+    proc = subprocess.Popen(cmd, env=env, start_new_session=True)
+    try:
+        returncode = proc.wait(timeout=timeout or None)
+    except subprocess.TimeoutExpired:
+        _killpg(proc)
+        print(f"WARNING: {label} timed out after {timeout}s; killed", file=sys.stderr)
+        return False
+    if returncode != 0:
+        print(f"WARNING: {label} exited {returncode}", file=sys.stderr)
+    return True
+
+
+def _killpg(proc: subprocess.Popen) -> None:
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        proc.kill()
+    proc.wait()
 
 
 def parse_scores(
@@ -171,6 +209,20 @@ def _find_category_summary(score_root: Path, category: str) -> tuple[float, int]
         if acc is not None:
             return float(acc), int(summary.get("total_count", 0))
     return None
+
+
+def incompleteness(arm: Arm, categories: list[str]) -> str | None:
+    """Why this arm can't be compared (timed out / unscored categories), else None."""
+    missing = [c for c in categories if c not in arm.scores]
+    if not missing and not arm.timed_out:
+        return None
+    reason = f"no score for {len(missing)}/{len(categories)} categories"
+    if arm.timed_out:
+        reason += f"; timed out during: {', '.join(arm.timed_out)}"
+    if missing:
+        shown = ", ".join(missing[:8]) + (f", +{len(missing) - 8} more" if len(missing) > 8 else "")
+        reason += f"; unscored: {shown}"
+    return reason
 
 
 def build_report(baseline: Arm, candidate: Arm, categories: list[str]) -> tuple[str, dict]:
@@ -231,6 +283,12 @@ def build_report(baseline: Arm, candidate: Arm, categories: list[str]) -> tuple[
     lines.append(overall_row("overall (unweighted)", b_overall, c_overall, overall_delta))
     lines.append(overall_row("overall (weighted by n)", b_weighted, c_weighted, weighted_delta))
     lines.append("")
+    incomplete = {a.name: incompleteness(a, categories) for a in (baseline, candidate)}
+    incomplete = {k: v for k, v in incomplete.items() if v}
+    for name, reason in incomplete.items():
+        lines.append(f"> ⚠️ **Incomplete arm `{name}`** — {reason}.")
+    if incomplete:
+        lines.append("")
     lines.append(
         "_Scores are % accuracy (official BFCL, FC mode). Same model, engine, "
         "checkpoint and sampling on both arms — the only difference is the "
@@ -246,13 +304,16 @@ def build_report(baseline: Arm, candidate: Arm, categories: list[str]) -> tuple[
             "base_url": baseline.base_url,
             "scores": baseline.scores,
             "counts": baseline.counts,
+            "timed_out": baseline.timed_out,
         },
         "candidate": {
             "name": candidate.name,
             "base_url": candidate.base_url,
             "scores": candidate.scores,
             "counts": candidate.counts,
+            "timed_out": candidate.timed_out,
         },
+        "incomplete": incomplete,
         "per_category": rows,
         "overall": {"baseline": b_overall, "candidate": c_overall, "delta": overall_delta},
         "overall_weighted": {
@@ -277,6 +338,7 @@ def save_scores(arm: Arm, path: Path) -> None:
                 "base_url": arm.base_url,
                 "scores": arm.scores,
                 "counts": arm.counts,
+                "timed_out": arm.timed_out,
             },
             indent=2,
         )
@@ -286,20 +348,21 @@ def save_scores(arm: Arm, path: Path) -> None:
 
 
 def load_scores(path: Path) -> Arm:
-    """Rebuild an Arm (name + scores + counts) from a file written by save_scores."""
+    """Rebuild an Arm from a file written by save_scores."""
     data = json.loads(path.read_text(encoding="utf-8"))
     return Arm(
         name=data["name"],
         base_url=data.get("base_url", ""),
         scores=data["scores"],
         counts=data.get("counts", {}),
+        timed_out=data.get("timed_out", []),
     )
 
 
 def write_report_and_gate(
     baseline: Arm, candidate: Arm, categories: list[str], args: argparse.Namespace
 ) -> int:
-    """Emit the markdown + JSON comparison and apply the regression gate."""
+    """Emit the markdown + JSON comparison and apply the completeness/regression gates."""
     report_md, payload = build_report(baseline, candidate, categories)
     print("\n" + report_md)
     if args.out:
@@ -307,6 +370,7 @@ def write_report_and_gate(
     if args.json_out:
         args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
+    exit_code = EXIT_OK
     overall = payload["overall"]
     if overall["delta"] is not None and overall["delta"] < -args.tolerance:
         print(
@@ -314,8 +378,14 @@ def write_report_and_gate(
             f"below {baseline.name} (tolerance {args.tolerance * 100:.2f}pp)",
             file=sys.stderr,
         )
-        return 1
-    return 0
+        exit_code = EXIT_REGRESSION
+
+    # An incomplete arm outranks a regression: there is no trustworthy delta to gate on.
+    for name, reason in payload["incomplete"].items():
+        print(f"\nINCOMPLETE: arm {name} — {reason}", file=sys.stderr)
+    if payload["incomplete"] and not args.allow_incomplete:
+        exit_code = EXIT_INCOMPLETE
+    return exit_code
 
 
 def main() -> int:
@@ -349,6 +419,17 @@ def main() -> int:
         help="max allowed candidate-below-baseline overall drop",
     )
     p.add_argument(
+        "--run-timeout",
+        default=0,
+        type=int,
+        help="seconds before a bfcl generate/evaluate is killed (0 = no cap)",
+    )
+    p.add_argument(
+        "--allow-incomplete",
+        action="store_true",
+        help="report a timed-out or unscored arm without failing (exit 2 otherwise)",
+    )
+    p.add_argument(
         "--skip-generate",
         action="store_true",
         help="reuse existing generation results, only evaluate",
@@ -380,10 +461,14 @@ def main() -> int:
             num_threads=args.num_threads,
             temperature=args.temperature,
             skip_generate=args.skip_generate,
+            run_timeout=args.run_timeout,
         )
         save_scores(arm, args.scores_out)
         print(f"[{arm.name}] scores -> {args.scores_out}: {arm.scores}")
-        return 0
+        if arm.timed_out:
+            print(f"WARNING: [{arm.name}] timed out during: {', '.join(arm.timed_out)}")
+        # Always 0: the gate runs once, on the --diff step that sees both arms.
+        return EXIT_OK
 
     # Mode: concurrent A/B — both arms serve at once on opposite GPU halves, so
     # score them in PARALLEL (separate servers, separate project_roots, no
@@ -402,6 +487,7 @@ def main() -> int:
             num_threads=args.num_threads,
             temperature=args.temperature,
             skip_generate=args.skip_generate,
+            run_timeout=args.run_timeout,
         )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:

--- a/scripts/tau2/README.md
+++ b/scripts/tau2/README.md
@@ -97,7 +97,7 @@ dominated by model-load time, serialized by a host lock, so a PR run is not fast
 |---|---|---|---|---|
 | qwen3.6 | Qwen/Qwen3.6-27B | 4-gpu-h100 (2) | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
 | gpt-oss | openai/gpt-oss-120b | 4-gpu-h100 (2) | `openai` / — | — / — (harmony auto) |
-| deepseek-v4 | deepseek-ai/DeepSeek-V4-Flash-0731 | blackwell (4) | `deepseek_v4` / `deepseek_v4` | `deepseek_v4` / `deepseek_v31` |
+| deepseek-v4 | deepseek-ai/DeepSeek-V4-Flash | blackwell (4) | `deepseek_v4` / `deepseek_v4` | `deepseek_v4` / `deepseek_v31` |
 | minimax-m2.7 | MiniMaxAI/MiniMax-M2.7 | blackwell (4) | `minimax_m2` / `minimax_m2` | `minimax_m2` / `minimax` |
 | kimi-k2.6 | moonshotai/Kimi-K2.6 | blackwell (4) | `kimi_k2` / `kimi_k2` | `kimik2` / `kimi_k25` |
 | glm-5.2 | zai-org/GLM-5.2-FP8 | blackwell (8, seq) | `glm47` / `glm45` | `glm47_moe` / `glm45` |

--- a/scripts/tau2/run_ab.py
+++ b/scripts/tau2/run_ab.py
@@ -6,6 +6,9 @@ OpenAI /v1 endpoint; the official `tau2` CLI points --agent-llm at each arm and
 --user-llm at a FIXED gpt-5.2, so any score delta is attributable to the
 frontend (tokenization + tool/reasoning parsing). Arms must already be serving
 (see launch_arms.sh); this driver does not launch them.
+
+Exit codes: 0 clean, 1 score regression beyond --tolerance, 2 an arm did not
+finish (timed out or scored nothing), so there is nothing to compare.
 """
 
 from __future__ import annotations
@@ -20,12 +23,17 @@ from dataclasses import dataclass, field
 from math import comb
 from pathlib import Path
 
+EXIT_OK = 0
+EXIT_REGRESSION = 1
+EXIT_INCOMPLETE = 2
+
 
 @dataclass
 class Arm:
     name: str
     base_url: str
     scores: dict[str, dict[str, float]] = field(default_factory=dict)
+    timed_out: list[str] = field(default_factory=list)  # domains killed by --run-timeout
 
 
 def passk(num_success: int, num_trials: int, k: int) -> float:
@@ -144,6 +152,7 @@ def run_tau2(
             f"WARNING: [{arm.name}/{domain}] timed out after {run_timeout}s; killed",
             file=sys.stderr,
         )
+        arm.timed_out.append(domain)
         return
     if proc.returncode != 0:
         print(f"WARNING: [{arm.name}/{domain}] exited {proc.returncode}", file=sys.stderr)
@@ -157,6 +166,19 @@ def run_tau2(
         # Skip this domain rather than aborting — build_report renders "—" for a
         # missing domain, so one failure doesn't discard the rest of the run.
         print(f"WARNING: [{arm.name}/{domain}] no usable results ({e})", file=sys.stderr)
+
+
+def incompleteness(arm: Arm, domains: list[str]) -> str | None:
+    """Why this arm can't be compared (timed out / unscored domains), else None."""
+    missing = [d for d in domains if d not in arm.scores]
+    if not missing and not arm.timed_out:
+        return None
+    reason = f"no score for {len(missing)}/{len(domains)} domains"
+    if arm.timed_out:
+        reason += f"; timed out: {', '.join(arm.timed_out)}"
+    if missing:
+        reason += f"; unscored: {', '.join(missing)}"
+    return reason
 
 
 def build_report(baseline: Arm, candidate: Arm, domains: list[str], k: int):
@@ -240,6 +262,11 @@ def build_report(baseline: Arm, candidate: Arm, domains: list[str], k: int):
         + " | ".join(triple(overall[m], bold=True) for m in metrics)
         + " |"
     )
+    lines.append("")
+    incomplete = {a.name: incompleteness(a, domains) for a in (baseline, candidate)}
+    incomplete = {n: r for n, r in incomplete.items() if r}
+    for name, reason in incomplete.items():
+        lines.append(f"> ⚠️ **Incomplete arm `{name}`** — {reason}.")
     lines += [
         "",
         f"_N = simulations per arm (baseline/candidate) = tasks × {k} trials. "
@@ -249,8 +276,17 @@ def build_report(baseline: Arm, candidate: Arm, domains: list[str], k: int):
     overall_out = dict(overall)
     overall_out["n"] = {"baseline": nsum["b"], "candidate": nsum["c"]}
     payload = {
-        "baseline": {"name": baseline.name, "scores": baseline.scores},
-        "candidate": {"name": candidate.name, "scores": candidate.scores},
+        "baseline": {
+            "name": baseline.name,
+            "scores": baseline.scores,
+            "timed_out": baseline.timed_out,
+        },
+        "candidate": {
+            "name": candidate.name,
+            "scores": candidate.scores,
+            "timed_out": candidate.timed_out,
+        },
+        "incomplete": incomplete,
         "per_domain": rows,
         "overall": overall_out,
     }
@@ -296,7 +332,15 @@ def save_scores(arm: Arm, path: Path) -> None:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        json.dumps({"name": arm.name, "base_url": arm.base_url, "scores": arm.scores}, indent=2)
+        json.dumps(
+            {
+                "name": arm.name,
+                "base_url": arm.base_url,
+                "scores": arm.scores,
+                "timed_out": arm.timed_out,
+            },
+            indent=2,
+        )
         + "\n",
         encoding="utf-8",
     )
@@ -305,19 +349,26 @@ def save_scores(arm: Arm, path: Path) -> None:
 def load_scores(path: Path) -> Arm:
     """Rebuild an Arm (name + per-domain scores) from a file written by save_scores."""
     data = json.loads(path.read_text(encoding="utf-8"))
-    return Arm(name=data["name"], base_url=data.get("base_url", ""), scores=data["scores"])
+    return Arm(
+        name=data["name"],
+        base_url=data.get("base_url", ""),
+        scores=data["scores"],
+        timed_out=data.get("timed_out", []),
+    )
 
 
 def write_report_and_gate(
     baseline: Arm, candidate: Arm, domains: list[str], k: int, args: argparse.Namespace
 ) -> int:
-    """Emit the markdown + JSON comparison and apply the informational regression gate."""
+    """Emit the markdown + JSON comparison and apply the completeness/regression gates."""
     report_md, payload = build_report(baseline, candidate, domains, k)
     print("\n" + report_md)
     if args.out:
         args.out.write_text(report_md + "\n", encoding="utf-8")
     if args.json_out:
         args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    exit_code = EXIT_OK
     delta = payload["overall"]["passk"]["delta"]
     if delta is not None and delta < -args.tolerance:
         print(
@@ -325,8 +376,14 @@ def write_report_and_gate(
             f"below {baseline.name} (tol {args.tolerance * 100:.2f}pp)",
             file=sys.stderr,
         )
-        return 1
-    return 0
+        exit_code = EXIT_REGRESSION
+
+    # An incomplete arm outranks a regression: there is no trustworthy delta to gate on.
+    for name, reason in payload["incomplete"].items():
+        print(f"\nINCOMPLETE: arm {name} — {reason}", file=sys.stderr)
+    if payload["incomplete"] and not args.allow_incomplete:
+        exit_code = EXIT_INCOMPLETE
+    return exit_code
 
 
 def _parse_arm(spec: str) -> Arm:
@@ -379,6 +436,11 @@ def main() -> int:
         help="tau2 DATA_DIR (results written/read under <data-dir>/simulations)",
     )
     p.add_argument("--tolerance", type=float, default=0.02)
+    p.add_argument(
+        "--allow-incomplete",
+        action="store_true",
+        help="report a timed-out or unscored arm without failing (exit 2 otherwise)",
+    )
     p.add_argument("--out", type=Path)
     p.add_argument("--json-out", type=Path)
     args = p.parse_args()
@@ -391,7 +453,9 @@ def main() -> int:
             p.error("--diff-baseline and --diff-candidate must be given together")
         baseline = load_scores(args.diff_baseline)
         candidate = load_scores(args.diff_candidate)
-        diff_domains = sorted(set(baseline.scores) | set(candidate.scores)) or domains
+        # Requested domains are part of the expected set, so one that neither arm
+        # scored still shows up as missing instead of silently vanishing.
+        diff_domains = sorted(set(domains) | set(baseline.scores) | set(candidate.scores))
         return write_report_and_gate(baseline, candidate, diff_domains, args.num_trials, args)
 
     # Mode: score a single live arm and persist its scores (sequential mode, per arm).
@@ -414,7 +478,10 @@ def main() -> int:
         )
         save_scores(arm, args.scores_out)
         print(f"[{arm.name}] scores -> {args.scores_out}: {arm.scores}")
-        return 0
+        if arm.timed_out:
+            print(f"WARNING: [{arm.name}] timed out on: {', '.join(arm.timed_out)}")
+        # Always 0: the gate runs once, on the --diff step that sees both arms.
+        return EXIT_OK
 
     # Mode: concurrent A/B — arms serve on opposite GPU halves, so score them in
     # PARALLEL (separate servers, separate save_to dirs) to roughly halve wall-clock.


### PR DESCRIPTION
## Description

### Problem

Two nightly A/B legs for `deepseek-ai/DeepSeek-V4-Flash-0731` misbehaved, both traced to the same root cause: the SMG arm emits token-level garbage from the first generation onward, so nothing ever emits EOS or a parseable tool call and every request runs to the generation cap.

- [Nightly BFCL](https://github.com/smg-project/smg/actions/runs/30994736289/job/92272193944) — crawled to `3992/4441 (90%) [5:55:11]` and was killed by `timeout-minutes: 360`. `scripts/bfcl/run_ab.py` used `subprocess.run()` with **no timeout**, so there was no bound below the job limit. Six hours of a Blackwell node, zero output: no report, no artifacts.
- [Nightly tau2](https://github.com/smg-project/smg/actions/runs/30898785855/job/91960269262) — took 4h35m and was marked ✅. tau2 *does* have `--run-timeout`, and the SMG arm hit the 5400s cap on all three domains (3 × 90m = 4h30m), but a run-timeout was only a warning. The report shows `overall 120/—` and the job was green. That is why this went unnoticed for at least two nightlies. (The pure-vLLM arm also hit the cap on `airline` in that run, so this leg is broken on both frontends for at least one domain — `vllm/retail` scored in 3m16s by contrast.)

Separately, both workflows ended their A/B invocation with `|| echo "BFCL_AB_REGRESSION=1" >> "$GITHUB_ENV"`. Nothing anywhere reads those variables — the regression gate has been inert in both pipelines.

### Solution

Give BFCL tau2's fail-fast bound, and make an arm that did not finish fail the job instead of rendering as `—`.

## Changes

**`scripts/bfcl/run_ab.py`**
- `--run-timeout N` (0 = off) caps `bfcl generate` and `bfcl evaluate`. The child starts in its own session and a timeout `SIGKILL`s the whole process group: `bfcl generate` fans out over a thread pool that can sit blocked on a hung HTTP read, which signalling only the direct child leaves behind.
- `evaluate` still runs after a killed `generate`, so the categories that did complete are scored rather than discarded.

**Both drivers** (`scripts/bfcl/run_ab.py`, `scripts/tau2/run_ab.py`)
- Track which stages (BFCL) / domains (tau2) were killed by the timeout, and persist them through `--scores-out` / `--diff-*` so sequential mode keeps the signal.
- `incompleteness()` reports an arm that timed out or left requested categories/domains unscored, in the markdown report, in the JSON payload, and on stderr.
- Exit codes are now `0` clean, `1` score regression beyond `--tolerance` (unchanged, informational), `2` incomplete arm. `--allow-incomplete` opts back out.

**`scripts/tau2/run_ab.py`**
- Diff mode's expected domain set now includes the requested `--domains`, so a domain that *neither* arm scored is still counted as missing instead of silently vanishing from the table.

**Both workflows**
- Consume the `run_ab.py` exit code via a small `gate` helper, replacing the dead `$GITHUB_ENV` writes. Exit 1 emits a `::warning::`; exit 2 emits a `::error::` and fails the leg. The failure is raised *after* the report is written, so the `always()` summary/transcript/artifact steps still publish the partial table — and the `failure()` arm-log upload now fires, which puts the SMG gateway log (`arm_b_gateway.log`) in the artifacts for the first time on this failure mode.
- `nightly-bfcl.yml`: per-leg `run_timeout` in the matrix (alongside the existing `startup_timeout`), plus a `run_timeout` workflow_dispatch override.
- `nightly-tau2.yml`: pass `--domains "$DOMAINS"` to the diff step, which it previously omitted; `run_timeout` becomes a per-leg matrix field (it was a single global default) with the dispatch input as an override.
- Both: the `deepseek-v4` leg now runs base `deepseek-ai/DeepSeek-V4-Flash` instead of the `-0731` refresh, which is not supported yet.

Timeouts are sized from measured healthy durations in run 30994736289 rather than guessed:

| leg | mode | healthy | `run_timeout` |
|---|---|---|---|
| qwen3.6 | concurrent | 4h02m generate/arm | 18000 (5h) |
| gpt-oss | concurrent | 31m both arms | 7200 (2h) |
| glm-5.2 | sequential | 2h52m both arms | 7200 (2h) — two arms share the 360m job |
| minimax-m2.7 / kimi-k2.6 | concurrent | no clean baseline | 14400 (4h) |
| deepseek-v4 | concurrent | no clean baseline | 5400 (90m) |

`deepseek-v4` is deliberately tighter than its peers: it has never produced a clean A/B, so there is no real cost to protect. tau2 gets the same treatment — there `run_timeout` is per *domain*, so the leg's 1200 is ~1h/arm across the three nightly domains, against 5400 elsewhere.

Note that qwen3.6 is genuinely a 4-hour leg, so its cap buys little wall-clock inside the current 360m budget — but it still converts "killed with nothing" into "red, with a report". Trimming that leg's real cost needs a smaller category set or a bigger budget, not a timeout.

### Not included

No `--request-timeout` for BFCL. BFCL's FC handler builds an `openai.OpenAI` client, which infers `api_key`, `base_url`, `organization`, `project` and `webhook_secret` from the environment but **not** `timeout`, and `bfcl generate` exposes no passthrough for it. There is no per-request hook to wire, so shipping the flag would be a no-op; the client default (600s × 2 retries) remains the per-call ceiling. Per-category granularity for `--run-timeout` (fail on the first bad category rather than after the whole run) is a reasonable follow-up, deliberately not bundled here.

This PR bounds the blast radius and makes the failure visible. It does **not** fix the underlying DeepSeek-V4 garbage generation, which is still under investigation.

## Test Plan

Unit-level verification of both gates against synthetic score files:

```console
$ python scripts/bfcl/run_ab.py --diff-baseline b.json --diff-candidate c_ok.json \
    --categories simple_python,multiple
0

$ python scripts/bfcl/run_ab.py --diff-baseline b.json --diff-candidate c_incomplete.json \
    --categories simple_python,multiple
> ⚠️ **Incomplete arm `smg`** — no score for 1/2 categories; timed out during: generate; unscored: multiple.
INCOMPLETE: arm smg — no score for 1/2 categories; timed out during: generate; unscored: multiple
2

$ ... --allow-incomplete
0
```

Same three cases pass for `scripts/tau2/run_ab.py`, plus the new diff-mode behaviour — a domain requested via `--domains` but scored by neither arm is now reported (`INCOMPLETE: arm vllm — no score for 1/3 domains; unscored: telecom`) where it previously disappeared from the table.

The `gate` shell helper was verified under `set -euo pipefail` to pass through 0, warn on 1, and exit 2 only after reaching the end of the step:

```console
after0 AB_RC=0
::warning::regression
after1 AB_RC=0
::error::incomplete (exit 2)
after2 AB_RC=2
reached end
step exit=2
```

Both workflow files parse (`yaml.safe_load`) and both A/B run steps pass `bash -n`. `pre-commit run` passes on all four files.

Before/after on real hardware needs a nightly run: a `workflow_dispatch` of Nightly BFCL with `only: deepseek-v4` should now go red at ~90m with a report and the SMG gateway log attached, instead of being killed at 6h with nothing.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

