### PR TITLE
ci(bench): re-pin BFCL and tau2 deepseek-v4 legs to Flash-0731

### DIFF
--- a/.github/workflows/nightly-bfcl.yml
+++ b/.github/workflows/nightly-bfcl.yml
@@ -161,16 +161,16 @@ jobs:
               # Concurrent TP=4 per arm (0-3 + 4-7).
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
-               # Base V4-Flash: the -0731 refresh is not supported yet.
-               "model": "deepseek-ai/DeepSeek-V4-Flash", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-FC",
+               # -0731 encoding + deepseek_v4 SMG reasoning parser landed in #2080;
+               # B300 A/B validated at parity (simple_python/irrelevance/multiple).
+               "model": "deepseek-ai/DeepSeek-V4-Flash-0731", "bfcl_model": "deepseek-ai/DeepSeek-V4-Flash-0731-FC",
                "vllm_tool": "deepseek_v4", "vllm_reason": "deepseek_v4",
-               "smg_tool": "deepseek_v4",
-               "smg_reason": "deepseek_v31",  # TODO(confirm): no deepseek_v4 SMG reasoning parser yet
+               "smg_tool": "deepseek_v4", "smg_reason": "deepseek_v4",
                # --kv-cache-dtype fp8 + --block-size 256 REQUIRED: V4's FlashMLA fp8
                # kernel asserts fp8 kv-cache (else EngineCore dies at startup).
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
                "gpu_mem": "0.90", "startup_timeout": "2400", "model_cache": "/raid/models",
-               # No healthy baseline yet; kept tight until the leg scores cleanly.
+               # Kept tight until the first clean nightly score on this leg.
                "run_timeout": "5400",
                "arm_mode": "concurrent", "max_model_len": "auto"},
               {"name": "minimax-m2.7", "runner": "blackwell", "tp": 4,

--- a/.github/workflows/nightly-tau2.yml
+++ b/.github/workflows/nightly-tau2.yml
@@ -166,10 +166,10 @@ jobs:
               # Concurrent TP=4 per arm (0-3 + 4-7); num_tasks-capped.
               {"name": "deepseek-v4", "runner": "blackwell", "tp": 4,
                "gpu_a": "0,1,2,3", "gpu_b": "4,5,6,7",
-               # Base V4-Flash: the -0731 refresh is not supported yet.
-               "model": "deepseek-ai/DeepSeek-V4-Flash",
+               # -0731 encoding + deepseek_v4 SMG reasoning parser landed in #2080.
+               "model": "deepseek-ai/DeepSeek-V4-Flash-0731",
                "vllm_tool": "deepseek_v4", "vllm_reason": "deepseek_v4",
-               "smg_tool": "deepseek_v4", "smg_reason": "deepseek_v31",
+               "smg_tool": "deepseek_v4", "smg_reason": "deepseek_v4",
                "vllm_extra": "--tokenizer-mode deepseek_v4 --trust-remote-code --kv-cache-dtype fp8 --block-size 256",
                "gpu_mem": "0.90", "startup_timeout": "2400", "model_cache": "/raid/models",
                "arm_mode": "concurrent", "max_model_len": "auto", "num_tasks": 30,

--- a/scripts/bfcl/README.md
+++ b/scripts/bfcl/README.md
@@ -64,7 +64,7 @@ Key env knobs for `launch_arm.sh`: `BFCL_GPU` (CUDA_VISIBLE_DEVICES, e.g. `0,1`)
 |---|---|---|---|---|
 | Qwen3.6-27B (`qwen3.6`) | `4-gpu-h100` | 2 | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
 | gpt-oss-120b (`gpt-oss`) | `4-gpu-h100` | 2 | `openai` / — | _(none — SMG auto-routes harmony)_ / — |
-| DeepSeek-V4-Flash (`deepseek-v4`) | `blackwell` | 4 | `deepseek_v4` / `deepseek_v4` (+`--tokenizer-mode deepseek_v4 --trust-remote-code`) | `deepseek_v4` / `deepseek_v31`† |
+| DeepSeek-V4-Flash-0731 (`deepseek-v4`) | `blackwell` | 4 | `deepseek_v4` / `deepseek_v4` (+`--tokenizer-mode deepseek_v4 --trust-remote-code`) | `deepseek_v4` / `deepseek_v4` |
 | MiniMax-M2.7 (`minimax-m2.7`) | `blackwell` | 4 | `minimax_m2` / `minimax_m2` (+`--trust-remote-code`) | `minimax_m2` / `minimax` |
 | Kimi-K2.6 int4 (`kimi-k2.6`) | `blackwell` | 4 | `kimi_k2` / `kimi_k2` (+`--trust-remote-code`) | `kimik2` / `kimi_k25`† |
 
@@ -75,10 +75,10 @@ Key env knobs for `launch_arm.sh`: `BFCL_GPU` (CUDA_VISIBLE_DEVICES, e.g. `0,1`)
 > `—` in **both** reasoning-parser columns for gpt-oss is likewise intentional:
 > harmony carries its own reasoning channel, so neither arm sets a reasoning parser.
 >
-> **† Reasoning-parser fallbacks.** SMG's reasoning registry has no `deepseek_v4` or
-> `kimi_k2` entry yet; the closest existing parsers (`deepseek_v31`, `kimi_k25`) are
-> used. Confirm on the first nightly; adding exact parsers to `crates/reasoning_parser`
-> is a follow-up if outputs diverge.
+> **† Reasoning-parser fallbacks.** SMG's reasoning registry has no `kimi_k2` entry
+> yet; the closest existing parser (`kimi_k25`) is used. Confirm on the first
+> nightly; adding exact parsers to `crates/reasoning_parser` is a follow-up if
+> outputs diverge.
 >
 > The mid-2026 SKU ids and a couple of vLLM parser names may shift; confirm against
 > the installed vLLM build: `vllm serve --help | grep -A40 tool-call-parser`.
@@ -89,7 +89,7 @@ The nightly (`.github/workflows/nightly-bfcl.yml`) runs the A/B as a GitHub Acti
 matrix — one leg per model, `fail-fast: false`, each on its own runner:
 
 - `4-gpu-h100` — Qwen3.6-27B and gpt-oss-120b, TP=2 per arm (GPUs 0,1 + 2,3).
-- `blackwell` (B200) — DeepSeek-V4-Flash, MiniMax-M2.7, Kimi-K2.6 int4, TP=4 per arm
+- `blackwell` (B200) — DeepSeek-V4-Flash-0731, MiniMax-M2.7, Kimi-K2.6 int4, TP=4 per arm
   (GPUs 0-3 + 4-7).
 
 All legs use `max_model_len` **32768**: the `multi_turn` categories emit ~18k-token
@@ -107,7 +107,7 @@ Each leg sets `arm_mode`:
   saved score files. Flip a leg's `arm_mode` to enable it.
 
 Per the A/B's premise, model size is irrelevant — a smaller same-family checkpoint
-exercises the identical parser — so the matrix uses DeepSeek-V4-Flash and int4
+exercises the identical parser — so the matrix uses DeepSeek-V4-Flash-0731 and int4
 Kimi-K2.6 to validate the `deepseek_v4` / `kimi_k2` parsers without the full weights.
 
 `workflow_dispatch` can target one leg via the `only` input and override

--- a/scripts/tau2/README.md
+++ b/scripts/tau2/README.md
@@ -97,7 +97,7 @@ dominated by model-load time, serialized by a host lock, so a PR run is not fast
 |---|---|---|---|---|
 | qwen3.6 | Qwen/Qwen3.6-27B | 4-gpu-h100 (2) | `qwen3_xml` / `qwen3` | `qwen_xml` / `qwen3` |
 | gpt-oss | openai/gpt-oss-120b | 4-gpu-h100 (2) | `openai` / — | — / — (harmony auto) |
-| deepseek-v4 | deepseek-ai/DeepSeek-V4-Flash | blackwell (4) | `deepseek_v4` / `deepseek_v4` | `deepseek_v4` / `deepseek_v31` |
+| deepseek-v4 | deepseek-ai/DeepSeek-V4-Flash-0731 | blackwell (4) | `deepseek_v4` / `deepseek_v4` | `deepseek_v4` / `deepseek_v4` |
 | minimax-m2.7 | MiniMaxAI/MiniMax-M2.7 | blackwell (4) | `minimax_m2` / `minimax_m2` | `minimax_m2` / `minimax` |
 | kimi-k2.6 | moonshotai/Kimi-K2.6 | blackwell (4) | `kimi_k2` / `kimi_k2` | `kimik2` / `kimi_k25` |
 | glm-5.2 | zai-org/GLM-5.2-FP8 | blackwell (8, seq) | `glm47` / `glm45` | `glm47_moe` / `glm45` |


### PR DESCRIPTION
## Description

### Problem

The nightly BFCL and tau2 `deepseek-v4` legs were un-pinned from `DeepSeek-V4-Flash-0731` back to the base checkpoint in #2070, because every `-0731` nightly burned the entire job producing non-terminating garbage on the SMG arm with nothing scored. The SMG arm also ran with a `deepseek_v31` reasoning-parser fallback (`TODO(confirm)`) — the mis-split failure class documented for Kimi-K2.6 in the same workflow — since no `deepseek_v4` reasoning parser existed.

### Solution

#2080 landed the 0731 effort encoding with per-checkpoint identification and registered a real `deepseek_v4` SMG reasoning parser, and validated the stack live on a B300 A/B against `DeepSeek-V4-Flash-0731` (TP2 per arm, vLLM 0.26.0 engines): SMG scored at parity with pure vLLM (+0.42pp unweighted overall across `simple_python`/`irrelevance`/`multiple`, never worse on any category), with clean stops throughout — the full 840-case × 2-arm run finished in ~4.5 minutes, where nightlies previously died at the 360m cap. Details: https://github.com/smg-project/smg/pull/2080#issuecomment-5230452525

Re-pin both legs to `-0731` and use the real parser.

## Changes

- `.github/workflows/nightly-bfcl.yml`: `deepseek-v4` leg model/handler → `deepseek-ai/DeepSeek-V4-Flash-0731`(-FC); `smg_reason` `deepseek_v31` → `deepseek_v4`; comments updated. `run_timeout` stays at 5400s until the first clean nightly score.
- `.github/workflows/nightly-tau2.yml`: same re-pin and parser change for the `deepseek-v4` leg.
- `scripts/bfcl/README.md`, `scripts/tau2/README.md`: matrix tables and the reasoning-parser-fallback footnote updated to match.

Note for the Blackwell runner: `-0731` weights (~156 GB) may need pre-staging at `/raid/models/deepseek-ai/DeepSeek-V4-Flash-0731`; otherwise the first run downloads them via the HF id.

## Test Plan

- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflow files — parses clean.
- Config-only change; the serving stack itself was validated end-to-end on B300 in #2080 (BFCL A/B parity table + effort matrix posted there), including a 50/50 `simple_python` tool-call pre-check through the SMG arm with auto-selected parsers.
- First scheduled run (BFCL Mon/Wed/Fri, tau2 Tue/Thu/Sat, 07:17 UTC) will confirm on the CI runner; the exit-2 unscored-arm gate from #2070 fails the leg loudly if anything regresses.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
