### PR TITLE
fix(packaging): point package readmes inside their project directories

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "Keyang Ru", email = "rukeyang@gmail.com"}
 ]
 requires-python = ">=3.9"
-readme = "../../README.md"
+readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 classifiers = [

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,0 +1,9 @@
+# smg-client
+
+Typed Python client for the SMG gateway: OpenAI-compatible chat, completions,
+embeddings, and responses surfaces plus SMG's own control-plane endpoints,
+with request/response models generated from the gateway's OpenAPI schema
+(`smg_client/types/_generated.py`).
+
+Part of the [SMG](https://github.com/smg-project/smg) repository; see the
+repository README for the full project overview.

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "Keyang Ru", email = "rukeyang@gmail.com"},
 ]
 requires-python = ">=3.10"
-readme = "../../README.md"
+readme = "README.md"
 license = { text = "Apache-2.0" }
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Description

### Problem

Every e2e job dies in **Install wheel and test dependencies** since hatchling 1.27.0 released upstream (unpinned in pip's build env):

```
ValueError: Readme path must be within the project directory: ../../README.md
```

`clients/python` (hatchling backend, source-installed by `ci_install_e2e_deps.sh` in every e2e lane) and `bindings/python` (maturin, tolerant today but same latent defect) both declared `readme = "../../README.md"`. First hit: #2087's run 31460158272 (20+ jobs down); main's post-#2060 run hits the same wall as its e2e installs proceed. Same failure class as #2086 — unpinned build tooling moved underneath us.

### Solution

The metadata was always out-of-spec — a wheel embeds its readme, so a path outside the sdist boundary never round-tripped; older hatchling merely tolerated it. Point both packages at local readmes rather than pinning hatchling back: `bindings/python` already had a real README its pyproject was pointing past, and `smg_client` gets a short one describing the package.

## Changes

- `clients/python/README.md`: new package readme; `pyproject.toml` points at it.
- `bindings/python/pyproject.toml`: point at the existing local `README.md`.

## Test Plan

- Built the `smg_client` sdist against `hatchling==1.27.0` exactly (the version that broke CI): succeeds; fails identically to CI before the fix.
- The e2e lanes on this PR exercise the real install path in every job.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>