### PR TITLE
fix(zmq): bound engine input sends so a wedged engine can't freeze the client

### DIFF
--- a/crates/engine_zmq_client/src/connector.rs
+++ b/crates/engine_zmq_client/src/connector.rs
@@ -152,6 +152,14 @@ impl<P: EngineProtocol> ClientInner<P> {
     }
 
     /// Send an encoded request frame to one engine over the shared input socket.
+    ///
+    /// The send is bounded by [`ENGINE_SEND_TIMEOUT`]: a healthy engine drains its
+    /// input continuously, so a send that cannot complete in that window means the
+    /// engine's event loop is wedged. Because the timeout cancels the send
+    /// mid-frame (leaving the shared socket unusable), the timeout is fatal — it
+    /// fails every in-flight request and closes the client so health checks evict
+    /// this worker, instead of the untimed send freezing the dispatcher (starving
+    /// the death watchdog) and every concurrent submit behind the shared lock.
     async fn send_to_engine(
         &self,
         engine_id: &EngineId,
@@ -160,14 +168,26 @@ impl<P: EngineProtocol> ClientInner<P> {
         aux_frames: Vec<Bytes>,
     ) -> Result<()> {
         let mut input_send = self.input_send.lock().await;
-        send_message(
+        let send = send_message(
             &mut input_send,
             engine_id,
             request_type,
             payload.into(),
             aux_frames,
-        )
-        .await
+        );
+        match tokio::time::timeout(ENGINE_SEND_TIMEOUT, send).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                warn!(
+                    timeout = ?ENGINE_SEND_TIMEOUT,
+                    "engine input send timed out; treating engine as dead"
+                );
+                self.registry
+                    .lock()
+                    .fail_all(Arc::new(Error::EngineCoreDead));
+                Err(Error::EngineCoreDead)
+            }
+        }
     }
 
     /// Tell every rank but `exclude_index` to start `wave`. Does nothing for a
@@ -401,6 +421,13 @@ impl<P: EngineProtocol> Drop for Client<P> {
 /// PUSH peer vanishes — so silence is the only available death signal. Generous
 /// so a slow first token never trips it, while still bounding an otherwise
 /// infinite hang.
+/// Maximum time to wait for a single request frame to be accepted by an engine's
+/// input socket before treating the engine as wedged. A healthy engine drains its
+/// input continuously; a send that blocks this long means its event loop is stuck.
+/// Bounds an otherwise unbounded await under the shared input lock (see
+/// [`ClientInner::send_to_engine`]).
+const ENGINE_SEND_TIMEOUT: Duration = Duration::from_secs(10);
+
 const ENGINE_SILENCE_DEATH_TIMEOUT: Duration = Duration::from_secs(300);
 
 async fn run_dispatcher<P: EngineProtocol>(
@@ -442,6 +469,11 @@ async fn run_dispatcher<P: EngineProtocol>(
                     inner.registry.lock().remove_all([&request_id]);
                     if let Err(error) = inner.abort(&engine_id, &request_id).await {
                         warn!(%error, %request_id, "failed to send abort");
+                        if matches!(error, Error::EngineCoreDead | Error::Transport(_)) {
+                            // The engine is dead — send_to_engine already failed all
+                            // in-flight requests; stop dispatching.
+                            return;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description

### Problem

`ClientInner::send_to_engine` awaited the input-socket send under the shared `input_send` mutex with **no timeout**. A single engine whose event loop wedges (input socket no longer draining) then froze the entire ZMQ client: the dispatcher's `abort` arm awaits this send inside its `select!`, so a stuck send parked the dispatcher loop — starving the positive-liveness death watchdog — while every concurrent `submit` blocked on the same lock. `is_alive()` stayed `true`, so the gateway never evicted the worker: an unrecoverable wedge that looks alive until process restart. Audit F113 family (connector.rs F116–F122), re-verified against `main` (survived the post-audit ZMQ refactor).

### Solution

Bound the send with `ENGINE_SEND_TIMEOUT` (10s). Because the timeout cancels the send mid-frame (leaving the shared socket unusable), it is treated as **fatal**: `send_to_engine` fails all in-flight requests and closes the client, so `is_alive()` flips false and health checks evict the worker. The dispatcher's `abort` arm returns on a dead-engine error so it stops dispatching promptly. Healthy sends complete far under the window, so normal operation is unchanged.

## Changes

- `crates/engine_zmq_client/src/connector.rs`: add `ENGINE_SEND_TIMEOUT`; wrap the input-socket send in `tokio::time::timeout` with `fail_all` on elapse; dispatcher abort arm returns on `EngineCoreDead`/`Transport`.

## Test Plan

- `cargo test -p engine-zmq-client` — 69 passed (healthy submit/stream/abort and existing engine-death paths unchanged)
- `cargo clippy -p engine-zmq-client --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt -p engine-zmq-client -- --check` — clean

Follow-up: a deterministic wedged-engine integration test needs a blocking-transport harness (a real ZMQ send only blocks once its buffer fills); left out rather than adding fragile HWM-fill scaffolding.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
