### PR TITLE
fix(routers): avoid duplicate Authorization header on proxied requests

### DIFF
--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -238,6 +238,42 @@ pub fn extract_auth_header(
         .or_else(|| worker_api_key.and_then(|k| HeaderValue::from_str(&format!("Bearer {k}")).ok()))
 }
 
+/// Apply the effective `Authorization` header plus every other forwardable
+/// request header to an outbound reqwest builder, without ever emitting a
+/// duplicate `Authorization`.
+///
+/// `reqwest::RequestBuilder::header` appends rather than replaces, so setting the
+/// worker API key and *then* forwarding the caller's `Authorization` separately
+/// sends two `Authorization` headers (worker-key-first) and inverts the
+/// passthrough precedence documented on [`extract_auth_header`]. Callers that
+/// proxy a request to a worker should use this instead of doing both: it resolves
+/// the single correct value (user header wins, worker key is the fallback) and
+/// forwards every other allow-listed header.
+pub fn apply_forwarded_request_headers(
+    mut builder: reqwest::RequestBuilder,
+    headers: Option<&HeaderMap>,
+    worker_api_key: Option<&String>,
+) -> reqwest::RequestBuilder {
+    if let Some(auth) = extract_auth_header(headers, worker_api_key) {
+        builder = builder.header(http::header::AUTHORIZATION, auth);
+    }
+
+    if let Some(headers) = headers {
+        for (name, value) in headers {
+            // Authorization is applied above with the correct precedence; never
+            // forward it again or reqwest appends a second header.
+            if name.as_str().eq_ignore_ascii_case("authorization") {
+                continue;
+            }
+            if should_forward_request_header(name.as_str()) {
+                builder = builder.header(name, value);
+            }
+        }
+    }
+
+    builder
+}
+
 /// Extract the subset of request headers that SMG is allowed to preserve for
 /// internal execution paths such as MCP tool calls.
 pub fn extract_forwardable_request_headers(headers: Option<&HeaderMap>) -> HashMap<String, String> {
@@ -286,6 +322,63 @@ pub fn should_forward_request_header(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apply_forwarded_request_headers_user_auth_wins_without_duplicate() {
+        let client = reqwest::Client::new();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer user-token"),
+        );
+        headers.insert("x-request-id", HeaderValue::from_static("abc"));
+        headers.insert("x-not-allowlisted", HeaderValue::from_static("nope"));
+        let worker_key = "worker-key".to_string();
+
+        let req = apply_forwarded_request_headers(
+            client.get("http://example.invalid/"),
+            Some(&headers),
+            Some(&worker_key),
+        )
+        .build()
+        .unwrap();
+
+        let auths: Vec<_> = req
+            .headers()
+            .get_all(http::header::AUTHORIZATION)
+            .iter()
+            .collect();
+        assert_eq!(auths.len(), 1, "exactly one Authorization header");
+        assert_eq!(auths[0].to_str().unwrap(), "Bearer user-token");
+        assert!(req.headers().get("x-request-id").is_some());
+        assert!(
+            req.headers().get("x-not-allowlisted").is_none(),
+            "non-allowlisted headers must not be forwarded"
+        );
+    }
+
+    #[test]
+    fn apply_forwarded_request_headers_falls_back_to_worker_key() {
+        let client = reqwest::Client::new();
+        let headers = HeaderMap::new(); // caller sent no Authorization
+        let worker_key = "worker-key".to_string();
+
+        let req = apply_forwarded_request_headers(
+            client.get("http://example.invalid/"),
+            Some(&headers),
+            Some(&worker_key),
+        )
+        .build()
+        .unwrap();
+
+        let auths: Vec<_> = req
+            .headers()
+            .get_all(http::header::AUTHORIZATION)
+            .iter()
+            .collect();
+        assert_eq!(auths.len(), 1);
+        assert_eq!(auths[0].to_str().unwrap(), "Bearer worker-key");
+    }
 
     #[test]
     fn test_extract_header_value_returns_value() {

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -508,10 +508,16 @@ impl Router {
             return error::service_unavailable("no_workers", "No available workers");
         }
 
+        // Caller Authorization takes precedence over each worker's API key;
+        // forward all other allow-listed headers without duplicating auth.
+        let client_auth = header_utils::extract_auth_header(headers, None);
         let filtered_headers: Vec<_> = headers
             .map(|hdrs| {
                 hdrs.iter()
-                    .filter(|(name, _)| header_utils::should_forward_request_header(name.as_str()))
+                    .filter(|(name, _)| {
+                        !name.as_str().eq_ignore_ascii_case("authorization")
+                            && header_utils::should_forward_request_header(name.as_str())
+                    })
                     .collect()
             })
             .unwrap_or_default();
@@ -524,7 +530,7 @@ impl Router {
                 let method = method.clone();
 
                 let headers = filtered_headers.clone();
-
+                let client_auth = client_auth.clone();
                 let api_key = worker.api_key().cloned();
 
                 async move {
@@ -539,11 +545,12 @@ impl Router {
                         }
                     };
 
-                    if let Some(key) = api_key {
-                        let mut auth_header = String::with_capacity(7 + key.len());
-                        auth_header.push_str("Bearer ");
-                        auth_header.push_str(&key);
-                        request_builder = request_builder.header("Authorization", auth_header);
+                    // Caller header wins; fall back to the worker's API key.
+                    let auth = client_auth.or_else(|| {
+                        api_key.and_then(|k| HeaderValue::from_str(&format!("Bearer {k}")).ok())
+                    });
+                    if let Some(auth) = auth {
+                        request_builder = request_builder.header("Authorization", auth);
                     }
 
                     for (name, value) in headers {
@@ -763,28 +770,13 @@ impl Router {
         let endpoint_url = worker.endpoint_url(route);
         let mut request_builder = self.client.post(&endpoint_url).multipart(form);
 
-        if let Some(key) = worker.api_key().cloned() {
-            let mut auth_header = String::with_capacity(7 + key.len());
-            auth_header.push_str("Bearer ");
-            auth_header.push_str(&key);
-            request_builder = request_builder.header("Authorization", auth_header);
-        }
-
-        if let Some(headers) = headers {
-            for (name, value) in headers {
-                // Skip Content-Type and Content-Length — reqwest sets the
-                // correct multipart boundary itself.
-                let name_str = name.as_str();
-                if name_str.eq_ignore_ascii_case("content-type")
-                    || name_str.eq_ignore_ascii_case("content-length")
-                {
-                    continue;
-                }
-                if header_utils::should_forward_request_header(name_str) {
-                    request_builder = request_builder.header(name, value);
-                }
-            }
-        }
+        // reqwest sets the multipart Content-Type (with boundary) itself; the
+        // forward allow-list already excludes Content-Type/Content-Length.
+        request_builder = header_utils::apply_forwarded_request_headers(
+            request_builder,
+            headers,
+            worker.api_key(),
+        );
 
         let res = match request_builder.send().await {
             Ok(res) => res,
@@ -1029,21 +1021,11 @@ impl Router {
 
         let mut request_builder = self.client.post(&endpoint_url).json(&json_val);
 
-        if let Some(key) = api_key {
-            // Pre-allocate string with capacity to avoid reallocation
-            let mut auth_header = String::with_capacity(7 + key.len());
-            auth_header.push_str("Bearer ");
-            auth_header.push_str(&key);
-            request_builder = request_builder.header("Authorization", auth_header);
-        }
-
-        if let Some(headers) = headers {
-            for (name, value) in headers {
-                if header_utils::should_forward_request_header(name.as_str()) {
-                    request_builder = request_builder.header(name, value);
-                }
-            }
-        }
+        request_builder = header_utils::apply_forwarded_request_headers(
+            request_builder,
+            headers,
+            api_key.as_ref(),
+        );
 
         let res = match request_builder.send().await {
             Ok(res) => res,


### PR DESCRIPTION
## Description

### Problem

The HTTP proxy paths set the worker API key as `Authorization` and then **separately** forwarded the caller's `Authorization` header (it is on the forward allow-list). `reqwest::RequestBuilder::header` **appends** rather than replaces, so both were sent — two `Authorization` headers, worker-key-first — inverting the documented passthrough precedence (caller header wins, worker key is the fallback; `header_utils::extract_auth_header`). A downstream that honors the first header authenticates with the wrong credential. Three sites had this shape: `send_typed_request`, the multipart transcription path, and the broadcast fan-out path. Audit finding F274, re-verified against `main`.

### Solution

Add `header_utils::apply_forwarded_request_headers(builder, headers, worker_api_key)`, which resolves the single correct `Authorization` value via the existing `extract_auth_header` (caller wins, worker key fallback) and forwards every other allow-listed header exactly once, skipping `authorization`. The fan-out path gets the same precedence inline (caller auth computed once, worker key as fallback). `proxy_get_request` (no worker key) was already single-header and is unchanged.

## Changes

- `model_gateway/src/routers/common/header_utils.rs`: new `apply_forwarded_request_headers` helper + two tests (one Authorization header; caller-wins vs worker-fallback).
- `model_gateway/src/routers/http/router.rs`: use the helper on the typed-request and multipart paths; fix the fan-out path inline.

## Test Plan

- `cargo test -p smg --lib header_utils` — 14 passed (2 new)
- `cargo clippy -p smg --all-targets -- -D warnings` — clean (`--all-features` needs opencv/pkg-config, unavailable locally; covered by CI)
- `cargo +nightly fmt -p smg -- --check` — clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (via CI; `--all-features` needs opencv locally)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
