### PR TITLE
feat(zmq): vLLM DP>1 as grouped engine workers with least-loaded selection

### DIFF
--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -59,6 +59,11 @@ on:
         type: string
         default: ""
         description: "Wire override for local backends: zmq runs the local cases over ZMQ"
+      zmq_engine_count:
+        required: false
+        type: string
+        default: ""
+        description: "DP engines per ZMQ worker (grouped vLLM launch; empty = 1)"
 
 jobs:
   run:
@@ -72,6 +77,7 @@ jobs:
       E2E_GPU_TIER: ${{ inputs.gpu_tier }}
       E2E_VLLM_KV_BACKEND: ${{ inputs.vllm_kv_backend }}
       E2E_CONNECTION_MODE: ${{ inputs.connection_mode }}
+      E2E_ZMQ_ENGINE_COUNT: ${{ inputs.zmq_engine_count }}
       ROUTER_LOCAL_MODEL_PATH: /models
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -582,6 +582,33 @@ jobs:
       connection_mode: zmq
     secrets: inherit
 
+  e2e-2gpu-chat-zmq-dp:
+    name: e2e-2gpu-chat-zmq-dp (vllm)
+    needs: [build-wheel, detect-changes]
+    if: >-
+      always()
+      && !cancelled()
+      && needs.build-wheel.result == 'success'
+      && (github.event_name != 'pull_request'
+          || (needs.detect-changes.result == 'success'
+              && (needs.detect-changes.outputs.common == 'true'
+                  || needs.detect-changes.outputs.chat-completions == 'true')))
+    # The 1-GPU ZMQ suite with grouped workers: each vLLM ZMQ worker launches
+    # two DP engines on one socket set (tp=1 models, one GPU per engine), so
+    # the gateway's handshake, the connector's least-loaded selection, and the
+    # wave protocol all run against a real dp=2 group.
+    uses: ./.github/workflows/e2e-gpu-job.yml
+    with:
+      engine: vllm
+      gpu_tier: "2"
+      runner: 2-gpu-h100
+      timeout: 46
+      test_timeout: 40
+      test_dirs: e2e_test/chat_completions
+      connection_mode: zmq
+      zmq_engine_count: "2"
+    secrets: inherit
+
   e2e-1gpu-completions:
     name: e2e-1gpu-completions (${{ matrix.engine }})
     needs: [build-wheel, detect-changes]

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -600,7 +600,10 @@ jobs:
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: vllm
-      gpu_tier: "2"
+      # Tier selects the TEST SET (and model downloads): this lane runs the
+      # tier-1 chat suite; the second GPU serves the second engine of the
+      # group, not 2-GPU-marked tests.
+      gpu_tier: "1"
       runner: 2-gpu-h100
       timeout: 46
       test_timeout: 40

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -462,6 +462,8 @@ struct Router {
     mcp_config_path: Option<String>,
     storage_hook_wasm_path: Option<String>,
     backend: BackendType,
+    /// DP engines per startup ZMQ worker (grouped worker; None/1 = ungrouped).
+    zmq_engine_count: Option<usize>,
     history_backend: HistoryBackendType,
     oracle_config: Option<PyOracleConfig>,
     postgres_config: Option<PyPostgresConfig>,
@@ -769,6 +771,7 @@ impl Router {
             .health_check_port(self.health_check_port)
             .connection_mode(self.connection_mode)
             .startup_worker_runtime_type(startup_worker_runtime_type)
+            .zmq_engine_count(self.zmq_engine_count)
             .max_payload_size(self.max_payload_size)
             .request_timeout_secs(self.request_timeout_secs)
             .worker_startup_timeout_secs(self.worker_startup_timeout_secs)
@@ -953,6 +956,7 @@ impl Router {
         mcp_config_path = None,
         storage_hook_wasm_path = None,
         backend = BackendType::Sglang,
+        zmq_engine_count = None,
         history_backend = HistoryBackendType::Memory,
         oracle_config = None,
         postgres_config = None,
@@ -1083,6 +1087,7 @@ impl Router {
         mcp_config_path: Option<String>,
         storage_hook_wasm_path: Option<String>,
         backend: BackendType,
+        zmq_engine_count: Option<usize>,
         history_backend: HistoryBackendType,
         oracle_config: Option<PyOracleConfig>,
         postgres_config: Option<PyPostgresConfig>,
@@ -1231,6 +1236,7 @@ impl Router {
             mcp_config_path,
             storage_hook_wasm_path,
             backend,
+            zmq_engine_count,
             history_backend,
             oracle_config,
             postgres_config,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -462,8 +462,6 @@ struct Router {
     mcp_config_path: Option<String>,
     storage_hook_wasm_path: Option<String>,
     backend: BackendType,
-    /// DP engines per startup ZMQ worker (grouped worker; None/1 = ungrouped).
-    zmq_engine_count: Option<usize>,
     history_backend: HistoryBackendType,
     oracle_config: Option<PyOracleConfig>,
     postgres_config: Option<PyPostgresConfig>,
@@ -497,6 +495,10 @@ struct Router {
     model_aliases: HashMap<String, String>,
     worker_startup_delay: u64,
     worker_ports_annotation: String,
+    /// DP engines per startup ZMQ worker (grouped worker; None/1 = ungrouped).
+    /// Appended last: positional constructor compatibility (see the field
+    /// ordering rule on this struct's signature).
+    zmq_engine_count: Option<usize>,
 }
 
 impl Router {
@@ -956,7 +958,6 @@ impl Router {
         mcp_config_path = None,
         storage_hook_wasm_path = None,
         backend = BackendType::Sglang,
-        zmq_engine_count = None,
         history_backend = HistoryBackendType::Memory,
         oracle_config = None,
         postgres_config = None,
@@ -993,6 +994,7 @@ impl Router {
         model_aliases = HashMap::new(),
         worker_startup_delay = 0,
         worker_ports_annotation = String::from("smg.ai/worker-ports"),
+        zmq_engine_count = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1087,7 +1089,6 @@ impl Router {
         mcp_config_path: Option<String>,
         storage_hook_wasm_path: Option<String>,
         backend: BackendType,
-        zmq_engine_count: Option<usize>,
         history_backend: HistoryBackendType,
         oracle_config: Option<PyOracleConfig>,
         postgres_config: Option<PyPostgresConfig>,
@@ -1123,6 +1124,7 @@ impl Router {
         model_aliases: HashMap<String, String>,
         worker_startup_delay: u64,
         worker_ports_annotation: String,
+        zmq_engine_count: Option<usize>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1236,7 +1238,6 @@ impl Router {
             mcp_config_path,
             storage_hook_wasm_path,
             backend,
-            zmq_engine_count,
             history_backend,
             oracle_config,
             postgres_config,
@@ -1267,6 +1268,7 @@ impl Router {
             model_aliases,
             worker_startup_delay,
             worker_ports_annotation,
+            zmq_engine_count,
         })
     }
 

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -154,6 +154,8 @@ class RouterArgs:
     mcp_config_path: str | None = None
     # Backend selection
     backend: str = "sglang"
+    # DP engines per startup ZMQ worker (grouped worker; None/1 = ungrouped)
+    zmq_engine_count: int | None = None
     # WASM support
     enable_wasm: bool = False
     # Storage hooks (WASM)
@@ -1010,6 +1012,16 @@ class RouterArgs:
             help=(
                 "Backend runtime to use (default: sglang). For ZMQ workers, vllm/"
                 "tokenspeed also pin the wire protocol (it cannot be auto-detected)"
+            ),
+        )
+        backend_group.add_argument(
+            f"--{prefix}zmq-engine-count",
+            type=int,
+            default=RouterArgs.zmq_engine_count,
+            help=(
+                "DP engines per startup ZMQ worker: each ipc:// worker becomes a "
+                "grouped worker whose handshake awaits this many engines on one "
+                "socket set (vLLM only; default: 1)"
             ),
         )
         backend_group.add_argument(

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -154,8 +154,6 @@ class RouterArgs:
     mcp_config_path: str | None = None
     # Backend selection
     backend: str = "sglang"
-    # DP engines per startup ZMQ worker (grouped worker; None/1 = ungrouped)
-    zmq_engine_count: int | None = None
     # WASM support
     enable_wasm: bool = False
     # Storage hooks (WASM)
@@ -206,6 +204,8 @@ class RouterArgs:
     # Append new fields here to preserve positional callers.
     model_aliases: dict[str, str] = dataclasses.field(default_factory=dict)
     worker_startup_delay: int = 0
+    # DP engines per startup ZMQ worker (grouped worker; None/1 = ungrouped)
+    zmq_engine_count: int | None = None
 
     @staticmethod
     def add_cli_args(

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -37,6 +37,22 @@ def _zmq_ipc_url(port: int) -> str:
     return f"ipc://{_ZMQ_SOCKET_DIR}/engine-{port}"
 
 
+def _backend_arg_int(backend_args: list[str], flag: str, default: int) -> int:
+    """Read an integer flag from raw backend args (``--flag N`` or ``--flag=N``)."""
+    for i, arg in enumerate(backend_args):
+        if arg == flag and i + 1 < len(backend_args):
+            try:
+                return int(backend_args[i + 1])
+            except ValueError:
+                return default
+        if arg.startswith(f"{flag}="):
+            try:
+                return int(arg.split("=", 1)[1])
+            except ValueError:
+                return default
+    return default
+
+
 def _zmq_handshake_port(ipc_url: str) -> int:
     """The tcp handshake port SMG derives from an ipc:// URL.
 
@@ -274,13 +290,16 @@ class VllmWorkerLauncher(WorkerLauncher):
     def _build_zmq_command(
         self, args: argparse.Namespace, backend_args: list[str], port: int
     ) -> list[str]:
-        """Launch a headless vLLM EngineCore that dials SMG's ZMQ handshake.
+        """Launch a headless vLLM EngineCore group that dials SMG's ZMQ handshake.
 
         SMG (the router) binds the tcp handshake + ipc data-plane sockets it
-        derives from the ipc:// worker URL; this engine connects in. Each worker
-        is a standalone engine (`--data-parallel-size 1`); running several is
-        dense data parallelism as N independent ZMQ workers.
+        derives from the ipc:// worker URL; the engines connect in. An
+        engine-level ``--data-parallel-size N`` (after ``--``) launches a
+        grouped worker: N engines on one socket set, balanced by the
+        connector. The default stays one standalone engine per worker;
+        running several workers is dense data parallelism.
         """
+        engine_dp = _backend_arg_int(backend_args, "--data-parallel-size", 1)
         rpc_port = _zmq_handshake_port(_zmq_ipc_url(port))
         cmd = [
             sys.executable,
@@ -290,9 +309,9 @@ class VllmWorkerLauncher(WorkerLauncher):
             getattr(args, "model", ""),
             "--headless",
             "--data-parallel-size",
-            "1",
+            str(engine_dp),
             "--data-parallel-size-local",
-            "1",
+            str(engine_dp),
             "--data-parallel-address",
             "127.0.0.1",
             "--data-parallel-rpc-port",
@@ -877,6 +896,11 @@ class ServeOrchestrator:
         # --backend does not reach.)
         if getattr(self.args, "connection_mode", "grpc") == "zmq":
             router_args.backend = self.backend
+            # A grouped vLLM launch (engine-level --data-parallel-size N after
+            # `--`) needs the router to await N engines per worker handshake.
+            engine_dp = _backend_arg_int(self.backend_args, "--data-parallel-size", 1)
+            if engine_dp > 1 and self.backend == "vllm":
+                router_args.zmq_engine_count = engine_dp
         # Router-level retries and circuit breaker are redundant when there is a
         # single worker — per-worker resilience already handles failures — so
         # disable them by default for dp<=1. Users who want them must run dp>1.

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -38,17 +38,25 @@ def _zmq_ipc_url(port: int) -> str:
 
 
 def _backend_arg_int(backend_args: list[str], flag: str, default: int) -> int:
-    """Read an integer flag from raw backend args (``--flag N`` or ``--flag=N``)."""
+    """Read an integer flag from raw backend args (``--flag N`` or ``--flag=N``).
+
+    An unparseable value falls back to the default with a warning — the
+    launcher owns this flag downstream, so silence would quietly discard the
+    operator's intent.
+    """
     for i, arg in enumerate(backend_args):
+        value = None
         if arg == flag and i + 1 < len(backend_args):
+            value = backend_args[i + 1]
+        elif arg.startswith(f"{flag}="):
+            value = arg.split("=", 1)[1]
+        if value is not None:
             try:
-                return int(backend_args[i + 1])
+                return int(value)
             except ValueError:
-                return default
-        if arg.startswith(f"{flag}="):
-            try:
-                return int(arg.split("=", 1)[1])
-            except ValueError:
+                logger.warning(
+                    "Ignoring non-integer value %r for %s; using %d", value, flag, default
+                )
                 return default
     return default
 

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -40,7 +40,7 @@ def _zmq_ipc_url(port: int) -> str:
 def _backend_arg_int(backend_args: list[str], flag: str, default: int) -> int:
     """Read an integer flag from raw backend args (``--flag N`` or ``--flag=N``).
 
-    An unparseable value falls back to the default with a warning — the
+    An unparsable value falls back to the default with a warning — the
     launcher owns this flag downstream, so silence would quietly discard the
     operator's intent.
     """

--- a/bindings/python/tests/test_serve.py
+++ b/bindings/python/tests/test_serve.py
@@ -770,6 +770,30 @@ class TestVllmWorkerLauncher:
         for arg in backend_args:
             assert arg in cmd
 
+    def test_build_zmq_command_defaults_to_single_engine(self):
+        launcher = VllmWorkerLauncher()
+        args = argparse.Namespace(model="/tmp/model", connection_mode="zmq")
+        cmd = launcher.build_command(args, [], "127.0.0.1", 31000)
+        assert cmd[cmd.index("--data-parallel-size") + 1] == "1"
+        assert cmd[cmd.index("--data-parallel-size-local") + 1] == "1"
+
+    def test_build_zmq_command_grouped_engine_dp(self):
+        """Engine-level --data-parallel-size N launches a grouped worker:
+        the launcher owns both dp flags (operator's copy is filtered) and
+        emits N for size and size-local."""
+        launcher = VllmWorkerLauncher()
+        args = argparse.Namespace(model="/tmp/model", connection_mode="zmq")
+        cmd = launcher.build_command(args, ["--data-parallel-size", "2"], "127.0.0.1", 31000)
+        assert cmd.count("--data-parallel-size") == 1
+        assert cmd[cmd.index("--data-parallel-size") + 1] == "2"
+        assert cmd[cmd.index("--data-parallel-size-local") + 1] == "2"
+
+    def test_build_zmq_command_grouped_engine_dp_equals_form(self):
+        launcher = VllmWorkerLauncher()
+        args = argparse.Namespace(model="/tmp/model", connection_mode="zmq")
+        cmd = launcher.build_command(args, ["--data-parallel-size=4"], "127.0.0.1", 31000)
+        assert cmd[cmd.index("--data-parallel-size") + 1] == "4"
+
     def test_worker_url(self):
         launcher = VllmWorkerLauncher()
         args = argparse.Namespace(connection_mode="grpc")

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -518,8 +518,6 @@ impl<P: EngineProtocol> Drop for Client<P> {
     }
 }
 
-/// Route decoded outputs to per-request streams and forward auto-abort requests
-/// to their engines. Runs until the output channel closes or the engine dies.
 /// If the engine emits no output for this long while requests are in flight, the
 /// dispatcher treats it as dead. A hard engine death (SIGKILL/OOM) sends no
 /// `ENGINE_CORE_DEAD` sentinel, and a bound PULL socket never errors when its
@@ -528,6 +526,8 @@ impl<P: EngineProtocol> Drop for Client<P> {
 /// infinite hang.
 const ENGINE_SILENCE_DEATH_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Route decoded outputs to per-request streams and forward auto-abort requests
+/// to their engines. Runs until the output channel closes or the engine dies.
 async fn run_dispatcher<P: EngineProtocol>(
     mut out_rx: mpsc::Receiver<Result<EngineBatch<P::Output>>>,
     mut abort_rx: mpsc::UnboundedReceiver<(EngineId, String)>,

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -279,26 +279,28 @@ impl<P: EngineProtocol> ClientInner<P> {
     /// progress: its peers must be stepping too, because every rank joins the
     /// same all-reduce. Upstream vLLM has a DP coordinator process broadcast the
     /// restart; SMG owns rank selection, so it sends the same signal over the
-    /// input socket each rank already listens on. A no-op for independent ranks
-    /// and for a group that is already running.
+    /// input socket each rank already listens on. A no-op for independent
+    /// ranks.
+    ///
+    /// The wake is UNCONDITIONAL for a lockstep group. Gating it on the
+    /// tracked `running` flag raced the drain: between the ranks agreeing to
+    /// park and this client processing their `wave_complete`, a submit would
+    /// see a stale "running" state, skip the wake, and — without a
+    /// coordinator, a parked engine does not self-wake on ADD — strand the
+    /// request until the silence watchdog killed the group. Redundant wakes
+    /// are idempotent on the engine (`new_wave >= current_wave` while
+    /// stepping is a no-op; a stale wave is ignored), so the gate bought one
+    /// saved message per submit at the price of a stall window.
     async fn wake_group(&self, holder_index: u32) -> Result<()> {
         let Some(state) = self.wave.as_ref() else {
             return Ok(());
         };
         let wave = {
             let mut state = state.lock();
-            if state.running {
-                return Ok(());
-            }
             state.running = true;
             state.current
         };
-        if let Err(error) = self.broadcast_start_wave(wave, holder_index).await {
-            // The group is still asleep, so let the next submit try again.
-            state.lock().running = false;
-            return Err(error);
-        }
-        Ok(())
+        self.broadcast_start_wave(wave, holder_index).await
     }
 
     /// Fold a wave notification from an engine into the group's state.
@@ -1144,8 +1146,9 @@ mod tests {
         ));
     }
 
-    /// While the group runs, submits carry no wake; once it reports the wave
-    /// drained, the next submit wakes it again on the following wave.
+    /// Every submit to a lockstep group wakes it — including submits that
+    /// race the group's drain — and after a drained wave the wake names the
+    /// wave the engines moved on to.
     #[tokio::test]
     async fn a_drained_wave_re_arms_the_wake() {
         let (client, mut engines, _ns) = connect_ranks(2, true).await;
@@ -1156,12 +1159,29 @@ mod tests {
             EngineInbound::StartDpWave { wave: 0, .. }
         ));
 
-        // Running group: the second submit only sends the Add.
+        // The wake is unconditional: even while the client believes the group
+        // is running, a submit re-sends the (engine-idempotent) wake. Gating
+        // on the tracked state raced the drain — a parked engine holding a
+        // fresh Add never self-wakes without a coordinator, and the stranded
+        // request would hit the silence watchdog.
         let _second = client.submit(request_for("req-2", 0)).await.unwrap();
         match engines[0].recv().await.unwrap() {
             EngineInbound::Add(request) => assert_eq!(request.request_id, "req-2"),
-            other => panic!("expected the Add with no wake, got {other:?}"),
+            other => panic!("expected the Add first, got {other:?}"),
         }
+        // Rank 1 already holds its own req-1 Add; the racing submit's wake
+        // arrives behind it.
+        match engines[1].recv().await.unwrap() {
+            EngineInbound::Add(request) => assert_eq!(request.request_id, "req-1"),
+            other => panic!("expected rank 1's own Add, got {other:?}"),
+        }
+        assert!(matches!(
+            engines[1].recv().await.unwrap(),
+            EngineInbound::StartDpWave {
+                wave: 0,
+                exclude_engine_index: 0,
+            }
+        ));
 
         // The group drains wave 0 and parks itself.
         engines[0]

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -126,10 +126,15 @@ struct ClientInner<P: EngineProtocol> {
 
 impl<P: EngineProtocol> ClientInner<P> {
     /// Pick the engine for a request: by `data_parallel_rank` if set, else the
-    /// sole engine. SMG routing is authoritative for rank selection. The rank is
-    /// matched against the engine's ZMQ index (Python `EngineCoreProc`'s 2-byte
+    /// least-loaded engine. An SMG-pinned rank is authoritative; it is matched
+    /// against the engine's ZMQ index (Python `EngineCoreProc`'s 2-byte
     /// identity), which is version-independent — unlike the `data_parallel_rank`
     /// field, which not every vLLM version sends in `EngineCoreReadyResponse`.
+    ///
+    /// Unpinned requests balance on the piggybacked per-rank load — queue
+    /// depth first, then in-flight batch size — mirroring vLLM's own frontend
+    /// DP client. An engine that has not reported load yet scores zero, so
+    /// cold ranks fill first; with one engine this degenerates to that engine.
     fn select_engine(&self, data_parallel_rank: Option<u32>) -> Result<EngineId> {
         match data_parallel_rank {
             Some(rank) => self
@@ -141,13 +146,22 @@ impl<P: EngineProtocol> ClientInner<P> {
                     rank,
                     num_engines: self.engines.len() as u32,
                 }),
-            None => self
-                .engines
-                .first()
-                .map(|engine| engine.engine_id.clone())
-                .ok_or(Error::ClientClosed {
-                    message: "no engines connected".to_string(),
-                }),
+            None => {
+                let load = self.load.lock();
+                self.engines
+                    .iter()
+                    .min_by_key(|engine| {
+                        engine
+                            .engine_id
+                            .engine_index()
+                            .and_then(|index| load.get(&index))
+                            .map_or((0, 0), |l| (l.num_waiting, l.num_running))
+                    })
+                    .map(|engine| engine.engine_id.clone())
+                    .ok_or(Error::ClientClosed {
+                        message: "no engines connected".to_string(),
+                    })
+            }
         }
     }
 

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -2,9 +2,10 @@
 // [`ConnectedTransport`]. Adapted from the Apache-2.0 reference
 // `vllm-engine-core-client` (vllm-project/vllm) client, scoped to SMG's needs:
 //
-// - No client-side DP load balancing. SMG routing picks the rank and stamps
-//   `data_parallel_rank`; the connector consumes the piggybacked per-rank
-//   `scheduler_stats` as the load signal.
+// - DP load balancing for unpinned requests: the connector picks the
+//   least-loaded engine from the piggybacked per-rank `scheduler_stats`
+//   (mirroring vLLM's frontend DP client). An SMG-stamped
+//   `data_parallel_rank` remains authoritative.
 // - No DP coordinator process: for a lockstep engine group the connector plays
 //   the wake role itself, over the input socket each rank already listens on.
 // - No utility RPC (deferred).
@@ -762,6 +763,57 @@ mod tests {
         let load = client.engine_load(0).expect("load recorded");
         assert_eq!(load.num_running, 3);
         assert_eq!(load.num_waiting, 5);
+    }
+
+    #[tokio::test]
+    async fn unpinned_requests_prefer_the_least_loaded_engine() {
+        let (client, mut engines, _ns) = connect_ranks(2, false).await;
+
+        // Make engine 0 report load via a pinned warm-up request; engine 1
+        // never reports and therefore scores zero.
+        let mut stream = client.submit(request_for("warm", 0)).await.unwrap();
+        engines[0].recv_request().await.unwrap();
+        let outputs = EngineCoreOutputs::RequestBatch(RequestBatchOutputs {
+            engine_index: 0,
+            outputs: vec![EngineCoreOutput {
+                request_id: "warm".into(),
+                new_token_ids: vec![7],
+                finish_reason: Some(EngineCoreFinishReason::Stop),
+                ..Default::default()
+            }],
+            scheduler_stats: Some(Box::new(SchedulerStats {
+                num_running_reqs: 3,
+                num_waiting_reqs: 5,
+                ..Default::default()
+            })),
+            finished_requests: Some(std::collections::BTreeSet::from(["warm".to_string()])),
+            ..Default::default()
+        });
+        engines[0]
+            .send_output(vec![Bytes::from(encode_msgpack(&outputs).unwrap())])
+            .await
+            .unwrap();
+        while stream.next().await.is_some() {}
+        assert!(client.engine_load(0).is_some(), "warm-up load recorded");
+
+        // An unpinned request must now land on the idle engine 1, not
+        // engines.first().
+        let _stream = client
+            .submit(EngineCoreRequest {
+                request_id: "cold".into(),
+                prompt_token_ids: Some(vec![1, 2, 3]),
+                ..EngineCoreRequest::default()
+            })
+            .await
+            .unwrap();
+        let inbound = tokio::time::timeout(TIMEOUT, engines[1].recv())
+            .await
+            .expect("unpinned request should route to the least-loaded engine")
+            .unwrap();
+        match inbound {
+            EngineInbound::Add(request) => assert_eq!(request.request_id, "cold"),
+            other => panic!("expected Add on engine 1, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -124,9 +124,8 @@ struct ClientInner<P: EngineProtocol> {
     engines: Vec<ConnectedEngine>,
     registry: Mutex<RequestRegistry<P::Output>>,
     /// Latest per-rank load, keyed by engine index. SMG's DP load signal.
-    /// `select_engine` optimistically bumps the chosen rank's `num_waiting`
-    /// so a burst between reports spreads instead of dogpiling; the next
-    /// real report overwrites the estimate.
+    /// Reported values only — `select_engine` never mutates this map; its
+    /// reservations live in `inflight`.
     load: Mutex<HashMap<u32, EngineLoad>>,
     /// Exact per-rank count of this client's own unfinished requests: a floor
     /// under the (possibly stale) reported load, so routing never trusts a
@@ -155,28 +154,40 @@ impl<P: EngineProtocol> ClientInner<P> {
     /// and the reported `waiting + running` (the floor survives stale
     /// snapshots), plus a KV-pressure penalty — a queue on a KV-bound engine
     /// drains slowly, so `waiting` is scaled up as `kv_cache_usage` passes
-    /// 50%. The chosen rank's `num_waiting` is bumped optimistically so a
-    /// burst between reports spreads, and the scan start rotates so all-zero
-    /// ties don't always resolve to the first engine.
+    /// 50%. The scan start rotates so all-zero ties don't always resolve to
+    /// the first engine.
+    ///
+    /// Selection RESERVES the choice: the in-flight count is incremented here,
+    /// under the same lock the scores were read with, so a burst between load
+    /// reports spreads across ranks instead of dogpiling one snapshot.
+    /// Reported load is never mutated — reservations live only in `inflight`,
+    /// and every failed submit path must release its reservation via
+    /// [`Self::unreserve`]. (vLLM additionally bumps its report cache because
+    /// multiple client processes share its engines; this connector is the
+    /// sole client of its group, so the in-flight floor already covers it.)
     fn select_engine(&self, data_parallel_rank: Option<u32>) -> Result<EngineId> {
         match data_parallel_rank {
-            Some(rank) => self
-                .engines
-                .iter()
-                .find(|engine| engine.engine_id.engine_index() == Some(rank))
-                .map(|engine| engine.engine_id.clone())
-                .ok_or(Error::InvalidDataParallelRank {
-                    rank,
-                    num_engines: self.engines.len() as u32,
-                }),
+            Some(rank) => {
+                let engine_id = self
+                    .engines
+                    .iter()
+                    .find(|engine| engine.engine_id.engine_index() == Some(rank))
+                    .map(|engine| engine.engine_id.clone())
+                    .ok_or(Error::InvalidDataParallelRank {
+                        rank,
+                        num_engines: self.engines.len() as u32,
+                    })?;
+                *self.inflight.lock().entry(rank).or_insert(0) += 1;
+                Ok(engine_id)
+            }
             None => {
                 if self.engines.is_empty() {
                     return Err(Error::ClientClosed {
                         message: "no engines connected".to_string(),
                     });
                 }
-                let mut load = self.load.lock();
-                let inflight = self.inflight.lock();
+                let load = self.load.lock();
+                let mut inflight = self.inflight.lock();
                 let count = self.engines.len();
                 let start = self.scan_start.fetch_add(1, Ordering::Relaxed) % count;
                 let mut best: Option<(f64, usize)> = None;
@@ -201,18 +212,18 @@ impl<P: EngineProtocol> ClientInner<P> {
                 let (_, position) = best.unwrap_or((0.0, 0));
                 let engine = &self.engines[position];
                 if let Some(index) = engine.engine_id.engine_index() {
-                    load.entry(index).or_default().num_waiting += 1;
+                    *inflight.entry(index).or_insert(0) += 1;
                 }
                 Ok(engine.engine_id.clone())
             }
         }
     }
 
-    /// Record a request landing on / leaving an engine, for the in-flight
-    /// floor `select_engine` scores with.
-    fn inflight_add(&self, engine_id: &EngineId) {
+    /// Release a [`Self::select_engine`] reservation whose submit did not
+    /// reach the engine (registry/encode/send/wake failure).
+    fn unreserve(&self, engine_id: &EngineId) {
         if let Some(index) = engine_id.engine_index() {
-            *self.inflight.lock().entry(index).or_insert(0) += 1;
+            self.inflight_remove(index, 1);
         }
     }
 
@@ -410,12 +421,27 @@ impl<P: EngineProtocol> Client<P> {
     /// Dropping the returned stream before it finishes aborts the request.
     pub async fn submit(&self, request: P::Request) -> Result<RequestStream<P>> {
         P::validate(&request)?;
+        // Selection reserves the engine's in-flight slot; every failure path
+        // from here to a successful hand-off must release it.
         let engine_id = self.inner.select_engine(P::data_parallel_rank(&request))?;
 
         let request_id = P::request_id(&request).to_string();
-        let receiver = self.inner.registry.lock().register(request_id.clone())?;
+        let receiver = match self.inner.registry.lock().register(request_id.clone()) {
+            Ok(receiver) => receiver,
+            Err(error) => {
+                self.inner.unreserve(&engine_id);
+                return Err(error);
+            }
+        };
 
-        let (payload, aux_frames) = P::encode_add(&request)?;
+        let (payload, aux_frames) = match P::encode_add(&request) {
+            Ok(encoded) => encoded,
+            Err(error) => {
+                self.inner.registry.lock().remove_all([&request_id]);
+                self.inner.unreserve(&engine_id);
+                return Err(error);
+            }
+        };
         if let Err(error) = self
             .inner
             .send_to_engine(&engine_id, P::add_frame(), payload, aux_frames)
@@ -423,9 +449,9 @@ impl<P: EngineProtocol> Client<P> {
         {
             // Roll back the registry entry so a failed send doesn't leak it.
             self.inner.registry.lock().remove_all([&request_id]);
+            self.inner.unreserve(&engine_id);
             return Err(error);
         }
-        self.inner.inflight_add(&engine_id);
 
         // The rank now holds the request; its peers must be awake for it to
         // step. Waking after the send keeps the group parked (and so unable to
@@ -438,9 +464,7 @@ impl<P: EngineProtocol> Client<P> {
             // The request can never make progress with its peers asleep, so
             // take it back rather than leaving it stranded on the engine.
             self.inner.registry.lock().remove_all([&request_id]);
-            if let Some(index) = engine_id.engine_index() {
-                self.inner.inflight_remove(index, 1);
-            }
+            self.inner.unreserve(&engine_id);
             let _ = self.inner.abort(&engine_id, &request_id).await;
             return Err(error);
         }
@@ -460,6 +484,7 @@ impl<P: EngineProtocol> Client<P> {
             .registry
             .lock()
             .remove_all([&request_id.to_string()]);
+        self.inner.unreserve(engine_id);
         self.inner.abort(engine_id, request_id).await
     }
 }
@@ -546,6 +571,7 @@ async fn run_dispatcher<P: EngineProtocol>(
             () = tokio::time::sleep(ENGINE_SILENCE_DEATH_TIMEOUT) => {
                 let mut registry = inner.registry.lock();
                 if !registry.requests.is_empty() {
+                    inner.inflight.lock().clear();
                     warn!(
                         "no engine output for {ENGINE_SILENCE_DEATH_TIMEOUT:?} with in-flight \
                          requests; treating engine as dead"
@@ -563,6 +589,7 @@ async fn run_dispatcher<P: EngineProtocol>(
         .fail_all(Arc::new(Error::ClientClosed {
             message: "engine output stream ended".to_string(),
         }));
+    inner.inflight.lock().clear();
 }
 
 /// Stream of outputs for one submitted request. Dropping it before the terminal
@@ -921,6 +948,37 @@ mod tests {
                 }
                 other => panic!("expected Add, got {other:?}"),
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_submit_releases_its_reservation() {
+        // A rejected submit (duplicate request id) must release the in-flight
+        // reservation selection took, or the failed attempt permanently
+        // penalizes that engine's score.
+        let (client, mut engines, _ns) = connect_ranks(2, false).await;
+        let unpinned = |id: &str| EngineCoreRequest {
+            request_id: id.into(),
+            prompt_token_ids: Some(vec![1, 2, 3]),
+            ..EngineCoreRequest::default()
+        };
+        let _held = client.submit(unpinned("dup")).await.unwrap();
+        engines[0].recv().await.unwrap();
+        // Second submit with the same id fails at registration; its
+        // reservation must roll back, leaving the counts (1, 0).
+        assert!(client.submit(unpinned("dup")).await.is_err());
+
+        // With counts (1, 0) the next request must land on engine 1. If the
+        // failed attempt leaked its reservation the counts would read (1, 1)
+        // and rotation could send this to engine 0.
+        let _next = client.submit(unpinned("after")).await.unwrap();
+        match tokio::time::timeout(TIMEOUT, engines[1].recv())
+            .await
+            .expect("request should route to the unloaded engine")
+            .unwrap()
+        {
+            EngineInbound::Add(request) => assert_eq!(request.request_id, "after"),
+            other => panic!("expected Add on engine 1, got {other:?}"),
         }
     }
 

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -109,15 +109,6 @@ impl<O: EngineOutput> RequestRegistry<O> {
     }
 }
 
-/// Per-group wave bookkeeping (see [`WaveEvent`] for what a wave is), mirroring
-/// the state vLLM's DP coordinator keeps: which wave the group is on, and
-/// whether it is stepping.
-#[derive(Default)]
-struct WaveState {
-    current: u32,
-    running: bool,
-}
-
 struct ClientInner<P: EngineProtocol> {
     /// Shared input ROUTER send half (serialized across concurrent submits).
     input_send: tokio::sync::Mutex<RouterSendHalf>,
@@ -134,9 +125,11 @@ struct ClientInner<P: EngineProtocol> {
     /// Rotates the selection scan start so all-zero ties (cold start, fresh
     /// stats) don't systematically favor the first engine.
     scan_start: AtomicUsize,
-    /// Wave state for a lockstep engine group; `None` when the ranks step
-    /// independently (dense DP, DP=1) and so never pause together.
-    wave: Option<Mutex<WaveState>>,
+    /// Wave clock for a lockstep engine group (see [`WaveEvent`] for what a
+    /// wave is), mirroring the `current_wave` vLLM's DP coordinator keeps.
+    /// `None` when the ranks step independently (dense DP, DP=1) and so never
+    /// pause together.
+    wave: Option<Mutex<u64>>,
     /// Auto-abort channel fed by dropped streams.
     abort_tx: mpsc::UnboundedSender<(EngineId, String)>,
 }
@@ -254,16 +247,18 @@ impl<P: EngineProtocol> ClientInner<P> {
         .await
     }
 
-    /// Tell every rank but `exclude_index` to start `wave`. Does nothing for a
-    /// protocol without a wave protocol.
-    async fn broadcast_start_wave(&self, wave: u32, exclude_index: u32) -> Result<()> {
-        let Some((frame, payload)) = P::encode_start_wave(wave, exclude_index)? else {
+    /// Tell every rank to start `wave`. Does nothing for a protocol without a
+    /// wave protocol.
+    ///
+    /// No rank is excluded, not even the one already holding the request: a
+    /// rank that skips an update keeps a lower `current_wave` than its peers,
+    /// and the group's wave numbers must stay identical for
+    /// [`Self::wake_group`]'s ordering argument to hold.
+    async fn broadcast_start_wave(&self, wave: u64) -> Result<()> {
+        let Some((frame, payload)) = P::encode_start_wave(wave)? else {
             return Ok(());
         };
         for engine in &self.engines {
-            if engine.engine_id.engine_index() == Some(exclude_index) {
-                continue;
-            }
             self.send_to_engine(
                 &engine.engine_id,
                 frame.clone(),
@@ -287,49 +282,56 @@ impl<P: EngineProtocol> ClientInner<P> {
     /// park and this client processing their `wave_complete`, a submit would
     /// see a stale "running" state, skip the wake, and — without a
     /// coordinator, a parked engine does not self-wake on ADD — strand the
-    /// request until the silence watchdog killed the group. Redundant wakes
-    /// are idempotent on the engine (`new_wave >= current_wave` while
-    /// stepping is a no-op; a stale wave is ignored), so the gate bought one
-    /// saved message per submit at the price of a stall window.
-    async fn wake_group(&self, holder_index: u32) -> Result<()> {
+    /// request until the silence watchdog killed the group.
+    ///
+    /// The wave number is a logical clock this client owns, bumped on every
+    /// wake, and an engine only obeys a wave at or above its own. Bumping is
+    /// what makes the wake reliable across that same drain window: the ranks
+    /// increment `current_wave` themselves as they park, so re-sending the
+    /// number we last knew about would land *below* theirs and be dropped on
+    /// the floor — a lost wake, whose peers then never join the holder's
+    /// all-reduce, hanging the group until vLLM's own RPC timeout kills the
+    /// engine. Bumping keeps us ahead: every rank sits at the last number we
+    /// broadcast plus at most one self-increment (a second needs another wave,
+    /// which needs another wake), so `last + 1` is never stale.
+    async fn wake_group(&self) -> Result<()> {
         let Some(state) = self.wave.as_ref() else {
             return Ok(());
         };
         let wave = {
-            let mut state = state.lock();
-            state.running = true;
-            state.current
+            let mut current = state.lock();
+            *current = current.saturating_add(1);
+            *current
         };
-        self.broadcast_start_wave(wave, holder_index).await
+        self.broadcast_start_wave(wave).await
     }
 
-    /// Fold a wave notification from an engine into the group's state.
+    /// Fold a wave notification from an engine into the group's clock.
     async fn observe_wave(&self, event: WaveEvent, engine_index: u32) {
         let Some(state) = self.wave.as_ref() else {
-            warn!(?event, "wave notification from independent ranks; ignoring");
+            warn!(
+                ?event,
+                engine_index, "wave notification from independent ranks; ignoring"
+            );
             return;
         };
         match event {
-            // The group drained the wave and parked itself; the engines have
-            // already moved on to the next one. The next submit wakes them.
+            // The group drained the wave and parked itself, incrementing its
+            // own `current_wave` on the way out; track that so the next wake
+            // names a wave the ranks will still accept.
             WaveEvent::Complete(wave) => {
-                let mut state = state.lock();
-                if wave >= state.current {
-                    state.current = wave.saturating_add(1);
-                    state.running = false;
-                }
+                let mut current = state.lock();
+                *current = (*current).max(wave.saturating_add(1));
             }
             // A rank took a request for an already-drained wave and is asking
             // for the rest of the group to catch up.
             WaveEvent::Start(wave) => {
                 {
-                    let mut state = state.lock();
-                    state.current = state.current.max(wave);
-                    state.running = true;
+                    let mut current = state.lock();
+                    *current = (*current).max(wave);
                 }
-                if let Err(error) = self.broadcast_start_wave(wave, engine_index).await {
+                if let Err(error) = self.wake_group().await {
                     warn!(%error, wave, "failed to start the requested wave");
-                    state.lock().running = false;
                 }
             }
         }
@@ -377,7 +379,7 @@ impl<P: EngineProtocol> Client<P> {
             load: Mutex::new(HashMap::new()),
             inflight: Mutex::new(HashMap::new()),
             scan_start: AtomicUsize::new(0),
-            wave: lockstep.then(|| Mutex::new(WaveState::default())),
+            wave: lockstep.then(|| Mutex::new(0)),
             abort_tx,
         });
 
@@ -458,11 +460,7 @@ impl<P: EngineProtocol> Client<P> {
         // The rank now holds the request; its peers must be awake for it to
         // step. Waking after the send keeps the group parked (and so unable to
         // report another drained wave) for the whole window.
-        if let Err(error) = self
-            .inner
-            .wake_group(engine_id.engine_index().unwrap_or(u32::MAX))
-            .await
-        {
+        if let Err(error) = self.inner.wake_group().await {
             // The request can never make progress with its peers asleep, so
             // take it back rather than leaving it stranded on the engine.
             self.inner.registry.lock().remove_all([&request_id]);
@@ -1126,7 +1124,8 @@ mod tests {
     }
 
     /// A lockstep group is paused when the client connects, so the first submit
-    /// must wake every rank except the one taking the request.
+    /// must wake every rank — including the one taking the request, so the
+    /// whole group shares one wave number.
     #[tokio::test]
     async fn first_submit_wakes_the_paused_lockstep_group() {
         let (client, mut engines, _ns) = connect_ranks(2, true).await;
@@ -1137,73 +1136,81 @@ mod tests {
             EngineInbound::Add(request) => assert_eq!(request.request_id, "req-1"),
             other => panic!("rank 1 expected the Add, got {other:?}"),
         }
-        assert!(matches!(
-            engines[0].recv().await.unwrap(),
-            EngineInbound::StartDpWave {
-                wave: 0,
-                exclude_engine_index: 1,
-            }
-        ));
+        assert_eq!(next_wake(&mut engines[0]).await, 1);
+        assert_eq!(next_wake(&mut engines[1]).await, 1);
     }
 
-    /// Every submit to a lockstep group wakes it — including submits that
-    /// race the group's drain — and after a drained wave the wake names the
-    /// wave the engines moved on to.
+    /// Every submit to a lockstep group wakes it with a FRESH wave number,
+    /// even submits that race the group's drain.
+    ///
+    /// This is the load-bearing property. The ranks bump their own
+    /// `current_wave` as they park, and an engine drops any wave below its
+    /// own, so a wake that reuses the last number the client saw is silently
+    /// discarded — the holder's peers stay parked, never join its all-reduce,
+    /// and vLLM kills the engine on its own RPC timeout. The client's clock is
+    /// therefore monotonic and independent of when the `wave_complete`
+    /// notifications arrive.
     #[tokio::test]
-    async fn a_drained_wave_re_arms_the_wake() {
+    async fn every_wake_names_a_wave_the_ranks_will_accept() {
         let (client, mut engines, _ns) = connect_ranks(2, true).await;
 
         let _first = client.submit(request_for("req-1", 1)).await.unwrap();
-        assert!(matches!(
-            engines[0].recv().await.unwrap(),
-            EngineInbound::StartDpWave { wave: 0, .. }
-        ));
+        let first = next_wake(&mut engines[0]).await;
+        assert_eq!(next_wake(&mut engines[1]).await, first);
 
-        // The wake is unconditional: even while the client believes the group
-        // is running, a submit re-sends the (engine-idempotent) wake. Gating
-        // on the tracked state raced the drain — a parked engine holding a
-        // fresh Add never self-wakes without a coordinator, and the stranded
-        // request would hit the silence watchdog.
+        // The group drains the wave and parks, moving on to `first + 1` — but
+        // the client has not heard about it yet. Its next wake must still
+        // outrank the engines' self-increment.
         let _second = client.submit(request_for("req-2", 0)).await.unwrap();
-        match engines[0].recv().await.unwrap() {
-            EngineInbound::Add(request) => assert_eq!(request.request_id, "req-2"),
-            other => panic!("expected the Add first, got {other:?}"),
-        }
-        // Rank 1 already holds its own req-1 Add; the racing submit's wake
-        // arrives behind it.
-        match engines[1].recv().await.unwrap() {
-            EngineInbound::Add(request) => assert_eq!(request.request_id, "req-1"),
-            other => panic!("expected rank 1's own Add, got {other:?}"),
-        }
-        assert!(matches!(
-            engines[1].recv().await.unwrap(),
-            EngineInbound::StartDpWave {
-                wave: 0,
-                exclude_engine_index: 0,
-            }
-        ));
+        let second = next_wake(&mut engines[0]).await;
+        assert!(
+            second > first,
+            "wake {second} does not outrank the parked ranks at {}",
+            first + 1
+        );
+        assert_eq!(next_wake(&mut engines[1]).await, second);
 
-        // The group drains wave 0 and parks itself.
+        // A rank can also report a wave AHEAD of the client's clock — it kept
+        // its `current_wave` across a gateway restart, say. Folding that in is
+        // the other half of the same invariant: the next wake must clear the
+        // highest wave any rank is known to hold.
+        let ahead = second + 5;
         engines[0]
-            .send_output(wave_control(0, DpControlMessage::WaveComplete(0)))
+            .send_output(wave_control(0, DpControlMessage::WaveComplete(ahead)))
             .await
             .unwrap();
-        // The notification travels through the dispatcher, so wait for it to
-        // land before submitting against the parked group.
         tokio::time::timeout(TIMEOUT, async {
-            while client.inner.wave.as_ref().unwrap().lock().running {
+            while *client.inner.wave.as_ref().unwrap().lock() <= ahead {
                 tokio::time::sleep(Duration::from_millis(5)).await;
             }
         })
         .await
-        .expect("the drained wave never parked the group");
+        .expect("the reported wave never reached the clock");
 
         let _third = client.submit(request_for("req-3", 1)).await.unwrap();
-        match engines[0].recv().await.unwrap() {
-            // The engines moved on to wave 1 as they paused, so that is the
-            // wave the wake must name.
-            EngineInbound::StartDpWave { wave, .. } => assert_eq!(wave, 1),
-            other => panic!("expected a wake for the next wave, got {other:?}"),
+        let third = next_wake(&mut engines[0]).await;
+        assert!(
+            third > ahead,
+            "wake {third} does not clear the rank already on {ahead}"
+        );
+    }
+
+    /// Read one engine's inbound queue up to its next wake, returning the wave
+    /// it names.
+    async fn next_wake(engine: &mut MockEngine) -> u64 {
+        loop {
+            match engine.recv().await.unwrap() {
+                EngineInbound::StartDpWave {
+                    wave,
+                    exclude_engine_index,
+                } => {
+                    // No rank is excluded: the whole group shares one wave.
+                    assert_eq!(exclude_engine_index, u32::MAX);
+                    return wave;
+                }
+                EngineInbound::Add(_) => continue,
+                other => panic!("expected a wake or an Add, got {other:?}"),
+            }
         }
     }
 

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -10,7 +10,14 @@
 //   the wake role itself, over the input socket each rank already listens on.
 // - No utility RPC (deferred).
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use bytes::Bytes;
 use futures::Stream;
@@ -117,7 +124,17 @@ struct ClientInner<P: EngineProtocol> {
     engines: Vec<ConnectedEngine>,
     registry: Mutex<RequestRegistry<P::Output>>,
     /// Latest per-rank load, keyed by engine index. SMG's DP load signal.
+    /// `select_engine` optimistically bumps the chosen rank's `num_waiting`
+    /// so a burst between reports spreads instead of dogpiling; the next
+    /// real report overwrites the estimate.
     load: Mutex<HashMap<u32, EngineLoad>>,
+    /// Exact per-rank count of this client's own unfinished requests: a floor
+    /// under the (possibly stale) reported load, so routing never trusts a
+    /// snapshot that says an engine we just loaded is idle.
+    inflight: Mutex<HashMap<u32, u64>>,
+    /// Rotates the selection scan start so all-zero ties (cold start, fresh
+    /// stats) don't systematically favor the first engine.
+    scan_start: AtomicUsize,
     /// Wave state for a lockstep engine group; `None` when the ranks step
     /// independently (dense DP, DP=1) and so never pause together.
     wave: Option<Mutex<WaveState>>,
@@ -132,10 +149,15 @@ impl<P: EngineProtocol> ClientInner<P> {
     /// identity), which is version-independent — unlike the `data_parallel_rank`
     /// field, which not every vLLM version sends in `EngineCoreReadyResponse`.
     ///
-    /// Unpinned requests balance on the piggybacked per-rank load — queue
-    /// depth first, then in-flight batch size — mirroring vLLM's own frontend
-    /// DP client. An engine that has not reported load yet scores zero, so
-    /// cold ranks fill first; with one engine this degenerates to that engine.
+    /// Unpinned requests use vLLM's own frontend DP scoring
+    /// (`DPLBAsyncMPClient.get_core_engine_for_request`), single-client form:
+    /// an engine's score is the greater of this client's exact in-flight count
+    /// and the reported `waiting + running` (the floor survives stale
+    /// snapshots), plus a KV-pressure penalty — a queue on a KV-bound engine
+    /// drains slowly, so `waiting` is scaled up as `kv_cache_usage` passes
+    /// 50%. The chosen rank's `num_waiting` is bumped optimistically so a
+    /// burst between reports spreads, and the scan start rotates so all-zero
+    /// ties don't always resolve to the first engine.
     fn select_engine(&self, data_parallel_rank: Option<u32>) -> Result<EngineId> {
         match data_parallel_rank {
             Some(rank) => self
@@ -148,20 +170,56 @@ impl<P: EngineProtocol> ClientInner<P> {
                     num_engines: self.engines.len() as u32,
                 }),
             None => {
-                let load = self.load.lock();
-                self.engines
-                    .iter()
-                    .min_by_key(|engine| {
-                        engine
-                            .engine_id
-                            .engine_index()
-                            .and_then(|index| load.get(&index))
-                            .map_or((0, 0), |l| (l.num_waiting, l.num_running))
-                    })
-                    .map(|engine| engine.engine_id.clone())
-                    .ok_or(Error::ClientClosed {
+                if self.engines.is_empty() {
+                    return Err(Error::ClientClosed {
                         message: "no engines connected".to_string(),
-                    })
+                    });
+                }
+                let mut load = self.load.lock();
+                let inflight = self.inflight.lock();
+                let count = self.engines.len();
+                let start = self.scan_start.fetch_add(1, Ordering::Relaxed) % count;
+                let mut best: Option<(f64, usize)> = None;
+                for offset in 0..count {
+                    let position = (start + offset) % count;
+                    let index = self.engines[position].engine_id.engine_index();
+                    let reported = index
+                        .and_then(|i| load.get(&i))
+                        .copied()
+                        .unwrap_or_default();
+                    let own = index.and_then(|i| inflight.get(&i)).copied().unwrap_or(0);
+                    let mut score = own.max(reported.num_waiting + reported.num_running) as f64;
+                    if reported.num_waiting > 0 {
+                        score += reported.num_waiting as f64
+                            * 6.0
+                            * (reported.kv_cache_usage - 0.5).max(0.0);
+                    }
+                    if best.is_none_or(|(best_score, _)| score < best_score) {
+                        best = Some((score, position));
+                    }
+                }
+                let (_, position) = best.unwrap_or((0.0, 0));
+                let engine = &self.engines[position];
+                if let Some(index) = engine.engine_id.engine_index() {
+                    load.entry(index).or_default().num_waiting += 1;
+                }
+                Ok(engine.engine_id.clone())
+            }
+        }
+    }
+
+    /// Record a request landing on / leaving an engine, for the in-flight
+    /// floor `select_engine` scores with.
+    fn inflight_add(&self, engine_id: &EngineId) {
+        if let Some(index) = engine_id.engine_index() {
+            *self.inflight.lock().entry(index).or_insert(0) += 1;
+        }
+    }
+
+    fn inflight_remove(&self, engine_index: u32, finished: u64) {
+        if finished > 0 {
+            if let Some(count) = self.inflight.lock().get_mut(&engine_index) {
+                *count = count.saturating_sub(finished);
             }
         }
     }
@@ -304,6 +362,8 @@ impl<P: EngineProtocol> Client<P> {
             engines,
             registry: Mutex::new(RequestRegistry::default()),
             load: Mutex::new(HashMap::new()),
+            inflight: Mutex::new(HashMap::new()),
+            scan_start: AtomicUsize::new(0),
             wave: lockstep.then(|| Mutex::new(WaveState::default())),
             abort_tx,
         });
@@ -365,6 +425,7 @@ impl<P: EngineProtocol> Client<P> {
             self.inner.registry.lock().remove_all([&request_id]);
             return Err(error);
         }
+        self.inner.inflight_add(&engine_id);
 
         // The rank now holds the request; its peers must be awake for it to
         // step. Waking after the send keeps the group parked (and so unable to
@@ -377,6 +438,9 @@ impl<P: EngineProtocol> Client<P> {
             // The request can never make progress with its peers asleep, so
             // take it back rather than leaving it stranded on the engine.
             self.inner.registry.lock().remove_all([&request_id]);
+            if let Some(index) = engine_id.engine_index() {
+                self.inner.inflight_remove(index, 1);
+            }
             let _ = self.inner.abort(&engine_id, &request_id).await;
             return Err(error);
         }
@@ -434,16 +498,29 @@ async fn run_dispatcher<P: EngineProtocol>(
                         if let Some(event) = batch.wave {
                             inner.observe_wave(event, batch.engine_index).await;
                         }
+                        // Unique finished ids: a terminal output and the
+                        // out-of-band finished list may name the same request.
+                        let mut finished: HashSet<String> = batch
+                            .finished_request_ids
+                            .iter()
+                            .cloned()
+                            .collect();
                         let mut registry = inner.registry.lock();
                         for output in batch.outputs {
+                            if output.finished() {
+                                finished.insert(output.request_id().to_string());
+                            }
                             registry.route(output);
                         }
                         registry.remove_all(&batch.finished_request_ids);
+                        drop(registry);
+                        inner.inflight_remove(batch.engine_index, finished.len() as u64);
                     }
                     Some(Err(error)) => {
                         if matches!(error, Error::EngineCoreDead | Error::Transport(_)) {
                             warn!(%error, "engine transport failed; failing all in-flight requests");
                             inner.registry.lock().fail_all(Arc::new(error));
+                            inner.inflight.lock().clear();
                             return;
                         }
                         // A per-message decode error is non-fatal; keep going.
@@ -455,6 +532,9 @@ async fn run_dispatcher<P: EngineProtocol>(
             abort = abort_rx.recv() => {
                 if let Some((engine_id, request_id)) = abort {
                     inner.registry.lock().remove_all([&request_id]);
+                    if let Some(index) = engine_id.engine_index() {
+                        inner.inflight_remove(index, 1);
+                    }
                     if let Err(error) = inner.abort(&engine_id, &request_id).await {
                         warn!(%error, %request_id, "failed to send abort");
                     }
@@ -813,6 +893,34 @@ mod tests {
         match inbound {
             EngineInbound::Add(request) => assert_eq!(request.request_id, "cold"),
             other => panic!("expected Add on engine 1, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_cold_burst_spreads_across_engines() {
+        // No engine has reported load yet: the in-flight floor plus the
+        // rotating scan start must spread a burst instead of dogpiling the
+        // first engine (which is what a pure snapshot-min would do).
+        let (client, mut engines, _ns) = connect_ranks(2, false).await;
+        let unpinned = |id: &str| EngineCoreRequest {
+            request_id: id.into(),
+            prompt_token_ids: Some(vec![1, 2, 3]),
+            ..EngineCoreRequest::default()
+        };
+        let _first = client.submit(unpinned("burst-0")).await.unwrap();
+        let _second = client.submit(unpinned("burst-1")).await.unwrap();
+
+        for engine in &mut engines {
+            let inbound = tokio::time::timeout(TIMEOUT, engine.recv())
+                .await
+                .expect("each engine should receive exactly one of the burst")
+                .unwrap();
+            match inbound {
+                EngineInbound::Add(request) => {
+                    assert!(request.request_id.starts_with("burst-"));
+                }
+                other => panic!("expected Add, got {other:?}"),
+            }
         }
     }
 

--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -118,10 +118,16 @@ struct ClientInner<P: EngineProtocol> {
     /// Reported values only — `select_engine` never mutates this map; its
     /// reservations live in `inflight`.
     load: Mutex<HashMap<u32, EngineLoad>>,
-    /// Exact per-rank count of this client's own unfinished requests: a floor
-    /// under the (possibly stale) reported load, so routing never trusts a
-    /// snapshot that says an engine we just loaded is idle.
-    inflight: Mutex<HashMap<u32, u64>>,
+    /// This client's own unfinished request ids, per rank: a floor under the
+    /// (possibly stale) reported load, so routing never trusts a snapshot that
+    /// says an engine we just loaded is idle. Keyed by id rather than counted,
+    /// because a request has several racing ways to finish — the explicit
+    /// [`Client::abort`], a dropped stream's auto-abort, and the engine's own
+    /// terminal output or finished-id report — and only the first of them may
+    /// count. Identity makes every release idempotent; counters would let one
+    /// request retire several slots and leave the rank looking emptier than it
+    /// is.
+    inflight: Mutex<HashMap<u32, HashSet<String>>>,
     /// Rotates the selection scan start so all-zero ties (cold start, fresh
     /// stats) don't systematically favor the first engine.
     scan_start: AtomicUsize,
@@ -150,15 +156,15 @@ impl<P: EngineProtocol> ClientInner<P> {
     /// 50%. The scan start rotates so all-zero ties don't always resolve to
     /// the first engine.
     ///
-    /// Selection RESERVES the choice: the in-flight count is incremented here,
-    /// under the same lock the scores were read with, so a burst between load
-    /// reports spreads across ranks instead of dogpiling one snapshot.
+    /// Selection RESERVES the choice: `request_id` is recorded as in flight
+    /// here, under the same lock the scores were read with, so a burst between
+    /// load reports spreads across ranks instead of dogpiling one snapshot.
     /// Reported load is never mutated — reservations live only in `inflight`,
     /// and every failed submit path must release its reservation via
-    /// [`Self::unreserve`]. (vLLM additionally bumps its report cache because
+    /// [`Self::release`]. (vLLM additionally bumps its report cache because
     /// multiple client processes share its engines; this connector is the
     /// sole client of its group, so the in-flight floor already covers it.)
-    fn select_engine(&self, data_parallel_rank: Option<u32>) -> Result<EngineId> {
+    fn select_engine(&self, data_parallel_rank: Option<u32>, request_id: &str) -> Result<EngineId> {
         match data_parallel_rank {
             Some(rank) => {
                 let engine_id = self
@@ -170,7 +176,11 @@ impl<P: EngineProtocol> ClientInner<P> {
                         rank,
                         num_engines: self.engines.len() as u32,
                     })?;
-                *self.inflight.lock().entry(rank).or_insert(0) += 1;
+                self.inflight
+                    .lock()
+                    .entry(rank)
+                    .or_default()
+                    .insert(request_id.to_string());
                 Ok(engine_id)
             }
             None => {
@@ -191,7 +201,7 @@ impl<P: EngineProtocol> ClientInner<P> {
                         .and_then(|i| load.get(&i))
                         .copied()
                         .unwrap_or_default();
-                    let own = index.and_then(|i| inflight.get(&i)).copied().unwrap_or(0);
+                    let own = index.and_then(|i| inflight.get(&i)).map_or(0, HashSet::len) as u64;
                     let mut score = own.max(reported.num_waiting + reported.num_running) as f64;
                     if reported.num_waiting > 0 {
                         score += reported.num_waiting as f64
@@ -205,26 +215,32 @@ impl<P: EngineProtocol> ClientInner<P> {
                 let (_, position) = best.unwrap_or((0.0, 0));
                 let engine = &self.engines[position];
                 if let Some(index) = engine.engine_id.engine_index() {
-                    *inflight.entry(index).or_insert(0) += 1;
+                    inflight
+                        .entry(index)
+                        .or_default()
+                        .insert(request_id.to_string());
                 }
                 Ok(engine.engine_id.clone())
             }
         }
     }
 
-    /// Release a [`Self::select_engine`] reservation whose submit did not
-    /// reach the engine (registry/encode/send/wake failure).
-    fn unreserve(&self, engine_id: &EngineId) {
-        if let Some(index) = engine_id.engine_index() {
-            self.inflight_remove(index, 1);
+    /// Retire in-flight request ids from a rank. Idempotent: an id already
+    /// retired by a racing path is simply absent.
+    fn release<'a>(&self, engine_index: u32, request_ids: impl IntoIterator<Item = &'a String>) {
+        let mut inflight = self.inflight.lock();
+        let Some(ids) = inflight.get_mut(&engine_index) else {
+            return;
+        };
+        for request_id in request_ids {
+            ids.remove(request_id);
         }
     }
 
-    fn inflight_remove(&self, engine_index: u32, finished: u64) {
-        if finished > 0 {
-            if let Some(count) = self.inflight.lock().get_mut(&engine_index) {
-                *count = count.saturating_sub(finished);
-            }
+    /// Retire one request from the rank named by `engine_id`, if it has one.
+    fn release_one(&self, engine_id: &EngineId, request_id: &String) {
+        if let Some(index) = engine_id.engine_index() {
+            self.release(index, [request_id]);
         }
     }
 
@@ -425,15 +441,22 @@ impl<P: EngineProtocol> Client<P> {
     /// Dropping the returned stream before it finishes aborts the request.
     pub async fn submit(&self, request: P::Request) -> Result<RequestStream<P>> {
         P::validate(&request)?;
+        let request_id = P::request_id(&request).to_string();
+        // Register before selecting: registration is the admission gate (it
+        // rejects a duplicate id), and in-flight slots are held by id, so a
+        // reservation taken before that gate could collide with the live
+        // request's own slot and release it on rollback.
+        let receiver = self.inner.registry.lock().register(request_id.clone())?;
+
         // Selection reserves the engine's in-flight slot; every failure path
         // from here to a successful hand-off must release it.
-        let engine_id = self.inner.select_engine(P::data_parallel_rank(&request))?;
-
-        let request_id = P::request_id(&request).to_string();
-        let receiver = match self.inner.registry.lock().register(request_id.clone()) {
-            Ok(receiver) => receiver,
+        let engine_id = match self
+            .inner
+            .select_engine(P::data_parallel_rank(&request), &request_id)
+        {
+            Ok(engine_id) => engine_id,
             Err(error) => {
-                self.inner.unreserve(&engine_id);
+                self.inner.registry.lock().remove_all([&request_id]);
                 return Err(error);
             }
         };
@@ -442,7 +465,7 @@ impl<P: EngineProtocol> Client<P> {
             Ok(encoded) => encoded,
             Err(error) => {
                 self.inner.registry.lock().remove_all([&request_id]);
-                self.inner.unreserve(&engine_id);
+                self.inner.release_one(&engine_id, &request_id);
                 return Err(error);
             }
         };
@@ -453,7 +476,7 @@ impl<P: EngineProtocol> Client<P> {
         {
             // Roll back the registry entry so a failed send doesn't leak it.
             self.inner.registry.lock().remove_all([&request_id]);
-            self.inner.unreserve(&engine_id);
+            self.inner.release_one(&engine_id, &request_id);
             return Err(error);
         }
 
@@ -464,7 +487,7 @@ impl<P: EngineProtocol> Client<P> {
             // The request can never make progress with its peers asleep, so
             // take it back rather than leaving it stranded on the engine.
             self.inner.registry.lock().remove_all([&request_id]);
-            self.inner.unreserve(&engine_id);
+            self.inner.release_one(&engine_id, &request_id);
             let _ = self.inner.abort(&engine_id, &request_id).await;
             return Err(error);
         }
@@ -480,12 +503,10 @@ impl<P: EngineProtocol> Client<P> {
 
     /// Explicitly abort an in-flight request.
     pub async fn abort(&self, engine_id: &EngineId, request_id: &str) -> Result<()> {
-        self.inner
-            .registry
-            .lock()
-            .remove_all([&request_id.to_string()]);
-        self.inner.unreserve(engine_id);
-        self.inner.abort(engine_id, request_id).await
+        let request_id = request_id.to_string();
+        self.inner.registry.lock().remove_all([&request_id]);
+        self.inner.release_one(engine_id, &request_id);
+        self.inner.abort(engine_id, &request_id).await
     }
 }
 
@@ -539,7 +560,7 @@ async fn run_dispatcher<P: EngineProtocol>(
                         }
                         registry.remove_all(&batch.finished_request_ids);
                         drop(registry);
-                        inner.inflight_remove(batch.engine_index, finished.len() as u64);
+                        inner.release(batch.engine_index, &finished);
                     }
                     Some(Err(error)) => {
                         if matches!(error, Error::EngineCoreDead | Error::Transport(_)) {
@@ -557,9 +578,7 @@ async fn run_dispatcher<P: EngineProtocol>(
             abort = abort_rx.recv() => {
                 if let Some((engine_id, request_id)) = abort {
                     inner.registry.lock().remove_all([&request_id]);
-                    if let Some(index) = engine_id.engine_index() {
-                        inner.inflight_remove(index, 1);
-                    }
+                    inner.release_one(&engine_id, &request_id);
                     if let Err(error) = inner.abort(&engine_id, &request_id).await {
                         warn!(%error, %request_id, "failed to send abort");
                     }
@@ -980,6 +999,71 @@ mod tests {
             EngineInbound::Add(request) => assert_eq!(request.request_id, "after"),
             other => panic!("expected Add on engine 1, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn retiring_one_request_twice_frees_only_its_own_slot() {
+        // A request has several racing ways to finish: the explicit abort API,
+        // the dropped stream's auto-abort, and the engine's own finished
+        // report. Counting each one would retire slots the request never held
+        // and leave the rank looking emptier than it is; slots are keyed by
+        // request id so only the first retirement lands.
+        let (client, mut engines, _ns) = connect_ranks(2, false).await;
+        let pinned = |id: &str| EngineCoreRequest {
+            request_id: id.into(),
+            prompt_token_ids: Some(vec![1, 2, 3]),
+            data_parallel_rank: Some(0),
+            ..EngineCoreRequest::default()
+        };
+        let doomed = client.submit(pinned("doomed")).await.unwrap();
+        let _held = client.submit(pinned("held")).await.unwrap();
+        engines[0].recv().await.unwrap();
+        engines[0].recv().await.unwrap();
+
+        // Abort retires "doomed"; dropping its unfinished stream sends the
+        // auto-abort for the same id behind it.
+        client
+            .abort(&engines_id(&client, 0), "doomed")
+            .await
+            .unwrap();
+        drop(doomed);
+        for _ in 0..2 {
+            tokio::time::timeout(TIMEOUT, engines[0].recv())
+                .await
+                .expect("both aborts should reach the engine")
+                .unwrap();
+        }
+
+        // Engine 0 still holds "held". An unpinned request must therefore go
+        // to the idle engine 1 — it would go to 0 if the second retirement had
+        // freed "held"'s slot too.
+        let _next = client
+            .submit(EngineCoreRequest {
+                request_id: "next".into(),
+                prompt_token_ids: Some(vec![1, 2, 3]),
+                ..EngineCoreRequest::default()
+            })
+            .await
+            .unwrap();
+        match tokio::time::timeout(TIMEOUT, engines[1].recv())
+            .await
+            .expect("request should route to the idle engine")
+            .unwrap()
+        {
+            EngineInbound::Add(request) => assert_eq!(request.request_id, "next"),
+            other => panic!("expected Add on engine 1, got {other:?}"),
+        }
+    }
+
+    /// The `EngineId` of one connected rank, by index.
+    fn engines_id(client: &EngineCoreClient, engine_index: u32) -> EngineId {
+        client
+            .engines()
+            .iter()
+            .find(|engine| engine.engine_id.engine_index() == Some(engine_index))
+            .expect("connected rank")
+            .engine_id
+            .clone()
     }
 
     #[tokio::test]

--- a/crates/engine_zmq_client/src/mock_engine.rs
+++ b/crates/engine_zmq_client/src/mock_engine.rs
@@ -97,7 +97,7 @@ pub enum EngineInbound {
     /// A lockstep-group wake (`EngineCoreRequestType::StartDpWave`): start this
     /// wave unless this engine is the excluded one.
     StartDpWave {
-        wave: u32,
+        wave: u64,
         exclude_engine_index: u32,
     },
     /// Any other request type byte (Utility), unhandled here.

--- a/crates/engine_zmq_client/src/protocol/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/mod.rs
@@ -40,10 +40,10 @@ pub struct EngineLoad {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WaveEvent {
     /// The group drained this wave and is now parked (vLLM `wave_complete`).
-    Complete(u32),
+    Complete(u64),
     /// A rank took a request for an already-drained wave and needs the rest of
     /// the group started on this one (vLLM `start_wave`).
-    Start(u32),
+    Start(u64),
 }
 
 /// A single per-request output decoded from one engine tick. Lets the
@@ -112,11 +112,12 @@ pub trait EngineProtocol: Send + Sync + 'static {
     fn encode_add(request: &Self::Request) -> Result<(Vec<u8>, Vec<Bytes>)>;
     /// Encode the abort payload for one request id.
     fn encode_abort(request_id: &str) -> Result<Vec<u8>>;
-    /// Encode "start `wave` on every rank but `exclude_engine_index`" (the one
-    /// already holding the request) as `(request-type frame, payload)`.
-    /// `Ok(None)` when the protocol has no wave protocol — its ranks run
-    /// independently, so there is nothing to wake.
-    fn encode_start_wave(wave: u32, exclude_engine_index: u32) -> Result<Option<(Bytes, Vec<u8>)>>;
+    /// Encode "start `wave` on every rank" as `(request-type frame, payload)`.
+    /// No rank is excluded: a rank that skips the update keeps an older wave
+    /// number, and an engine ignores any wave below its own. `Ok(None)` when
+    /// the protocol has no wave protocol — its ranks run independently, so
+    /// there is nothing to wake.
+    fn encode_start_wave(wave: u64) -> Result<Option<(Bytes, Vec<u8>)>>;
     /// Decode one output message (frame 0 plus ordered aux frames) into a batch.
     fn decode_batch(frames: &[Bytes]) -> Result<EngineBatch<Self::Output>>;
 }

--- a/crates/engine_zmq_client/src/protocol/tokenspeed/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/tokenspeed/mod.rs
@@ -121,10 +121,7 @@ impl EngineProtocol for TokenSpeedProtocol {
         encode_msgpack(&[request_id.to_string()])
     }
 
-    fn encode_start_wave(
-        _wave: u32,
-        _exclude_engine_index: u32,
-    ) -> Result<Option<(Bytes, Vec<u8>)>> {
+    fn encode_start_wave(_wave: u64) -> Result<Option<(Bytes, Vec<u8>)>> {
         // TokenSpeed has no wave protocol: its scheduler never pauses a group
         // of ranks, so there is nothing to wake.
         Ok(None)

--- a/crates/engine_zmq_client/src/protocol/vllm/mod.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/mod.rs
@@ -96,12 +96,14 @@ impl EngineProtocol for VllmProtocol {
         encode_msgpack(&[request_id.to_string()])
     }
 
-    fn encode_start_wave(wave: u32, exclude_engine_index: u32) -> Result<Option<(Bytes, Vec<u8>)>> {
+    fn encode_start_wave(wave: u64) -> Result<Option<(Bytes, Vec<u8>)>> {
         // Python decodes this with the generic msgpack decoder and unpacks it
-        // positionally as `new_wave, exclude_eng_index`.
+        // positionally as `new_wave, exclude_eng_index`. The sentinel matches
+        // no rank, so every rank adopts `wave`.
+        const NO_EXCLUDED_RANK: u32 = u32::MAX;
         Ok(Some((
             EngineCoreRequestType::StartDpWave.to_frame(),
-            encode_msgpack(&(wave, exclude_engine_index))?,
+            encode_msgpack(&(wave, NO_EXCLUDED_RANK))?,
         )))
     }
 

--- a/crates/engine_zmq_client/src/protocol/vllm/output.rs
+++ b/crates/engine_zmq_client/src/protocol/vllm/output.rs
@@ -143,18 +143,18 @@ struct WireEngineCoreOutputs {
     finished_requests: Option<BTreeSet<String>>,
     /// In DP mode, signals that the current wave finished and engines are paused.
     #[serde(default)]
-    wave_complete: Option<u32>,
+    wave_complete: Option<u64>,
     /// In DP mode, signals that a request arrived for an old wave and the next
     /// wave needs to start in other engines.
     #[serde(default)]
-    start_wave: Option<u32>,
+    start_wave: Option<u64>,
 }
 
 /// Data-parallel control notifications multiplexed through `EngineCoreOutputs`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DpControlMessage {
-    WaveComplete(u32),
-    StartWave(u32),
+    WaveComplete(u64),
+    StartWave(u64),
 }
 
 /// A batch of per-request outputs plus the piggybacked scheduler stats.

--- a/e2e_test/infra/constants.py
+++ b/e2e_test/infra/constants.py
@@ -63,6 +63,9 @@ ENV_RUNTIME = (
 ENV_CONNECTION_MODE = (
     "E2E_CONNECTION_MODE"  # Per-lane wire override — see get_connection_mode_override
 )
+ENV_ZMQ_ENGINE_COUNT = (
+    "E2E_ZMQ_ENGINE_COUNT"  # DP engines per ZMQ worker (grouped vLLM launch; empty = 1)
+)
 ENV_STARTUP_TIMEOUT = "E2E_STARTUP_TIMEOUT"
 ENV_SKIP_MODEL_POOL = "SKIP_MODEL_POOL"
 ENV_SKIP_BACKEND_SETUP = "SKIP_BACKEND_SETUP"
@@ -152,6 +155,22 @@ def get_connection_mode_override() -> "ConnectionMode | None":
         raise ValueError(
             f"{ENV_CONNECTION_MODE}={value!r} is not a valid connection mode; use one of {valid}"
         ) from None
+
+
+def get_zmq_engine_count() -> int:
+    """DP engines per ZMQ worker (grouped vLLM launch).
+
+    Set ``E2E_ZMQ_ENGINE_COUNT`` to run a ZMQ lane with grouped workers: the
+    worker launches that many engines on one socket set and the gateway's
+    handshake awaits them all. Unset/blank means one engine per worker.
+    """
+    value = os.environ.get(ENV_ZMQ_ENGINE_COUNT, "").strip()
+    if not value:
+        return 1
+    count = int(value)
+    if count < 1:
+        raise ValueError(f"{ENV_ZMQ_ENGINE_COUNT}={value!r} must be a positive integer")
+    return count
 
 
 ENV_VLLM_KV_BACKEND = "E2E_VLLM_KV_BACKEND"

--- a/e2e_test/infra/gateway.py
+++ b/e2e_test/infra/gateway.py
@@ -12,7 +12,12 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from .constants import DEFAULT_HOST, DEFAULT_ROUTER_TIMEOUT, ENV_SHOW_ROUTER_LOGS
+from .constants import (
+    DEFAULT_HOST,
+    DEFAULT_ROUTER_TIMEOUT,
+    ENV_SHOW_ROUTER_LOGS,
+    get_zmq_engine_count,
+)
 from .process_utils import (
     get_open_port,
     kill_process_tree,
@@ -235,6 +240,11 @@ class Gateway:
             # cannot probe the backend from the ipc:// URL — pin it explicitly.
             if backend is not None:
                 mode_args += ["--backend", backend]
+            # Grouped ZMQ lane: the handshake must await every engine the
+            # worker launched (see get_zmq_engine_count).
+            engine_count = get_zmq_engine_count()
+            if engine_count > 1:
+                mode_args += ["--zmq-engine-count", str(engine_count)]
             self._launch(
                 mode_args=mode_args,
                 timeout=timeout,

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -624,8 +624,16 @@ def start_workers(
     gpus_per_worker = gpus or spec.get("tp", 1)
     if gpus is None and mode == ConnectionMode.ZMQ:
         # A grouped ZMQ worker launches get_zmq_engine_count() engines, each
-        # tp-wide, in one process — size its GPU slice accordingly.
-        gpus_per_worker *= get_zmq_engine_count()
+        # tp-wide, in one process — size its GPU slice accordingly. Only the
+        # vLLM launcher starts engine groups; a grouped count on any other
+        # runtime would reserve GPUs for engines that never launch and leave
+        # the gateway awaiting handshakes that never come.
+        zmq_engine_count = get_zmq_engine_count()
+        if zmq_engine_count > 1 and engine != "vllm":
+            raise ValueError(
+                f"E2E_ZMQ_ENGINE_COUNT={zmq_engine_count} is vLLM-only; got engine={engine!r}"
+            )
+        gpus_per_worker *= zmq_engine_count
     timeout = spec.get("startup_timeout", timeout)
 
     # Detect IB device for PD workers

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -24,6 +24,7 @@ from .constants import (
     ConnectionMode,
     WorkerType,
     get_runtime,
+    get_zmq_engine_count,
     vllm_kv_backend,
 )
 from .model_specs import get_model_spec
@@ -287,9 +288,13 @@ class Worker:
         args = argparse.Namespace(
             connection_mode="zmq", model=model_path, tensor_parallel_size=tp_size
         )
-        return VllmWorkerLauncher().build_command(
-            args, list(spec.get("vllm_args", [])), DEFAULT_HOST, self.port
-        )
+        backend_args = list(spec.get("vllm_args", []))
+        # Grouped lane: an engine-level dp flag makes the launcher start that
+        # many engines on this worker's socket set (see get_zmq_engine_count).
+        engine_count = get_zmq_engine_count()
+        if engine_count > 1:
+            backend_args += ["--data-parallel-size", str(engine_count)]
+        return VllmWorkerLauncher().build_command(args, backend_args, DEFAULT_HOST, self.port)
 
     def _build_vllm_grpc_cmd(self, model_path: str, tp_size: int, spec: dict) -> list[str]:
         """Build vLLM gRPC server command."""
@@ -617,6 +622,10 @@ def start_workers(
 
     spec = get_model_spec(model_id)
     gpus_per_worker = gpus or spec.get("tp", 1)
+    if gpus is None and mode == ConnectionMode.ZMQ:
+        # A grouped ZMQ worker launches get_zmq_engine_count() engines, each
+        # tp-wide, in one process — size its GPU slice accordingly.
+        gpus_per_worker *= get_zmq_engine_count()
     timeout = spec.get("startup_timeout", timeout)
 
     # Detect IB device for PD workers

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -154,6 +154,13 @@ impl RouterConfigBuilder {
         self
     }
 
+    /// DP engines per startup ZMQ worker (grouped worker; see
+    /// `RouterConfig::zmq_engine_count`).
+    pub fn zmq_engine_count(mut self, count: Option<usize>) -> Self {
+        self.config.zmq_engine_count = count;
+        self
+    }
+
     pub fn connection_mode(mut self, mode: ConnectionMode) -> Self {
         self.config.connection_mode = mode;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -27,6 +27,12 @@ pub struct RouterConfig {
     /// this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub startup_worker_runtime_type: Option<RuntimeType>,
+    /// DP engines per startup ZMQ worker: each `--worker-urls` ZMQ worker
+    /// becomes a grouped worker whose handshake awaits this many engines on
+    /// one socket set (`dp_size` on the worker spec, no rank). `None`/1 keeps
+    /// today's one-engine workers; HTTP/gRPC workers ignore this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zmq_engine_count: Option<usize>,
     pub policy: PolicyConfig,
     /// Per-request sticky-routing override (honors `X-SMG-Routing-Key`).
     #[serde(default)]
@@ -852,6 +858,7 @@ impl Default for RouterConfig {
             enable_igw: false,
             connection_mode: ConnectionMode::Http,
             startup_worker_runtime_type: None,
+            zmq_engine_count: None,
             model_path: None,
             tokenizer_path: None,
             chat_template: None,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -314,6 +314,11 @@ struct CliArgs {
     #[arg(long, default_value_t = 30, help_heading = "PD Disaggregation")]
     worker_startup_check_interval: u64,
 
+    /// DP engines per startup ZMQ worker: each ipc:// worker becomes a grouped
+    /// worker whose handshake awaits this many engines on one socket set.
+    #[arg(long, help_heading = "Worker Configuration")]
+    zmq_engine_count: Option<usize>,
+
     /// Interval in seconds between load monitor checks for PowerOfTwo routing
     #[arg(long, default_value_t = 10, help_heading = "Load Monitoring")]
     load_monitor_interval: u64,
@@ -1469,6 +1474,7 @@ impl CliArgs {
             .policy(policy)
             .connection_mode(connection_mode)
             .startup_worker_runtime_type(startup_worker_runtime_type)
+            .zmq_engine_count(self.zmq_engine_count)
             .host(&self.host)
             .port(self.port)
             .health_check_port(self.health_check_port)

--- a/model_gateway/src/routers/grpc/zmq_client.rs
+++ b/model_gateway/src/routers/grpc/zmq_client.rs
@@ -305,16 +305,19 @@ async fn unlink_stale_socket(address: &str) -> Result<(), String> {
     }
 }
 
-/// Bind the SMG-side ZMQ sockets and complete the handshake with the engine:
-/// the single connect path for a worker's `ipc://` URL, shared by the lazy
-/// client accessor and the background handshake driver. `model_id` is the
-/// config-resolved served model (EngineCore reports none). Errors are plain
-/// reasons; the worker layer wraps them in its own error type.
+/// Bind the SMG-side ZMQ sockets and complete the handshake with the
+/// engine(s): the single connect path for a worker's `ipc://` URL, shared by
+/// the lazy client accessor and the background handshake driver. `model_id` is
+/// the config-resolved served model (EngineCore reports none). `engine_count`
+/// is the number of DP engines that will dial this worker's sockets (1 for an
+/// ungrouped worker). Errors are plain reasons; the worker layer wraps them in
+/// its own error type.
 pub(crate) async fn connect_for_worker(
     base_url: &str,
     model_id: String,
     runtime: RuntimeType,
     handshake_override: Option<&str>,
+    engine_count: usize,
 ) -> Result<ZmqEngineClient, String> {
     let (handshake, input, output) = zmq_socket_addresses(base_url, handshake_override)?;
     ensure_ipc_socket_dir(base_url).await?;
@@ -339,12 +342,14 @@ pub(crate) async fn connect_for_worker(
         );
         EosTokenIds::default()
     };
-    tracing::info!("Binding ZMQ client for worker {base_url} (handshake={handshake})");
+    tracing::info!(
+        "Binding ZMQ client for worker {base_url} (handshake={handshake}, engines={engine_count})"
+    );
     ZmqEngineClient::connect(
         &handshake,
         &input,
         &output,
-        1,
+        engine_count,
         model_id,
         eos,
         runtime,

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -253,6 +253,15 @@ impl BasicWorkerBuilder {
         self
     }
 
+    /// Configure a grouped ZMQ DP worker: one worker and one socket set that
+    /// `size` engines dial into. Sets `dp_size` without a rank — the URL is
+    /// untouched and the worker is not rank-pinned; the connector balances
+    /// across the group's engines internally.
+    pub fn zmq_engine_group(mut self, size: usize) -> Self {
+        self.spec.dp_size = Some(size);
+        self
+    }
+
     /// Build the BasicWorker instance
     pub fn build(mut self) -> BasicWorker {
         use std::sync::{atomic::AtomicBool, Arc};
@@ -379,6 +388,28 @@ mod tests {
 
     use super::*;
     use crate::worker::worker::Worker;
+
+    #[test]
+    fn zmq_engine_group_sets_size_without_rank_or_url_rewrite() {
+        // A grouped ZMQ worker is one worker awaiting N engines: dp_size set,
+        // no rank, URL untouched — the opposite of dp_config's rank expansion.
+        let worker = BasicWorkerBuilder::new("ipc:///tmp/w.ipc")
+            .connection_mode(ConnectionMode::Zmq)
+            .zmq_engine_group(4)
+            .build();
+        assert_eq!(worker.metadata().spec.url, "ipc:///tmp/w.ipc");
+        assert_eq!(worker.metadata().spec.dp_size, Some(4));
+        assert_eq!(worker.metadata().spec.dp_rank, None);
+        assert_eq!(worker.metadata().zmq_engine_count(), 4);
+    }
+
+    #[test]
+    fn ungrouped_worker_awaits_one_engine() {
+        let worker = BasicWorkerBuilder::new("ipc:///tmp/w.ipc")
+            .connection_mode(ConnectionMode::Zmq)
+            .build();
+        assert_eq!(worker.metadata().zmq_engine_count(), 1);
+    }
 
     #[test]
     fn zmq_handshake_address_reaches_the_built_spec() {

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -57,14 +57,21 @@ async fn connect_zmq_backend(
     model_id: String,
     runtime: RuntimeType,
     handshake_override: Option<String>,
+    engine_count: usize,
 ) -> WorkerResult<Arc<BackendClient>> {
-    zmq_client::connect_for_worker(&base_url, model_id, runtime, handshake_override.as_deref())
-        .await
-        .map(|client| Arc::new(BackendClient::Zmq(client)))
-        .map_err(|reason| WorkerError::ConnectionFailed {
-            url: base_url,
-            reason,
-        })
+    zmq_client::connect_for_worker(
+        &base_url,
+        model_id,
+        runtime,
+        handshake_override.as_deref(),
+        engine_count,
+    )
+    .await
+    .map(|client| Arc::new(BackendClient::Zmq(client)))
+    .map_err(|reason| WorkerError::ConnectionFailed {
+        url: base_url,
+        reason,
+    })
 }
 
 /// Default bootstrap port for PD disaggregation (used by SGLang and vLLM Mooncake)
@@ -758,6 +765,15 @@ impl WorkerMetadata {
         self.spec.dp_size
     }
 
+    /// Number of ZMQ engines this worker's handshake awaits. A grouped ZMQ
+    /// worker carries `dp_size = Some(N)` with no `dp_rank` — one worker, one
+    /// socket set, N engines dialing in (the connector balances across them
+    /// and drives the wave protocol for lockstep groups). Rank-expanded DP
+    /// workers never reach ZMQ connect (rejected at registration).
+    pub fn zmq_engine_count(&self) -> usize {
+        self.spec.dp_size.unwrap_or(1).max(1)
+    }
+
     /// Transform a request for DP-aware routing.
     ///
     /// When the worker has a `dp_rank`, injects `data_parallel_rank`
@@ -1322,10 +1338,17 @@ impl Worker for BasicWorker {
                 let model_id = self.metadata.model_id().to_string();
                 let runtime = self.metadata.spec.runtime_type;
                 let handshake_override = self.metadata.spec.zmq_handshake_address.clone();
+                let engine_count = self.metadata.zmq_engine_count();
                 let cell = self.backend_client.load_full();
                 let client = cell
                     .get_or_try_init(|| {
-                        connect_zmq_backend(base_url, model_id, runtime, handshake_override)
+                        connect_zmq_backend(
+                            base_url,
+                            model_id,
+                            runtime,
+                            handshake_override,
+                            engine_count,
+                        )
                     })
                     .await?;
                 Ok(Some(Arc::clone(client)))
@@ -1416,6 +1439,7 @@ impl Worker for BasicWorker {
             let url = self.metadata.spec.url.clone();
             let runtime = self.metadata.spec.runtime_type;
             let handshake_override = self.metadata.spec.zmq_handshake_address.clone();
+            let engine_count = self.metadata.zmq_engine_count();
             // Capture the readiness signal and the revision at hand-off. The
             // manager only promotes if this revision still matches, so a
             // same-URL replacement racing the handshake is discarded.
@@ -1429,7 +1453,13 @@ impl Worker for BasicWorker {
             let _handle = tokio::spawn(async move {
                 match cell
                     .get_or_try_init(|| {
-                        connect_zmq_backend(base_url, model_id, runtime, handshake_override)
+                        connect_zmq_backend(
+                            base_url,
+                            model_id,
+                            runtime,
+                            handshake_override,
+                            engine_count,
+                        )
                     })
                     .await
                 {

--- a/model_gateway/src/workflow/job_queue.rs
+++ b/model_gateway/src/workflow/job_queue.rs
@@ -10,7 +10,7 @@ use std::{
 
 use dashmap::DashMap;
 use openai_protocol::worker::{
-    JobStatus, RuntimeType, WorkerSpec, WorkerType, WorkerUpdateRequest,
+    ConnectionMode, JobStatus, RuntimeType, WorkerSpec, WorkerType, WorkerUpdateRequest,
 };
 use smg_mcp::McpConfig;
 use tokio::sync::{mpsc, Semaphore};
@@ -571,6 +571,14 @@ impl JobQueue {
                     // keeps auto-detection in detect_backend.
                     if let Some(runtime) = router_config.startup_worker_runtime_type {
                         spec.runtime_type = runtime;
+                    }
+                    // Grouped ZMQ worker: the handshake awaits this many DP
+                    // engines on one socket set. Only ZMQ URLs — dp_size on an
+                    // HTTP/gRPC startup worker would misread as dp-awareness.
+                    if let Some(count) = router_config.zmq_engine_count.filter(|&n| n > 1) {
+                        if ConnectionMode::from_url(&spec.url) == Some(ConnectionMode::Zmq) {
+                            spec.dp_size = Some(count);
+                        }
                     }
                     // Health config is resolved at worker build time from router
                     // defaults + per-worker overrides (spec.health). No need to

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -133,6 +133,25 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
             });
         }
 
+        // A grouped ZMQ worker (`dp_size: N` on the spec) awaits N engines on
+        // one socket set. TokenSpeed's msgpack wire carries no DP-rank routing
+        // yet, so fail its groups at registration for the same reason as the
+        // runtime check above.
+        let zmq_engine_group = config
+            .dp_size
+            .filter(|&n| n > 1 && *connection_mode == ConnectionMode::Zmq);
+        if zmq_engine_group.is_some() && runtime_type == RuntimeType::TokenSpeed {
+            return Err(WorkflowError::StepFailed {
+                step_id: StepId::new("create_worker"),
+                message: format!(
+                    "ZMQ worker {} configures dp_size={} but the TokenSpeed wire \
+                     does not support DP>1 yet; only vllm engine groups are supported",
+                    config.url,
+                    config.dp_size.unwrap_or_default()
+                ),
+            });
+        }
+
         // Normalize URL
         let url = normalize_url(&config.url, *connection_mode);
 
@@ -215,6 +234,9 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
                 }
                 if let Some(ref address) = config.zmq_handshake_address {
                     builder = builder.zmq_handshake_address(address.clone());
+                }
+                if let Some(group_size) = zmq_engine_group {
+                    builder = builder.zmq_engine_group(group_size);
                 }
                 // ZMQ promotion is event-driven: the worker signals the manager
                 // the instant its handshake completes, so wire the registry's
@@ -417,10 +439,12 @@ fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
 
 /// Reject a data-parallel worker the ZMQ path cannot serve.
 ///
-/// A ZMQ worker binds a single EngineCore connection (engine_count=1); DP>1
-/// needs the coordinator + wave protocol (not yet implemented), so fail loudly
-/// rather than silently under-connecting. Only ZMQ with `dp_size > 1` is
-/// rejected; gRPC/HTTP data parallelism and single-engine ZMQ are fine.
+/// dp-aware expansion creates one rank-pinned worker per DP rank, but each
+/// ZMQ worker owns its own socket bind — N expanded workers would fight over
+/// the same ipc paths. ZMQ DP runs as a *grouped* worker instead (`dp_size: N`
+/// on the worker spec: one worker, one socket set, N engines dialing in), so
+/// reject the expansion loudly and point at the grouped form. gRPC/HTTP
+/// expansion and single-engine ZMQ are fine.
 fn validate_zmq_dp(
     connection_mode: ConnectionMode,
     dp_size: usize,
@@ -430,8 +454,8 @@ fn validate_zmq_dp(
         return Err(WorkflowError::StepFailed {
             step_id: StepId::new("create_worker"),
             message: format!(
-                "ZMQ worker {url} cannot run data-parallel (dp_size={dp_size}); \
-                 DP>1 over ZMQ is not yet supported"
+                "ZMQ worker {url} cannot be dp-aware expanded (dp_size={dp_size}); \
+                 configure a grouped ZMQ worker (`dp_size` on the worker spec) instead"
             ),
         });
     }


### PR DESCRIPTION
## Description

### Problem

DP>1 over the ZMQ direct backend is rejected end-to-end: `validate_zmq_dp` fails registration, the client hardcodes `engine_count=1`, and the serve launcher filters the engine-level `--data-parallel-size` down to 1. The connector's wave protocol (C1, #2078) landed with nothing able to use it. Additionally, the connector sent every unpinned request to `engines.first()` — any multi-engine group would have funneled all traffic to rank 0.

### Solution

A ZMQ DP group is **one worker, one socket set, N engines** (`dp_size: N` on the worker spec with no rank — the existing seam, no new field). dp-aware *expansion* stays rejected: each ZMQ worker owns its socket bind, so N expanded workers would fight over the same ipc paths and unlink each other's live sockets; `validate_zmq_dp` now says so and points at the grouped form. Unpinned requests balance inside the group on the piggybacked per-rank scheduler stats — least `(num_waiting, num_running)` first, mirroring vLLM's own frontend DP client — so the group stays opaque to gateway policies. An SMG-stamped `data_parallel_rank` remains authoritative, and TokenSpeed groups are rejected at registration (its wire has no DP-rank routing yet; upstream fix follows).

## Changes

- `crates/engine_zmq_client/src/connector.rs`: `select_engine` picks the least-loaded engine for unpinned requests (unreported engines score zero, so cold ranks fill first; single-engine groups degenerate to prior behavior); module header updated.
- `model_gateway`: `WorkerMetadata::zmq_engine_count()` feeds both ZMQ connect paths, replacing the hardcoded 1; `BasicWorkerBuilder::zmq_engine_group`; `create_worker` carries `config.dp_size` onto grouped ZMQ workers and rejects TokenSpeed groups; `RouterConfig.zmq_engine_count` stamps startup `--worker-urls` ZMQ workers (the `startup_worker_runtime_type` pattern, ZMQ-URLs-only); `--zmq-engine-count` CLI flag.
- `bindings/python`: `zmq_engine_count` on the Router constructor and `RouterArgs` (+ `--zmq-engine-count`); serve launcher launches a grouped headless vLLM when an engine-level `--data-parallel-size N` is passed after `--` and stamps the router args to await N engines. The smg-level `--data-parallel-size` keeps meaning worker replicas; the two compose as replicas of groups.

## Test Plan

- **Live dp=2**: the new `e2e-2gpu-chat-zmq-dp (vllm)` lane on this PR runs the chat suite against a real two-engine group on the 2-GPU runner — grouped handshake, least-loaded selection, and wave protocol end-to-end (rides the ZMQ lane scaffolding #2060 merged).

- Connector (mock-engine harness): two engines, engine 0 reports `(waiting=5, running=3)` via a pinned warm-up, engine 1 never reports — an unpinned request must land on engine 1. Fails on the old `engines.first()` behavior. 70 crate tests green.
- Builder: grouped spec shape (`dp_size` set, no rank, URL untouched) and the single-engine default.
- serve: grouped launch coverage (space and equals flag forms, launcher flag ownership, single-engine default) — 146 tests green.
- Live `dp=2` validation comes with C4's 2-GPU e2e lane, which extends the ZMQ lane scaffolding landing in #2060 and follows that merge as a small separate PR.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>