### PR TITLE
fix(ci): resolve flashinfer-jit-cache index to the nearest published CUDA tag

### DIFF
--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -52,6 +52,17 @@ uv pip install --prerelease=allow "sglang[all]==0.5.16"
 FLASHINFER_VERSION=$(uv pip show flashinfer-python 2>/dev/null | grep "^Version:" | awk '{print $2}')
 CU_VERSION=$(python3 -c "import torch; print('cu' + torch.version.cuda.replace('.', ''))" 2>/dev/null || echo "cu130")
 if [ -n "$FLASHINFER_VERSION" ]; then
+    # flashinfer hosts one wheel index per CUDA tag and lags new CUDA minors
+    # (a missing index 404s and uv reports it as "package not found"). CUDA
+    # minor versions are ABI-compatible, so walk down to the nearest
+    # published tag in this major.
+    CUDA_TAG=${CU_VERSION#cu}
+    CUDA_MAJOR_FLOOR=$((CUDA_TAG / 10 * 10))
+    while [ "${CUDA_TAG}" -gt "${CUDA_MAJOR_FLOOR}" ] \
+        && ! curl -sfo /dev/null "https://flashinfer.ai/whl/cu${CUDA_TAG}/flashinfer-jit-cache/"; do
+        CUDA_TAG=$((CUDA_TAG - 1))
+    done
+    CU_VERSION="cu${CUDA_TAG}"
     echo "Installing flashinfer-jit-cache==${FLASHINFER_VERSION} (${CU_VERSION})..."
     uv pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
         --index-url "https://flashinfer.ai/whl/${CU_VERSION}"

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -87,6 +87,15 @@ fi
 echo "Installing flashinfer-jit-cache..."
 CUDA_TAG=$(python3 -c "import torch; print(torch.version.cuda.replace('.', ''))")
 FLASHINFER_VERSION=$(python3 -c "import importlib.metadata as m; print(m.version('flashinfer-python'))")
+# flashinfer hosts one wheel index per CUDA tag and lags new CUDA minors
+# (torch moved to +cu132 while the newest index is cu130; a missing index
+# 404s and uv reports it as "package not found"). CUDA minor versions are
+# ABI-compatible, so walk down to the nearest published tag in this major.
+CUDA_MAJOR_FLOOR=$((CUDA_TAG / 10 * 10))
+while [ "${CUDA_TAG}" -gt "${CUDA_MAJOR_FLOOR}" ] \
+    && ! curl -sfo /dev/null "https://flashinfer.ai/whl/cu${CUDA_TAG}/flashinfer-jit-cache/"; do
+    CUDA_TAG=$((CUDA_TAG - 1))
+done
 uv pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
     --index-url "https://flashinfer.ai/whl/cu${CUDA_TAG}"
 


### PR DESCRIPTION
## Problem

Every vLLM e2e lane dies in **Setup** (~1m40s) on main and on this PR's first revision:

```
× No solution found ... flashinfer-jit-cache==0.6.16.post3 was not found in the package registry
```

## Real cause (first revision of this PR diagnosed it wrong)

torch now resolves to `2.13.0+cu132` in the vLLM install. The scripts derive the flashinfer wheel index from `torch.version.cuda`, but flashinfer hosts **one index per CUDA tag** and its newest is `cu130` — `https://flashinfer.ai/whl/cu132` 404s, and uv reports a missing index as *"package not found in the registry"*. The `.post3` in the error was a red herring: `0.6.16.post3` exists on the cu130 index (verified live). This PR's first revision added a version fallback for that red herring; both its installs failed identically because the index itself was absent.

## Fix

CUDA minor versions are ABI-compatible, so probe the index URL and walk down to the nearest published tag within the same major:

```bash
CUDA_MAJOR_FLOOR=$((CUDA_TAG / 10 * 10))
while [ "${CUDA_TAG}" -gt "${CUDA_MAJOR_FLOOR}" ] \
    && ! curl -sfo /dev/null "https://flashinfer.ai/whl/cu${CUDA_TAG}/flashinfer-jit-cache/"; do
    CUDA_TAG=$((CUDA_TAG - 1))
done
```

Applied to both `ci_install_vllm.sh` and `ci_install_sglang.sh` — sglang's torch is still cu130 so its lanes pass today, but it carries the same latent assumption. The major floor stops the walk from crossing into cu12x (a different ABI).

Verified against the live index: 132 → 130; 130 stays 130.

## Verification

The vLLM lanes on this PR exercise the cu132→cu130 walk end-to-end; the sglang lanes prove no regression on the already-working path.