### PR TITLE
feat(tokenizer): identify DeepSeek-V4 0731 effort encoding per checkpoint

### DIFF
--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -162,6 +162,21 @@ impl ParserFactory {
             Box::new(BaseReasoningParser::new(config).with_model_type("deepseek_v31".to_string()))
         });
 
+        // DeepSeek V4 prefills <think> in the generation prompt when thinking
+        // is enabled, so request processing marks the parser as already in
+        // reasoning (via think_in_prefill) before the first generated token
+        // arrives.
+        registry.register_parser("deepseek_v4", || {
+            let config = ParserConfig {
+                think_start_token: "<think>".to_string(),
+                think_end_token: "</think>".to_string(),
+                stream_reasoning: true,
+                max_buffer_size: DEFAULT_MAX_BUFFER_SIZE,
+                always_in_reasoning: false,
+            };
+            Box::new(BaseReasoningParser::new(config).with_model_type("deepseek_v4".to_string()))
+        });
+
         registry.register_parser("kimi_k25", || {
             let config = ParserConfig {
                 think_start_token: "<think>".to_string(),
@@ -188,6 +203,8 @@ impl ParserFactory {
         registry.register_parser("kimi_k3", || Box::new(KimiK3Parser::new()));
 
         registry.register_pattern("deepseek-r1", "deepseek_r1");
+        registry.register_pattern("deepseek-v4", "deepseek_v4");
+        registry.register_pattern("deepseek_v4", "deepseek_v4");
         registry.register_pattern("deepseek-v3.1", "deepseek_v31");
         registry.register_pattern("deepseek-v3-1", "deepseek_v31");
         registry.register_pattern("qwen3-thinking", "qwen3_thinking");
@@ -271,6 +288,37 @@ mod tests {
         let factory = ParserFactory::new();
         let parser = factory.create("deepseek-r1-distill");
         assert_eq!(parser.model_type(), "deepseek_r1");
+    }
+
+    #[test]
+    fn test_factory_auto_registers_deepseek_v4_models() {
+        let factory = ParserFactory::new();
+        assert!(factory.list_parsers().contains(&"deepseek_v4".to_string()));
+
+        for model in [
+            "deepseek-ai/DeepSeek-V4-Flash",
+            "deepseek-ai/DeepSeek-V4-Flash-0731",
+            "deepseek-ai/DeepSeek-V4-Flash-DSpark",
+            "deepseek-ai/DeepSeek-V4-Pro",
+            "DEEPSEEK_V4_LOCAL",
+        ] {
+            assert_eq!(
+                factory.create(model).model_type(),
+                "deepseek_v4",
+                "model: {model}"
+            );
+        }
+
+        // The prompt prefills <think>; request processing marks the parser as
+        // in-reasoning before the first generated token.
+        let mut parser = factory.create("deepseek-ai/DeepSeek-V4-Flash-0731");
+        assert!(!parser.is_in_reasoning());
+        parser.mark_reasoning_started();
+        let parsed = parser
+            .detect_and_parse_reasoning("analysis</think>answer")
+            .unwrap();
+        assert_eq!(parsed.reasoning_text, "analysis");
+        assert_eq!(parsed.normal_text, "answer");
     }
 
     #[test]

--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -162,19 +162,13 @@ impl ParserFactory {
             Box::new(BaseReasoningParser::new(config).with_model_type("deepseek_v31".to_string()))
         });
 
-        // DeepSeek V4 prefills <think> in the generation prompt when thinking
-        // is enabled, so request processing marks the parser as already in
-        // reasoning (via think_in_prefill) before the first generated token
-        // arrives.
+        // V4 prefills <think>; request processing arms the parser via
+        // mark_reasoning_started.
         registry.register_parser("deepseek_v4", || {
-            let config = ParserConfig {
-                think_start_token: "<think>".to_string(),
-                think_end_token: "</think>".to_string(),
-                stream_reasoning: true,
-                max_buffer_size: DEFAULT_MAX_BUFFER_SIZE,
-                always_in_reasoning: false,
-            };
-            Box::new(BaseReasoningParser::new(config).with_model_type("deepseek_v4".to_string()))
+            Box::new(
+                BaseReasoningParser::new(ParserConfig::default())
+                    .with_model_type("deepseek_v4".to_string()),
+            )
         });
 
         registry.register_parser("kimi_k25", || {
@@ -293,26 +287,18 @@ mod tests {
     #[test]
     fn test_factory_auto_registers_deepseek_v4_models() {
         let factory = ParserFactory::new();
-        assert!(factory.list_parsers().contains(&"deepseek_v4".to_string()));
+        assert_eq!(
+            factory
+                .create("deepseek-ai/DeepSeek-V4-Flash-0731")
+                .model_type(),
+            "deepseek_v4"
+        );
+        assert_eq!(
+            factory.create("DEEPSEEK_V4_LOCAL").model_type(),
+            "deepseek_v4"
+        );
 
-        for model in [
-            "deepseek-ai/DeepSeek-V4-Flash",
-            "deepseek-ai/DeepSeek-V4-Flash-0731",
-            "deepseek-ai/DeepSeek-V4-Flash-DSpark",
-            "deepseek-ai/DeepSeek-V4-Pro",
-            "DEEPSEEK_V4_LOCAL",
-        ] {
-            assert_eq!(
-                factory.create(model).model_type(),
-                "deepseek_v4",
-                "model: {model}"
-            );
-        }
-
-        // The prompt prefills <think>; request processing marks the parser as
-        // in-reasoning before the first generated token.
-        let mut parser = factory.create("deepseek-ai/DeepSeek-V4-Flash-0731");
-        assert!(!parser.is_in_reasoning());
+        let mut parser = factory.create("deepseek-ai/DeepSeek-V4-Flash");
         parser.mark_reasoning_started();
         let parsed = parser
             .detect_and_parse_reasoning("analysis</think>answer")

--- a/crates/tokenizer/src/cache/mod.rs
+++ b/crates/tokenizer/src/cache/mod.rs
@@ -297,6 +297,11 @@ impl Tokenizer for CachedTokenizer {
     fn thinking_key_name(&self) -> Option<ThinkingKeyName> {
         self.inner.thinking_key_name()
     }
+
+    fn template_reasoning_effort_enables_thinking(&self) -> bool {
+        self.inner.template_reasoning_effort_enables_thinking()
+    }
+
     fn think_in_prefill(&self) -> bool {
         self.inner.think_in_prefill()
     }

--- a/crates/tokenizer/src/cache/mod.rs
+++ b/crates/tokenizer/src/cache/mod.rs
@@ -298,8 +298,8 @@ impl Tokenizer for CachedTokenizer {
         self.inner.thinking_key_name()
     }
 
-    fn template_reasoning_effort_enables_thinking(&self) -> bool {
-        self.inner.template_reasoning_effort_enables_thinking()
+    fn native_reasoning_effort_values(&self) -> &'static [&'static str] {
+        self.inner.native_reasoning_effort_values()
     }
 
     fn think_in_prefill(&self) -> bool {

--- a/crates/tokenizer/src/encoders/deepseek_v4.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v4.rs
@@ -35,10 +35,13 @@ impl EffortEncoding {
 
     /// Parse a native effort name against this revision's accepted set.
     pub fn parse_native(self, value: &str) -> Option<ReasoningEffort> {
-        match (self, value) {
-            (Self::V0731, "low") => Some(ReasoningEffort::Low),
-            (_, "high") => Some(ReasoningEffort::High),
-            (_, "max") => Some(ReasoningEffort::Max),
+        if !self.valid_native_values().contains(&value) {
+            return None;
+        }
+        match value {
+            "low" => Some(ReasoningEffort::Low),
+            "high" => Some(ReasoningEffort::High),
+            "max" => Some(ReasoningEffort::Max),
             _ => None,
         }
     }

--- a/crates/tokenizer/src/encoders/deepseek_v4.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v4.rs
@@ -1,8 +1,6 @@
 // Ported from the `encoding/encoding_dsv4.py` shipped with the DeepSeek V4
-// checkpoints. Two revisions of that file exist in the wild and they disagree
-// only in the reasoning-effort block:
-//   - https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash (also -DSpark, -Pro)
-//   - https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
+// checkpoints (deepseek-ai/DeepSeek-V4-Flash and -Flash-0731 on HF); the two
+// revisions differ only in the reasoning-effort block.
 
 use std::fmt::Write as _;
 
@@ -15,18 +13,14 @@ pub use super::deepseek_v32::ThinkingMode;
 
 /// Which reasoning-effort prompt revision the checkpoint was trained with.
 ///
-/// The 0731 refresh shifted the effort levels down one: the text the original
-/// checkpoint emits for `max` became 0731's `high`, and 0731's `max` is a new,
-/// stronger prompt. Everything else in the encoding is byte-identical, so this
-/// is the only per-checkpoint switch the encoder needs.
+/// The 0731 refresh shifted the levels down one: the original's `max` text
+/// became 0731's `high`, and 0731's `max` is a new, stronger prompt.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EffortEncoding {
-    /// `DeepSeek-V4-Flash` / `-DSpark` / `-Pro`: accepts `high`/`max`, only
-    /// `max` emits a prefix (`high` is accepted but renders nothing).
+    /// `DeepSeek-V4-Flash` / `-DSpark` / `-Pro`.
     #[default]
     Original,
-    /// `DeepSeek-V4-Flash-0731`: accepts `low`/`high`/`max`; `low` is the
-    /// default and renders nothing.
+    /// `DeepSeek-V4-Flash-0731`.
     V0731,
 }
 
@@ -46,6 +40,20 @@ impl EffortEncoding {
             (_, "high") => Some(ReasoningEffort::High),
             (_, "max") => Some(ReasoningEffort::Max),
             _ => None,
+        }
+    }
+
+    /// Identify the revision from the checkpoint's own `encoding_dsv4.py`
+    /// source: only the 0731 file contains its new `max` prompt text.
+    pub fn detect_from_encoder_source(source: &str) -> Self {
+        let marker = REASONING_EFFORT_BEYOND_MAXIMUM
+            .split_inclusive('\n')
+            .next()
+            .unwrap_or(REASONING_EFFORT_BEYOND_MAXIMUM);
+        if source.contains(marker.trim_end()) {
+            Self::V0731
+        } else {
+            Self::Original
         }
     }
 }
@@ -138,10 +146,8 @@ fn task_sp_token(task: &str) -> Option<&'static str> {
 // ---------------------------------------------------------------------------
 // Templates
 // ---------------------------------------------------------------------------
-// Original `REASONING_EFFORT_MAX`; the 0731 refresh reuses this exact text
-// for its `high` level.
+// Original `max` prefix; the 0731 refresh reuses this exact text for `high`.
 const REASONING_EFFORT_ABSOLUTE_MAXIMUM: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
-// 0731's `max` level.
 const REASONING_EFFORT_BEYOND_MAXIMUM: &str = "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\nYou MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\nDo not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n";
 
 /// Mirrors V4's `TOOLS_TEMPLATE`. The block name is `tool_calls` (not
@@ -308,8 +314,7 @@ fn render_message(
     let tool_calls_owned = tool_calls_raw.map(|tc| tool_calls_from_openai_format(tc));
     let tool_calls = tool_calls_owned.as_deref();
 
-    // Reasoning effort prefix (only at index 0 in thinking mode). Which levels
-    // emit which text depends on the checkpoint's encoding revision.
+    // Reasoning effort prefix: index 0, thinking mode only.
     if index == 0 && thinking_mode == ThinkingMode::Thinking {
         match (effort_encoding, reasoning_effort) {
             (EffortEncoding::Original, Some(ReasoningEffort::Max)) => {
@@ -818,32 +823,31 @@ mod tests {
                 ),
                 None => assert!(!out.contains("Reasoning Effort"), "effort {effort:?}"),
             }
-            // Chat mode never emits an effort prefix.
-            let out_chat = encode_messages(&msgs, ThinkingMode::Chat, &params).unwrap();
-            assert!(!out_chat.contains("Reasoning Effort"), "effort {effort:?}");
         }
     }
 
     #[test]
     fn effort_encoding_native_value_sets() {
-        assert_eq!(
-            EffortEncoding::Original.parse_native("max"),
-            Some(ReasoningEffort::Max)
-        );
-        assert_eq!(
-            EffortEncoding::Original.parse_native("high"),
-            Some(ReasoningEffort::High)
-        );
-        // `low` only exists in the 0731 revision.
+        // `low` only exists in the 0731 revision; unknown names parse nowhere.
         assert_eq!(EffortEncoding::Original.parse_native("low"), None);
         assert_eq!(
             EffortEncoding::V0731.parse_native("low"),
             Some(ReasoningEffort::Low)
         );
-        for encoding in [EffortEncoding::Original, EffortEncoding::V0731] {
-            assert_eq!(encoding.parse_native("medium"), None);
-            assert_eq!(encoding.parse_native("turbo"), None);
-        }
+        assert_eq!(EffortEncoding::V0731.parse_native("medium"), None);
+    }
+
+    #[test]
+    fn effort_encoding_detected_from_encoder_source() {
+        let v0731_src = format!("PROMPTS = {{'max': {REASONING_EFFORT_BEYOND_MAXIMUM:?}}}");
+        assert_eq!(
+            EffortEncoding::detect_from_encoder_source(&v0731_src),
+            EffortEncoding::V0731
+        );
+        assert_eq!(
+            EffortEncoding::detect_from_encoder_source("REASONING_EFFORT_MAX = '...'"),
+            EffortEncoding::Original
+        );
     }
 
     #[test]

--- a/crates/tokenizer/src/encoders/deepseek_v4.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v4.rs
@@ -1,4 +1,8 @@
-// Ported from https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py
+// Ported from the `encoding/encoding_dsv4.py` shipped with the DeepSeek V4
+// checkpoints. Two revisions of that file exist in the wild and they disagree
+// only in the reasoning-effort block:
+//   - https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash (also -DSpark, -Pro)
+//   - https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731
 
 use std::fmt::Write as _;
 
@@ -9,13 +13,50 @@ use thiserror::Error;
 // "thinking" / "chat" mode invariant identical across DeepSeek versions.
 pub use super::deepseek_v32::ThinkingMode;
 
+/// Which reasoning-effort prompt revision the checkpoint was trained with.
+///
+/// The 0731 refresh shifted the effort levels down one: the text the original
+/// checkpoint emits for `max` became 0731's `high`, and 0731's `max` is a new,
+/// stronger prompt. Everything else in the encoding is byte-identical, so this
+/// is the only per-checkpoint switch the encoder needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EffortEncoding {
+    /// `DeepSeek-V4-Flash` / `-DSpark` / `-Pro`: accepts `high`/`max`, only
+    /// `max` emits a prefix (`high` is accepted but renders nothing).
+    #[default]
+    Original,
+    /// `DeepSeek-V4-Flash-0731`: accepts `low`/`high`/`max`; `low` is the
+    /// default and renders nothing.
+    V0731,
+}
+
+impl EffortEncoding {
+    /// Native effort names this revision's Python encoder accepts.
+    pub fn valid_native_values(self) -> &'static [&'static str] {
+        match self {
+            Self::Original => &["high", "max"],
+            Self::V0731 => &["low", "high", "max"],
+        }
+    }
+
+    /// Parse a native effort name against this revision's accepted set.
+    pub fn parse_native(self, value: &str) -> Option<ReasoningEffort> {
+        match (self, value) {
+            (Self::V0731, "low") => Some(ReasoningEffort::Low),
+            (_, "high") => Some(ReasoningEffort::High),
+            (_, "max") => Some(ReasoningEffort::Max),
+            _ => None,
+        }
+    }
+}
+
 /// Reasoning effort for the V4 prompt prefix.
 ///
-/// Mirrors the Python `reasoning_effort` parameter, which only accepts
-/// `None`, `"high"`, or `"max"`. Only `Max` actually emits a prefix today;
-/// `High` is accepted for parity with the Python signature.
+/// Union of the levels across both encoding revisions; which values are
+/// accepted and what they render is decided by [`EffortEncoding`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReasoningEffort {
+    Low,
     High,
     Max,
 }
@@ -29,6 +70,7 @@ pub struct EncodeParams {
     pub add_default_bos_token: bool,
     pub drop_thinking: bool,
     pub reasoning_effort: Option<ReasoningEffort>,
+    pub effort_encoding: EffortEncoding,
 }
 impl Default for EncodeParams {
     fn default() -> Self {
@@ -36,6 +78,7 @@ impl Default for EncodeParams {
             add_default_bos_token: true,
             drop_thinking: true,
             reasoning_effort: None,
+            effort_encoding: EffortEncoding::Original,
         }
     }
 }
@@ -95,7 +138,11 @@ fn task_sp_token(task: &str) -> Option<&'static str> {
 // ---------------------------------------------------------------------------
 // Templates
 // ---------------------------------------------------------------------------
-const REASONING_EFFORT_MAX: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
+// Original `REASONING_EFFORT_MAX`; the 0731 refresh reuses this exact text
+// for its `high` level.
+const REASONING_EFFORT_ABSOLUTE_MAXIMUM: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
+// 0731's `max` level.
+const REASONING_EFFORT_BEYOND_MAXIMUM: &str = "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\nYou MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\nDo not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n";
 
 /// Mirrors V4's `TOOLS_TEMPLATE`. The block name is `tool_calls` (not
 /// `function_calls` like V3.2) and the wording is updated.
@@ -234,6 +281,7 @@ fn render_message(
     thinking_mode: ThinkingMode,
     drop_thinking: bool,
     reasoning_effort: Option<ReasoningEffort>,
+    effort_encoding: EffortEncoding,
 ) -> Result<String, DsEncodingError> {
     if index >= messages.len() {
         return Err(DsEncodingError::IndexOutOfRange {
@@ -260,12 +308,21 @@ fn render_message(
     let tool_calls_owned = tool_calls_raw.map(|tc| tool_calls_from_openai_format(tc));
     let tool_calls = tool_calls_owned.as_deref();
 
-    // Reasoning effort prefix (only at index 0 in thinking mode with max effort)
-    if index == 0
-        && thinking_mode == ThinkingMode::Thinking
-        && reasoning_effort == Some(ReasoningEffort::Max)
-    {
-        prompt.push_str(REASONING_EFFORT_MAX);
+    // Reasoning effort prefix (only at index 0 in thinking mode). Which levels
+    // emit which text depends on the checkpoint's encoding revision.
+    if index == 0 && thinking_mode == ThinkingMode::Thinking {
+        match (effort_encoding, reasoning_effort) {
+            (EffortEncoding::Original, Some(ReasoningEffort::Max)) => {
+                prompt.push_str(REASONING_EFFORT_ABSOLUTE_MAXIMUM);
+            }
+            (EffortEncoding::V0731, Some(ReasoningEffort::High)) => {
+                prompt.push_str(REASONING_EFFORT_ABSOLUTE_MAXIMUM);
+            }
+            (EffortEncoding::V0731, Some(ReasoningEffort::Max)) => {
+                prompt.push_str(REASONING_EFFORT_BEYOND_MAXIMUM);
+            }
+            _ => {}
+        }
     }
 
     match role {
@@ -671,6 +728,7 @@ pub fn encode_messages(
             thinking_mode,
             effective_drop_thinking,
             params.reasoning_effort,
+            params.effort_encoding,
         )?);
     }
     Ok(prompt)
@@ -705,23 +763,87 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_effort_max_prepends_prefix() {
+    fn original_encoding_only_max_prepends_prefix() {
         let msgs = [user("Hello")];
+        // `max` emits the prefix immediately after BOS.
         let params = EncodeParams {
             reasoning_effort: Some(ReasoningEffort::Max),
             ..EncodeParams::default()
         };
         let out = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();
-        // The prefix appears immediately after BOS, before the user message.
-        let expected_start = format!("{BOS_TOKEN}{REASONING_EFFORT_MAX}");
+        let expected_start = format!("{BOS_TOKEN}{REASONING_EFFORT_ABSOLUTE_MAXIMUM}");
         assert!(
             out.starts_with(&expected_start),
-            "expected prompt to start with BOS+REASONING_EFFORT_MAX, got: {:?}",
+            "expected prompt to start with BOS + the original max prefix, got: {:?}",
             &out[..120.min(out.len())]
         );
-        // Without max effort, the prefix is absent.
+        // `high` is accepted but renders nothing in the original encoding.
+        let params_high = EncodeParams {
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..EncodeParams::default()
+        };
+        let out_high = encode_messages(&msgs, ThinkingMode::Thinking, &params_high).unwrap();
+        assert!(!out_high.contains("Reasoning Effort"));
+        // Outside thinking mode the prefix is absent.
         let out_chat = encode_messages(&msgs, ThinkingMode::Chat, &params).unwrap();
         assert!(!out_chat.contains("Reasoning Effort"));
+    }
+
+    #[test]
+    fn v0731_encoding_shifts_effort_levels() {
+        let msgs = [user("Hello")];
+        for (effort, expected_prefix) in [
+            (None, None),
+            (Some(ReasoningEffort::Low), None),
+            (
+                Some(ReasoningEffort::High),
+                Some("Reasoning Effort: Absolute maximum"),
+            ),
+            (
+                Some(ReasoningEffort::Max),
+                Some("Reasoning Effort: Beyond maximum"),
+            ),
+        ] {
+            let params = EncodeParams {
+                reasoning_effort: effort,
+                effort_encoding: EffortEncoding::V0731,
+                ..EncodeParams::default()
+            };
+            let out = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();
+            match expected_prefix {
+                Some(prefix) => assert!(
+                    out.starts_with(&format!("{BOS_TOKEN}{prefix}")),
+                    "effort {effort:?}: {:?}",
+                    &out[..120.min(out.len())]
+                ),
+                None => assert!(!out.contains("Reasoning Effort"), "effort {effort:?}"),
+            }
+            // Chat mode never emits an effort prefix.
+            let out_chat = encode_messages(&msgs, ThinkingMode::Chat, &params).unwrap();
+            assert!(!out_chat.contains("Reasoning Effort"), "effort {effort:?}");
+        }
+    }
+
+    #[test]
+    fn effort_encoding_native_value_sets() {
+        assert_eq!(
+            EffortEncoding::Original.parse_native("max"),
+            Some(ReasoningEffort::Max)
+        );
+        assert_eq!(
+            EffortEncoding::Original.parse_native("high"),
+            Some(ReasoningEffort::High)
+        );
+        // `low` only exists in the 0731 revision.
+        assert_eq!(EffortEncoding::Original.parse_native("low"), None);
+        assert_eq!(
+            EffortEncoding::V0731.parse_native("low"),
+            Some(ReasoningEffort::Low)
+        );
+        for encoding in [EffortEncoding::Original, EffortEncoding::V0731] {
+            assert_eq!(encoding.parse_native("medium"), None);
+            assert_eq!(encoding.parse_native("turbo"), None);
+        }
     }
 
     #[test]

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -594,6 +594,12 @@ impl TokenizerTrait for HuggingFaceTokenizer {
             Renderer::Jinja => self.chat_template.thinking_key_name(),
         }
     }
+    fn template_reasoning_effort_enables_thinking(&self) -> bool {
+        // A native effort is a request to reason; apply_deepseek_v4 switches
+        // into thinking mode for it, so report the same preference here.
+        matches!(self.renderer, Renderer::DeepseekV4(_))
+    }
+
     fn think_in_prefill(&self) -> bool {
         match self.renderer {
             // Both encoders emit `<｜Assistant｜><think>` at the end of the

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -30,7 +30,7 @@ use crate::{
 enum Renderer {
     Jinja,
     DeepseekV32,
-    DeepseekV4,
+    DeepseekV4(deepseek_v4::EffortEncoding),
 }
 
 /// HuggingFace tokenizer wrapper
@@ -570,7 +570,7 @@ impl TokenizerTrait for HuggingFaceTokenizer {
                 self.chat_template.apply(messages, params)
             }
             Renderer::DeepseekV32 => apply_deepseek_v32(messages, &params),
-            Renderer::DeepseekV4 => apply_deepseek_v4(messages, &params),
+            Renderer::DeepseekV4(encoding) => apply_deepseek_v4(messages, &params, encoding),
         }
     }
 
@@ -583,14 +583,14 @@ impl TokenizerTrait for HuggingFaceTokenizer {
             // DeepSeek V3.2 and V4 encoders gate thinking on the `thinking`
             // kwarg, default off. The Jinja processor has no knowledge of
             // the native encoder so we must report it directly.
-            Renderer::DeepseekV32 | Renderer::DeepseekV4 => ThinkingToggle::DefaultOff,
+            Renderer::DeepseekV32 | Renderer::DeepseekV4(_) => ThinkingToggle::DefaultOff,
             Renderer::Jinja => self.chat_template.thinking_toggle(),
         }
     }
 
     fn thinking_key_name(&self) -> Option<ThinkingKeyName> {
         match self.renderer {
-            Renderer::DeepseekV32 | Renderer::DeepseekV4 => Some(ThinkingKeyName::Thinking),
+            Renderer::DeepseekV32 | Renderer::DeepseekV4(_) => Some(ThinkingKeyName::Thinking),
             Renderer::Jinja => self.chat_template.thinking_key_name(),
         }
     }
@@ -599,7 +599,7 @@ impl TokenizerTrait for HuggingFaceTokenizer {
             // Both encoders emit `<｜Assistant｜><think>` at the end of the
             // prompt when thinking mode is on; the completion therefore starts
             // mid-reasoning and the parser must be told so.
-            Renderer::DeepseekV32 | Renderer::DeepseekV4 => true,
+            Renderer::DeepseekV32 | Renderer::DeepseekV4(_) => true,
             Renderer::Jinja => self.chat_template.think_in_prefill(),
         }
     }
@@ -644,10 +644,50 @@ fn detect_renderer_from_config(dir: &Path) -> Renderer {
         return Renderer::DeepseekV32;
     }
     if arch_strs.contains(&"DeepseekV4ForCausalLM") {
-        debug!(?path, "selected DeepseekV4 chat-template renderer");
-        return Renderer::DeepseekV4;
+        let encoding = detect_dsv4_effort_encoding(dir);
+        debug!(
+            ?path,
+            ?encoding,
+            "selected DeepseekV4 chat-template renderer"
+        );
+        return Renderer::DeepseekV4(encoding);
     }
     Renderer::Jinja
+}
+
+/// Marker unique to the 0731 revision of `encoding/encoding_dsv4.py` (its new
+/// `max` effort prompt).
+const DSV4_0731_ENCODER_MARKER: &str = "Reasoning Effort: Beyond maximum";
+
+/// Decide which reasoning-effort prompt revision a DeepSeek V4 checkpoint was
+/// trained with.
+///
+/// `config.json` and `tokenizer_config.json` are byte-identical across the V4
+/// family (the `dspark_*` keys appear in both `-DSpark` and `-0731`, so they
+/// don't discriminate). The only artifact that declares the effort encoding is
+/// the `encoding/encoding_dsv4.py` the checkpoint ships: fingerprint it when
+/// present, and otherwise fall back to a `0731` marker in the model path
+/// (which also covers HF-hub cache dirs, e.g.
+/// `models--deepseek-ai--DeepSeek-V4-Flash-0731/...`). Default to the original
+/// encoding: three of the four released V4 checkpoints use it.
+fn detect_dsv4_effort_encoding(dir: &Path) -> deepseek_v4::EffortEncoding {
+    let encoder_path = dir.join("encoding").join("encoding_dsv4.py");
+    match std::fs::read_to_string(&encoder_path) {
+        Ok(source) => {
+            if source.contains(DSV4_0731_ENCODER_MARKER) {
+                deepseek_v4::EffortEncoding::V0731
+            } else {
+                deepseek_v4::EffortEncoding::Original
+            }
+        }
+        Err(_) => {
+            if dir.to_string_lossy().contains("0731") {
+                deepseek_v4::EffortEncoding::V0731
+            } else {
+                deepseek_v4::EffortEncoding::Original
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -728,23 +768,45 @@ fn apply_deepseek_v32(
 fn apply_deepseek_v4(
     messages: &[serde_json::Value],
     params: &ChatTemplateParams,
+    effort_encoding: deepseek_v4::EffortEncoding,
 ) -> Result<String> {
     let owned = inject_tools_into_messages(messages, params.tools);
     let msgs: &[serde_json::Value] = owned.as_deref().unwrap_or(messages);
-    let thinking_mode = derive_thinking_mode(params);
     let reasoning_effort = params
         .template_kwargs
         .and_then(|k| k.get("reasoning_effort"))
-        .and_then(|v| v.as_str())
-        .and_then(|s| match s {
-            "max" => Some(deepseek_v4::ReasoningEffort::Max),
-            "high" => Some(deepseek_v4::ReasoningEffort::High),
-            _ => None,
-        });
+        .map(|value| {
+            value
+                .as_str()
+                .and_then(|s| effort_encoding.parse_native(s))
+                .ok_or_else(|| {
+                    Error::msg(format!(
+                        "chat_template_kwargs.reasoning_effort must be one of {} for this \
+                         DeepSeek V4 checkpoint, got {value}",
+                        effort_encoding.valid_native_values().join(", "),
+                    ))
+                })
+        })
+        .transpose()?;
+    // A native effort is a request to reason: the prefix only renders in
+    // thinking mode. An explicit `thinking` kwarg / caller preference still
+    // wins, matching the Jinja-path precedence.
+    let explicit_thinking = params
+        .template_kwargs
+        .and_then(|k| k.get("thinking"))
+        .and_then(serde_json::Value::as_bool)
+        .or(params.thinking);
+    let thinking_mode = match explicit_thinking {
+        Some(true) => deepseek_v32::ThinkingMode::Thinking,
+        Some(false) => deepseek_v32::ThinkingMode::Chat,
+        None if reasoning_effort.is_some() => deepseek_v32::ThinkingMode::Thinking,
+        None => derive_thinking_mode(params),
+    };
     let encode_params = deepseek_v4::EncodeParams {
         add_default_bos_token: true,
         drop_thinking: resolve_drop_thinking(msgs),
         reasoning_effort,
+        effort_encoding,
     };
     deepseek_v4::encode_messages(msgs, thinking_mode, &encode_params)
         .map_err(|e| Error::msg(format!("DeepSeek V4 encode failed: {e}")))

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -594,10 +594,11 @@ impl TokenizerTrait for HuggingFaceTokenizer {
             Renderer::Jinja => self.chat_template.thinking_key_name(),
         }
     }
-    fn template_reasoning_effort_enables_thinking(&self) -> bool {
-        // A native effort is a request to reason; apply_deepseek_v4 switches
-        // into thinking mode for it, so report the same preference here.
-        matches!(self.renderer, Renderer::DeepseekV4(_))
+    fn native_reasoning_effort_values(&self) -> &'static [&'static str] {
+        match self.renderer {
+            Renderer::DeepseekV4(encoding) => encoding.valid_native_values(),
+            Renderer::DeepseekV32 | Renderer::Jinja => &[],
+        }
     }
 
     fn think_in_prefill(&self) -> bool {
@@ -661,38 +662,16 @@ fn detect_renderer_from_config(dir: &Path) -> Renderer {
     Renderer::Jinja
 }
 
-/// Marker unique to the 0731 revision of `encoding/encoding_dsv4.py` (its new
-/// `max` effort prompt).
-const DSV4_0731_ENCODER_MARKER: &str = "Reasoning Effort: Beyond maximum";
-
-/// Decide which reasoning-effort prompt revision a DeepSeek V4 checkpoint was
-/// trained with.
-///
-/// `config.json` and `tokenizer_config.json` are byte-identical across the V4
-/// family (the `dspark_*` keys appear in both `-DSpark` and `-0731`, so they
-/// don't discriminate). The only artifact that declares the effort encoding is
-/// the `encoding/encoding_dsv4.py` the checkpoint ships: fingerprint it when
-/// present, and otherwise fall back to a `0731` marker in the model path
-/// (which also covers HF-hub cache dirs, e.g.
-/// `models--deepseek-ai--DeepSeek-V4-Flash-0731/...`). Default to the original
-/// encoding: three of the four released V4 checkpoints use it.
+/// Pick the effort-prompt revision for a V4 checkpoint. `config.json` and
+/// `tokenizer_config.json` are identical across the V4 family, so the only
+/// discriminator is the shipped `encoding/encoding_dsv4.py`; when it is
+/// absent, fall back to a `0731` marker in the path (covers HF-hub cache
+/// dirs like `models--deepseek-ai--DeepSeek-V4-Flash-0731/...`).
 fn detect_dsv4_effort_encoding(dir: &Path) -> deepseek_v4::EffortEncoding {
-    let encoder_path = dir.join("encoding").join("encoding_dsv4.py");
-    match std::fs::read_to_string(&encoder_path) {
-        Ok(source) => {
-            if source.contains(DSV4_0731_ENCODER_MARKER) {
-                deepseek_v4::EffortEncoding::V0731
-            } else {
-                deepseek_v4::EffortEncoding::Original
-            }
-        }
-        Err(_) => {
-            if dir.to_string_lossy().contains("0731") {
-                deepseek_v4::EffortEncoding::V0731
-            } else {
-                deepseek_v4::EffortEncoding::Original
-            }
-        }
+    match std::fs::read_to_string(dir.join("encoding").join("encoding_dsv4.py")) {
+        Ok(source) => deepseek_v4::EffortEncoding::detect_from_encoder_source(&source),
+        Err(_) if dir.to_string_lossy().contains("0731") => deepseek_v4::EffortEncoding::V0731,
+        Err(_) => deepseek_v4::EffortEncoding::Original,
     }
 }
 
@@ -706,17 +685,21 @@ fn detect_dsv4_effort_encoding(dir: &Path) -> deepseek_v4::EffortEncoding {
 /// `ThinkingConfig`) — same precedence as the Jinja path. Default off, matching
 /// the `ThinkingKeyName::Thinking` / `DefaultOff` contract reported here.
 fn derive_thinking_mode(params: &ChatTemplateParams) -> deepseek_v32::ThinkingMode {
-    let enabled = params
-        .template_kwargs
-        .and_then(|k| k.get("thinking"))
-        .and_then(serde_json::Value::as_bool)
-        .or(params.thinking)
-        .unwrap_or(false);
-    if enabled {
+    if explicit_thinking(params).unwrap_or(false) {
         deepseek_v32::ThinkingMode::Thinking
     } else {
         deepseek_v32::ThinkingMode::Chat
     }
+}
+
+/// Explicit thinking preference: `template_kwargs["thinking"]` wins, else
+/// `params.thinking`.
+fn explicit_thinking(params: &ChatTemplateParams) -> Option<bool> {
+    params
+        .template_kwargs
+        .and_then(|k| k.get("thinking"))
+        .and_then(serde_json::Value::as_bool)
+        .or(params.thinking)
 }
 
 /// Per DeepSeek's encoding README, preserve all reasoning when a system or
@@ -778,35 +761,18 @@ fn apply_deepseek_v4(
 ) -> Result<String> {
     let owned = inject_tools_into_messages(messages, params.tools);
     let msgs: &[serde_json::Value] = owned.as_deref().unwrap_or(messages);
+    // Values the revision doesn't recognize are ignored, matching the
+    // template-owns-interpretation contract for merged public efforts.
     let reasoning_effort = params
         .template_kwargs
         .and_then(|k| k.get("reasoning_effort"))
-        .map(|value| {
-            value
-                .as_str()
-                .and_then(|s| effort_encoding.parse_native(s))
-                .ok_or_else(|| {
-                    Error::msg(format!(
-                        "chat_template_kwargs.reasoning_effort must be one of {} for this \
-                         DeepSeek V4 checkpoint, got {value}",
-                        effort_encoding.valid_native_values().join(", "),
-                    ))
-                })
-        })
-        .transpose()?;
-    // A native effort is a request to reason: the prefix only renders in
-    // thinking mode. An explicit `thinking` kwarg / caller preference still
-    // wins, matching the Jinja-path precedence.
-    let explicit_thinking = params
-        .template_kwargs
-        .and_then(|k| k.get("thinking"))
-        .and_then(serde_json::Value::as_bool)
-        .or(params.thinking);
-    let thinking_mode = match explicit_thinking {
-        Some(true) => deepseek_v32::ThinkingMode::Thinking,
-        Some(false) => deepseek_v32::ThinkingMode::Chat,
-        None if reasoning_effort.is_some() => deepseek_v32::ThinkingMode::Thinking,
-        None => derive_thinking_mode(params),
+        .and_then(|v| v.as_str())
+        .and_then(|s| effort_encoding.parse_native(s));
+    // A recognized effort implies thinking; an explicit toggle still wins.
+    let thinking_mode = if explicit_thinking(params).unwrap_or_else(|| reasoning_effort.is_some()) {
+        deepseek_v32::ThinkingMode::Thinking
+    } else {
+        deepseek_v32::ThinkingMode::Chat
     };
     let encode_params = deepseek_v4::EncodeParams {
         add_default_bos_token: true,

--- a/crates/tokenizer/src/traits.rs
+++ b/crates/tokenizer/src/traits.rs
@@ -109,10 +109,11 @@ pub trait Tokenizer: Encoder + Decoder {
         None
     }
 
-    /// Whether a native `chat_template_kwargs.reasoning_effort` value switches
-    /// this tokenizer's renderer into thinking mode.
-    fn template_reasoning_effort_enables_thinking(&self) -> bool {
-        false
+    /// `chat_template_kwargs.reasoning_effort` values that switch this
+    /// tokenizer's renderer into thinking mode. Empty for renderers that
+    /// don't interpret the kwarg natively.
+    fn native_reasoning_effort_values(&self) -> &'static [&'static str] {
+        &[]
     }
 
     /// Whether the template injects `<think>` in the generation prompt.

--- a/crates/tokenizer/src/traits.rs
+++ b/crates/tokenizer/src/traits.rs
@@ -109,6 +109,12 @@ pub trait Tokenizer: Encoder + Decoder {
         None
     }
 
+    /// Whether a native `chat_template_kwargs.reasoning_effort` value switches
+    /// this tokenizer's renderer into thinking mode.
+    fn template_reasoning_effort_enables_thinking(&self) -> bool {
+        false
+    }
+
     /// Whether the template injects `<think>` in the generation prompt.
     fn think_in_prefill(&self) -> bool {
         false

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -343,40 +343,23 @@ mod tests {
     }
 
     #[test]
-    fn shipped_0731_encoder_selects_0731_effort_encoding() {
-        // The dir name says nothing about 0731 — the shipped encoder decides.
+    fn shipped_encoder_fingerprint_beats_dir_name() {
+        // Neutral dir name + 0731 encoder -> 0731 encoding.
         let (_tmp, tok) = write_v4_model_dir("my-local-v4-copy", Some(V0731_ENCODER_SNIPPET));
         let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
-
         let out = render_with_native_effort(&tokenizer, "max").unwrap();
         assert!(out.contains("Reasoning Effort: Beyond maximum"), "{out}");
-        let out = render_with_native_effort(&tokenizer, "high").unwrap();
-        assert!(out.contains("Reasoning Effort: Absolute maximum"), "{out}");
-        assert!(!out.contains("Beyond maximum"), "{out}");
-        // `low` is valid in 0731 and renders no prefix.
-        let out = render_with_native_effort(&tokenizer, "low").unwrap();
-        assert!(!out.contains("Reasoning Effort:"), "{out}");
-    }
 
-    #[test]
-    fn shipped_base_encoder_wins_over_0731_dir_name() {
-        // Fingerprint beats the name: a dir named 0731 that ships the base
-        // encoder still gets the original effort encoding.
+        // 0731 dir name + base encoder -> original encoding, where `low`
+        // doesn't exist and is ignored (no thinking, no prefix).
         let (_tmp, tok) = write_v4_model_dir("DeepSeek-V4-Flash-0731", Some(BASE_ENCODER_SNIPPET));
         let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
-
         let out = render_with_native_effort(&tokenizer, "max").unwrap();
         assert!(out.contains("Reasoning Effort: Absolute maximum"), "{out}");
         assert!(!out.contains("Beyond maximum"), "{out}");
-        // The original Python encoder accepts `high` but renders nothing.
-        let out = render_with_native_effort(&tokenizer, "high").unwrap();
+        let out = render_with_native_effort(&tokenizer, "low").unwrap();
         assert!(!out.contains("Reasoning Effort:"), "{out}");
-        // `low` does not exist in the original revision.
-        let err = render_with_native_effort(&tokenizer, "low").unwrap_err();
-        assert!(
-            err.to_string().contains("must be one of high, max"),
-            "unexpected error: {err}"
-        );
+        assert!(out.ends_with("</think>"), "{out}");
     }
 
     #[test]
@@ -394,29 +377,14 @@ mod tests {
     }
 
     #[test]
-    fn invalid_native_effort_is_rejected_loudly() {
+    fn unrecognized_native_effort_is_ignored() {
+        // The renderer owns interpretation; values outside the revision's set
+        // (including merged public efforts like "medium") render chat mode.
         let (_tmp, tok) = write_v4_model_dir("DeepSeek-V4-Flash-0731", None);
         let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
-        for effort in ["medium", "turbo", "MAX"] {
-            let err = render_with_native_effort(&tokenizer, effort).unwrap_err();
-            assert!(
-                err.to_string().contains("must be one of low, high, max"),
-                "effort {effort}: unexpected error: {err}"
-            );
-        }
-        // Non-string values are rejected too.
-        let messages = vec![json!({ "role": "user", "content": "Hello" })];
-        let kwargs = HashMap::from([("reasoning_effort".to_string(), json!(3))]);
-        let err = tokenizer
-            .apply_chat_template(
-                &messages,
-                ChatTemplateParams {
-                    template_kwargs: Some(&kwargs),
-                    ..Default::default()
-                },
-            )
-            .unwrap_err();
-        assert!(err.to_string().contains("must be one of low, high, max"));
+        let out = render_with_native_effort(&tokenizer, "medium").unwrap();
+        assert!(!out.contains("Reasoning Effort:"), "{out}");
+        assert!(out.ends_with("</think>"), "{out}");
     }
 
     #[test]

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -291,4 +291,159 @@ mod tests {
             "thinking mode should leave a <think> token open"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // 0731-vs-original effort-encoding identification
+    // -----------------------------------------------------------------------
+
+    /// Stand-ins for the `encoding/encoding_dsv4.py` each checkpoint ships;
+    /// only the effort block differs between revisions, so the fingerprint is
+    /// the 0731-only `max` prompt text.
+    const BASE_ENCODER_SNIPPET: &str = r#"REASONING_EFFORT_MAX = (
+    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+)"#;
+    const V0731_ENCODER_SNIPPET: &str = r#"REASONING_EFFORT_PROMPTS = {
+    "low": "",
+    "high": "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n",
+    "max": "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n",
+}"#;
+
+    /// Build `<temp>/<model_name>/` with a V4 config and optionally the
+    /// checkpoint's shipped Python encoder.
+    fn write_v4_model_dir(model_name: &str, encoder_source: Option<&str>) -> (TempDir, String) {
+        let temp = TempDir::new().unwrap();
+        let model_dir = temp.path().join(model_name);
+        fs::create_dir(&model_dir).unwrap();
+        let tok_path = model_dir.join("tokenizer.json");
+        fs::write(&tok_path, MIN_TOKENIZER_JSON).unwrap();
+        fs::write(
+            model_dir.join("config.json"),
+            json!({ "architectures": ["DeepseekV4ForCausalLM"] }).to_string(),
+        )
+        .unwrap();
+        if let Some(source) = encoder_source {
+            let encoding_dir = model_dir.join("encoding");
+            fs::create_dir(&encoding_dir).unwrap();
+            fs::write(encoding_dir.join("encoding_dsv4.py"), source).unwrap();
+        }
+        (temp, tok_path.to_str().unwrap().to_string())
+    }
+
+    fn render_with_native_effort(
+        tokenizer: &HuggingFaceTokenizer,
+        effort: &str,
+    ) -> anyhow::Result<String> {
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let kwargs = HashMap::from([("reasoning_effort".to_string(), json!(effort))]);
+        let params = ChatTemplateParams {
+            template_kwargs: Some(&kwargs),
+            ..Default::default()
+        };
+        tokenizer.apply_chat_template(&messages, params)
+    }
+
+    #[test]
+    fn shipped_0731_encoder_selects_0731_effort_encoding() {
+        // The dir name says nothing about 0731 — the shipped encoder decides.
+        let (_tmp, tok) = write_v4_model_dir("my-local-v4-copy", Some(V0731_ENCODER_SNIPPET));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+
+        let out = render_with_native_effort(&tokenizer, "max").unwrap();
+        assert!(out.contains("Reasoning Effort: Beyond maximum"), "{out}");
+        let out = render_with_native_effort(&tokenizer, "high").unwrap();
+        assert!(out.contains("Reasoning Effort: Absolute maximum"), "{out}");
+        assert!(!out.contains("Beyond maximum"), "{out}");
+        // `low` is valid in 0731 and renders no prefix.
+        let out = render_with_native_effort(&tokenizer, "low").unwrap();
+        assert!(!out.contains("Reasoning Effort:"), "{out}");
+    }
+
+    #[test]
+    fn shipped_base_encoder_wins_over_0731_dir_name() {
+        // Fingerprint beats the name: a dir named 0731 that ships the base
+        // encoder still gets the original effort encoding.
+        let (_tmp, tok) = write_v4_model_dir("DeepSeek-V4-Flash-0731", Some(BASE_ENCODER_SNIPPET));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+
+        let out = render_with_native_effort(&tokenizer, "max").unwrap();
+        assert!(out.contains("Reasoning Effort: Absolute maximum"), "{out}");
+        assert!(!out.contains("Beyond maximum"), "{out}");
+        // The original Python encoder accepts `high` but renders nothing.
+        let out = render_with_native_effort(&tokenizer, "high").unwrap();
+        assert!(!out.contains("Reasoning Effort:"), "{out}");
+        // `low` does not exist in the original revision.
+        let err = render_with_native_effort(&tokenizer, "low").unwrap_err();
+        assert!(
+            err.to_string().contains("must be one of high, max"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_encoder_falls_back_to_dir_name() {
+        let (_tmp, tok) = write_v4_model_dir("DeepSeek-V4-Flash-0731", None);
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let out = render_with_native_effort(&tokenizer, "max").unwrap();
+        assert!(out.contains("Reasoning Effort: Beyond maximum"), "{out}");
+
+        let (_tmp, tok) = write_v4_model_dir("DeepSeek-V4-Flash", None);
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let out = render_with_native_effort(&tokenizer, "max").unwrap();
+        assert!(out.contains("Reasoning Effort: Absolute maximum"), "{out}");
+        assert!(!out.contains("Beyond maximum"), "{out}");
+    }
+
+    #[test]
+    fn invalid_native_effort_is_rejected_loudly() {
+        let (_tmp, tok) = write_v4_model_dir("DeepSeek-V4-Flash-0731", None);
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        for effort in ["medium", "turbo", "MAX"] {
+            let err = render_with_native_effort(&tokenizer, effort).unwrap_err();
+            assert!(
+                err.to_string().contains("must be one of low, high, max"),
+                "effort {effort}: unexpected error: {err}"
+            );
+        }
+        // Non-string values are rejected too.
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let kwargs = HashMap::from([("reasoning_effort".to_string(), json!(3))]);
+        let err = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    template_kwargs: Some(&kwargs),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("must be one of low, high, max"));
+    }
+
+    #[test]
+    fn native_effort_enables_thinking_unless_overridden() {
+        let (_tmp, tok) = write_v4_model_dir("DeepSeek-V4-Flash-0731", None);
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+
+        // Effort alone implies thinking mode (the prefix only exists there).
+        let out = render_with_native_effort(&tokenizer, "max").unwrap();
+        assert!(out.ends_with("<think>"), "{out}");
+
+        // An explicit thinking=false still wins and suppresses the prefix.
+        let kwargs = HashMap::from([
+            ("reasoning_effort".to_string(), json!("max")),
+            ("thinking".to_string(), json!(false)),
+        ]);
+        let out = tokenizer
+            .apply_chat_template(
+                &messages,
+                ChatTemplateParams {
+                    template_kwargs: Some(&kwargs),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(out.ends_with("</think>"), "{out}");
+        assert!(!out.contains("Reasoning Effort:"), "{out}");
+    }
 }

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -29,16 +29,38 @@ mod tests {
         }
     }"#;
     fn write_dir(architectures: Option<&[&str]>) -> (TempDir, String) {
+        write_model_dir(None, architectures, None)
+    }
+
+    /// Build a model dir (optionally named, under the temp root) with the
+    /// minimal tokenizer, an optional V4-style config, and an optional
+    /// shipped Python encoder.
+    fn write_model_dir(
+        model_name: Option<&str>,
+        architectures: Option<&[&str]>,
+        encoder_source: Option<&str>,
+    ) -> (TempDir, String) {
         let temp = TempDir::new().unwrap();
-        let tok_path = temp.path().join("tokenizer.json");
+        let model_dir = match model_name {
+            Some(name) => {
+                let dir = temp.path().join(name);
+                fs::create_dir(&dir).unwrap();
+                dir
+            }
+            None => temp.path().to_path_buf(),
+        };
+        let tok_path = model_dir.join("tokenizer.json");
         fs::write(&tok_path, MIN_TOKENIZER_JSON).unwrap();
         if let Some(archs) = architectures {
-            let cfg_path = temp.path().join("config.json");
             let body = json!({ "architectures": archs }).to_string();
-            fs::write(&cfg_path, body).unwrap();
+            fs::write(model_dir.join("config.json"), body).unwrap();
         }
-        let p = tok_path.to_str().unwrap().to_string();
-        (temp, p)
+        if let Some(source) = encoder_source {
+            let encoding_dir = model_dir.join("encoding");
+            fs::create_dir(&encoding_dir).unwrap();
+            fs::write(encoding_dir.join("encoding_dsv4.py"), source).unwrap();
+        }
+        (temp, tok_path.to_str().unwrap().to_string())
     }
 
     #[test]
@@ -308,25 +330,12 @@ mod tests {
     "max": "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n",
 }"#;
 
-    /// Build `<temp>/<model_name>/` with a V4 config and optionally the
-    /// checkpoint's shipped Python encoder.
     fn write_v4_model_dir(model_name: &str, encoder_source: Option<&str>) -> (TempDir, String) {
-        let temp = TempDir::new().unwrap();
-        let model_dir = temp.path().join(model_name);
-        fs::create_dir(&model_dir).unwrap();
-        let tok_path = model_dir.join("tokenizer.json");
-        fs::write(&tok_path, MIN_TOKENIZER_JSON).unwrap();
-        fs::write(
-            model_dir.join("config.json"),
-            json!({ "architectures": ["DeepseekV4ForCausalLM"] }).to_string(),
+        write_model_dir(
+            Some(model_name),
+            Some(&["DeepseekV4ForCausalLM"]),
+            encoder_source,
         )
-        .unwrap();
-        if let Some(source) = encoder_source {
-            let encoding_dir = model_dir.join("encoding");
-            fs::create_dir(&encoding_dir).unwrap();
-            fs::write(encoding_dir.join("encoding_dsv4.py"), source).unwrap();
-        }
-        (temp, tok_path.to_str().unwrap().to_string())
     }
 
     fn render_with_native_effort(

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -46,27 +46,30 @@ pub(crate) fn extract_thinking_from_kwargs(
     .and_then(|v| v.as_bool())
 }
 
-/// For renderers where a native `chat_template_kwargs.reasoning_effort`
-/// switches the template into thinking mode (DeepSeek V4), report that
-/// preference so downstream reasoning parsing is armed consistently with what
-/// the renderer will emit.
+/// Report `Some(true)` when the renderer will enter thinking mode because of
+/// a native reasoning-effort value, so the reasoning parser is armed
+/// consistently with the rendered prompt. Mirrors the template-kwargs merge:
+/// an explicit kwargs entry wins over the top-level `reasoning_effort` field.
 fn extract_template_effort_thinking(
     kwargs: Option<&std::collections::HashMap<String, Value>>,
+    reasoning_effort: Option<&str>,
     tokenizer: &dyn Tokenizer,
 ) -> Option<bool> {
-    if !tokenizer.template_reasoning_effort_enables_thinking() {
+    let native_values = tokenizer.native_reasoning_effort_values();
+    if native_values.is_empty() {
         return None;
     }
-    match kwargs?.get("reasoning_effort").and_then(Value::as_str) {
-        Some("low" | "high" | "max") => Some(true),
-        _ => None,
-    }
+    let effort = kwargs
+        .and_then(|k| k.get("reasoning_effort"))
+        .and_then(Value::as_str)
+        .or(reasoning_effort)?;
+    native_values.contains(&effort).then_some(true)
 }
 
 /// Precedence for the effective thinking preference: an explicit template
-/// toggle (already extracted from kwargs) always wins, then a native template
-/// effort for renderers that support it, then the protocol-level OpenAI
-/// `reasoning_effort` mapping ([`thinking_from_reasoning_effort`]).
+/// toggle always wins, then a native template effort for renderers that
+/// support it, then the protocol-level OpenAI `reasoning_effort` mapping
+/// ([`thinking_from_reasoning_effort`]).
 fn resolve_thinking_pref(
     explicit: Option<bool>,
     template_effort: Option<bool>,
@@ -77,10 +80,7 @@ fn resolve_thinking_pref(
         .or_else(|| thinking_from_reasoning_effort(reasoning_effort))
 }
 
-/// Resolve the user's effective thinking preference, honoring an explicit
-/// template thinking kwarg first (it always wins), then a native template
-/// effort for renderers that support it, then falling back to the OpenAI
-/// `reasoning_effort` mapping.
+/// Resolve the user's effective thinking preference.
 pub fn resolve_user_thinking(
     kwargs: Option<&std::collections::HashMap<String, Value>>,
     reasoning_effort: Option<&str>,
@@ -88,7 +88,7 @@ pub fn resolve_user_thinking(
 ) -> Option<bool> {
     resolve_thinking_pref(
         extract_thinking_from_kwargs(kwargs, tokenizer),
-        extract_template_effort_thinking(kwargs, tokenizer),
+        extract_template_effort_thinking(kwargs, reasoning_effort, tokenizer),
         reasoning_effort,
     )
 }
@@ -220,42 +220,88 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_thinking_pref_explicit_kwarg_wins() {
-        // An explicit template toggle always wins over the template effort and
-        // the reasoning_effort mapping.
-        assert_eq!(
-            resolve_thinking_pref(Some(true), None, Some("none")),
-            Some(true)
-        );
+    fn resolve_thinking_pref_precedence() {
+        // Explicit toggle > native template effort > reasoning_effort mapping.
         assert_eq!(
             resolve_thinking_pref(Some(false), Some(true), Some("high")),
             Some(false)
         );
-        // A native template effort wins over the public effort mapping.
         assert_eq!(
             resolve_thinking_pref(None, Some(true), Some("none")),
             Some(true)
         );
-        // No explicit toggle -> fall back to the reasoning_effort mapping.
         assert_eq!(resolve_thinking_pref(None, None, Some("none")), Some(false));
-        assert_eq!(
-            resolve_thinking_pref(None, None, Some("minimal")),
-            Some(false)
-        );
         assert_eq!(resolve_thinking_pref(None, None, Some("high")), None);
         assert_eq!(resolve_thinking_pref(None, None, None), None);
     }
 
     #[test]
-    fn deepseek_v4_reasoning_parser_is_available_without_override() {
-        let factory = ReasoningParserFactory::new();
-        let model = "deepseek-ai/DeepSeek-V4-Flash-0731";
+    fn template_effort_thinking_covers_kwargs_and_top_level_field() {
+        use llm_tokenizer::traits::{Encoder, Encoding};
+        struct T(llm_tokenizer::MockTokenizer);
+        impl Encoder for T {
+            fn encode(&self, i: &str, s: bool) -> anyhow::Result<Encoding> {
+                self.0.encode(i, s)
+            }
+            fn encode_batch(&self, i: &[&str], s: bool) -> anyhow::Result<Vec<Encoding>> {
+                self.0.encode_batch(i, s)
+            }
+        }
+        impl llm_tokenizer::traits::Decoder for T {
+            fn decode(&self, ids: &[u32], s: bool) -> anyhow::Result<String> {
+                self.0.decode(ids, s)
+            }
+        }
+        impl Tokenizer for T {
+            fn vocab_size(&self) -> usize {
+                self.0.vocab_size()
+            }
+            fn get_special_tokens(&self) -> &llm_tokenizer::traits::SpecialTokens {
+                self.0.get_special_tokens()
+            }
+            fn token_to_id(&self, t: &str) -> Option<u32> {
+                self.0.token_to_id(t)
+            }
+            fn id_to_token(&self, id: u32) -> Option<String> {
+                self.0.id_to_token(id)
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            fn native_reasoning_effort_values(&self) -> &'static [&'static str] {
+                &["low", "high", "max"]
+            }
+        }
+        let tok = T(llm_tokenizer::MockTokenizer::new());
 
-        assert!(check_reasoning_parser_availability(&factory, None, model));
-        let parser = create_reasoning_parser(&factory, None, model)
-            .expect("DeepSeek V4 parser should be selected automatically");
-        assert_eq!(parser.model_type(), "deepseek_v4");
-        assert!(!parser.is_in_reasoning());
+        // Top-level field arms thinking when the renderer would interpret it.
+        assert_eq!(
+            extract_template_effort_thinking(None, Some("high"), &tok),
+            Some(true)
+        );
+        // Unrecognized values never arm (the renderer ignores them too).
+        assert_eq!(
+            extract_template_effort_thinking(None, Some("medium"), &tok),
+            None
+        );
+        // A kwargs entry wins over the top-level field, matching the merge.
+        let kwargs = std::collections::HashMap::from([(
+            "reasoning_effort".to_string(),
+            Value::String("max".to_string()),
+        )]);
+        assert_eq!(
+            extract_template_effort_thinking(Some(&kwargs), Some("medium"), &tok),
+            Some(true)
+        );
+        // Renderers without native efforts never arm.
+        assert_eq!(
+            extract_template_effort_thinking(
+                Some(&kwargs),
+                Some("high"),
+                &llm_tokenizer::MockTokenizer::new()
+            ),
+            None
+        );
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -46,17 +46,41 @@ pub(crate) fn extract_thinking_from_kwargs(
     .and_then(|v| v.as_bool())
 }
 
+/// For renderers where a native `chat_template_kwargs.reasoning_effort`
+/// switches the template into thinking mode (DeepSeek V4), report that
+/// preference so downstream reasoning parsing is armed consistently with what
+/// the renderer will emit.
+fn extract_template_effort_thinking(
+    kwargs: Option<&std::collections::HashMap<String, Value>>,
+    tokenizer: &dyn Tokenizer,
+) -> Option<bool> {
+    if !tokenizer.template_reasoning_effort_enables_thinking() {
+        return None;
+    }
+    match kwargs?.get("reasoning_effort").and_then(Value::as_str) {
+        Some("low" | "high" | "max") => Some(true),
+        _ => None,
+    }
+}
+
 /// Precedence for the effective thinking preference: an explicit template
-/// toggle (already extracted from kwargs) always wins; otherwise fall back to
-/// the protocol-level OpenAI `reasoning_effort` mapping
-/// ([`thinking_from_reasoning_effort`]).
-fn resolve_thinking_pref(explicit: Option<bool>, reasoning_effort: Option<&str>) -> Option<bool> {
-    explicit.or_else(|| thinking_from_reasoning_effort(reasoning_effort))
+/// toggle (already extracted from kwargs) always wins, then a native template
+/// effort for renderers that support it, then the protocol-level OpenAI
+/// `reasoning_effort` mapping ([`thinking_from_reasoning_effort`]).
+fn resolve_thinking_pref(
+    explicit: Option<bool>,
+    template_effort: Option<bool>,
+    reasoning_effort: Option<&str>,
+) -> Option<bool> {
+    explicit
+        .or(template_effort)
+        .or_else(|| thinking_from_reasoning_effort(reasoning_effort))
 }
 
 /// Resolve the user's effective thinking preference, honoring an explicit
-/// template thinking kwarg first (it always wins), then falling back to the
-/// OpenAI `reasoning_effort` mapping.
+/// template thinking kwarg first (it always wins), then a native template
+/// effort for renderers that support it, then falling back to the OpenAI
+/// `reasoning_effort` mapping.
 pub fn resolve_user_thinking(
     kwargs: Option<&std::collections::HashMap<String, Value>>,
     reasoning_effort: Option<&str>,
@@ -64,6 +88,7 @@ pub fn resolve_user_thinking(
 ) -> Option<bool> {
     resolve_thinking_pref(
         extract_thinking_from_kwargs(kwargs, tokenizer),
+        extract_template_effort_thinking(kwargs, tokenizer),
         reasoning_effort,
     )
 }
@@ -196,17 +221,41 @@ mod tests {
 
     #[test]
     fn resolve_thinking_pref_explicit_kwarg_wins() {
-        // An explicit template toggle always wins over the reasoning_effort mapping.
-        assert_eq!(resolve_thinking_pref(Some(true), Some("none")), Some(true));
+        // An explicit template toggle always wins over the template effort and
+        // the reasoning_effort mapping.
         assert_eq!(
-            resolve_thinking_pref(Some(false), Some("high")),
+            resolve_thinking_pref(Some(true), None, Some("none")),
+            Some(true)
+        );
+        assert_eq!(
+            resolve_thinking_pref(Some(false), Some(true), Some("high")),
             Some(false)
         );
+        // A native template effort wins over the public effort mapping.
+        assert_eq!(
+            resolve_thinking_pref(None, Some(true), Some("none")),
+            Some(true)
+        );
         // No explicit toggle -> fall back to the reasoning_effort mapping.
-        assert_eq!(resolve_thinking_pref(None, Some("none")), Some(false));
-        assert_eq!(resolve_thinking_pref(None, Some("minimal")), Some(false));
-        assert_eq!(resolve_thinking_pref(None, Some("high")), None);
-        assert_eq!(resolve_thinking_pref(None, None), None);
+        assert_eq!(resolve_thinking_pref(None, None, Some("none")), Some(false));
+        assert_eq!(
+            resolve_thinking_pref(None, None, Some("minimal")),
+            Some(false)
+        );
+        assert_eq!(resolve_thinking_pref(None, None, Some("high")), None);
+        assert_eq!(resolve_thinking_pref(None, None, None), None);
+    }
+
+    #[test]
+    fn deepseek_v4_reasoning_parser_is_available_without_override() {
+        let factory = ReasoningParserFactory::new();
+        let model = "deepseek-ai/DeepSeek-V4-Flash-0731";
+
+        assert!(check_reasoning_parser_availability(&factory, None, model));
+        let parser = create_reasoning_parser(&factory, None, model)
+            .expect("DeepSeek V4 parser should be selected automatically");
+        assert_eq!(parser.model_type(), "deepseek_v4");
+        assert!(!parser.is_in_reasoning());
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

The DeepSeek-V4-Flash-0731 refresh changed the reasoning-effort prompt encoding relative to the original checkpoint family, and the two cannot be told apart by `config.json` or `tokenizer_config.json`:

- **Original** (`DeepSeek-V4-Flash`, `-DSpark`, `-Pro`): accepts `high`/`max`; only `max` emits a prefix ("Reasoning Effort: Absolute maximum …"); `high` renders nothing.
- **0731**: levels shifted down one — `high` now emits the original's `max` text, `max` emits a new stronger text ("Reasoning Effort: Beyond maximum …"), and `low` (no prefix) is the default.

`architectures`/`model_type` are identical across the family, `tokenizer_config.json` is byte-identical, and the `dspark_*` config keys don't discriminate (`-DSpark` has them but ships the *original* encoding). vLLM sidesteps this by unconditionally applying 0731 semantics to every `DeepseekV4ForCausalLM` (commit `7743486190`), silently changing behavior for the three original-encoding checkpoints. SMG previously rendered only the original encoding and had **no registered reasoning parser** for DeepSeek V4 — the nightly BFCL leg pinned `deepseek_v31` with a `TODO(confirm)`, which mis-splits because the V4 template prefills `<think>` (the same failure class recorded for Kimi-K2.6 in `nightly-bfcl.yml`).

### Solution

Identify the encoding revision from the checkpoint itself: the only artifact that declares it is the `encoding/encoding_dsv4.py` the checkpoint ships. At renderer-detection time (where we already read the sibling `config.json`), fingerprint that file for the 0731-only `max` prompt text (the marker is derived from the ported prompt constant, so they cannot drift); when the repo was pruned, fall back to a `0731` marker in the model path (covers HF cache layouts like `models--deepseek-ai--DeepSeek-V4-Flash-0731/...`); default to the original encoding, which three of the four released checkpoints use.

The encoder renders the correct per-revision prefixes. A recognized native effort implies thinking mode (an explicit `thinking` toggle still wins); unrecognized values are ignored, preserving the existing template-owns-interpretation contract for the merged public `reasoning_effort` field. The tokenizer exposes its per-revision native effort values through the `Tokenizer` trait (defaulted, non-breaking), and request processing uses that single source of truth to arm reasoning separation consistently with the rendered prompt — for both `chat_template_kwargs.reasoning_effort` and the top-level field. A `deepseek_v4` reasoning parser is registered and auto-selected from the model name.

Scope note: strict validation of effort values and mapping OpenAI-level `reasoning_effort` / Responses `reasoning.effort` names into the native buckets require provenance (native kwarg vs merged public field) and come in a follow-up PR, along with the Responses API usage/reasoning preservation fixes (splitting up #2025).

## Changes

- `crates/tokenizer/src/encoders/deepseek_v4.rs`: `EffortEncoding { Original, V0731 }` with `parse_native`/`valid_native_values` and `detect_from_encoder_source`; `ReasoningEffort::Low`; revision-aware prefix rendering.
- `crates/tokenizer/src/huggingface.rs`: `Renderer::DeepseekV4(EffortEncoding)`; detection (shipped-encoder fingerprint → path fallback → original default); native effort implies thinking mode.
- `crates/tokenizer/src/traits.rs` + `cache/mod.rs`: `native_reasoning_effort_values` trait hook (defaults to empty; only the DeepSeek V4 renderer opts in).
- `model_gateway/src/routers/grpc/utils/parsers.rs`: arm reasoning parsing when the renderer will enter thinking mode from a native effort (kwargs entry wins over the top-level field, mirroring the template-kwargs merge).
- `crates/reasoning_parser/src/factory.rs`: register `deepseek_v4` parser and map `deepseek-v4`/`deepseek_v4` model names to it.

## Test Plan

- `cargo test -p llm-tokenizer` — 188 tests pass, covering per-revision prefix rendering, fingerprint-beats-dir-name, dir-name fallback, unrecognized-effort tolerance, native-effort-implies-thinking with explicit override, and encoder-source detection.
- `cargo test -p reasoning-parser` — 99 tests pass, including V4 parser auto-selection.
- `cargo test -p smg routers::grpc::utils::parsers` — thinking-precedence tiers and kwargs-vs-top-level arming.
- Byte-exact validation against the 0731 checkpoint's own golden encode vectors (`encoding/tests/test_{input,output}_{1..4}`): all 4 cases match.
- `cargo +nightly fmt --all -- --check` and `cargo clippy -p llm-tokenizer -p reasoning-parser -p smg --all-targets -- -D warnings` pass (workspace-wide `--all-features` clippy blocked locally by the pre-existing `llm-multimodal` pkg-config/OpenCV requirement, same as #2025).
- Live B300 validation (TP2 per arm, vLLM 0.26.0): BFCL A/B at parity with pure vLLM (+0.42pp overall, never worse per category; details in comments), full effort matrix verified through the SMG arm for both `chat_template_kwargs.reasoning_effort` and the top-level field.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (changed crates; workspace blocked locally by pkg-config/OpenCV)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
