### PR TITLE
test(responses): stop pinning OpenAI's mcp_list_tools cache behavior

### DIFF
--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -289,7 +289,11 @@ def assert_previous_response_id_mcp_binding_behavior_non_streaming(model, api_cl
     )
     assert resp3.error is None
     assert resp3.status == "completed"
-    assert mcp_list_tools_labels(resp3.output) == ["deepwiki"]
+    # OpenAI may serve the newly added server's tool list from cache (other
+    # tests in this suite attach deepwiki minutes earlier), in which case no
+    # mcp_list_tools item is emitted. Pin only the stable contract: existing
+    # bindings are never relisted, and the request still completes with calls.
+    assert mcp_list_tools_labels(resp3.output) in ([], ["deepwiki"])
     assert any(item.type == "mcp_call" for item in resp3.output)
 
 
@@ -341,12 +345,20 @@ def assert_previous_response_id_mcp_binding_behavior_streaming(model, api_client
             reasoning={"effort": "low"},
         )
     )
-    assert streaming_added_mcp_list_tools_labels(events3) == ["deepwiki"]
-    assert [e.type for e in events3].count("response.mcp_list_tools.in_progress") == 1
-    assert [e.type for e in events3].count("response.mcp_list_tools.completed") == 1
+    # Same cache caveat as the non-streaming variant: the added server's
+    # listing may be cache-suppressed, but a listing for an already-bound
+    # server must never reappear, and the event stream must stay consistent
+    # with whichever happened.
+    labels3 = streaming_added_mcp_list_tools_labels(events3)
+    assert labels3 in ([], ["deepwiki"])
+    expected_listings = len(labels3)
+    assert [e.type for e in events3].count(
+        "response.mcp_list_tools.in_progress"
+    ) == expected_listings
+    assert [e.type for e in events3].count("response.mcp_list_tools.completed") == expected_listings
     completed_events = [e for e in events3 if e.type == "response.completed"]
     assert len(completed_events) == 1
-    assert mcp_list_tools_labels(completed_events[0].response.output) == ["deepwiki"]
+    assert mcp_list_tools_labels(completed_events[0].response.output) == labels3
 
 
 @pytest.mark.vendor("openai")


### PR DESCRIPTION
## Problem

`test_previous_response_id_mcp_binding_behavior[openai]` (and its streaming twin) is a recurring flake that usually needs manual retries — most recently 3 consecutive failures on #2083's `openai-responses` job:

```
assert mcp_list_tools_labels(resp3.output) == ["deepwiki"]
E   AssertionError: assert [] == ['deepwiki']
```

## Root cause

Turn 3 adds the deepwiki MCP server to a resumed conversation and asserts a fresh `mcp_list_tools` item appears. But OpenAI documents the imported tool list as **cacheable**, and several other tests in this suite attach the same deepwiki server minutes earlier. When OpenAI serves the listing from cache, the turn completes with deepwiki fully bound but emits no relist item — the strict `== ["deepwiki"]` then fails. Timing/test-order dependent, hence the flake pattern.

## Fix

The contract this test exists to pin (from #1060, our no-relist-on-resume gateway behavior) is narrower than what it asserted. Keep the load-bearing assertions exact:
- turn 2: an already-bound server is **never** relisted (`== []`) and the call still happens — untouched;
- turn 1/2 assertions untouched entirely (they have not flaked; weakening them would give up real signal).

Relax only the cache-dependent piece: the added server's listing may be present **or** cache-suppressed (`in ([], ["deepwiki"])`), and in the streaming variant the `mcp_list_tools.in_progress`/`completed` event counts and the final output must stay consistent with whichever happened — so a relist of *brave* (a real contract violation) still fails loudly.