### PR TITLE
fix(gateway): register unidentified OpenAI-compatible HTTP backends as generic

### DIFF
--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -243,6 +243,10 @@ pub enum RuntimeType {
     Mlx,
     /// TokenSpeed runtime.
     TokenSpeed,
+    /// Generic OpenAI-compatible HTTP backend whose engine could not be
+    /// identified (e.g. a nested SMG gateway fronting the real engine).
+    /// Routed as plain OpenAI HTTP; no engine-specific features are assumed.
+    Generic,
     /// External OpenAI-compatible API (not local inference).
     External,
 }
@@ -263,6 +267,7 @@ impl RuntimeType {
             RuntimeType::Trtllm => "trtllm",
             RuntimeType::Mlx => "mlx",
             RuntimeType::TokenSpeed => "tokenspeed",
+            RuntimeType::Generic => "generic",
             RuntimeType::External => "external",
         }
     }
@@ -290,6 +295,8 @@ impl std::str::FromStr for RuntimeType {
             Ok(RuntimeType::Mlx)
         } else if s.eq_ignore_ascii_case("tokenspeed") {
             Ok(RuntimeType::TokenSpeed)
+        } else if s.eq_ignore_ascii_case("generic") {
+            Ok(RuntimeType::Generic)
         } else if s.eq_ignore_ascii_case("external") {
             Ok(RuntimeType::External)
         } else {
@@ -1432,6 +1439,33 @@ mod connection_mode_tests {
     fn from_url_returns_none_for_bare_or_unknown() {
         assert_eq!(ConnectionMode::from_url("host:30000"), None);
         assert_eq!(ConnectionMode::from_url("ftp://host"), None);
+    }
+}
+
+#[cfg(test)]
+mod runtime_type_tests {
+    use super::RuntimeType;
+
+    #[test]
+    fn generic_round_trips_through_str_and_serde() {
+        assert_eq!(RuntimeType::Generic.as_str(), "generic");
+        assert_eq!(
+            "generic".parse::<RuntimeType>().unwrap(),
+            RuntimeType::Generic
+        );
+        assert_eq!(
+            serde_json::to_string(&RuntimeType::Generic).unwrap(),
+            "\"generic\""
+        );
+        assert_eq!(
+            serde_json::from_str::<RuntimeType>("\"generic\"").unwrap(),
+            RuntimeType::Generic
+        );
+    }
+
+    #[test]
+    fn generic_counts_as_specified() {
+        assert!(RuntimeType::Generic.is_specified());
     }
 }
 

--- a/model_gateway/src/routers/grpc/common/stages/encode.rs
+++ b/model_gateway/src/routers/grpc/common/stages/encode.rs
@@ -364,8 +364,9 @@ fn backend_name(client: &BackendClient) -> &'static str {
         RuntimeType::Mlx => "MLX",
         RuntimeType::TokenSpeed => "TokenSpeed",
         // A gRPC/ZMQ worker is always a local runtime; External (an upstream
-        // OpenAI-compatible API, HTTP-proxied) and Unspecified never reach here.
-        RuntimeType::External | RuntimeType::Unspecified => "unknown",
+        // OpenAI-compatible API, HTTP-proxied), Generic (an unidentified
+        // OpenAI-compatible HTTP backend), and Unspecified never reach here.
+        RuntimeType::External | RuntimeType::Generic | RuntimeType::Unspecified => "unknown",
     }
 }
 

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -274,6 +274,7 @@ impl RequestExecutionStage {
             }
             Some(RuntimeType::Trtllm)
             | Some(RuntimeType::Mlx)
+            | Some(RuntimeType::Generic)
             | Some(RuntimeType::External)
             | Some(RuntimeType::Unspecified) => {
                 error!(

--- a/model_gateway/src/workflow/steps/local/detect_backend.rs
+++ b/model_gateway/src/workflow/steps/local/detect_backend.rs
@@ -1,7 +1,11 @@
 //! Backend runtime detection step.
 //!
-//! Detects the runtime type (sglang, vllm, trtllm, tokenspeed, mlx) for both HTTP and gRPC workers.
-//! - HTTP: probes `/v1/models` (owned_by field), falls back to unique endpoints.
+//! Detects the runtime type for both HTTP and gRPC workers.
+//! - HTTP: probes `/v1/models` (owned_by field), falls back to unique endpoints
+//!   (`/version` → vllm, `/server_info` → sglang). A live OpenAI-compatible
+//!   server matching neither fingerprint is registered as `generic` rather than
+//!   rejected — e.g. the SMG gateway `tokenspeed serve` embeds in front of its
+//!   engine, which reports `owned_by: "self_hosted"` (issue #2085).
 //! - gRPC: tries sglang → vllm → trtllm → tokenspeed → mlx health checks sequentially.
 
 use std::time::Duration;
@@ -63,13 +67,25 @@ async fn detect_grpc_backend(
 
 // ─── HTTP backend detection ────────────────────────────────────────────────
 
-/// Detect HTTP backend by checking `/v1/models` `owned_by` field.
-async fn detect_via_models_endpoint(
+/// Outcome of probing `/v1/models`.
+enum ModelsProbe {
+    /// `owned_by` matched a known engine.
+    Detected(String),
+    /// The endpoint answered like an OpenAI server, but `owned_by` does not
+    /// name a known engine (e.g. a nested SMG gateway reports "self_hosted").
+    UnrecognizedOwnedBy(Option<String>),
+    /// The endpoint could not be probed: unreachable, non-2xx, bad JSON, or
+    /// no models loaded yet.
+    Failed(String),
+}
+
+/// Probe `/v1/models` and classify the backend from its `owned_by` field.
+async fn probe_models_endpoint(
     url: &str,
     timeout_secs: u64,
     client: &Client,
     api_key: Option<&str>,
-) -> Result<String, String> {
+) -> ModelsProbe {
     let models_url = format!("{}/v1/models", http_base_url(url));
 
     let mut req = client
@@ -79,33 +95,33 @@ async fn detect_via_models_endpoint(
         req = req.bearer_auth(key);
     }
 
-    let response = req
-        .send()
-        .await
-        .map_err(|e| format!("Failed to reach {models_url}: {e}"))?;
+    let response = match req.send().await {
+        Ok(response) => response,
+        Err(e) => return ModelsProbe::Failed(format!("failed to reach {models_url}: {e}")),
+    };
 
     if !response.status().is_success() {
-        return Err(format!(
-            "/v1/models returned status {} from {}",
-            response.status(),
-            models_url
+        return ModelsProbe::Failed(format!(
+            "{models_url} returned status {}",
+            response.status()
         ));
     }
 
-    let models: ModelsResponse = response
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse /v1/models response: {e}"))?;
+    let models: ModelsResponse = match response.json().await {
+        Ok(models) => models,
+        Err(e) => {
+            return ModelsProbe::Failed(format!("failed to parse {models_url} response: {e}"))
+        }
+    };
 
-    let first_model = models
-        .data
-        .first()
-        .ok_or_else(|| format!("/v1/models returned empty data array from {models_url}"))?;
+    let Some(first_model) = models.data.first() else {
+        return ModelsProbe::Failed(format!("{models_url} returned an empty data array"));
+    };
 
     match first_model.owned_by.as_deref() {
-        Some("sglang" | "nvidia") => Ok("sglang".to_string()),
-        Some("vllm") => Ok("vllm".to_string()),
-        other => Err(format!("Unrecognized owned_by value: {other:?}")),
+        Some("sglang" | "nvidia") => ModelsProbe::Detected("sglang".to_string()),
+        Some("vllm") => ModelsProbe::Detected("vllm".to_string()),
+        _ => ModelsProbe::UnrecognizedOwnedBy(first_model.owned_by.clone()),
     }
 }
 
@@ -170,6 +186,8 @@ async fn try_sglang_server_info(
 /// Strategy:
 /// 1. Primary: `GET /v1/models` → check `owned_by` field
 /// 2. Fallback: probe `/version` (vLLM) and `/server_info` (SGLang) in parallel
+/// 3. Last resort: a live OpenAI-compatible server matching no engine
+///    fingerprint is registered as `generic` rather than rejected
 async fn detect_http_backend(
     url: &str,
     timeout_secs: u64,
@@ -177,12 +195,19 @@ async fn detect_http_backend(
     api_key: Option<&str>,
 ) -> Result<String, String> {
     // Strategy 1: /v1/models owned_by
-    match detect_via_models_endpoint(url, timeout_secs, client, api_key).await {
-        Ok(runtime) => {
+    let models_probe = probe_models_endpoint(url, timeout_secs, client, api_key).await;
+    match &models_probe {
+        ModelsProbe::Detected(runtime) => {
             debug!("Detected HTTP backend via /v1/models owned_by: {}", runtime);
-            return Ok(runtime);
+            return Ok(runtime.clone());
         }
-        Err(e) => {
+        ModelsProbe::UnrecognizedOwnedBy(owned_by) => {
+            debug!(
+                "No known engine in /v1/models owned_by ({:?}), trying fallback probes",
+                owned_by
+            );
+        }
+        ModelsProbe::Failed(e) => {
             debug!(
                 "Could not detect backend via /v1/models, trying fallback: {}",
                 e
@@ -200,28 +225,57 @@ async fn detect_http_backend(
         try_sglang_server_info(url, timeout_secs, client, api_key),
     );
 
-    if vllm_result.is_ok() {
-        if sglang_result.is_ok() {
-            debug!(
-                "Both /version and /server_info succeeded for {}; /version is vLLM-specific, detecting as vllm",
-                url
-            );
+    let vllm_failure = match vllm_result {
+        Ok(()) => {
+            if sglang_result.is_ok() {
+                debug!(
+                    "Both /version and /server_info succeeded for {}; /version is vLLM-specific, detecting as vllm",
+                    url
+                );
+            }
+            return Ok("vllm".to_string());
         }
-        return Ok("vllm".to_string());
-    }
-    if sglang_result.is_ok() {
-        debug!("Detected HTTP backend via /server_info (no /version): sglang");
-        return Ok("sglang".to_string());
-    }
+        Err(e) => e,
+    };
+    let sglang_failure = match sglang_result {
+        Ok(()) => {
+            debug!("Detected HTTP backend via /server_info (no /version): sglang");
+            return Ok("sglang".to_string());
+        }
+        Err(e) => e,
+    };
 
-    Err(format!(
-        "Could not detect HTTP backend for {url} (tried /v1/models, /version, /server_info)"
-    ))
+    match models_probe {
+        // Strategy 3: the server speaks OpenAI (a live /v1/models with at least
+        // one model) but matches no engine fingerprint — e.g. a nested SMG
+        // gateway such as the one `tokenspeed serve` embeds, which reports
+        // owned_by "self_hosted" and exposes neither /version nor /server_info
+        // (issue #2085). Register it as a generic OpenAI-compatible backend
+        // instead of rejecting a healthy worker.
+        ModelsProbe::UnrecognizedOwnedBy(owned_by) => {
+            warn!(
+                worker = %url,
+                owned_by = ?owned_by,
+                "Could not identify backend engine: /v1/models responded but its \
+                 owned_by is not a known engine, and neither /version (vllm) nor \
+                 /server_info (sglang) is exposed; registering as `generic` \
+                 OpenAI-compatible. Set runtime_type on the worker to override."
+            );
+            Ok("generic".to_string())
+        }
+        ModelsProbe::Failed(models_failure) => Err(format!(
+            "Could not detect HTTP backend for {url}: /v1/models: {models_failure}; \
+             /version: {vllm_failure}; /server_info: {sglang_failure}"
+        )),
+        // Detected returned early above.
+        ModelsProbe::Detected(runtime) => Ok(runtime),
+    }
 }
 
 // ─── Step implementation ───────────────────────────────────────────────────
 
-/// Step 2: Detect backend runtime type (sglang, vllm, trtllm, mlx).
+/// Step 2: Detect backend runtime type (sglang, vllm, trtllm, tokenspeed, mlx,
+/// or `generic` for an unidentified OpenAI-compatible HTTP backend).
 ///
 /// Runs after `detect_connection_mode` and before `discover_metadata`.
 /// Sets `detected_runtime_type` in workflow data for all downstream steps.
@@ -322,37 +376,124 @@ mod tests {
     use serde_json::json;
     use tokio::net::TcpListener;
 
-    use super::detect_via_models_endpoint;
+    use super::detect_http_backend;
 
-    #[tokio::test]
-    async fn detect_via_models_endpoint_maps_nvidia_to_sglang() {
-        async fn models() -> Json<serde_json::Value> {
-            Json(json!({
-                "data": [{
-                    "id": "test-model",
-                    "object": "model",
-                    "owned_by": "nvidia"
-                }],
-                "object": "list"
-            }))
-        }
-
+    async fn serve_router(router: Router) -> (String, tokio::task::JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         #[expect(
             clippy::disallowed_methods,
-            reason = "test-only mock /v1/models server; handle is aborted at test end"
+            reason = "test-only mock backend server; handle is aborted at test end"
         )]
-        let server = tokio::spawn(async move {
-            axum::serve(listener, Router::new().route("/v1/models", get(models)))
-                .await
-                .unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
         });
+        (format!("http://{addr}"), handle)
+    }
 
-        let runtime =
-            detect_via_models_endpoint(&format!("http://{addr}"), 5, &Client::new(), None)
-                .await
-                .unwrap();
+    fn models_route(payload: serde_json::Value) -> Router {
+        Router::new().route(
+            "/v1/models",
+            get(move || {
+                let payload = payload.clone();
+                async move { Json(payload) }
+            }),
+        )
+    }
+
+    #[tokio::test]
+    async fn http_detection_falls_back_to_generic_for_unrecognized_owned_by() {
+        // A nested SMG gateway (e.g. started by `tokenspeed serve`) reports
+        // owned_by "self_hosted" and exposes neither /version nor /server_info.
+        let (url, server) = serve_router(models_route(json!({
+            "object": "list",
+            "data": [{"id": "kimi-k3-256k", "object": "model", "created": 0, "owned_by": "self_hosted"}]
+        })))
+        .await;
+
+        let runtime = detect_http_backend(&url, 5, &Client::new(), None)
+            .await
+            .unwrap();
+        server.abort();
+
+        assert_eq!(runtime, "generic");
+    }
+
+    #[tokio::test]
+    async fn http_detection_falls_back_to_generic_when_owned_by_missing() {
+        let (url, server) = serve_router(models_route(json!({
+            "object": "list",
+            "data": [{"id": "some-model", "object": "model"}]
+        })))
+        .await;
+
+        let runtime = detect_http_backend(&url, 5, &Client::new(), None)
+            .await
+            .unwrap();
+        server.abort();
+
+        assert_eq!(runtime, "generic");
+    }
+
+    #[tokio::test]
+    async fn http_detection_prefers_version_probe_over_generic_fallback() {
+        // Unrecognized owned_by but a live /version endpoint → vllm, not generic.
+        let router = models_route(json!({
+            "object": "list",
+            "data": [{"id": "m", "object": "model", "owned_by": "self_hosted"}]
+        }))
+        .route(
+            "/version",
+            get(|| async { Json(json!({"version": "0.9.0"})) }),
+        );
+        let (url, server) = serve_router(router).await;
+
+        let runtime = detect_http_backend(&url, 5, &Client::new(), None)
+            .await
+            .unwrap();
+        server.abort();
+
+        assert_eq!(runtime, "vllm");
+    }
+
+    #[tokio::test]
+    async fn http_detection_fails_when_models_endpoint_unreachable() {
+        // Bind then drop to get a port that refuses connections: a backend that
+        // is not up must stay an error so the retryable step keeps polling.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let err = detect_http_backend(&format!("http://{addr}"), 1, &Client::new(), None)
+            .await
+            .unwrap_err();
+
+        assert!(err.contains("Could not detect HTTP backend"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn http_detection_fails_when_models_data_empty() {
+        // Server is up but no model is loaded yet — keep failing so the step
+        // retries instead of registering a backend with nothing to serve.
+        let (url, server) = serve_router(models_route(json!({"object": "list", "data": []}))).await;
+
+        let result = detect_http_backend(&url, 5, &Client::new(), None).await;
+        server.abort();
+
+        result.unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn http_detection_maps_nvidia_owned_by_to_sglang() {
+        let (url, server) = serve_router(models_route(json!({
+            "object": "list",
+            "data": [{"id": "test-model", "object": "model", "owned_by": "nvidia"}]
+        })))
+        .await;
+
+        let runtime = detect_http_backend(&url, 5, &Client::new(), None)
+            .await
+            .unwrap();
         server.abort();
 
         assert_eq!(runtime, "sglang");


### PR DESCRIPTION
## Description

### Problem

`smg launch --worker-urls http://<host>:8000` pointed at a server started by `tokenspeed serve` (kimi-k3 recipe) fails registration with:

```
Step failed: detect_backend - HTTP backend detection failed for http://...:
Could not detect HTTP backend for http://... (tried /v1/models, /version, /server_info)
```

while `curl http://<host>:8000/v1/models` answers fine (#2085).

Root cause: HTTP detection recognizes only `owned_by ∈ {sglang, nvidia, vllm}` plus the `/version` (vLLM) and `/server_info` (SGLang) probes. The endpoint in the issue is the SMG gateway that `tokenspeed serve` embeds in front of the engine — it reports `owned_by: "self_hosted"` (SMG's own no-provider model-card value, `crates/protocols/src/model_card.rs`) and exposes neither fallback endpoint, so a healthy OpenAI-compatible worker was rejected until the startup timeout. The gRPC path already fingerprints tokenspeed; the HTTP path had no way to label "OpenAI-compatible, engine unidentified".

### Solution

- New `RuntimeType::Generic` (`"generic"`): a generic OpenAI-compatible HTTP backend whose engine could not be identified. No engine guessed, no sglang default — the label states exactly what was verified.
- `detect_http_backend` strategy 3: if `/v1/models` was live with ≥1 model but neither `owned_by` nor the `/version`/`/server_info` probes identify the engine, register as `generic` and WARN with the per-probe evidence plus an override hint.
- Unreachable or model-less endpoints still fail (the step keeps retrying), and the failure message now lists per-probe outcomes instead of a bare endpoint list.
- Explicit `runtime_type` config still bypasses detection entirely; `generic` is also accepted as an explicit value (escape hatch).
- gRPC pipeline treats `Generic` like External/Unspecified: no PD dispatch, never behind a gRPC/ZMQ client.
- DP-aware discovery: `generic` HTTP workers take the existing warn-and-skip path (same as vllm/tokenspeed HTTP).

## Changes

- `crates/protocols/src/worker.rs`: `RuntimeType::Generic` + as_str/FromStr/serde round-trip tests
- `model_gateway/src/workflow/steps/local/detect_backend.rs`: `ModelsProbe` outcome enum, generic fallback, evidence-rich warn/error, module docs corrected (they claimed tokenspeed/mlx HTTP detection that never existed)
- `model_gateway/src/routers/grpc/common/stages/{request_execution,encode}.rs`: exhaustive-match arms for the new variant
- No bindings changes needed: Python/Go only construct specific variants; verified by `maturin develop` + import

## Test Plan

Unit tests in `detect_backend.rs` against a mock axum backend (`cargo test -p smg --lib detect_backend`):

- `owned_by: "self_hosted"`, no `/version`, no `/server_info` → detects `generic` (reproduces #2085; failed with the exact issue error before the fix)
- missing `owned_by` → `generic`
- unrecognized `owned_by` but live `/version` → still `vllm` (probe priority preserved)
- `nvidia` `owned_by` → still `sglang`
- unreachable endpoint → still errors (step retries)
- `/v1/models` with empty `data` → still errors (engine not up yet)

`cargo test -p openai-protocol`: `generic` round-trips str/serde and counts as specified.

Known coverage boundary: no e2e for tokenspeed-serve-over-HTTP — the e2e infra runs TokenSpeed only in gRPC/ZMQ modes (the same gap that let #2085 slip through).

Gates: `cargo +nightly fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (`--all-features` needs system OpenCV, per CONTRIBUTING fallback); full `cargo test` green (105 suites); `make python-dev` equivalent builds and imports.

Closes #2085

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (workspace fallback; no system OpenCV for `--all-features`)
- [x] Documentation updated (module/step docs in `detect_backend.rs`)

</details>