### PR TITLE
fix(deps): pin zune-core to 0.5.1 to keep zune-jpeg compiling

### DIFF
--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -20,6 +20,11 @@ default = []
 opencv-video = ["dep:opencv"]
 
 [dependencies]
+# Not used directly: constrains resolution. zune-core 0.5.2 breaks
+# zune-jpeg 0.5.15's compile (its no-op log macros stop expanding to
+# expressions), and zune-jpeg rides in via `image`. Without this pin any
+# fresh resolve — every CI run — fails. Drop once a fixed zune-jpeg ships.
+zune-core = "=0.5.1"
 base64 = "0.22"
 hf-hub = { version = "0.5.0", default-features = false, features = ["tokio", "rustls-tls"] }
 bytes = { version = "1.12.0", features = ["serde"] }


### PR DESCRIPTION
## Motivation

Main CI fails with zero repo changes: `Verify default multimodal build` dies compiling **zune-jpeg 0.5.15** (`error: macro expansion ends with an incomplete expression`). Trigger: upstream released **zune-core 0.5.2**, whose no-op log macros no longer expand to expressions, breaking zune-jpeg 0.5.15 (pulled in via `image`). Since `Cargo.lock` isn't committed, every CI run resolves fresh and picks it up.

## Verification

- Reproduced with a controlled A/B: `cargo update -p zune-core --precise 0.5.2` alone breaks `cargo check -p llm-multimodal`; 0.5.1 compiles.
- Verified the fix under CI's exact conditions: deleted the local lock (fresh resolve, like CI), ran `cargo check -p llm-multimodal` on **Rust 1.95.0** (CI's pinned toolchain) — green, with zune-core resolved to 0.5.1.

## Modification

One resolution-constraint entry in `crates/multimodal/Cargo.toml` (`zune-core = "=0.5.1"`, commented as such) — it travels with the crate into the separately-resolved python/golang binding builds. Drop when a zune-jpeg release compatible with zune-core 0.5.2 ships.