### PR TITLE
fix(e2e): disable layerwise PD transfer for tokenspeed disaggregation workers

### DIFF
--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -183,6 +183,14 @@ MODEL_SPECS: dict[str, dict] = {
             "4",
             "--gpu-memory-utilization",
             "0.8",
+            # This model's hybrid-attention KV pool opts into tokenspeed's
+            # paged-cache PD adjunct on prefill/decode roles, which rejects
+            # layerwise transfer — yet layerwise defaults ON (interval=1), so
+            # the engine dies at startup under its own defaults. Scoped here
+            # rather than to every disaggregation worker: non-hybrid models
+            # support layerwise and should keep exercising that default path.
+            "--disaggregation-layerwise-interval",
+            "0",
         ],
         # TokenSpeed-only (GDN + MoE arch won't load under sglang/vllm/trt), so
         # keep it out of the tier-wide pre-download; the EPD job fetches it by id.

--- a/e2e_test/infra/test_epd_cmd_builders.py
+++ b/e2e_test/infra/test_epd_cmd_builders.py
@@ -112,3 +112,7 @@ def test_qwen35_9b_spec_present_and_multimodal():
     ts_args = spec["tokenspeed_args"]
     assert "--attention-backend" in ts_args
     assert ts_args[ts_args.index("--attention-backend") + 1] == "fa3"
+    # Hybrid-attention pool + paged-cache PD adjunct rejects layerwise
+    # transfer; the spec must pin it off or PD/EPD workers die at startup.
+    idx = ts_args.index("--disaggregation-layerwise-interval")
+    assert ts_args[idx + 1] == "0"


### PR DESCRIPTION
## Problem

`e2e-4gpu-epd (tokenspeed)` is red on main since the pin bump (#2081, first failing commit `234b5026`): the Qwen3.5-9B worker dies at startup with

```
NotImplementedError: Paged-cache PD currently does not support: layerwise cache transfer
```

## Cause

The bumped tokenspeed carries the paged-cache PD adjunct (entered at `57b49061` — the same commit as the msgpack ZMQ mode). **Hybrid-attention** KV pools (Qwen3.5's `hybrid_mha`) opt into it on prefill/decode roles via `supports_disaggregation`, and the adjunct's guard rejects layerwise cache transfer. But layerwise defaults **on** (`disaggregation_layerwise_interval: int = 1` in `server_args.py`), so a hybrid-model PD launch crashes under tokenspeed's own defaults.

This regression is from the `0f686760 → 57b49061` span, not the newest commits — the EPD lane failed identically on the #2060 branch runs that pinned `57b49061` directly.

## Scope — deliberately narrow

Only workers where **both** hold: a disaggregation role (prefill/decode) **and** a hybrid-attention model whose pool opts in. Regular tokenspeed workers (ZMQ direct backend, gRPC servicer, every chat-lane model) are untouched, and non-hybrid models in PD roles still run layerwise fine.

Accordingly the flag is pinned in the **Qwen3.5 model spec** (`tokenspeed_args`), not blanket-applied to every disaggregation worker — non-hybrid PD tests should keep exercising layerwise, the default production path. A builder test pins the flag's presence.

## Verification

- `test_epd_cmd_builders.py`: 10 passed locally (includes the new assertion).
- The `e2e-4gpu-epd (tokenspeed)` lane on this PR is the live test.

The self-conflicting upstream default (pool opts in + layerwise default = crash on defaults) is worth reconciling in tokenspeed itself — auto-disable layerwise when the paged adjunct engages instead of dying at startup.