### PR TITLE
feat(kv_index): bound the positional indexer with TTL and capacity pruning

### DIFF
--- a/crates/kv_index/src/event_tree.rs
+++ b/crates/kv_index/src/event_tree.rs
@@ -1,7 +1,8 @@
 //! Positional indexer for cache-aware routing.
 //!
-//! Uses a single `DashMap<(usize, ContentHash), SeqEntry>` keyed by (position, content_hash).
-//! No capacity limit — the map grows unboundedly as blocks are stored.
+//! Uses a single `DashMap<(usize, ContentHash), IndexEntry>` keyed by (position, content_hash).
+//! Unbounded by default; [`PositionalIndexer::prune`] optionally bounds it with a
+//! last-touch TTL and/or a capacity ceiling (oldest-first eviction).
 //! Jump search skips positions in strides, yielding amortized O(D/J + W) complexity.
 //!
 //! **Dual-hash scheme**: backends send a position-aware `block_hash` (SequenceHash)
@@ -23,9 +24,10 @@
 use std::{
     fmt,
     sync::{
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering},
         Arc, OnceLock,
     },
+    time::Instant,
 };
 
 use dashmap::{mapref::entry::Entry, DashMap};
@@ -42,6 +44,19 @@ const INDEX_SHARD_COUNT: usize = 1024;
 /// Shard count for worker-keyed DashMaps (worker_blocks, worker_to_id).
 /// These maps hold at most ~500 entries (one per worker), so 8 shards is sufficient.
 const WORKER_SHARD_COUNT: usize = 8;
+
+/// Capacity-pass eviction skips entries touched within this many seconds.
+///
+/// `apply_stored` inserts a batch's index entries before its single deferred
+/// `tree_sizes` increment; evicting one of those entries in that gap would
+/// decrement a counter that was never incremented (clamping at zero) and
+/// leave the later increment counting an already-evicted entry. Entries
+/// stamped within the grace are never capacity-eviction candidates, so a
+/// prune cannot race a store batch that is still being accounted (the TTL
+/// pass is inherently safe: a just-stored stamp is always newer than any
+/// cutoff). Side effect: a burst of all-fresh entries can transiently exceed
+/// the ceiling until they age past the grace.
+const CAPACITY_EVICTION_GRACE_SECS: u32 = 2;
 
 /// Length of the first `TreeSizes` segment (covers worker ids 0..2048).
 /// Segment `s` doubles to `FIRST_SEGMENT_LEN << s` entries, so worker count is
@@ -196,40 +211,67 @@ impl SeqEntry {
     }
 
     /// Insert a worker for a given seq_hash, upgrading to Multi if needed.
-    fn insert(&mut self, seq_hash: SequenceHash, worker_id: u32) {
+    /// Returns whether the membership was newly added (false for a duplicate
+    /// store of an existing membership) so callers can keep `tree_sizes`
+    /// consistent with what is actually in the index.
+    fn insert(&mut self, seq_hash: SequenceHash, worker_id: u32) -> bool {
         match self {
             Self::Single(existing_hash, workers) if *existing_hash == seq_hash => {
-                workers.insert(worker_id);
+                workers.insert(worker_id)
             }
             Self::Single(existing_hash, existing_workers) => {
                 let mut map = FxHashMap::with_capacity_and_hasher(2, FxBuildHasher);
                 map.insert(*existing_hash, std::mem::take(existing_workers));
-                map.entry(seq_hash).or_default().insert(worker_id);
+                let added = map.entry(seq_hash).or_default().insert(worker_id);
                 *self = Self::Multi(map);
+                added
             }
-            Self::Multi(map) => {
-                map.entry(seq_hash).or_default().insert(worker_id);
-            }
+            Self::Multi(map) => map.entry(seq_hash).or_default().insert(worker_id),
         }
     }
 
     /// Remove a worker from a given seq_hash.
-    /// Returns true if the entry is now completely empty and should be removed.
-    fn remove(&mut self, seq_hash: SequenceHash, worker_id: u32) -> bool {
+    /// Returns `(removed, now_empty)`: whether the worker was actually present
+    /// under that seq_hash (so callers can keep `tree_sizes` consistent — a
+    /// membership already gone, e.g. pruned, must not be decremented twice),
+    /// and whether the entry is now completely empty and should be dropped.
+    fn remove(&mut self, seq_hash: SequenceHash, worker_id: u32) -> (bool, bool) {
         match self {
             Self::Single(existing_hash, workers) if *existing_hash == seq_hash => {
-                workers.remove(&worker_id);
-                workers.is_empty()
+                let removed = workers.remove(&worker_id);
+                (removed, workers.is_empty())
             }
-            Self::Single(_, _) => false,
+            Self::Single(_, _) => (false, false),
             Self::Multi(map) => {
+                let mut removed = false;
                 if let Some(workers) = map.get_mut(&seq_hash) {
-                    workers.remove(&worker_id);
+                    removed = workers.remove(&worker_id);
                     if workers.is_empty() {
                         map.remove(&seq_hash);
                     }
                 }
-                map.is_empty()
+                (removed, map.is_empty())
+            }
+        }
+    }
+
+    /// Count per-worker memberships in this entry, accumulating into `acc`.
+    /// A worker appearing under multiple prefix hashes counts once per prefix
+    /// hash — mirroring how `apply_stored` incremented `tree_sizes`. Used by
+    /// [`PositionalIndexer::prune`] to decrement counters on eviction.
+    fn accumulate_worker_counts(&self, acc: &mut FxHashMap<u32, usize>) {
+        match self {
+            Self::Single(_, workers) => {
+                for &w in workers {
+                    *acc.entry(w).or_default() += 1;
+                }
+            }
+            Self::Multi(map) => {
+                for workers in map.values() {
+                    for &w in workers {
+                        *acc.entry(w).or_default() += 1;
+                    }
+                }
             }
         }
     }
@@ -341,6 +383,21 @@ impl TreeSizes {
             .map(|size| size.load(Ordering::Relaxed))
             .sum()
     }
+
+    /// Subtract `n` from a worker's count, saturating at 0. Prune-side
+    /// decrements are approximate (see `apply_stored`'s duplicate-store
+    /// counting), so saturation — not wrapping — is the safe failure mode.
+    fn sub_saturating(&self, id: u32, n: usize) {
+        let slot = self.slot(id);
+        let mut current = slot.load(Ordering::Relaxed);
+        loop {
+            let next = current.saturating_sub(n);
+            match slot.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(observed) => current = observed,
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -353,19 +410,61 @@ impl TreeSizes {
 /// Callers own one `WorkerBlockMap` per worker and pass it to write-path methods.
 pub type WorkerBlockMap = FxHashMap<SequenceHash, (usize, ContentHash, SequenceHash)>;
 
+/// Value stored in the positional index: the seq-hash/worker entry plus a
+/// coarse last-access stamp consumed by [`PositionalIndexer::prune`].
+#[derive(Debug)]
+struct IndexEntry {
+    seq: SeqEntry,
+    /// Seconds since the indexer's epoch at the last store or successful query
+    /// read. Relaxed atomics throughout: a stamp stale by one prune cycle only
+    /// delays eviction by one interval.
+    last_touch: AtomicU32,
+}
+
+impl IndexEntry {
+    fn new(seq: SeqEntry, now: u32) -> Self {
+        Self {
+            seq,
+            last_touch: AtomicU32::new(now),
+        }
+    }
+
+    #[inline]
+    fn touch(&self, now: u32) {
+        self.last_touch.store(now, Ordering::Relaxed);
+    }
+}
+
+/// The positional index map type (see [`IndexEntry`]).
+type PosIndex = DashMap<(usize, ContentHash), IndexEntry, FxBuildHasher>;
+
+/// Outcome of a [`PositionalIndexer::prune`] pass.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PruneStats {
+    /// Entries inspected across both passes.
+    pub scanned: usize,
+    /// Entries evicted because their last touch exceeded the TTL.
+    pub evicted_ttl: usize,
+    /// Entries evicted to enforce the capacity ceiling (oldest first).
+    pub evicted_capacity: usize,
+    /// Entries remaining after the pass.
+    pub remaining: usize,
+}
+
 /// Positional indexer for cache-aware routing.
 ///
-/// Uses a single `DashMap<(usize, ContentHash), SeqEntry>` — keyed by
-/// (position, content_hash). Grows unboundedly (no capacity limit).
+/// Uses a single `DashMap<(usize, ContentHash), IndexEntry>` — keyed by
+/// (position, content_hash). Unbounded by default; [`prune`](Self::prune)
+/// optionally bounds it with a last-touch TTL and a capacity ceiling.
 /// Jump search gives amortized O(D/J + W) matching complexity.
 ///
 /// Write-path methods take a caller-owned `&mut WorkerBlockMap` (one per worker).
 /// This gives direct HashMap access (~5ns) instead of DashMap hash+shard locking
 /// (~25ns), achieving zero-contention for single-writer-per-worker.
 pub struct PositionalIndexer {
-    /// Single flat index: (position, content_hash) → SeqEntry.
-    /// No capacity limit — grows as blocks are stored.
-    index: DashMap<(usize, ContentHash), SeqEntry, FxBuildHasher>,
+    /// Single flat index: (position, content_hash) → IndexEntry.
+    /// Bounded only when the owner runs [`prune`](Self::prune).
+    index: PosIndex,
     /// Per-worker block counts, tracked atomically for O(1) reads during queries.
     /// Segmented array indexed by worker_id — lock-free reads on the query hot
     /// path (array index ~1ns vs DashMap hash+lock+probe ~25ns per access),
@@ -378,6 +477,11 @@ pub struct PositionalIndexer {
     next_worker_id: AtomicU64,
     /// Jump size for search optimization (default 64).
     jump_size: usize,
+    /// Origin of the coarse `last_touch` clock (whole seconds since creation).
+    epoch: Instant,
+    /// Test override for the coarse clock; `u32::MAX` = disabled.
+    #[cfg(test)]
+    test_now: AtomicU32,
 }
 
 impl PositionalIndexer {
@@ -394,7 +498,30 @@ impl PositionalIndexer {
             worker_to_id: DashMap::with_hasher_and_shard_amount(FxBuildHasher, WORKER_SHARD_COUNT),
             next_worker_id: AtomicU64::new(0),
             jump_size,
+            epoch: Instant::now(),
+            #[cfg(test)]
+            test_now: AtomicU32::new(u32::MAX),
         }
+    }
+
+    /// Coarse clock: whole seconds since this indexer was created. Saturates
+    /// at `u32::MAX - 1` (~136 years) so `u32::MAX` stays free as the test
+    /// override sentinel.
+    fn now_secs(&self) -> u32 {
+        #[cfg(test)]
+        {
+            let t = self.test_now.load(Ordering::Relaxed);
+            if t != u32::MAX {
+                return t;
+            }
+        }
+        self.epoch.elapsed().as_secs().min(u32::MAX as u64 - 1) as u32
+    }
+
+    /// Override the coarse clock in tests (u32::MAX restores the real clock).
+    #[cfg(test)]
+    fn set_test_now(&self, now: u32) {
+        self.test_now.store(now, Ordering::Relaxed);
     }
 
     /// Get the internal u32 ID for a worker URL, if it has been interned.
@@ -439,6 +566,9 @@ impl PositionalIndexer {
 
         let mut prev_prefix = parent_prefix;
         let mut num_new_blocks = 0usize;
+        // One coarse stamp per batch — cheaper than per-block clock reads and
+        // precise enough for prune's second-granularity TTL.
+        let now = self.now_secs();
         for (i, block) in blocks.iter().enumerate() {
             let position = start_pos + i;
             let content_hash = block.content_hash;
@@ -451,17 +581,27 @@ impl PositionalIndexer {
                 None => SequenceHash(content_hash.0),
             };
 
-            self.index
-                .entry((position, content_hash))
-                .and_modify(|entry| entry.insert(prefix_hash, worker_id))
-                .or_insert_with(|| SeqEntry::new(prefix_hash, worker_id));
+            let membership_added = match self.index.entry((position, content_hash)) {
+                Entry::Occupied(mut occupied) => {
+                    let entry = occupied.get_mut();
+                    let added = entry.seq.insert(prefix_hash, worker_id);
+                    entry.touch(now);
+                    added
+                }
+                Entry::Vacant(vacant) => {
+                    vacant.insert(IndexEntry::new(SeqEntry::new(prefix_hash, worker_id), now));
+                    true
+                }
+            };
 
-            // Only count genuinely new blocks — duplicate store events must not
-            // inflate tree_sizes, which would cause incorrect routing decisions.
-            if worker_blocks
-                .insert(block.seq_hash, (position, content_hash, prefix_hash))
-                .is_none()
-            {
+            // Keep the reverse map current regardless; count only memberships
+            // actually added to the index. Duplicate store events still don't
+            // inflate tree_sizes, and re-storing a block whose entry was
+            // pruned (its stale reverse mapping kept) restores its count —
+            // mirroring apply_removed, which decrements only memberships
+            // actually removed.
+            worker_blocks.insert(block.seq_hash, (position, content_hash, prefix_hash));
+            if membership_added {
                 num_new_blocks += 1;
             }
             prev_prefix = Some(prefix_hash);
@@ -502,12 +642,18 @@ impl PositionalIndexer {
                 continue;
             };
 
+            // Count only memberships actually removed from the index. A stale
+            // reverse-map entry (its index entry was pruned earlier) must not
+            // decrement tree_sizes a second time.
             if let Entry::Occupied(mut occupied) = self.index.entry((position, content_hash)) {
-                if occupied.get_mut().remove(prefix_hash, worker_id) {
+                let (removed, now_empty) = occupied.get_mut().seq.remove(prefix_hash, worker_id);
+                if now_empty {
                     occupied.remove();
                 }
+                if removed {
+                    num_removed += 1;
+                }
             }
-            num_removed += 1;
         }
 
         if num_removed > 0 {
@@ -525,7 +671,8 @@ impl PositionalIndexer {
         let drained = std::mem::take(worker_blocks);
         for &(position, content_hash, prefix_hash) in drained.values() {
             if let Entry::Occupied(mut occ) = self.index.entry((position, content_hash)) {
-                if occ.get_mut().remove(prefix_hash, worker_id) {
+                let (_, now_empty) = occ.get_mut().seq.remove(prefix_hash, worker_id);
+                if now_empty {
                     occ.remove();
                 }
             }
@@ -540,7 +687,8 @@ impl PositionalIndexer {
     pub fn remove_worker(&self, worker_id: u32, worker_blocks: WorkerBlockMap) {
         for &(position, content_hash, prefix_hash) in worker_blocks.values() {
             if let Entry::Occupied(mut occ) = self.index.entry((position, content_hash)) {
-                if occ.get_mut().remove(prefix_hash, worker_id) {
+                let (_, now_empty) = occ.get_mut().seq.remove(prefix_hash, worker_id);
+                if now_empty {
                     occ.remove();
                 }
             }
@@ -551,6 +699,118 @@ impl PositionalIndexer {
     /// Get total number of blocks across all workers.
     pub fn current_size(&self) -> usize {
         self.tree_sizes.total()
+    }
+
+    /// Number of `(position, content_hash)` entries currently in the index.
+    /// O(shards); intended for prune decisions and observability, not hot paths.
+    pub fn entry_count(&self) -> usize {
+        self.index.len()
+    }
+
+    /// Evict stale and/or excess index entries. Intended to be driven
+    /// periodically by the owner (e.g. the routing policy's eviction cycle).
+    ///
+    /// * `ttl_secs`: entries neither stored to nor read by a query within this
+    ///   many seconds are evicted. `None` or `Some(0)` disables the TTL pass.
+    /// * `max_entries`: when the index holds more entries than this ceiling,
+    ///   the oldest-touched entries are evicted down to a low-water mark of
+    ///   90% of the ceiling (avoids re-evicting every cycle at the boundary).
+    ///   `None` or `Some(0)` disables the capacity pass.
+    ///
+    /// Semantics and caveats:
+    /// * Queries touch exactly the entries they read (position 0, jump
+    ///   landings, and linear-scan ranges), so entries a hot request stream
+    ///   actually needs stay resident; interior positions the jump shortcut
+    ///   skips may age out — harmless, the shortcut never reads them, and a
+    ///   later drain across an evicted position under-counts that one score
+    ///   (same tolerance as the documented `apply_removed` gap behavior).
+    /// * Eviction leaves the per-worker reverse maps (`WorkerBlockMap`)
+    ///   untouched; a later `apply_removed` for a pruned block is a safe
+    ///   no-op (membership check), and stale reverse entries are dropped by
+    ///   the backend's own removal/clear events or worker removal.
+    /// * `tree_sizes` is decremented per evicted membership (saturating), so
+    ///   worker totals stay approximately consistent under eviction.
+    ///
+    /// Runs off the hot path; both passes collect candidate keys first and
+    /// then re-check under the entry lock, sparing entries touched since the
+    /// scan.
+    pub fn prune(&self, ttl_secs: Option<u32>, max_entries: Option<usize>) -> PruneStats {
+        self.prune_with_now(self.now_secs(), ttl_secs, max_entries)
+    }
+
+    fn prune_with_now(
+        &self,
+        now: u32,
+        ttl_secs: Option<u32>,
+        max_entries: Option<usize>,
+    ) -> PruneStats {
+        let mut stats = PruneStats::default();
+        let mut decrements: FxHashMap<u32, usize> = FxHashMap::default();
+
+        // Pass 1: TTL. `cutoff == 0` (indexer younger than the TTL) means
+        // nothing can be stale yet.
+        if let Some(ttl) = ttl_secs.filter(|&t| t > 0) {
+            let cutoff = now.saturating_sub(ttl);
+            if cutoff > 0 {
+                let mut expired: Vec<(usize, ContentHash)> = Vec::new();
+                for item in &self.index {
+                    stats.scanned += 1;
+                    if item.value().last_touch.load(Ordering::Relaxed) < cutoff {
+                        expired.push(*item.key());
+                    }
+                }
+                for key in expired {
+                    if let Entry::Occupied(occ) = self.index.entry(key) {
+                        // Re-check under the entry lock: touched since the scan → spare.
+                        if occ.get().last_touch.load(Ordering::Relaxed) < cutoff {
+                            occ.get().seq.accumulate_worker_counts(&mut decrements);
+                            occ.remove();
+                            stats.evicted_ttl += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Pass 2: capacity ceiling, oldest-touched first. Entries inside the
+        // freshness grace are not candidates (see CAPACITY_EVICTION_GRACE_SECS),
+        // so eviction can fall short of the low-water mark under an all-fresh
+        // burst; the next cycle catches up once entries age.
+        if let Some(max) = max_entries.filter(|&m| m > 0) {
+            let len = self.index.len();
+            if len > max {
+                let low_water = max - max / 10;
+                let fresh_cutoff = now.saturating_sub(CAPACITY_EVICTION_GRACE_SECS);
+                let mut aged: Vec<(u32, (usize, ContentHash))> = Vec::new();
+                for item in &self.index {
+                    stats.scanned += 1;
+                    let stamp = item.value().last_touch.load(Ordering::Relaxed);
+                    if stamp < fresh_cutoff {
+                        aged.push((stamp, *item.key()));
+                    }
+                }
+                let evict_n = len.saturating_sub(low_water).min(aged.len());
+                if evict_n > 0 {
+                    aged.select_nth_unstable_by_key(evict_n - 1, |&(stamp, _)| stamp);
+                    for &(stamp, key) in &aged[..evict_n] {
+                        if let Entry::Occupied(occ) = self.index.entry(key) {
+                            // Touched since the scan → spare it this cycle.
+                            if occ.get().last_touch.load(Ordering::Relaxed) == stamp {
+                                occ.get().seq.accumulate_worker_counts(&mut decrements);
+                                occ.remove();
+                                stats.evicted_capacity += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        for (worker, n) in decrements {
+            self.tree_sizes.sub_saturating(worker, n);
+        }
+        stats.remaining = self.index.len();
+        stats
     }
 
     /// Find overlap scores for a request's content hash sequence.
@@ -648,20 +908,23 @@ impl PositionalIndexer {
     /// Copies worker IDs into a Vec — used only once at position 0 to initialize `active`.
     /// Skips rolling hash computation for Single entries (unambiguous match).
     fn get_workers_lazy(
-        index: &DashMap<(usize, ContentHash), SeqEntry, FxBuildHasher>,
+        index: &PosIndex,
         position: usize,
         content_hash: ContentHash,
         seq_hashes: &mut Vec<SequenceHash>,
         sequence: &[ContentHash],
+        now: u32,
     ) -> Option<Vec<u32>> {
         let entry = index.get(&(position, content_hash))?;
-        if let Some(workers) = entry.value().workers_if_single() {
+        entry.value().touch(now);
+        if let Some(workers) = entry.value().seq.workers_if_single() {
             return Some(workers.iter().copied().collect());
         }
         // Multi: need rolling hash to disambiguate
         Self::ensure_seq_hash_computed(seq_hashes, position, sequence);
         entry
             .value()
+            .seq
             .get(seq_hashes[position])
             .map(|workers| workers.iter().copied().collect())
     }
@@ -669,21 +932,25 @@ impl PositionalIndexer {
     /// Count workers at a position matching the prefix_hash (no set materialization).
     /// Skips rolling hash computation for Single entries (unambiguous match).
     fn count_workers_at(
-        index: &DashMap<(usize, ContentHash), SeqEntry, FxBuildHasher>,
+        index: &PosIndex,
         position: usize,
         content_hash: ContentHash,
         seq_hashes: &mut Vec<SequenceHash>,
         sequence: &[ContentHash],
+        now: u32,
     ) -> usize {
         let Some(entry) = index.get(&(position, content_hash)) else {
             return 0;
         };
-        if let Some(workers) = entry.value().workers_if_single() {
+        entry.value().touch(now);
+        if let Some(workers) = entry.value().seq.workers_if_single() {
             return workers.len();
         }
         // Multi: need rolling hash to disambiguate
         Self::ensure_seq_hash_computed(seq_hashes, position, sequence);
         entry
+            .value()
+            .seq
             .get(seq_hashes[position])
             .map(|workers| workers.len())
             .unwrap_or(0)
@@ -696,7 +963,7 @@ impl PositionalIndexer {
     /// (all active workers are still present, no work to do).
     #[expect(clippy::too_many_arguments)]
     fn linear_scan_drain(
-        index: &DashMap<(usize, ContentHash), SeqEntry, FxBuildHasher>,
+        index: &PosIndex,
         sequence: &[ContentHash],
         seq_hashes: &mut Vec<SequenceHash>,
         active: &mut Vec<u32>,
@@ -704,6 +971,7 @@ impl PositionalIndexer {
         lo: usize,
         hi: usize,
         early_exit: bool,
+        now: u32,
     ) {
         for (offset, &content_hash) in sequence[lo..hi].iter().enumerate() {
             if active.is_empty() {
@@ -718,9 +986,10 @@ impl PositionalIndexer {
                 active.clear();
                 break;
             };
+            entry.value().touch(now);
 
             // Fast path: Single entry — skip rolling hash, use workers directly.
-            if let Some(workers) = entry.value().workers_if_single() {
+            if let Some(workers) = entry.value().seq.workers_if_single() {
                 // Retain guard: only retain when some workers
                 // have dropped off. When workers.len() >= active.len(), all active
                 // workers are still present — skip the O(active) iteration.
@@ -745,7 +1014,7 @@ impl PositionalIndexer {
             Self::ensure_seq_hash_computed(seq_hashes, pos, sequence);
             let seq_hash = seq_hashes[pos];
 
-            let Some(workers) = entry.get(seq_hash) else {
+            let Some(workers) = entry.value().seq.get(seq_hash) else {
                 for &w in active.iter() {
                     internal_scores.insert(w, pos as u32);
                 }
@@ -784,6 +1053,7 @@ impl PositionalIndexer {
         }
 
         let mut seq_hashes = Vec::with_capacity(content_hashes.len());
+        let now = self.now_secs();
 
         let Some(initial_workers) = Self::get_workers_lazy(
             &self.index,
@@ -791,6 +1061,7 @@ impl PositionalIndexer {
             content_hashes[0],
             &mut seq_hashes,
             content_hashes,
+            now,
         ) else {
             return scores;
         };
@@ -828,6 +1099,7 @@ impl PositionalIndexer {
                 content_hashes[next_pos],
                 &mut seq_hashes,
                 content_hashes,
+                now,
             );
 
             // If the worker count at the jump destination matches the active set size,
@@ -844,6 +1116,7 @@ impl PositionalIndexer {
                     current_pos + 1,
                     next_pos + 1,
                     false,
+                    now,
                 );
                 current_pos = next_pos;
             }
@@ -2301,5 +2574,248 @@ mod tests {
                 assert_eq!(scores.scores.get(&wid), Some(&2));
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // prune: TTL + capacity bounding
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_prune_disabled_is_noop() {
+        let indexer = PositionalIndexer::new(64);
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let mut wb1 = WorkerBlockMap::default();
+        indexer
+            .apply_stored(w1, &make_blocks(&[10, 20, 30]), None, &mut wb1)
+            .unwrap();
+        indexer.set_test_now(1_000_000);
+
+        for (ttl, max) in [(None, None), (Some(0), Some(0)), (None, Some(0))] {
+            let stats = indexer.prune(ttl, max);
+            assert_eq!(stats.evicted_ttl, 0);
+            assert_eq!(stats.evicted_capacity, 0);
+            assert_eq!(stats.remaining, 3);
+        }
+        assert_eq!(indexer.current_size(), 3);
+        let scores = indexer.find_matches(&hashes(&[10, 20, 30]), false);
+        assert_eq!(scores.scores.get(&w1), Some(&3));
+    }
+
+    #[test]
+    fn test_prune_ttl_evicts_stale_keeps_recent() {
+        let indexer = PositionalIndexer::new(64);
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
+        let mut wb1 = WorkerBlockMap::default();
+        let mut wb2 = WorkerBlockMap::default();
+
+        indexer.set_test_now(0);
+        indexer
+            .apply_stored(w1, &make_blocks(&[10, 20, 30]), None, &mut wb1)
+            .unwrap();
+        indexer.set_test_now(500);
+        indexer
+            .apply_stored(w2, &make_blocks(&[40, 50]), None, &mut wb2)
+            .unwrap();
+
+        indexer.set_test_now(600);
+        let stats = indexer.prune(Some(200), None);
+        assert_eq!(stats.evicted_ttl, 3);
+        assert_eq!(stats.evicted_capacity, 0);
+        assert_eq!(stats.remaining, 2);
+
+        assert!(indexer
+            .find_matches(&hashes(&[10, 20, 30]), false)
+            .scores
+            .is_empty());
+        let scores = indexer.find_matches(&hashes(&[40, 50]), false);
+        assert_eq!(scores.scores.get(&w2), Some(&2));
+        assert_eq!(indexer.current_size(), 2);
+    }
+
+    #[test]
+    fn test_prune_ttl_query_touch_keeps_hot_entries() {
+        // jump_size 1 so a full query touches every position of the chain.
+        let indexer = PositionalIndexer::new(1);
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
+        let mut wb1 = WorkerBlockMap::default();
+        let mut wb2 = WorkerBlockMap::default();
+
+        indexer.set_test_now(0);
+        indexer
+            .apply_stored(w1, &make_blocks(&[10, 20, 30]), None, &mut wb1)
+            .unwrap();
+        indexer
+            .apply_stored(w2, &make_blocks(&[40, 50, 60]), None, &mut wb2)
+            .unwrap();
+
+        // Only w1's chain is queried (touched) after storing.
+        indexer.set_test_now(500);
+        let scores = indexer.find_matches(&hashes(&[10, 20, 30]), false);
+        assert_eq!(scores.scores.get(&w1), Some(&3));
+
+        indexer.set_test_now(600);
+        let stats = indexer.prune(Some(200), None);
+        assert_eq!(stats.evicted_ttl, 3); // w2's untouched chain
+
+        let scores = indexer.find_matches(&hashes(&[10, 20, 30]), false);
+        assert_eq!(scores.scores.get(&w1), Some(&3));
+        assert!(indexer
+            .find_matches(&hashes(&[40, 50, 60]), false)
+            .scores
+            .is_empty());
+    }
+
+    #[test]
+    fn test_prune_capacity_evicts_oldest_first() {
+        let indexer = PositionalIndexer::new(1);
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let mut wb1 = WorkerBlockMap::default();
+
+        // Ten independent single-block chains stored at increasing times.
+        for i in 0u64..10 {
+            indexer.set_test_now(i as u32);
+            indexer
+                .apply_stored(w1, &make_blocks(&[100 + i]), None, &mut wb1)
+                .unwrap();
+        }
+        assert_eq!(indexer.entry_count(), 10);
+
+        indexer.set_test_now(100);
+        // Ceiling 5 → low-water 5 (5/10 == 0) → evict the 5 oldest.
+        let stats = indexer.prune(None, Some(5));
+        assert_eq!(stats.evicted_ttl, 0);
+        assert_eq!(stats.evicted_capacity, 5);
+        assert_eq!(stats.remaining, 5);
+        assert_eq!(indexer.current_size(), 5);
+
+        for i in 0u64..10 {
+            let found = !indexer
+                .find_matches(&hashes(&[100 + i]), false)
+                .scores
+                .is_empty();
+            assert_eq!(found, i >= 5, "chain {i} presence");
+        }
+    }
+
+    #[test]
+    fn test_prune_capacity_spares_fresh_entries() {
+        // Entries stamped within the freshness grace are never capacity
+        // candidates — a prune must not race a store batch whose deferred
+        // tree_sizes increment hasn't landed yet.
+        let indexer = PositionalIndexer::new(1);
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let mut wb1 = WorkerBlockMap::default();
+
+        indexer.set_test_now(100);
+        for i in 0u64..10 {
+            indexer
+                .apply_stored(w1, &make_blocks(&[100 + i]), None, &mut wb1)
+                .unwrap();
+        }
+
+        // All entries are at now == stamp → inside the grace → spared.
+        let stats = indexer.prune(None, Some(5));
+        assert_eq!(stats.evicted_capacity, 0);
+        assert_eq!(indexer.entry_count(), 10);
+
+        // Once they age past the grace, the ceiling is enforced.
+        indexer.set_test_now(100 + CAPACITY_EVICTION_GRACE_SECS + 1);
+        let stats = indexer.prune(None, Some(5));
+        assert_eq!(stats.evicted_capacity, 5);
+        assert_eq!(indexer.entry_count(), 5);
+    }
+
+    #[test]
+    fn test_restore_after_prune_restores_counts() {
+        // Re-storing blocks whose entries were pruned (with the stale reverse
+        // mapping still present) must restore both the index entries and the
+        // per-worker counts — counting is keyed on index memberships, not on
+        // reverse-map novelty.
+        let indexer = PositionalIndexer::new(64);
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let mut wb1 = WorkerBlockMap::default();
+        let blocks = make_blocks(&[10, 20, 30]);
+
+        indexer.set_test_now(0);
+        indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
+        indexer.set_test_now(1000);
+        indexer.prune(Some(100), None);
+        assert_eq!(indexer.current_size(), 0);
+        assert_eq!(wb1.len(), 3); // reverse map untouched by prune
+
+        indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
+        assert_eq!(indexer.current_size(), 3);
+        let scores = indexer.find_matches(&hashes(&[10, 20, 30]), false);
+        assert_eq!(scores.scores.get(&w1), Some(&3));
+
+        // And duplicate stores of live memberships still don't inflate.
+        indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
+        assert_eq!(indexer.current_size(), 3);
+    }
+
+    #[test]
+    fn test_prune_capacity_noop_under_ceiling() {
+        let indexer = PositionalIndexer::new(64);
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let mut wb1 = WorkerBlockMap::default();
+        indexer
+            .apply_stored(w1, &make_blocks(&[10, 20, 30]), None, &mut wb1)
+            .unwrap();
+
+        let stats = indexer.prune(None, Some(10));
+        assert_eq!(stats.evicted_capacity, 0);
+        assert_eq!(stats.remaining, 3);
+    }
+
+    #[test]
+    fn test_prune_then_stale_removal_no_double_decrement() {
+        let indexer = PositionalIndexer::new(64);
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let mut wb1 = WorkerBlockMap::default();
+        let blocks = make_blocks(&[10, 20, 30]);
+
+        indexer.set_test_now(0);
+        indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
+        indexer.set_test_now(1000);
+        let stats = indexer.prune(Some(100), None);
+        assert_eq!(stats.evicted_ttl, 3);
+        assert_eq!(indexer.current_size(), 0);
+
+        // The reverse map still holds the pruned blocks; their removal events
+        // must be a counting no-op (a wrap would make current_size huge).
+        let seq_hashes: Vec<SequenceHash> = blocks.iter().map(|b| b.seq_hash).collect();
+        indexer.apply_removed(w1, &seq_hashes, &mut wb1);
+        assert!(wb1.is_empty());
+        assert_eq!(indexer.current_size(), 0);
+
+        // The worker can start a fresh chain afterwards.
+        indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
+        assert_eq!(indexer.current_size(), 3);
+        let scores = indexer.find_matches(&hashes(&[10, 20, 30]), false);
+        assert_eq!(scores.scores.get(&w1), Some(&3));
+    }
+
+    #[test]
+    fn test_prune_multi_worker_entry_decrements_each() {
+        let indexer = PositionalIndexer::new(64);
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
+        let mut wb1 = WorkerBlockMap::default();
+        let mut wb2 = WorkerBlockMap::default();
+        let blocks = make_blocks(&[10, 20, 30]);
+
+        indexer.set_test_now(0);
+        indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
+        indexer.apply_stored(w2, &blocks, None, &mut wb2).unwrap();
+        assert_eq!(indexer.current_size(), 6);
+        assert_eq!(indexer.entry_count(), 3); // shared entries
+
+        indexer.set_test_now(1000);
+        let stats = indexer.prune(Some(100), None);
+        assert_eq!(stats.evicted_ttl, 3);
+        assert_eq!(indexer.current_size(), 0);
+        assert_eq!(indexer.entry_count(), 0);
     }
 }

--- a/crates/kv_index/src/lib.rs
+++ b/crates/kv_index/src/lib.rs
@@ -21,7 +21,8 @@ mod token_tree;
 pub use common::{MatchResult, TenantId};
 pub use event_tree::{
     compute_content_hash, compute_request_content_hashes, ApplyError, ContentHash, OverlapScores,
-    PositionalIndexer, SequenceHash, StoredBlock, WorkerBlockMap, WorkerId, WorkerIdExhausted,
+    PositionalIndexer, PruneStats, SequenceHash, StoredBlock, WorkerBlockMap, WorkerId,
+    WorkerIdExhausted,
 };
 pub use path_hash::{hash_node_path, hash_token_path, GLOBAL_EVICTION_HASH};
 // Re-export under names matching old tree.rs API for easier migration

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -669,18 +669,48 @@ impl AppContextBuilder {
 
     /// Create KV event monitor for event-driven cache-aware routing.
     ///
-    /// The monitor is created when the default policy is cache_aware, regardless
-    /// of connection mode. The monitor itself is cheap (empty DashMaps) and stays
-    /// dormant until workers are added. The UpdatePoliciesStep gates subscriptions
-    /// on `cache_aware && gRPC`, so HTTP workers are never subscribed.
+    /// The monitor is created when ANY serving policy is cache_aware — the
+    /// global default or a PD/EPD role override (a non-cache-aware global with
+    /// a cache-aware decode policy still needs event-driven indexers) —
+    /// regardless of connection mode. The monitor itself is cheap (empty
+    /// DashMaps) and stays dormant until workers are added. The
+    /// UpdatePoliciesStep gates subscriptions on `cache_aware && gRPC`, so
+    /// HTTP workers are never subscribed.
     fn with_kv_event_monitor(mut self, config: &RouterConfig) -> Self {
-        use crate::config::types::PolicyConfig;
+        use crate::config::types::{PolicyConfig, RoutingMode};
 
-        let is_cache_aware = matches!(config.policy, PolicyConfig::CacheAware { .. });
+        let role_is_cache_aware =
+            |policy: &Option<PolicyConfig>| matches!(policy, Some(PolicyConfig::CacheAware { .. }));
+        let is_cache_aware = matches!(config.policy, PolicyConfig::CacheAware { .. })
+            || match &config.mode {
+                RoutingMode::PrefillDecode {
+                    prefill_policy,
+                    decode_policy,
+                    ..
+                } => role_is_cache_aware(prefill_policy) || role_is_cache_aware(decode_policy),
+                RoutingMode::EncodePrefillDecode {
+                    encode_policy,
+                    prefill_policy,
+                    decode_policy,
+                    ..
+                } => {
+                    role_is_cache_aware(encode_policy)
+                        || role_is_cache_aware(prefill_policy)
+                        || role_is_cache_aware(decode_policy)
+                }
+                _ => false,
+            };
 
         if is_cache_aware {
             let monitor = Arc::new(KvEventMonitor::new(None));
             debug!("Created KV event monitor for event-driven cache-aware routing");
+
+            // Optional indexer bounding: prune entries by last-touch TTL and/or
+            // capacity ceiling. Both default off (unbounded, prior behavior).
+            monitor.start_prune_task(
+                config.kv_indexer_ttl_secs.unwrap_or(0),
+                config.kv_indexer_max_entries.unwrap_or(0),
+            );
 
             // Inject monitor into PolicyRegistry — propagates to default_policy
             // and any other existing cache-aware policies.
@@ -783,6 +813,53 @@ mod tests {
             balance_token_usage_threshold: 1.0,
             overload_token_usage_threshold: 1.0,
         }));
+    }
+
+    /// A cache-aware PD/EPD role policy needs the monitor even when the
+    /// global policy is not cache-aware.
+    #[test]
+    fn test_cache_aware_role_policy_creates_kv_event_monitor() {
+        use crate::config::types::RoutingMode;
+
+        let cache_aware = PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 32,
+            balance_rel_threshold: 1.1,
+            eviction_interval_secs: 30,
+            max_tree_size: 1000,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+        };
+
+        let mut config = config_with_policy(PolicyConfig::Random);
+        config.mode = RoutingMode::PrefillDecode {
+            prefill_urls: vec![],
+            decode_urls: vec![],
+            prefill_policy: None,
+            decode_policy: Some(cache_aware.clone()),
+        };
+        let created = AppContextBuilder::new()
+            .with_policy_registry(&config)
+            .with_kv_event_monitor(&config)
+            .kv_event_monitor
+            .is_some();
+        assert!(created, "cache-aware decode policy must create the monitor");
+
+        // Non-cache-aware role policies still skip it.
+        let mut config = config_with_policy(PolicyConfig::Random);
+        config.mode = RoutingMode::PrefillDecode {
+            prefill_urls: vec![],
+            decode_urls: vec![],
+            prefill_policy: Some(PolicyConfig::RoundRobin),
+            decode_policy: None,
+        };
+        let created = AppContextBuilder::new()
+            .with_policy_registry(&config)
+            .with_kv_event_monitor(&config)
+            .kv_event_monitor
+            .is_some();
+        assert!(!created);
     }
 
     #[test]

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -221,6 +221,16 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn kv_indexer_ttl_secs(mut self, ttl: Option<u64>) -> Self {
+        self.config.kv_indexer_ttl_secs = ttl;
+        self
+    }
+
+    pub fn kv_indexer_max_entries(mut self, max: Option<usize>) -> Self {
+        self.config.kv_indexer_max_entries = max;
+        self
+    }
+
     pub fn engine_metrics(mut self, enabled: bool) -> Self {
         self.config.engine_metrics = enabled;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -54,6 +54,18 @@ pub struct RouterConfig {
     pub worker_startup_check_interval_secs: u64,
     #[serde(default = "default_load_monitor_interval_secs")]
     pub load_monitor_interval_secs: u64,
+    /// TTL in seconds for entries in the event-driven cache-aware positional
+    /// indexer: entries neither stored to nor read by a query within this
+    /// window are evicted by a periodic background prune. Bounds index growth
+    /// when a backend stops emitting removal events (crash, stream downgrade).
+    /// `None`/`0` disables the TTL pass (default, preserving unbounded growth).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kv_indexer_ttl_secs: Option<u64>,
+    /// Capacity ceiling per model for the positional indexer, enforced by the
+    /// same periodic prune: beyond it, oldest-touched entries are evicted down
+    /// to 90% of the ceiling. `None`/`0` disables the ceiling (default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kv_indexer_max_entries: Option<usize>,
     /// Re-export engine `GetLoads` signals as `smg_engine_*` gauges, polling
     /// even when no load-aware routing policy is active. Decouples engine
     /// observability from routing.
@@ -817,6 +829,8 @@ impl Default for RouterConfig {
             worker_startup_delay_secs: 0,
             worker_startup_check_interval_secs: 30,
             load_monitor_interval_secs: 10,
+            kv_indexer_ttl_secs: None,
+            kv_indexer_max_entries: None,
             engine_metrics: false,
             multimodal_tensor_transport: None,
             multimodal_shm_min_bytes: None,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -323,6 +323,19 @@ struct CliArgs {
     #[arg(long, default_value_t = false, help_heading = "Load Monitoring")]
     engine_metrics: bool,
 
+    /// TTL in seconds for event-driven cache-aware indexer entries: entries
+    /// neither stored nor read by a query within this window are pruned.
+    /// Bounds index growth when a backend stops emitting removal events.
+    /// Unset or 0 disables the TTL pass.
+    #[arg(long, help_heading = "Routing Policy")]
+    kv_indexer_ttl_secs: Option<u64>,
+
+    /// Capacity ceiling per model for the event-driven cache-aware indexer;
+    /// beyond it, oldest-touched entries are pruned down to 90% of the
+    /// ceiling. Unset or 0 disables the ceiling.
+    #[arg(long, help_heading = "Routing Policy")]
+    kv_indexer_max_entries: Option<usize>,
+
     /// Multimodal tensor transport mode: `inline` (default), `shm` (same-host
     /// /dev/shm), or `auto` (shm only when the worker shares /dev/shm). A
     /// per-worker `WorkerSpec.multimodal_tensor_transport` overrides this.
@@ -1479,6 +1492,8 @@ impl CliArgs {
             .worker_startup_delay_secs(self.worker_startup_delay)
             .worker_startup_check_interval_secs(self.worker_startup_check_interval)
             .load_monitor_interval_secs(self.load_monitor_interval)
+            .kv_indexer_ttl_secs(self.kv_indexer_ttl_secs)
+            .kv_indexer_max_entries(self.kv_indexer_max_entries)
             .engine_metrics(self.engine_metrics)
             .multimodal_tensor_transport(self.multimodal_tensor_transport)
             .multimodal_shm_min_bytes(self.multimodal_shm_min_bytes)
@@ -1798,6 +1813,25 @@ mod tests {
             .chain(args.iter().map(|s| (*s).to_string()))
             .collect();
         Cli::parse_from(argv).router_args
+    }
+
+    /// The indexer prune flags are router-only settings and must flow into
+    /// `RouterConfig` (unset by default so the indexer stays unbounded).
+    #[test]
+    fn kv_indexer_prune_flags_flow_into_router_config() {
+        let cli = cli_args_from(&[
+            "--kv-indexer-ttl-secs",
+            "600",
+            "--kv-indexer-max-entries",
+            "500000",
+        ]);
+        let router_config = cli.to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(router_config.kv_indexer_ttl_secs, Some(600));
+        assert_eq!(router_config.kv_indexer_max_entries, Some(500_000));
+
+        let defaults = cli_args_from(&[]).to_router_config(vec![], vec![]).unwrap();
+        assert_eq!(defaults.kv_indexer_ttl_secs, None);
+        assert_eq!(defaults.kv_indexer_max_entries, None);
     }
 
     /// `--health-check-port` must flow into BOTH conversion paths

--- a/model_gateway/src/policies/utils.rs
+++ b/model_gateway/src/policies/utils.rs
@@ -64,6 +64,18 @@ impl Drop for PeriodicTask {
         self.shutdown_flag.store(true, Ordering::Relaxed);
 
         if let Some(handle) = self.handle.take() {
+            // A task closure that (transitively) owns its own PeriodicTask —
+            // e.g. by holding the last Arc to the struct storing it — would
+            // run this drop on the task's own thread; joining would deadlock
+            // (or error) on self-join. Detach instead: the shutdown flag is
+            // already set, so the thread exits right after this drop returns.
+            if handle.thread().id() == thread::current().id() {
+                debug!(
+                    "{} dropped from its own thread; detaching instead of self-joining",
+                    self.debug_name
+                );
+                return;
+            }
             match handle.join() {
                 Ok(()) => debug!("{} thread shut down cleanly", self.debug_name),
                 Err(_) => debug!("{} thread panicked during shutdown", self.debug_name),

--- a/model_gateway/src/worker/kv_event_monitor.rs
+++ b/model_gateway/src/worker/kv_event_monitor.rs
@@ -28,11 +28,16 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     observability::metrics::Metrics,
+    policies::utils::PeriodicTask,
     worker::{ConnectionMode, Worker, UNKNOWN_MODEL_ID},
 };
 
 /// Default jump size for new `PositionalIndexer` instances.
 const DEFAULT_JUMP_SIZE: usize = 64;
+
+/// Interval between positional-indexer prune cycles (matches the routing
+/// policies' default eviction cadence).
+const PRUNE_INTERVAL_SECS: u64 = 30;
 
 /// Initial reconnection delay after stream failure.
 const INITIAL_RECONNECT_DELAY_MS: u64 = 100;
@@ -47,7 +52,11 @@ const MAX_RECONNECT_DELAY_MS: u64 = 30_000;
 /// (one per `model_id`). Workers serving the same model share the same indexer.
 pub struct KvEventMonitor {
     /// Per-model positional indexers: model_id → shared indexer.
-    pub(crate) indexers: DashMap<String, Arc<PositionalIndexer>>,
+    /// Arc-wrapped so the prune task can share the map WITHOUT holding (even
+    /// weakly) the monitor itself: `PeriodicTask` joins its thread on drop, so
+    /// a task that could ever own the last monitor reference would run the
+    /// monitor's drop — and thus its own join — on its own thread.
+    pub(crate) indexers: Arc<DashMap<String, Arc<PositionalIndexer>>>,
     /// Per-model block sizes learned from KV events or set via WorkerSpec.
     /// Used by CacheAwarePolicy to chunk request tokens at query time.
     /// Arc-wrapped so subscription tasks can update it from events.
@@ -57,6 +66,10 @@ pub struct KvEventMonitor {
     worker_handles: Mutex<HashMap<String, WorkerSubscription>>,
     /// Jump size for new PositionalIndexer instances.
     jump_size: usize,
+    /// Periodic indexer prune, held so it aborts when the monitor drops.
+    /// Set once by [`start_prune_task`](Self::start_prune_task); sync mutex
+    /// because it is touched only at startup, never on event paths.
+    prune_task: parking_lot::Mutex<Option<PeriodicTask>>,
 }
 
 /// Tracks a single worker's subscription state.
@@ -86,11 +99,66 @@ impl KvEventMonitor {
     pub fn new(jump_size: Option<usize>) -> Self {
         let jump_size = jump_size.unwrap_or(DEFAULT_JUMP_SIZE).max(1);
         Self {
-            indexers: DashMap::new(),
+            indexers: Arc::new(DashMap::new()),
             block_sizes: Arc::new(DashMap::new()),
             worker_handles: Mutex::new(HashMap::new()),
             jump_size,
+            prune_task: parking_lot::Mutex::new(None),
         }
+    }
+
+    /// Prune every model's positional indexer with the given bounds.
+    /// `ttl_secs`/`max_entries` of 0 disable the respective pass — see
+    /// [`PositionalIndexer::prune`].
+    pub fn prune_all(&self, ttl_secs: u64, max_entries: usize) {
+        Self::prune_indexers(&self.indexers, ttl_secs, max_entries);
+    }
+
+    fn prune_indexers(
+        indexers: &DashMap<String, Arc<PositionalIndexer>>,
+        ttl_secs: u64,
+        max_entries: usize,
+    ) {
+        let ttl = u32::try_from(ttl_secs).unwrap_or(u32::MAX - 1);
+        let ttl = (ttl > 0).then_some(ttl);
+        let max = (max_entries > 0).then_some(max_entries);
+        if ttl.is_none() && max.is_none() {
+            return;
+        }
+        for entry in indexers {
+            let stats = entry.value().prune(ttl, max);
+            if stats.evicted_ttl + stats.evicted_capacity > 0 {
+                info!(
+                    model_id = %entry.key(),
+                    evicted_ttl = stats.evicted_ttl,
+                    evicted_capacity = stats.evicted_capacity,
+                    remaining = stats.remaining,
+                    "Pruned positional indexer"
+                );
+            }
+        }
+    }
+
+    /// Start the periodic indexer prune. No-op when both bounds are 0/unset.
+    /// The task shares only the indexer map — never a reference to the monitor
+    /// itself — so it can never be the one to run the monitor's drop (and with
+    /// it its own thread's join; see the `indexers` field docs). The handle is
+    /// held by the monitor, so the task stops when the monitor drops.
+    pub fn start_prune_task(&self, ttl_secs: u64, max_entries: usize) {
+        if ttl_secs == 0 && max_entries == 0 {
+            return;
+        }
+        let indexers = Arc::clone(&self.indexers);
+        let task = PeriodicTask::spawn(PRUNE_INTERVAL_SECS, "KvIndexerPrune", move || {
+            Self::prune_indexers(&indexers, ttl_secs, max_entries);
+        });
+        *self.prune_task.lock() = Some(task);
+        info!(
+            ttl_secs,
+            max_entries,
+            interval_secs = PRUNE_INTERVAL_SECS,
+            "Started positional-indexer prune task"
+        );
     }
 
     /// Start a KV event subscription for a worker.
@@ -1035,5 +1103,55 @@ mod tests {
 
         monitor.stop().await;
         assert!(monitor.block_size("llama").is_none());
+    }
+
+    #[test]
+    fn test_prune_all_enforces_capacity_ceiling() {
+        let monitor = KvEventMonitor::new(None);
+        let indexer = monitor
+            .indexers
+            .entry("llama".to_string())
+            .or_insert_with(|| Arc::new(PositionalIndexer::new(64)))
+            .clone();
+
+        let worker = indexer.intern_worker("http://w1:8000").unwrap();
+        let mut worker_blocks = WorkerBlockMap::default();
+        // Ten independent single-block chains → ten index entries.
+        for i in 0u64..10 {
+            let block = StoredBlock {
+                seq_hash: SequenceHash(1000 + i),
+                content_hash: kv_index::ContentHash(2000 + i),
+            };
+            indexer
+                .apply_stored(worker, &[block], None, &mut worker_blocks)
+                .unwrap();
+        }
+        assert_eq!(indexer.entry_count(), 10);
+
+        // Disabled bounds → no-op.
+        monitor.prune_all(0, 0);
+        assert_eq!(indexer.entry_count(), 10);
+
+        // Freshly stored entries sit inside the capacity-eviction grace and
+        // are spared — a prune must not race a store batch's accounting.
+        monitor.prune_all(0, 5);
+        assert_eq!(indexer.entry_count(), 10);
+
+        // Age them past the grace (the indexer's test clock is crate-private
+        // to kv_index, so this test uses the real clock) and the ceiling is
+        // enforced down to the low-water mark (5 - 5/10 = 5).
+        std::thread::sleep(Duration::from_secs(3));
+        monitor.prune_all(0, 5);
+        assert_eq!(indexer.entry_count(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_start_prune_task_noop_when_disabled() {
+        let monitor = Arc::new(KvEventMonitor::new(None));
+        monitor.start_prune_task(0, 0);
+        assert!(monitor.prune_task.lock().is_none());
+
+        monitor.start_prune_task(60, 0);
+        assert!(monitor.prune_task.lock().is_some());
     }
 }


### PR DESCRIPTION
## Description

### Problem

`PositionalIndexer` — the event-driven index behind cache-aware routing on the gRPC path — grows without bound (its own docs said so). Entries leave the index only via backend removal/clear events or worker removal, so a backend that stops emitting removals (crash, servicer bug, event-stream downgrade) leaks index memory permanently and keeps stale entries contributing to overlap scores.

### Solution

An opt-in prune pass, driven by `KvEventMonitor` on a 30s cycle. Index entries carry a coarse last-touch stamp — refreshed on store and on exactly the reads a query performs (position 0, jump landings, linear-scan ranges) — so entries hot traffic actually needs stay resident while cold or stranded ones age out. Both bounds default off: behavior is unchanged unless configured.

## Changes

- `kv_index`: `PositionalIndexer::prune(ttl, max_entries)` + `PruneStats` + `entry_count()`. TTL pass evicts untouched entries; capacity pass evicts oldest-touched down to 90% of the ceiling. Candidates are collected first and re-checked under the entry lock.
- The capacity pass never evicts entries inside a short freshness grace, so a prune cannot race a store batch whose deferred `tree_sizes` increment hasn't landed (the TTL pass is inherently safe — a just-stored stamp is newer than any cutoff).
- Membership-keyed accounting on both sides: stores count only memberships actually added to the index (re-storing a pruned block restores its count; duplicate stores still don't inflate), removals count only memberships actually removed, prune-side decrements saturate.
- `KvEventMonitor::prune_all` + `start_prune_task` (the task shares only the Arc-wrapped indexer map — never a monitor reference — so it cannot self-join through the monitor drop; `PeriodicTask::drop` additionally detaches on self-join). Monitor creation now also recognizes cache-aware PD/EPD role policies, not just the global policy — previously a cache-aware decode policy under a non-cache-aware global got no monitor at all.
- Config/flags: `--kv-indexer-ttl-secs`, `--kv-indexer-max-entries` (RouterConfig + builder), unset by default.

## Test Plan

- `cargo test -p kv-index`: 206 passed — TTL eviction, query-touch retention, capacity oldest-first, freshness-grace sparing, restore-after-prune count restoration, stale-removal no-double-decrement, multi-worker decrement, disabled no-op, stats.
- `cargo test -p smg --lib`: 1451 passed — monitor capacity enforcement incl. grace aging, prune-task gating, CLI flag flow, PD role-policy monitor creation.
- `cargo +nightly fmt` clean; `cargo clippy -p kv-index -p smg --all-targets -- -D warnings` clean locally (`--all-features` runs in CI — this machine lacks the multimodal system deps); `cargo check -p smg-python` passes (config/types.rs changed; full wheel via CI build-wheel).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
