### PR TITLE
fix(zmq): enforce wire constraints on TokenSpeed direct-backend workers

### DIFF
--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -169,6 +169,20 @@ class WorkerLauncher(ABC):
             filtered.append(arg)
         return filtered
 
+    def _backend_arg_defaults(
+        self, backend_args: list[str], defaults: dict[str, list[str]]
+    ) -> list[str]:
+        """Expand each default the caller did not set themselves.
+
+        Unlike ``_filter_backend_args``, which strips flags the launcher owns
+        outright, these are engine defaults SMG needs for the wire to behave as
+        the API promises but an operator may legitimately override.
+        """
+        supplied = {arg.split("=", 1)[0] for arg in backend_args}
+        return [
+            token for flag, tokens in defaults.items() if flag not in supplied for token in tokens
+        ]
+
     def launch(
         self, args: argparse.Namespace, backend_args: list[str], host: str, port: int, env: dict
     ) -> subprocess.Popen:
@@ -342,6 +356,23 @@ class TokenspeedWorkerLauncher(WorkerLauncher):
             "--zmq-engine-index",
             "0",
         ]
+        cmd.extend(
+            self._backend_arg_defaults(
+                backend_args,
+                {
+                    # ``tool_choice=required``/``{function}`` and
+                    # ``response_format=json_schema`` reach the engine as
+                    # constraints on the wire, but TokenSpeed drops them without
+                    # complaint unless a grammar backend is configured, and its
+                    # default is none. Without this an unenforced constraint is
+                    # silently answered as freeform text.
+                    "--grammar-backend": ["--grammar-backend", "xgrammar"],
+                    # Output logprobs default off, so ``logprobs=true`` would
+                    # come back null rather than with per-token data.
+                    "--enable-output-logprobs": ["--enable-output-logprobs"],
+                },
+            )
+        )
         cmd.extend(
             self._filter_backend_args(
                 backend_args,

--- a/bindings/python/tests/test_serve.py
+++ b/bindings/python/tests/test_serve.py
@@ -859,6 +859,35 @@ class TestTokenspeedWorkerLauncher:
         assert "--mem-fraction-static" in cmd
         assert "0.8" in cmd
 
+    def test_build_zmq_command_enables_constraint_enforcement(self):
+        # TokenSpeed defaults its grammar backend to none and drops wire
+        # constraints without complaint, so tool_choice=required and
+        # response_format=json_schema would answer as freeform text.
+        launcher = TokenspeedWorkerLauncher()
+        args = argparse.Namespace(model="/tmp/model", connection_mode="zmq")
+        cmd = launcher.build_command(args, [], "127.0.0.1", 31000)
+
+        assert cmd[cmd.index("--grammar-backend") + 1] == "xgrammar"
+        assert "--enable-output-logprobs" in cmd
+
+    def test_build_zmq_command_defaults_yield_to_the_operator(self):
+        launcher = TokenspeedWorkerLauncher()
+        args = argparse.Namespace(model="/tmp/model", connection_mode="zmq")
+        cmd = launcher.build_command(args, ["--grammar-backend", "llguidance"], "127.0.0.1", 31000)
+
+        assert cmd.count("--grammar-backend") == 1
+        assert cmd[cmd.index("--grammar-backend") + 1] == "llguidance"
+        # An override of one default leaves the others in place.
+        assert "--enable-output-logprobs" in cmd
+
+    def test_build_zmq_command_default_honors_equals_form(self):
+        launcher = TokenspeedWorkerLauncher()
+        args = argparse.Namespace(model="/tmp/model", connection_mode="zmq")
+        cmd = launcher.build_command(args, ["--grammar-backend=none"], "127.0.0.1", 31000)
+
+        assert "--grammar-backend=none" in cmd
+        assert "xgrammar" not in cmd
+
     def test_build_command_rejects_non_zmq_modes(self):
         launcher = TokenspeedWorkerLauncher()
         for mode in ("grpc", "http"):


### PR DESCRIPTION
## Problem

TokenSpeed defaults `grammar_backend` to `none` and then drops structured-output constraints **without complaint**. The gateway does its part correctly — `apply_tokenspeed_constraint` maps all four constraint kinds onto the wire — so the request arrives intact at an engine that quietly ignores it.

The user-visible result is that `tool_choice=required`, `tool_choice={function}` and `response_format=json_schema` return freeform text with a 200. Output logprobs default off the same way, so `logprobs=true` returns null.

This is a **production** hole, not a test-harness one. The gRPC servicer path passes `--grammar-backend xgrammar` and `--enable-output-logprobs` explicitly, with a comment naming this exact failure mode; the `smg serve` ZMQ launcher never did. Anyone running TokenSpeed over ZMQ today gets silently unenforced constraints.

The e2e lane is just where it surfaced: on run [31243936303](https://github.com/smg-project/smg/actions/runs/31243936303) the `e2e-1gpu-chat-zmq (tokenspeed)` lane logged `grammar_backend='none'` at startup and produced **44 failures — every one a grammar test** (38 function-calling `required`/`specific`, 4 `json_schema`, 2 `regex`). `tool_choice=auto` passed throughout, so parsing was never the problem.

## Change

`TokenspeedWorkerLauncher` now supplies both flags as **defaults** rather than launcher-owned flags, via a new `WorkerLauncher._backend_arg_defaults` helper. The distinction matters: `_filter_backend_args` strips flags SMG owns outright, whereas these are engine defaults SMG needs for the wire to behave as the API promises but an operator may legitimately override. Pass `--grammar-backend llguidance` and you keep yours; the other defaults stay.

The e2e harness delegates to this launcher (`_build_tokenspeed_zmq_cmd`), so the ZMQ lane picks the fix up with no harness change.

## What this does not fix

Failing loud would be better than defaulting. The frontend cannot do that today: `EngineCoreReadyResponse` carries no grammar-backend field, so it cannot distinguish an unenforceable constraint from an enforceable one. That needs a handshake addition on the TokenSpeed side (#48 territory), and is worth doing — a silently-ignored constraint is a correctness bug that looks like a model quality problem.

## Test Plan

- `pytest tests/test_serve.py -k Tokenspeed` → 11 passed, including three new cases: defaults are applied, an operator override wins and leaves other defaults intact, and the `--flag=value` form is honored.
- `ruff check` / `ruff format --check` clean.
- The real proof is the `e2e-1gpu-chat-zmq (tokenspeed)` lane on this PR: those 44 failures should clear.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>