### PR TITLE
fix(mcp): fail closed on ambiguous pooled connection lookup

### DIFF
--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -51,7 +51,7 @@ use super::{
     config::{BuiltinToolType, McpConfig, McpProxyConfig, McpServerConfig, McpTransport},
     handler::{HandlerRequestContext, RefreshRequest, SmgClientHandler},
     metrics::McpMetrics,
-    pool::{McpConnectionPool, PoolKey},
+    pool::{McpConnectionPool, PoolKey, UrlLookup},
     reconnect::ReconnectionManager,
 };
 use crate::{
@@ -1153,15 +1153,32 @@ impl McpOrchestrator {
             });
         }
 
-        if let Some(client) = self.connection_pool.get_by_url(server_key) {
-            return client.call_tool(request).await.map_err(|e| match e {
-                ServiceError::TransportClosed | ServiceError::TransportSend(_) => {
-                    // Note: Pooled connections trigger Disconnected but
-                    // recovery logic is currently scoped to static servers.
-                    McpError::ServerDisconnected(server_key.to_string())
-                }
-                _ => McpError::ToolExecution(format!("MCP call failed: {e}")),
-            });
+        match self.connection_pool.get_unique_by_url(server_key) {
+            UrlLookup::Found(client) => {
+                return client.call_tool(request).await.map_err(|e| match e {
+                    ServiceError::TransportClosed | ServiceError::TransportSend(_) => {
+                        // Note: Pooled connections trigger Disconnected but
+                        // recovery logic is currently scoped to static servers.
+                        McpError::ServerDisconnected(server_key.to_string())
+                    }
+                    _ => McpError::ToolExecution(format!("MCP call failed: {e}")),
+                });
+            }
+            UrlLookup::Ambiguous => {
+                // Multiple pooled connections share this URL under different
+                // credentials/tenants. Picking one would run the call over
+                // another caller's authenticated connection, so fail closed.
+                warn!(
+                    "Refusing tool execution on '{}': multiple pooled connections share this \
+                     URL with different credentials/tenants; cannot select one safely",
+                    server_key
+                );
+                return Err(McpError::ServerAccessDenied(format!(
+                    "ambiguous MCP connection for '{server_key}': multiple credentials or \
+                     tenants are pooled for this URL"
+                )));
+            }
+            UrlLookup::NotFound => {}
         }
 
         Err(McpError::ServerNotFound(server_key.to_string()))

--- a/crates/mcp/src/core/pool.rs
+++ b/crates/mcp/src/core/pool.rs
@@ -103,6 +103,47 @@ impl CachedConnection {
     }
 }
 
+/// Outcome of a URL-scoped pooled-connection lookup on the tool-execution path.
+///
+/// Execution must never reuse a connection authenticated for a different caller.
+/// When a single URL is pooled under more than one [`PoolKey`] — i.e. the same
+/// server reached with different credentials or tenants — the lookup returns
+/// [`UrlLookup::Ambiguous`] so the caller fails closed instead of resolving to an
+/// arbitrary entry.
+pub(crate) enum UrlLookup {
+    Found(Arc<McpClient>),
+    NotFound,
+    Ambiguous,
+}
+
+/// How many pooled keys share a given URL (credential/tenant-agnostic).
+#[derive(Debug, PartialEq, Eq)]
+enum UrlMatch {
+    None,
+    Unique,
+    Ambiguous,
+}
+
+/// Classify how many pooled keys match `url`. Two or more matches means the URL
+/// is reachable under different credentials/tenants and therefore cannot be
+/// resolved to a single connection safely.
+fn classify_url_match<'a>(keys: impl Iterator<Item = &'a PoolKey>, url: &str) -> UrlMatch {
+    let mut count = 0usize;
+    for key in keys {
+        if key.url == url {
+            count += 1;
+            if count > 1 {
+                return UrlMatch::Ambiguous;
+            }
+        }
+    }
+    if count == 0 {
+        UrlMatch::None
+    } else {
+        UrlMatch::Unique
+    }
+}
+
 /// Thread-safe LRU connection pool for dynamic MCP servers.
 pub struct McpConnectionPool {
     connections: Arc<Mutex<LruCache<PoolKey, CachedConnection>>>,
@@ -227,17 +268,26 @@ impl McpConnectionPool {
         self.connections.lock().contains(key)
     }
 
-    /// Look up a connection by URL only (backward compatibility).
+    /// Look up a connection by URL, failing closed when the URL is ambiguous.
     ///
-    /// **O(n)** — performs a linear scan of all pooled connections under the
-    /// lock. Callers on hot paths should prefer [`get()`](Self::get) with a
-    /// full [`PoolKey`] for O(1) lookup.
-    pub fn get_by_url(&self, url: &str) -> Option<Arc<McpClient>> {
-        self.connections
-            .lock()
-            .iter()
-            .find(|(key, _)| key.url == url)
-            .map(|(_, cached)| Arc::clone(&cached.client))
+    /// The tool-execution path holds only the server URL, not the full
+    /// [`PoolKey`]. If exactly one pooled connection matches the URL it is
+    /// returned; if several do (same server, different credentials or tenants)
+    /// the result is [`UrlLookup::Ambiguous`] so the caller never reuses another
+    /// caller's authenticated connection. Callers that hold the full key should
+    /// prefer [`get()`](Self::get) for an O(1), unambiguous lookup.
+    ///
+    /// **O(n)** — linear scan under the lock (n ≤ `max_connections`).
+    pub(crate) fn get_unique_by_url(&self, url: &str) -> UrlLookup {
+        let connections = self.connections.lock();
+        match classify_url_match(connections.iter().map(|(key, _)| key), url) {
+            UrlMatch::None => UrlLookup::NotFound,
+            UrlMatch::Ambiguous => UrlLookup::Ambiguous,
+            UrlMatch::Unique => match connections.iter().find(|(key, _)| key.url == url) {
+                Some((_, cached)) => UrlLookup::Found(Arc::clone(&cached.client)),
+                None => UrlLookup::NotFound,
+            },
+        }
     }
 }
 
@@ -449,6 +499,45 @@ mod tests {
             stored_proxy.no_proxy.as_ref().unwrap(),
             "localhost,127.0.0.1"
         );
+    }
+
+    #[test]
+    fn classify_url_match_distinguishes_none_unique_and_ambiguous() {
+        let url = "http://localhost:3000";
+        let other = PoolKey::new("http://other:9000", 1, None);
+        let a = PoolKey::new(url, 111, None);
+        // Same URL, different auth hash (two callers with different tokens).
+        let b_diff_auth = PoolKey::new(url, 222, None);
+        // Same URL and auth, different tenant.
+        let a_diff_tenant = PoolKey::new(url, 111, Some("tenant-2".to_string()));
+
+        assert_eq!(
+            classify_url_match([&other].into_iter(), url),
+            UrlMatch::None
+        );
+        assert_eq!(
+            classify_url_match([&other, &a].into_iter(), url),
+            UrlMatch::Unique
+        );
+        // Different credentials on the same URL must never resolve to one entry.
+        assert_eq!(
+            classify_url_match([&a, &b_diff_auth].into_iter(), url),
+            UrlMatch::Ambiguous
+        );
+        // Different tenants on the same URL are equally ambiguous.
+        assert_eq!(
+            classify_url_match([&a, &a_diff_tenant].into_iter(), url),
+            UrlMatch::Ambiguous
+        );
+    }
+
+    #[test]
+    fn get_unique_by_url_on_empty_pool_is_not_found() {
+        let pool = McpConnectionPool::new();
+        assert!(matches!(
+            pool.get_unique_by_url("http://localhost:3000"),
+            UrlLookup::NotFound
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

The dynamic-server MCP tool-execution path resolved a pooled connection by **URL only** (`McpConnectionPool::get_by_url`), ignoring the `auth_hash`/`tenant_id` components of the `PoolKey`. When two callers point at the same MCP server URL with different `Authorization` tokens, the pool holds two entries under the same URL and the linear scan returns whichever it hits first — so caller B's `call_tool` can run over caller A's authenticated connection (cross-tenant credential reuse and data access). Audit findings F204 / F205, re-verified against `main`.

### Solution

Replace the URL-only lookup with `get_unique_by_url`, which **fails closed** when more than one pooled key shares a URL: `execute_on_server` denies the ambiguous case with `ServerAccessDenied` instead of picking an arbitrary connection. Single-credential / single-tenant use (the common case) is unaffected — a unique URL match still resolves normally. The classification rule is extracted into a pure `classify_url_match` helper.

## Changes

- `crates/mcp/src/core/pool.rs`: add `UrlLookup` enum, `classify_url_match`, and `get_unique_by_url` (fail-closed on ambiguity); remove the URL-only `get_by_url`.
- `crates/mcp/src/core/orchestrator.rs`: `execute_on_server` uses `get_unique_by_url`, denying ambiguous URLs with `ServerAccessDenied`.
- Unit tests for none / unique / ambiguous, including same-URL-different-auth and same-URL-different-tenant.

Follow-up (noted in the commit): thread the full `PoolKey` through the router-side binding and URL-keyed inventory so multi-tenant same-URL use *works* rather than fails closed — a larger cross-cutting refactor.

## Test Plan

- `cargo test -p smg-mcp` — 162 passed (2 new: none/unique/ambiguous classification, empty-pool lookup)
- `cargo clippy -p smg-mcp --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt -p smg-mcp -- --check` — clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
