### PR TITLE
fix(python): accumulate repeated list flags in launch_router argparse

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -221,6 +221,9 @@ class RouterArgs:
         """
         prefix = "router-" if use_router_prefix else ""
 
+        # Repeatable list flags must accumulate across occurrences
+        # (action="extend"/"append"), matching the Rust CLI.
+
         # Create argument groups for organized --help output
         worker_group = parser.add_argument_group(
             "Worker Configuration", "Settings for worker connections and URLs"
@@ -314,6 +317,7 @@ class RouterArgs:
             "--worker-urls",
             type=str,
             nargs="*",
+            action="extend",
             default=[],
             help=(
                 "List of worker URLs. Supports IPv4 and IPv6 addresses"
@@ -625,7 +629,8 @@ class RouterArgs:
             f"--{prefix}selector",
             type=str,
             nargs="+",
-            default={},
+            action="extend",
+            default=None,
             help="Label selector for Kubernetes service discovery (format: key1=value1 key2=value2)",
         )
         k8s_group.add_argument(
@@ -646,7 +651,8 @@ class RouterArgs:
             f"--{prefix}encode-selector",
             type=str,
             nargs="+",
-            default={},
+            action="extend",
+            default=None,
             help=(
                 "Label selector for encode server pods in EPD mode"
                 " (format: key1=value1 key2=value2)"
@@ -656,7 +662,8 @@ class RouterArgs:
             f"--{prefix}prefill-selector",
             type=str,
             nargs="+",
-            default={},
+            action="extend",
+            default=None,
             help=(
                 "Label selector for prefill server pods in PD mode"
                 " (format: key1=value1 key2=value2)"
@@ -666,7 +673,8 @@ class RouterArgs:
             f"--{prefix}decode-selector",
             type=str,
             nargs="+",
-            default={},
+            action="extend",
+            default=None,
             help=(
                 "Label selector for decode server pods in PD mode (format: key1=value1 key2=value2)"
             ),
@@ -675,7 +683,8 @@ class RouterArgs:
             f"--{prefix}router-selector",
             type=str,
             nargs="+",
-            default=[],
+            action="extend",
+            default=None,
             help=(
                 "Label selector for router pod discovery in HA mesh mode (format: key1=value1 key2=value2)"
             ),
@@ -721,6 +730,7 @@ class RouterArgs:
             f"--{prefix}prometheus-duration-buckets",
             type=float,
             nargs="+",
+            action="extend",
             help="Buckets for Prometheus duration metrics",
         )
 
@@ -729,6 +739,7 @@ class RouterArgs:
             f"--{prefix}request-id-headers",
             type=str,
             nargs="*",
+            action="extend",
             help=(
                 "Custom HTTP headers to check for request IDs (e.g., x-request-id x-trace-id)."
                 " If not specified, uses common defaults."
@@ -738,6 +749,7 @@ class RouterArgs:
             f"--{prefix}storage-context-headers",
             type=str,
             nargs="*",
+            action="extend",
             default=[],
             help=(
                 "Map HTTP headers into storage hook request context using HEADER=CONTEXT_KEY "
@@ -760,6 +772,7 @@ class RouterArgs:
             f"--{prefix}cors-allowed-origins",
             type=str,
             nargs="*",
+            action="extend",
             default=[],
             help="CORS allowed origins (e.g., http://localhost:3000 https://example.com)",
         )
@@ -1134,6 +1147,7 @@ class RouterArgs:
             f"--{prefix}ca-cert-paths",
             type=str,
             nargs="*",
+            action="extend",
             default=[],
             help=(
                 "Path(s) to CA certificate(s) for verifying worker TLS certificates."
@@ -1183,6 +1197,7 @@ class RouterArgs:
             f"--{prefix}control-plane-api-keys",
             type=str,
             nargs="*",
+            action="extend",
             default=[],
             help=(
                 "API keys for control plane authentication. Format: 'id:name:role:key'"
@@ -1227,6 +1242,7 @@ class RouterArgs:
             f"--{prefix}jwt-role-mapping",
             type=str,
             nargs="*",
+            action="extend",
             default=[],
             help=(
                 "Mapping from IDP role/group names to gateway roles."
@@ -1274,6 +1290,7 @@ class RouterArgs:
             f"--{prefix}mesh-peer-urls",
             type=str,
             nargs="*",
+            action="extend",
             default=[],
             help="Peer mesh server addresses to join (format: host:port)",
         )
@@ -1396,15 +1413,14 @@ class RouterArgs:
         if not selector_list:
             return {}
 
-        # Support `- --selector\n- a=b c=d` case
-        if len(selector_list) == 1 and (" " in selector_list[0]):
-            selector_list = selector_list[0].split(" ")
-
         selector = {}
+        # An item may hold several space-separated pairs (OME passes
+        # `key1=value1 key2=value2` as a single argv entry).
         for item in selector_list:
-            if "=" in item:
-                key, value = item.split("=", 1)
-                selector[key] = value
+            for token in item.split():
+                if "=" in token:
+                    key, value = token.split("=", 1)
+                    selector[key] = value
         return selector
 
     @staticmethod

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -74,6 +74,14 @@ class TestRouterArgs:
         result = RouterArgs._parse_selector(["app=worker=extra"])
         assert result == {"app": "worker=extra"}
 
+    def test_parse_selector_spaced_items(self):
+        """Every item may hold several space-separated pairs, in any mix."""
+        result = RouterArgs._parse_selector(["app=worker env=prod"])
+        assert result == {"app": "worker", "env": "prod"}
+
+        result = RouterArgs._parse_selector(["app=worker env=prod", "tier=engine"])
+        assert result == {"app": "worker", "env": "prod", "tier": "engine"}
+
     def test_parse_model_aliases(self):
         result = RouterArgs._parse_model_aliases(["GLM-5.2-Coding=GLM-5.2", "glm-5.2=GLM-5.2"])
 
@@ -687,6 +695,143 @@ class TestParseRouterArgs:
             assert router_args.selector == {"app": "worker", "env": "prod"}
             assert router_args.service_discovery_port == 8080
             assert router_args.service_discovery_namespace == "default"
+
+    def test_repeated_list_flags_accumulate(self):
+        """Repeated occurrences of list flags append, matching the Rust CLI."""
+        router_args = parse_router_args(
+            [
+                "--selector",
+                "component=engine",
+                "--selector",
+                "ome.io/inferenceservice=svc",
+                "--encode-selector",
+                "app=e",
+                "--encode-selector",
+                "role=encode",
+                "--prefill-selector",
+                "app=p",
+                "--prefill-selector",
+                "role=prefill",
+                "--decode-selector",
+                "app=d",
+                "--decode-selector",
+                "role=decode",
+                "--router-selector",
+                "app=r",
+                "--router-selector",
+                "role=router",
+                "--storage-context-headers",
+                "x-tenant-id=tenant_id",
+                "--storage-context-headers",
+                "x-user-id=user_id",
+                "--worker-urls",
+                "http://w1:8000",
+                "--worker-urls",
+                "http://w2:8000",
+                "--request-id-headers",
+                "x-request-id",
+                "--request-id-headers",
+                "x-trace-id",
+                "--cors-allowed-origins",
+                "http://a",
+                "--cors-allowed-origins",
+                "http://b",
+                "--ca-cert-paths",
+                "/ca/one.pem",
+                "--ca-cert-paths",
+                "/ca/two.pem",
+                "--mesh-peer-urls",
+                "peer1:39527",
+                "--mesh-peer-urls",
+                "peer2:39527",
+                "--prometheus-duration-buckets",
+                "0.1",
+                "--prometheus-duration-buckets",
+                "0.5",
+                "--control-plane-api-keys",
+                "k1:Svc:admin:s1",
+                "--control-plane-api-keys",
+                "k2:Ro:user:s2",
+                "--jwt-role-mapping",
+                "Gateway.Admin=admin",
+                "--jwt-role-mapping",
+                "Gateway.User=user",
+            ]
+        )
+
+        assert router_args.selector == {
+            "component": "engine",
+            "ome.io/inferenceservice": "svc",
+        }
+        assert router_args.encode_selector == {"app": "e", "role": "encode"}
+        assert router_args.prefill_selector == {"app": "p", "role": "prefill"}
+        assert router_args.decode_selector == {"app": "d", "role": "decode"}
+        assert router_args.router_selector == {"app": "r", "role": "router"}
+        assert router_args.storage_context_headers == {
+            "x-tenant-id": "tenant_id",
+            "x-user-id": "user_id",
+        }
+        assert router_args.worker_urls == ["http://w1:8000", "http://w2:8000"]
+        assert router_args.request_id_headers == ["x-request-id", "x-trace-id"]
+        assert router_args.cors_allowed_origins == ["http://a", "http://b"]
+        assert router_args.ca_cert_paths == ["/ca/one.pem", "/ca/two.pem"]
+        assert router_args.mesh_peer_urls == ["peer1:39527", "peer2:39527"]
+        assert router_args.prometheus_duration_buckets == [0.1, 0.5]
+        assert router_args.control_plane_api_keys == [
+            ("k1", "Svc", "s1", "admin"),
+            ("k2", "Ro", "s2", "user"),
+        ]
+        assert router_args.jwt_role_mapping == {
+            "Gateway.Admin": "admin",
+            "Gateway.User": "user",
+        }
+
+    def test_selector_spaced_values_mix_with_repeats(self):
+        """Spaced pairs in one occurrence compose with additional occurrences."""
+        router_args = parse_router_args(
+            [
+                "--selector",
+                "app=worker env=prod",
+                "--selector",
+                "tier=engine",
+            ]
+        )
+
+        assert router_args.selector == {"app": "worker", "env": "prod", "tier": "engine"}
+
+    def test_list_flags_default_empty(self):
+        """Absent list flags parse to the documented empty defaults."""
+        router_args = parse_router_args([])
+
+        assert router_args.selector == {}
+        assert router_args.encode_selector == {}
+        assert router_args.prefill_selector == {}
+        assert router_args.decode_selector == {}
+        assert router_args.router_selector == {}
+        assert router_args.storage_context_headers == {}
+        assert router_args.worker_urls == []
+        assert router_args.cors_allowed_origins == []
+        assert router_args.ca_cert_paths == []
+        assert router_args.mesh_peer_urls == []
+        assert router_args.control_plane_api_keys == []
+        assert router_args.jwt_role_mapping == {}
+
+    def test_prefixed_repeated_selector_accumulates(self):
+        """Repeated --router-selector occurrences accumulate in prefixed mode."""
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args(
+            [
+                "--router-selector",
+                "component=engine",
+                "--router-selector",
+                "env=prod",
+            ]
+        )
+
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+
+        assert router_args.selector == {"component": "engine", "env": "prod"}
 
     def test_parse_repeated_model_alias_args(self):
         router_args = parse_router_args(


### PR DESCRIPTION
## Problem

The Python launcher and the Rust CLI parse repeated list flags with opposite semantics:

- Rust (`clap`, `num_args = 0..`): `--selector a=1 --selector b=2` → **both pairs**
- Python (`argparse`, `nargs` + default `store` action): same argv → **only `b=2`** (each occurrence overwrites the previous one)

Since the Docker image entrypoint is `python3 -m smg.launch_router`, any deployment passing repeated selector flags silently loses all but the last one. For example, with `--selector component=engine --selector ome.io/inferenceservice=$(NAME)`, the effective K8s selector drops the `component=engine` term, so the gateway's own router pods can match the surviving selector and get endlessly (and unsuccessfully) probed as workers. Which term survives depends on argument order — with the opposite order the selector would match engine pods of every InferenceService in the namespace.

## Fix

- `action="extend"` on every repeatable list flag so occurrences accumulate, matching the Rust CLI: `--worker-urls`, `--selector`, `--encode-selector`, `--prefill-selector`, `--decode-selector`, `--router-selector`, `--prometheus-duration-buckets`, `--request-id-headers`, `--storage-context-headers`, `--cors-allowed-origins`, `--ca-cert-paths`, `--control-plane-api-keys`, `--jwt-role-mapping`, `--mesh-peer-urls` (dict defaults become `None`; `extend` cannot start from `{}`, and `_parse_selector` already normalizes)
- `_parse_selector` now flattens space-separated pairs in **any** item (previously only when the list had exactly one item), so the OME single-string style composes with repeated occurrences: `--selector "a=1 b=2" --selector c=3` → all three pairs

Behavior note: configurations that relied on a repeated flag *overriding* earlier occurrences now get accumulation instead. That matches the documented Rust behavior and the flags' help text.

## Tests

- `test_repeated_list_flags_accumulate`: all 14 flags, two occurrences each, exact expected values
- `test_selector_spaced_values_mix_with_repeats` + `_parse_selector` unit cases for mixed styles
- `test_list_flags_default_empty`: absent flags keep their documented empty defaults (guards the `default=None` change)
- `test_prefixed_repeated_selector_accumulates`: `--router-selector` in prefixed mode (the OME routerConfig path)

`pytest bindings/python/tests`: 269 passed, 4 skipped (against a locally built wheel). `ruff check`, `ruff format --check`, `mypy bindings/python/`: clean. Verified through `smg.launch_router.parse_router_args` that the two-occurrence and one-occurrence-two-values styles now both yield the full selector, identical to the Rust binary.
