### PR TITLE
fix(routers): bound SSE response-body channels for backpressure

### DIFF
--- a/model_gateway/src/routers/common/sse.rs
+++ b/model_gateway/src/routers/common/sse.rs
@@ -24,7 +24,7 @@ use http::{
 };
 use serde::Serialize;
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 
 // ============================================================================
 // SseEncoder
@@ -434,18 +434,42 @@ fn parse_frame(frame: &str) -> Option<SseFrame<'_>> {
 }
 
 // ============================================================================
+// Bounded SSE body channel
+// ============================================================================
+
+/// Buffer size for SSE / streaming HTTP response-body channels.
+///
+/// Mirrors `STREAM_RELAY_BUFFER` in [`crate::routers::http::router`] (the
+/// transcription relay). The channel is deliberately **bounded**: when a client
+/// reads the response slowly, [`SseSender::send`](tokio::sync::mpsc::Sender::send)
+/// awaits once the buffer fills, propagating backpressure to the backend read
+/// loop instead of buffering the entire response in RAM. An unbounded channel
+/// would let a slow/stalled client drive the gateway into OOM (slowloris).
+pub(crate) const SSE_CHANNEL_BUFFER: usize = 32;
+
+/// Sender half of a bounded SSE body channel (see [`SSE_CHANNEL_BUFFER`]).
+/// `send` is async: it awaits when the buffer is full, applying backpressure.
+pub(crate) type SseSender = mpsc::Sender<Result<Bytes, std::io::Error>>;
+
+/// Receiver half of a bounded SSE body channel, consumed by [`build_sse_response`].
+pub(crate) type SseReceiver = mpsc::Receiver<Result<Bytes, std::io::Error>>;
+
+/// Create a bounded SSE body channel (see [`SSE_CHANNEL_BUFFER`]).
+pub(crate) fn sse_channel() -> (SseSender, SseReceiver) {
+    mpsc::channel(SSE_CHANNEL_BUFFER)
+}
+
+// ============================================================================
 // Build SSE Response
 // ============================================================================
 
-/// Build an HTTP response with SSE headers and streaming body from an unbounded receiver.
+/// Build an HTTP response with SSE headers and streaming body from a bounded receiver.
 #[expect(
     clippy::expect_used,
     reason = "Response::builder with static headers and valid status code is infallible"
 )]
-pub fn build_sse_response(
-    rx: mpsc::UnboundedReceiver<Result<Bytes, std::io::Error>>,
-) -> axum::response::Response {
-    let stream = UnboundedReceiverStream::new(rx);
+pub fn build_sse_response(rx: SseReceiver) -> axum::response::Response {
+    let stream = ReceiverStream::new(rx);
     axum::response::Response::builder()
         .status(StatusCode::OK)
         .header(

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -16,13 +16,15 @@ use openai_protocol::{
 };
 use serde_json::json;
 use smg_mcp::{self as mcp};
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::warn;
 use uuid::Uuid;
 
 use crate::routers::{
-    common::openai_bridge::{self, descriptor, ResponseFormat},
+    common::{
+        openai_bridge::{self, descriptor, ResponseFormat},
+        sse::{SseReceiver, SseSender},
+    },
     grpc::harmony::responses::ToolResult,
 };
 
@@ -718,9 +720,9 @@ impl ResponseStreamEventEmitter {
     ///
     /// Reasoning items in OpenAI format are simple placeholders emitted between tool iterations.
     /// They don't have streaming content - just wrapper events with empty/null content.
-    pub fn emit_reasoning_item(
+    pub async fn emit_reasoning_item(
         &mut self,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+        tx: &SseSender,
         reasoning_content: Option<String>,
     ) -> Result<(), String> {
         // Allocate output index and generate ID
@@ -738,11 +740,11 @@ impl ResponseStreamEventEmitter {
 
         // Emit output_item.added
         let added_event = self.emit_output_item_added(output_index, &item);
-        self.send_event(&added_event, tx)?;
+        self.send_event(&added_event, tx).await?;
 
         // Immediately emit output_item.done (no streaming for reasoning)
         let done_event = self.emit_output_item_done(output_index, &item);
-        self.send_event(&done_event, tx)?;
+        self.send_event(&done_event, tx).await?;
 
         // Mark as completed
         self.complete_output_item(output_index);
@@ -751,10 +753,10 @@ impl ResponseStreamEventEmitter {
     }
 
     /// Process a chunk and emit appropriate events
-    pub fn process_chunk(
+    pub async fn process_chunk(
         &mut self,
         chunk: &ChatCompletionStreamResponse,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+        tx: &SseSender,
     ) -> Result<(), String> {
         // Process content if present
         if let Some(choice) = chunk.choices.first() {
@@ -775,7 +777,7 @@ impl ResponseStreamEventEmitter {
 
                         // Emit output_item.added
                         let event = self.emit_output_item_added(output_index, &item);
-                        self.send_event(&event, tx)?;
+                        self.send_event(&event, tx).await?;
                         self.has_emitted_output_item_added = true;
 
                         // Store for subsequent events
@@ -795,14 +797,14 @@ impl ResponseStreamEventEmitter {
                         if !self.has_emitted_content_part_added {
                             let event =
                                 self.emit_content_part_added(output_index, &item_id, content_index);
-                            self.send_event(&event, tx)?;
+                            self.send_event(&event, tx).await?;
                             self.has_emitted_content_part_added = true;
                         }
 
                         // Emit text delta
                         let event =
                             self.emit_text_delta(content, output_index, &item_id, content_index);
-                        self.send_event(&event, tx)?;
+                        self.send_event(&event, tx).await?;
                     }
                 }
             }
@@ -819,10 +821,10 @@ impl ResponseStreamEventEmitter {
                         // Emit closing events
                         if self.has_emitted_content_part_added {
                             let event = self.emit_text_done(output_index, &item_id, content_index);
-                            self.send_event(&event, tx)?;
+                            self.send_event(&event, tx).await?;
                             let event =
                                 self.emit_content_part_done(output_index, &item_id, content_index);
-                            self.send_event(&event, tx)?;
+                            self.send_event(&event, tx).await?;
                         }
 
                         if self.has_emitted_output_item_added {
@@ -837,7 +839,7 @@ impl ResponseStreamEventEmitter {
                                 }]
                             });
                             let event = self.emit_output_item_done(output_index, &item);
-                            self.send_event(&event, tx)?;
+                            self.send_event(&event, tx).await?;
                         }
 
                         // Mark item as completed
@@ -850,14 +852,10 @@ impl ResponseStreamEventEmitter {
         Ok(())
     }
 
-    #[expect(
-        clippy::unused_self,
-        reason = "method on emitter for API consistency with send_event_best_effort"
-    )]
-    pub fn send_event(
+    pub async fn send_event(
         &self,
         event: &serde_json::Value,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+        tx: &SseSender,
     ) -> Result<(), String> {
         let event_json =
             serde_json::to_string(event).map_err(|e| format!("Failed to serialize event: {e}"))?;
@@ -871,7 +869,7 @@ impl ResponseStreamEventEmitter {
         // Format as SSE with event: field
         let sse_message = format!("event: {event_type}\ndata: {event_json}\n\n");
 
-        if tx.send(Ok(Bytes::from(sse_message))).is_err() {
+        if tx.send(Ok(Bytes::from(sse_message))).await.is_err() {
             return Err("Client disconnected".to_string());
         }
 
@@ -883,12 +881,8 @@ impl ResponseStreamEventEmitter {
     /// This is a convenience method for streaming scenarios where client
     /// disconnection is expected and should be logged but not fail the operation.
     /// Returns true if sent successfully, false if client disconnected.
-    pub fn send_event_best_effort(
-        &self,
-        event: &serde_json::Value,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
-    ) -> bool {
-        match self.send_event(event, tx) {
+    pub async fn send_event_best_effort(&self, event: &serde_json::Value, tx: &SseSender) -> bool {
+        match self.send_event(event, tx).await {
             Ok(()) => true,
             Err(e) => {
                 tracing::debug!("Failed to send event (likely client disconnect): {}", e);
@@ -902,12 +896,7 @@ impl ResponseStreamEventEmitter {
     /// Creates and sends an error event with the given error message.
     /// Uses OpenAI's error event format.
     /// Use this for terminal errors that should abort the streaming response.
-    pub fn emit_error(
-        &mut self,
-        error_msg: &str,
-        error_code: Option<&str>,
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
-    ) {
+    pub async fn emit_error(&mut self, error_msg: &str, error_code: Option<&str>, tx: &SseSender) {
         let event = json!({
             "type": "error",
             "code": error_code.unwrap_or("internal_error"),
@@ -919,7 +908,7 @@ impl ResponseStreamEventEmitter {
             Ok(json) => format!("data: {json}\n\n"),
             Err(_) => "data: {\"type\":\"error\",\"code\":\"internal_error\",\"message\":\"serialization failed\",\"param\":null}\n\n".to_string(),
         };
-        let _ = tx.send(Ok(Bytes::from(sse_data)));
+        let _ = tx.send(Ok(Bytes::from(sse_data))).await;
     }
 
     /// Emit the full mcp_list_tools output-item sequence.
@@ -930,11 +919,11 @@ impl ResponseStreamEventEmitter {
     ///
     /// `server_label` is taken as an explicit parameter so callers can iterate
     /// over multiple MCP servers without mutating the emitter's own label.
-    pub fn emit_mcp_list_tools_sequence(
+    pub async fn emit_mcp_list_tools_sequence(
         &mut self,
         server_label: &str,
         tools: &[mcp::ToolEntry],
-        tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+        tx: &SseSender,
     ) -> Result<(), String> {
         let (output_index, item_id) = self.allocate_output_index(OutputItemKind::McpListTools);
 
@@ -955,15 +944,15 @@ impl ResponseStreamEventEmitter {
 
         // Emit output_item.added
         let event = self.emit_output_item_added(output_index, &item_in_progress);
-        self.send_event(&event, tx)?;
+        self.send_event(&event, tx).await?;
 
         // Emit mcp_list_tools.in_progress
         let event = self.emit_mcp_list_tools_in_progress(output_index);
-        self.send_event(&event, tx)?;
+        self.send_event(&event, tx).await?;
 
         // Emit mcp_list_tools.completed
         let event = self.emit_mcp_list_tools_completed(output_index, &tool_items);
-        self.send_event(&event, tx)?;
+        self.send_event(&event, tx).await?;
 
         // Completed item (with tools populated)
         let item_done = json!({
@@ -976,7 +965,7 @@ impl ResponseStreamEventEmitter {
 
         // Emit output_item.done (also stores item data internally)
         let event = self.emit_output_item_done(output_index, &item_done);
-        self.send_event(&event, tx)?;
+        self.send_event(&event, tx).await?;
 
         self.complete_output_item(output_index);
 
@@ -991,10 +980,8 @@ impl ResponseStreamEventEmitter {
     clippy::expect_used,
     reason = "Response::builder with static headers and valid status code is infallible"
 )]
-pub(crate) fn build_sse_response(
-    rx: mpsc::UnboundedReceiver<Result<Bytes, std::io::Error>>,
-) -> Response {
-    let stream = UnboundedReceiverStream::new(rx);
+pub(crate) fn build_sse_response(rx: SseReceiver) -> Response {
+    let stream = ReceiverStream::new(rx);
     Response::builder()
         .status(StatusCode::OK)
         .header(

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -3,11 +3,9 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::response::Response;
-use bytes::Bytes;
 use openai_protocol::responses::ResponsesRequest;
 use serde_json::json;
 use smg_mcp::{McpServerBinding, McpToolSession};
-use tokio::sync::mpsc;
 use tracing::{debug, warn};
 use uuid::Uuid;
 
@@ -22,7 +20,10 @@ use crate::{
     middleware::TenantRequestMeta,
     observability::metrics::Metrics,
     routers::{
-        common::mcp_utils::DEFAULT_MAX_ITERATIONS,
+        common::{
+            mcp_utils::DEFAULT_MAX_ITERATIONS,
+            sse::{sse_channel, SseSender},
+        },
         grpc::{
             common::responses::{
                 build_sse_response, ensure_mcp_connection, persist_response_if_needed,
@@ -65,7 +66,7 @@ pub(crate) async fn serve_harmony_responses_stream(
     };
 
     // Create SSE channel
-    let (tx, rx) = mpsc::unbounded_channel();
+    let (tx, rx) = sse_channel();
 
     // Create response event emitter
     let response_id = format!("resp_{}", Uuid::now_v7());
@@ -88,11 +89,11 @@ pub(crate) async fn serve_harmony_responses_stream(
 
         // Emit initial response.created and response.in_progress events
         let event = emitter.emit_created();
-        if emitter.send_event(&event, &tx).is_err() {
+        if emitter.send_event(&event, &tx).await.is_err() {
             return;
         }
         let event = emitter.emit_in_progress();
-        if emitter.send_event(&event, &tx).is_err() {
+        if emitter.send_event(&event, &tx).await.is_err() {
             return;
         }
 
@@ -139,7 +140,7 @@ async fn execute_mcp_tool_loop_streaming(
     tenant_request_meta: TenantRequestMeta,
     mcp_servers: Vec<McpServerBinding>,
     emitter: &mut ResponseStreamEventEmitter,
-    tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+    tx: &SseSender,
 ) {
     let max_tool_calls = current_request.max_tool_calls.map(|n| n as usize);
 
@@ -185,6 +186,7 @@ async fn execute_mcp_tool_loop_streaming(
 
         if emitter
             .emit_mcp_list_tools_sequence(&binding.label, &tools_for_server, tx)
+            .await
             .is_err()
         {
             return;
@@ -206,11 +208,13 @@ async fn execute_mcp_tool_loop_streaming(
 
         // Safety check: prevent infinite loops
         if iteration_count > DEFAULT_MAX_ITERATIONS {
-            emitter.emit_error(
-                &format!("Maximum tool iterations ({DEFAULT_MAX_ITERATIONS}) exceeded"),
-                Some("max_iterations_exceeded"),
-                tx,
-            );
+            emitter
+                .emit_error(
+                    &format!("Maximum tool iterations ({DEFAULT_MAX_ITERATIONS}) exceeded"),
+                    Some("max_iterations_exceeded"),
+                    tx,
+                )
+                .await;
             return;
         }
 
@@ -231,11 +235,13 @@ async fn execute_mcp_tool_loop_streaming(
         {
             Ok(result) => result,
             Err(err_response) => {
-                emitter.emit_error(
-                    &format!("Pipeline execution failed: {err_response:?}"),
-                    Some("pipeline_error"),
-                    tx,
-                );
+                emitter
+                    .emit_error(
+                        &format!("Pipeline execution failed: {err_response:?}"),
+                        Some("pipeline_error"),
+                        tx,
+                    )
+                    .await;
                 return;
             }
         };
@@ -252,7 +258,9 @@ async fn execute_mcp_tool_loop_streaming(
         {
             Ok(result) => result,
             Err(err_msg) => {
-                emitter.emit_error(&err_msg, Some("processing_error"), tx);
+                emitter
+                    .emit_error(&err_msg, Some("processing_error"), tx)
+                    .await;
                 return;
             }
         };
@@ -311,7 +319,7 @@ async fn execute_mcp_tool_loop_streaming(
                         "incomplete_details": incomplete_details,
                     });
                     let event = emitter.emit_completed(Some(&usage_json));
-                    emitter.send_event_best_effort(&event, tx);
+                    emitter.send_event_best_effort(&event, tx).await;
                     return;
                 }
 
@@ -336,11 +344,13 @@ async fn execute_mcp_tool_loop_streaming(
                     {
                         Ok(results) => results,
                         Err(err_response) => {
-                            emitter.emit_error(
-                                &format!("MCP tool execution failed: {err_response:?}"),
-                                Some("mcp_tool_error"),
-                                tx,
-                            );
+                            emitter
+                                .emit_error(
+                                    &format!("MCP tool execution failed: {err_response:?}"),
+                                    Some("mcp_tool_error"),
+                                    tx,
+                                )
+                                .await;
                             return;
                         }
                     }
@@ -365,7 +375,7 @@ async fn execute_mcp_tool_loop_streaming(
                         "total_tokens": usage.total_tokens,
                     });
                     let event = emitter.emit_completed(Some(&usage_json));
-                    emitter.send_event_best_effort(&event, tx);
+                    emitter.send_event_best_effort(&event, tx).await;
                     return;
                 }
 
@@ -418,7 +428,7 @@ async fn execute_mcp_tool_loop_streaming(
                     }
                 }
                 let event = emitter.emit_completed(Some(&usage_json));
-                emitter.send_event_best_effort(&event, tx);
+                emitter.send_event_best_effort(&event, tx).await;
                 return;
             }
         }
@@ -435,7 +445,7 @@ async fn execute_without_mcp_streaming(
     original_request: &ResponsesRequest,
     tenant_request_meta: TenantRequestMeta,
     emitter: &mut ResponseStreamEventEmitter,
-    tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+    tx: &SseSender,
 ) {
     debug!("No MCP tools - executing single iteration");
 
@@ -447,11 +457,13 @@ async fn execute_without_mcp_streaming(
     {
         Ok(result) => result,
         Err(err_response) => {
-            emitter.emit_error(
-                &format!("Pipeline execution failed: {err_response:?}"),
-                Some("pipeline_error"),
-                tx,
-            );
+            emitter
+                .emit_error(
+                    &format!("Pipeline execution failed: {err_response:?}"),
+                    Some("pipeline_error"),
+                    tx,
+                )
+                .await;
             return;
         }
     };
@@ -468,7 +480,9 @@ async fn execute_without_mcp_streaming(
     {
         Ok(result) => result,
         Err(err_msg) => {
-            emitter.emit_error(&err_msg, Some("processing_error"), tx);
+            emitter
+                .emit_error(&err_msg, Some("processing_error"), tx)
+                .await;
             return;
         }
     };
@@ -506,5 +520,5 @@ async fn execute_without_mcp_streaming(
         }
     }
     let event = emitter.emit_completed(Some(&usage_json));
-    emitter.send_event_best_effort(&event, tx);
+    emitter.send_event_best_effort(&event, tx).await;
 }

--- a/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -98,7 +98,8 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                             dispatch,
                             router_stop_strings(ctx),
                             reservation.clone(),
-                        );
+                        )
+                        .await;
 
                     // Attach load guards (and the reservation's
                     // disconnect/error safety net) to the response body for

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -2,13 +2,11 @@
 
 use std::{
     collections::{hash_map::Entry::Vacant, HashMap, HashSet},
-    io,
     sync::Arc,
     time::Instant,
 };
 
 use axum::response::Response;
-use bytes::Bytes;
 use openai_protocol::{
     chat::{
         ChatCompletionRequest, ChatCompletionStreamResponse, ChatMessageDelta, ChatStreamChoice,
@@ -21,7 +19,6 @@ use openai_protocol::{
 };
 use serde_json::json;
 use smg_mcp::{McpToolSession, DEFAULT_SERVER_LABEL};
-use tokio::sync::mpsc;
 use tracing::{debug, error};
 
 use super::{
@@ -37,7 +34,7 @@ use crate::{
     routers::{
         common::{
             openai_bridge::{self, descriptor, FormatRegistry, ResponseFormat},
-            sse::SseEncoder,
+            sse::{sse_channel, SseEncoder, SseSender},
         },
         grpc::{
             common::{
@@ -95,17 +92,13 @@ impl HarmonyStreamingProcessor {
     /// Note: Caller should attach load guards to the returned response using
     /// `WorkerLoadGuard::attach_to_response()` for proper RAII lifecycle management.
     #[expect(
-        clippy::unused_self,
-        reason = "takes Arc<Self> for API consistency with other streaming processors"
-    )]
-    #[expect(
         clippy::disallowed_methods,
         reason = "streaming tasks are fire-and-forget by design; client disconnect terminates them"
     )]
     /// `router_stop_strings` is non-empty only when the router must enforce
     /// string `stop` sequences itself (direct-ZMQ backends: the engine sees
     /// token ids only).
-    pub fn process_streaming_chat_response(
+    pub async fn process_streaming_chat_response(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
         chat_request: Arc<ChatCompletionRequest>,
@@ -114,7 +107,7 @@ impl HarmonyStreamingProcessor {
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Response {
         // Create SSE channel
-        let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
+        let (tx, rx) = sse_channel();
 
         // Spawn background task based on execution mode
         match execution_result {
@@ -132,10 +125,10 @@ impl HarmonyStreamingProcessor {
 
                     if let Err(e) = result {
                         error!("Harmony streaming error: {}", e);
-                        utils::send_error_sse(&tx, &e, "internal_error");
+                        utils::send_error_sse(&tx, &e, "internal_error").await;
                     }
 
-                    let _ = tx.send(Ok(SseEncoder::done()));
+                    let _ = tx.send(Ok(SseEncoder::done())).await;
                 });
             }
             context::ExecutionResult::PrefillDecode {
@@ -158,10 +151,10 @@ impl HarmonyStreamingProcessor {
 
                     if let Err(e) = result {
                         error!("Harmony prefill/decode streaming error: {}", e);
-                        utils::send_error_sse(&tx, &e, "internal_error");
+                        utils::send_error_sse(&tx, &e, "internal_error").await;
                     }
 
-                    let _ = tx.send(Ok(SseEncoder::done()));
+                    let _ = tx.send(Ok(SseEncoder::done())).await;
                 });
             }
             context::ExecutionResult::Embedding { .. } => {
@@ -170,8 +163,9 @@ impl HarmonyStreamingProcessor {
                     &tx,
                     "Embeddings not supported in Harmony streaming",
                     "invalid_request_error",
-                );
-                let _ = tx.send(Ok(SseEncoder::done()));
+                )
+                .await;
+                let _ = tx.send(Ok(SseEncoder::done())).await;
             }
             // Batch results exist only on the completions pipeline.
             context::ExecutionResult::Batch { .. } => {
@@ -180,8 +174,9 @@ impl HarmonyStreamingProcessor {
                     &tx,
                     "Batched results not supported in Harmony streaming",
                     "invalid_request_error",
-                );
-                let _ = tx.send(Ok(SseEncoder::done()));
+                )
+                .await;
+                let _ = tx.send(Ok(SseEncoder::done())).await;
             }
         }
 
@@ -194,7 +189,7 @@ impl HarmonyStreamingProcessor {
         grpc_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         original_request: Arc<ChatCompletionRequest>,
-        tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         router_stop_strings: Vec<String>,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
@@ -219,7 +214,7 @@ impl HarmonyStreamingProcessor {
         decode_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         original_request: Arc<ChatCompletionRequest>,
-        tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         router_stop_strings: Vec<String>,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
@@ -266,7 +261,7 @@ impl HarmonyStreamingProcessor {
         mut decode_stream: ProtoStream,
         dispatch: &context::DispatchMetadata,
         original_request: &ChatCompletionRequest,
-        tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         prompt_tokens: &mut HashMap<u32, u32>,
         cached_tokens: &mut HashMap<u32, u32>,
         router_stop_strings: &[String],
@@ -391,7 +386,8 @@ impl HarmonyStreamingProcessor {
                                 tx,
                                 &mut encoder,
                                 chunk_logprobs,
-                            )?;
+                            )
+                            .await?;
 
                             if is_first {
                                 is_firsts.insert(index, false);
@@ -410,7 +406,8 @@ impl HarmonyStreamingProcessor {
                                 original_request,
                                 tx,
                                 &mut encoder,
-                            )?;
+                            )
+                            .await?;
                             router_stopped.insert(index);
                         }
                     }
@@ -464,7 +461,8 @@ impl HarmonyStreamingProcessor {
                                 tx,
                                 &mut encoder,
                                 None,
-                            )?;
+                            )
+                            .await?;
                         }
 
                         Self::emit_final_chunk(
@@ -475,7 +473,8 @@ impl HarmonyStreamingProcessor {
                             original_request,
                             tx,
                             &mut encoder,
-                        )?;
+                        )
+                        .await?;
                     }
                 }
                 ProtoResponseVariant::None => {}
@@ -525,7 +524,8 @@ impl HarmonyStreamingProcessor {
                 original_request,
                 tx,
                 &mut encoder,
-            )?;
+            )
+            .await?;
         }
 
         // Record streaming metrics
@@ -545,13 +545,13 @@ impl HarmonyStreamingProcessor {
 
     /// Emit a chunk delta from Harmony channels
     #[expect(clippy::too_many_arguments)]
-    fn emit_chunk_delta(
+    async fn emit_chunk_delta(
         delta: &HarmonyChannelDelta,
         index: u32,
         is_first: bool,
         dispatch: &context::DispatchMetadata,
         original_request: &ChatCompletionRequest,
-        tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         encoder: &mut SseEncoder,
         logprobs: Option<ChatLogProbs>,
     ) -> Result<(), String> {
@@ -571,6 +571,7 @@ impl HarmonyStreamingProcessor {
                 .map_err(|e| format!("JSON serialization error: {e}"))?;
 
             tx.send(Ok(sse_data))
+                .await
                 .map_err(|_| "Failed to send role chunk".to_string())?;
         }
 
@@ -611,19 +612,20 @@ impl HarmonyStreamingProcessor {
             .map_err(|e| format!("JSON serialization error: {e}"))?;
 
         tx.send(Ok(sse_data))
+            .await
             .map_err(|_| "Failed to send chunk".to_string())?;
 
         Ok(())
     }
 
     /// Emit final chunk with finish_reason
-    fn emit_final_chunk(
+    async fn emit_final_chunk(
         index: u32,
         finish_reason: &str,
         matched_stop: Option<&serde_json::Value>,
         dispatch: &context::DispatchMetadata,
         original_request: &ChatCompletionRequest,
-        tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         encoder: &mut SseEncoder,
     ) -> Result<(), String> {
         let chunk =
@@ -638,19 +640,20 @@ impl HarmonyStreamingProcessor {
             .map_err(|e| format!("JSON serialization error: {e}"))?;
 
         tx.send(Ok(sse_data))
+            .await
             .map_err(|_| "Failed to send final chunk".to_string())?;
 
         Ok(())
     }
 
     /// Emit usage chunk at the end
-    fn emit_usage_chunk(
+    async fn emit_usage_chunk(
         prompt_tokens: u32,
         completion_tokens: u32,
         cached_tokens: u32,
         dispatch: &context::DispatchMetadata,
         original_request: &ChatCompletionRequest,
-        tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         encoder: &mut SseEncoder,
     ) -> Result<(), String> {
         let usage_chunk =
@@ -668,6 +671,7 @@ impl HarmonyStreamingProcessor {
             .map_err(|e| format!("JSON serialization error: {e}"))?;
 
         tx.send(Ok(sse_data))
+            .await
             .map_err(|_| "Failed to send usage chunk".to_string())?;
 
         Ok(())
@@ -684,7 +688,7 @@ impl HarmonyStreamingProcessor {
     pub async fn process_responses_iteration_stream(
         execution_result: context::ExecutionResult,
         emitter: &mut ResponseStreamEventEmitter,
-        tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         session: Option<&McpToolSession<'_>>,
         format_registry: Option<&FormatRegistry>,
     ) -> Result<ResponsesIterationResult, String> {
@@ -724,7 +728,7 @@ impl HarmonyStreamingProcessor {
         mut prefill_stream: ProtoStream,
         decode_stream: ProtoStream,
         emitter: &mut ResponseStreamEventEmitter,
-        tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         session: Option<&McpToolSession<'_>>,
         format_registry: Option<&FormatRegistry>,
     ) -> Result<ResponsesIterationResult, String> {
@@ -758,7 +762,7 @@ impl HarmonyStreamingProcessor {
     async fn process_decode_stream(
         mut decode_stream: ProtoStream,
         emitter: &mut ResponseStreamEventEmitter,
-        tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         session: Option<&McpToolSession<'_>>,
         format_registry: Option<&FormatRegistry>,
         prefill_cached_tokens: u32,
@@ -815,6 +819,7 @@ impl HarmonyStreamingProcessor {
                                 // Note: reasoning_content will be provided at finalize
                                 emitter
                                     .emit_reasoning_item(tx, None)
+                                    .await
                                     .map_err(|e| format!("Failed to emit reasoning item: {e}"))?;
 
                                 has_emitted_reasoning = true;
@@ -842,7 +847,7 @@ impl HarmonyStreamingProcessor {
 
                                     // Emit output_item.added
                                     let event = emitter.emit_output_item_added(output_index, &item);
-                                    emitter.send_event_best_effort(&event, tx);
+                                    emitter.send_event_best_effort(&event, tx).await;
                                 }
 
                                 let Some(output_index) = message_output_index else {
@@ -860,7 +865,7 @@ impl HarmonyStreamingProcessor {
                                         item_id,
                                         content_index,
                                     );
-                                    emitter.send_event_best_effort(&event, tx);
+                                    emitter.send_event_best_effort(&event, tx).await;
                                     has_emitted_content_part_added = true;
                                 }
 
@@ -871,7 +876,7 @@ impl HarmonyStreamingProcessor {
                                     item_id,
                                     content_index,
                                 );
-                                emitter.send_event_best_effort(&event, tx);
+                                emitter.send_event_best_effort(&event, tx).await;
 
                                 accumulated_final_text.push_str(final_delta);
                             }
@@ -933,7 +938,7 @@ impl HarmonyStreamingProcessor {
                                 );
 
                                 let event = emitter.emit_output_item_added(output_index, &item);
-                                emitter.send_event_best_effort(&event, tx);
+                                emitter.send_event_best_effort(&event, tx).await;
 
                                 // Emit in_progress event for MCP tools
                                 if let Some(fmt) = response_format {
@@ -942,7 +947,7 @@ impl HarmonyStreamingProcessor {
                                         &item_id,
                                         fmt,
                                     );
-                                    emitter.send_event_best_effort(&event, tx);
+                                    emitter.send_event_best_effort(&event, tx).await;
 
                                     // Emit searching/interpreting event for builtin tools
                                     if let Some(event) = emitter.emit_tool_call_searching(
@@ -950,7 +955,7 @@ impl HarmonyStreamingProcessor {
                                         &item_id,
                                         fmt,
                                     ) {
-                                        emitter.send_event_best_effort(&event, tx);
+                                        emitter.send_event_best_effort(&event, tx).await;
                                     }
                                 }
 
@@ -974,7 +979,7 @@ impl HarmonyStreamingProcessor {
                                             "",
                                         ),
                                     };
-                                    emitter.send_event_best_effort(&event, tx);
+                                    emitter.send_event_best_effort(&event, tx).await;
                                 }
                             } else {
                                 // Continuing tool call: emit arguments delta
@@ -1010,7 +1015,7 @@ impl HarmonyStreamingProcessor {
                                                 args,
                                             ),
                                         };
-                                        emitter.send_event_best_effort(&event, tx);
+                                        emitter.send_event_best_effort(&event, tx).await;
                                     }
                                 }
                             }
@@ -1067,7 +1072,7 @@ impl HarmonyStreamingProcessor {
                                             args_str,
                                         ),
                                     };
-                                    emitter.send_event_best_effort(&event, tx);
+                                    emitter.send_event_best_effort(&event, tx).await;
                                 }
 
                                 // Emit completed event for MCP tools
@@ -1077,7 +1082,7 @@ impl HarmonyStreamingProcessor {
                                         item_id,
                                         fmt,
                                     );
-                                    emitter.send_event_best_effort(&event, tx);
+                                    emitter.send_event_best_effort(&event, tx).await;
                                 }
 
                                 // Determine type string for JSON
@@ -1105,7 +1110,7 @@ impl HarmonyStreamingProcessor {
 
                                 let event = emitter.emit_output_item_done(*output_index, &item);
                                 emitter.complete_output_item(*output_index);
-                                emitter.send_event_best_effort(&event, tx);
+                                emitter.send_event_best_effort(&event, tx).await;
                             }
                         }
                     }
@@ -1118,12 +1123,12 @@ impl HarmonyStreamingProcessor {
 
                         // Emit text_done
                         let event = emitter.emit_text_done(output_index, item_id, content_index);
-                        emitter.send_event_best_effort(&event, tx);
+                        emitter.send_event_best_effort(&event, tx).await;
 
                         // Emit content_part.done
                         let event =
                             emitter.emit_content_part_done(output_index, item_id, content_index);
-                        emitter.send_event_best_effort(&event, tx);
+                        emitter.send_event_best_effort(&event, tx).await;
 
                         // Emit output_item.done
                         let item = json!({
@@ -1140,7 +1145,7 @@ impl HarmonyStreamingProcessor {
                         // Mark as completed before sending (so it's included in final output even if send fails)
                         emitter.complete_output_item(output_index);
 
-                        emitter.send_event_best_effort(&event, tx);
+                        emitter.send_event_best_effort(&event, tx).await;
                     }
                 }
                 ProtoResponseVariant::None => {}
@@ -1204,14 +1209,14 @@ impl HarmonyStreamingProcessor {
                                     args_str,
                                 ),
                             };
-                            emitter.send_event_best_effort(&event, tx);
+                            emitter.send_event_best_effort(&event, tx).await;
                         }
 
                         // Emit completed event for MCP tools
                         if let Some(fmt) = *response_format {
                             let event =
                                 emitter.emit_tool_call_completed(*output_index, item_id, fmt);
-                            emitter.send_event_best_effort(&event, tx);
+                            emitter.send_event_best_effort(&event, tx).await;
                         }
 
                         let type_str = ResponseStreamEventEmitter::type_str_for_format(
@@ -1238,7 +1243,7 @@ impl HarmonyStreamingProcessor {
 
                         let event = emitter.emit_output_item_done(*output_index, &item);
                         emitter.complete_output_item(*output_index);
-                        emitter.send_event_best_effort(&event, tx);
+                        emitter.send_event_best_effort(&event, tx).await;
                     }
                 }
             }

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -35,8 +35,7 @@ use smg_data_connector::{
     ResponseStorage,
 };
 use smg_mcp::{McpServerBinding, McpToolSession, ToolExecutionInput};
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, trace, warn};
 use uuid::Uuid;
 
@@ -53,6 +52,7 @@ use crate::{
         common::{
             mcp_utils::{prepare_hosted_dispatch_args, DEFAULT_MAX_ITERATIONS},
             openai_bridge::{self, ResponseFormat},
+            sse::{sse_channel, SseSender},
         },
         grpc::{
             common::responses::{
@@ -105,7 +105,7 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
     let (_parts, body) = chat_response.into_parts();
 
     // Create channel for transformed SSE events
-    let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();
+    let (tx, rx) = sse_channel();
 
     // Spawn background task to transform stream
     let original_request_clone = original_request.clone();
@@ -131,11 +131,11 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
         .await
         {
             warn!("Error transforming SSE stream: {}", e);
-            utils::send_error_sse(&tx, &e, "stream_error");
+            utils::send_error_sse(&tx, &e, "stream_error").await;
         }
 
         // Send final [DONE] event
-        let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+        let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
     });
 
     // Build SSE response with transformed stream
@@ -150,7 +150,7 @@ async fn process_and_transform_sse_stream(
     conversation_storage: Arc<dyn ConversationStorage>,
     conversation_item_storage: Arc<dyn ConversationItemStorage>,
     request_context: Option<StorageRequestContext>,
-    tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+    tx: SseSender,
 ) -> Result<(), String> {
     // Create accumulator for final response
     let mut accumulator = StreamingResponseAccumulator::new(&original_request);
@@ -166,11 +166,13 @@ async fn process_and_transform_sse_stream(
     let event = event_emitter.emit_created();
     event_emitter
         .send_event(&event, &tx)
+        .await
         .map_err(|_| "Failed to send response.created event".to_string())?;
 
     let event = event_emitter.emit_in_progress();
     event_emitter
         .send_event(&event, &tx)
+        .await
         .map_err(|_| "Failed to send response.in_progress event".to_string())?;
 
     // Convert body to data stream
@@ -200,12 +202,16 @@ async fn process_and_transform_sse_stream(
                     accumulator.process_chunk(&chat_chunk);
 
                     // Process chunk through event emitter (emits proper OpenAI events)
-                    event_emitter.process_chunk(&chat_chunk, &tx)?;
+                    event_emitter.process_chunk(&chat_chunk, &tx).await?;
                 }
                 Err(_) => {
                     // Not a valid chat chunk - might be error event, pass through
                     debug!("Non-chunk SSE event, passing through: {}", event);
-                    if tx.send(Ok(Bytes::from(format!("{event}\n\n")))).is_err() {
+                    if tx
+                        .send(Ok(Bytes::from(format!("{event}\n\n"))))
+                        .await
+                        .is_err()
+                    {
                         return Err("Client disconnected".to_string());
                     }
                 }
@@ -233,7 +239,7 @@ async fn process_and_transform_sse_stream(
     });
 
     let completed_event = event_emitter.emit_completed(usage_json.as_ref());
-    event_emitter.send_event(&completed_event, &tx)?;
+    event_emitter.send_event(&completed_event, &tx).await?;
 
     // Finalize and persist accumulated response
     let final_response = accumulator.finalize();
@@ -443,7 +449,7 @@ pub(super) fn execute_tool_loop_streaming(
     mcp_servers: Vec<McpServerBinding>,
 ) -> Response {
     // Create SSE channel for client
-    let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();
+    let (tx, rx) = sse_channel();
 
     // Clone data for background task
     let ctx_clone = ctx.clone();
@@ -467,15 +473,15 @@ pub(super) fn execute_tool_loop_streaming(
 
         if let Err(e) = result {
             warn!("Streaming tool loop error: {}", e);
-            utils::send_error_sse(&tx, &e, "tool_loop_error");
+            utils::send_error_sse(&tx, &e, "tool_loop_error").await;
         }
 
         // Send [DONE]
-        let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+        let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
     });
 
     // Build SSE response
-    let stream = UnboundedReceiverStream::new(rx);
+    let stream = ReceiverStream::new(rx);
     let body = Body::from_stream(stream);
 
     #[expect(
@@ -510,7 +516,7 @@ async fn execute_tool_loop_streaming_internal(
     original_request: &ResponsesRequest,
     params: ResponsesCallContext,
     mcp_servers: Vec<McpServerBinding>,
-    tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+    tx: SseSender,
 ) -> Result<(), String> {
     let mut state = ToolLoopState::new(original_request.input.clone());
     let max_tool_calls = original_request.max_tool_calls.map(|n| n as usize);
@@ -532,9 +538,9 @@ async fn execute_tool_loop_streaming_internal(
 
     // Emit initial response.created and response.in_progress events
     let event = emitter.emit_created();
-    emitter.send_event(&event, &tx)?;
+    emitter.send_event(&event, &tx).await?;
     let event = emitter.emit_in_progress();
-    emitter.send_event(&event, &tx)?;
+    emitter.send_event(&event, &tx).await?;
 
     // Get MCP tools and convert to chat format (do this once before loop)
     let mcp_chat_tools = convert_mcp_tools_to_chat_tools(&session);
@@ -565,7 +571,9 @@ async fn execute_tool_loop_streaming_internal(
             for binding in session.mcp_servers() {
                 let tools_for_server = session.list_tools_for_server(&binding.server_key);
 
-                emitter.emit_mcp_list_tools_sequence(&binding.label, &tools_for_server, &tx)?;
+                emitter
+                    .emit_mcp_list_tools_sequence(&binding.label, &tools_for_server, &tx)
+                    .await?;
             }
             mcp_list_tools_emitted = true;
         }
@@ -680,12 +688,12 @@ async fn execute_tool_loop_streaming_internal(
 
                 // Emit output_item.added
                 let event = emitter.emit_output_item_added(output_index, &item);
-                emitter.send_event(&event, &tx)?;
+                emitter.send_event(&event, &tx).await?;
 
                 // Emit tool_call.in_progress
                 let event =
                     emitter.emit_tool_call_in_progress(output_index, &item_id, response_format);
-                emitter.send_event(&event, &tx)?;
+                emitter.send_event(&event, &tx).await?;
 
                 // Emit arguments events for mcp_call only (skip for builtin tools)
                 if matches!(response_format, ResponseFormat::Passthrough) {
@@ -695,7 +703,7 @@ async fn execute_tool_loop_streaming_internal(
                         &item_id,
                         &tool_call.arguments,
                     );
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, &tx).await?;
 
                     // Emit mcp_call_arguments.done
                     let event = emitter.emit_mcp_call_arguments_done(
@@ -703,14 +711,14 @@ async fn execute_tool_loop_streaming_internal(
                         &item_id,
                         &tool_call.arguments,
                     );
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, &tx).await?;
                 }
 
                 // Emit searching/interpreting event for builtin tools
                 if let Some(event) =
                     emitter.emit_tool_call_searching(output_index, &item_id, response_format)
                 {
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, &tx).await?;
                 }
 
                 // Execute the MCP tool
@@ -775,7 +783,7 @@ async fn execute_tool_loop_streaming_internal(
                 if success {
                     let event =
                         emitter.emit_tool_call_completed(output_index, &item_id, response_format);
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, &tx).await?;
                 } else {
                     let err_text = tool_output
                         .error_message
@@ -790,19 +798,19 @@ async fn execute_tool_loop_streaming_internal(
                     // content.
                     if matches!(response_format, ResponseFormat::Passthrough) {
                         let event = emitter.emit_mcp_call_failed(output_index, &item_id, &err_text);
-                        emitter.send_event(&event, &tx)?;
+                        emitter.send_event(&event, &tx).await?;
                     } else {
                         let event = emitter.emit_tool_call_completed(
                             output_index,
                             &item_id,
                             response_format,
                         );
-                        emitter.send_event(&event, &tx)?;
+                        emitter.send_event(&event, &tx).await?;
                     }
                 }
 
                 let event = emitter.emit_output_item_done(output_index, &item_done);
-                emitter.send_event(&event, &tx)?;
+                emitter.send_event(&event, &tx).await?;
                 emitter.complete_output_item(output_index);
 
                 Metrics::record_mcp_tool_duration(
@@ -855,7 +863,7 @@ async fn execute_tool_loop_streaming_internal(
 
                     // Emit output_item.added
                     let event = emitter.emit_output_item_added(output_index, &item);
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, &tx).await?;
 
                     // Emit function_call_arguments.delta
                     let event = emitter.emit_function_call_arguments_delta(
@@ -863,7 +871,7 @@ async fn execute_tool_loop_streaming_internal(
                         &item_id,
                         &tool_call.arguments,
                     );
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, &tx).await?;
 
                     // Emit function_call_arguments.done
                     let event = emitter.emit_function_call_arguments_done(
@@ -871,7 +879,7 @@ async fn execute_tool_loop_streaming_internal(
                         &item_id,
                         &tool_call.arguments,
                     );
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, &tx).await?;
 
                     // Build complete item
                     let item_complete = json!({
@@ -885,7 +893,7 @@ async fn execute_tool_loop_streaming_internal(
 
                     // Emit output_item.done
                     let event = emitter.emit_output_item_done(output_index, &item_complete);
-                    emitter.send_event(&event, &tx)?;
+                    emitter.send_event(&event, &tx).await?;
 
                     emitter.complete_output_item(output_index);
                 }
@@ -912,7 +920,7 @@ async fn execute_tool_loop_streaming_internal(
         // Emit reasoning item if present
         if let Some(reasoning) = reasoning_content {
             if !reasoning.is_empty() {
-                emitter.emit_reasoning_item(&tx, Some(reasoning))?;
+                emitter.emit_reasoning_item(&tx, Some(reasoning)).await?;
             }
         }
 
@@ -928,7 +936,7 @@ async fn execute_tool_loop_streaming_internal(
             })
         });
         let event = emitter.emit_completed(usage_json.as_ref());
-        emitter.send_event(&event, &tx)?;
+        emitter.send_event(&event, &tx).await?;
 
         break;
     }
@@ -940,7 +948,7 @@ async fn execute_tool_loop_streaming_internal(
 async fn convert_and_accumulate_stream(
     body: Body,
     emitter: &mut ResponseStreamEventEmitter,
-    tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+    tx: &SseSender,
 ) -> Result<ChatCompletionResponse, String> {
     let mut accumulator = ChatResponseAccumulator::new();
     let mut stream = body.into_data_stream();
@@ -960,7 +968,7 @@ async fn convert_and_accumulate_stream(
             let json_str = json_str.trim();
             if let Ok(chat_chunk) = serde_json::from_str::<ChatCompletionStreamResponse>(json_str) {
                 // Convert chat chunk to Responses API events and emit
-                emitter.process_chunk(&chat_chunk, tx)?;
+                emitter.process_chunk(&chat_chunk, tx).await?;
 
                 // Accumulate for tool call detection
                 accumulator.process_chunk(&chat_chunk);

--- a/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/response_processing.rs
@@ -108,14 +108,18 @@ impl ChatResponseProcessingStage {
                 .and_then(RateLimitCell::take_for_streaming_handoff);
 
             // Streaming: Use StreamingProcessor and return SSE response
-            let response = self.streaming_processor.clone().process_streaming_response(
-                execution_result,
-                ctx.chat_request_arc(), // Cheap Arc clone (8 bytes)
-                dispatch,
-                tokenizer,
-                skip_special_tokens,
-                reservation.clone(),
-            );
+            let response = self
+                .streaming_processor
+                .clone()
+                .process_streaming_response(
+                    execution_result,
+                    ctx.chat_request_arc(), // Cheap Arc clone (8 bytes)
+                    dispatch,
+                    tokenizer,
+                    skip_special_tokens,
+                    reservation.clone(),
+                )
+                .await;
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) to the response body for proper RAII lifecycle.

--- a/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
@@ -96,7 +96,8 @@ impl PipelineStage for CompletionResponseProcessingStage {
                     dispatch,
                     tokenizer,
                     reservation.clone(),
-                );
+                )
+                .await;
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) to the response body for proper RAII lifecycle.

--- a/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/response_processing.rs
@@ -101,13 +101,17 @@ impl GenerateResponseProcessingStage {
                 .and_then(RateLimitCell::take_for_streaming_handoff);
 
             // Streaming: Use StreamingProcessor and return SSE response
-            let response = self.streaming_processor.clone().process_streaming_generate(
-                execution_result,
-                ctx.generate_request_arc(), // Cheap Arc clone (8 bytes)
-                dispatch,
-                tokenizer,
-                reservation.clone(),
-            );
+            let response = self
+                .streaming_processor
+                .clone()
+                .process_streaming_generate(
+                    execution_result,
+                    ctx.generate_request_arc(), // Cheap Arc clone (8 bytes)
+                    dispatch,
+                    tokenizer,
+                    reservation.clone(),
+                )
+                .await;
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) to the response body for proper RAII lifecycle.

--- a/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/response_processing.rs
@@ -102,7 +102,8 @@ impl PipelineStage for MessageResponseProcessingStage {
                     tokenizer,
                     skip_special_tokens,
                     reservation.clone(),
-                );
+                )
+                .await;
 
             // Attach load guards (and the reservation's disconnect/error
             // safety net) for RAII lifecycle.

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -4,7 +4,6 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    io,
     sync::Arc,
     time::Instant,
 };
@@ -30,7 +29,6 @@ use openai_protocol::{
 };
 use reasoning_parser::{ParserFactory as ReasoningParserFactory, ParserResult, ReasoningParser};
 use serde_json::{json, Value};
-use tokio::sync::{mpsc, mpsc::UnboundedSender};
 use tool_parser::{ParserFactory as ToolParserFactory, StreamingParseResult, ToolParser};
 use tracing::{debug, error, warn};
 
@@ -38,7 +36,7 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics, StreamingMetricsParams},
     rate_limit::{SharedReservationHandle, UsageSettlement},
     routers::{
-        common::sse::SseEncoder,
+        common::sse::{sse_channel, SseEncoder, SseSender},
         grpc::{
             common::{response_formatting::CompletionTokenTracker, responses::build_sse_response},
             context,
@@ -123,7 +121,7 @@ impl StreamingProcessor {
     ///
     /// Note: Caller should attach load guards to the returned response using
     /// `WorkerLoadGuard::attach_to_response()` for proper RAII lifecycle management.
-    pub fn process_streaming_response(
+    pub async fn process_streaming_response(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
         chat_request: Arc<ChatCompletionRequest>,
@@ -133,7 +131,6 @@ impl StreamingProcessor {
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Response {
         use bytes::Bytes;
-        use tokio::sync::mpsc;
 
         let stop_params = (
             chat_request.stop.clone(),
@@ -144,7 +141,7 @@ impl StreamingProcessor {
         );
 
         // Create SSE channel
-        let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
+        let (tx, rx) = sse_channel();
 
         // Spawn background task based on execution mode
         match execution_result {
@@ -170,10 +167,10 @@ impl StreamingProcessor {
                         .await;
 
                     if let Err(e) = result {
-                        utils::send_error_sse(&tx, &e, "internal_error");
+                        utils::send_error_sse(&tx, &e, "internal_error").await;
                     }
 
-                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
                 });
             }
             context::ExecutionResult::PrefillDecode {
@@ -203,10 +200,10 @@ impl StreamingProcessor {
                         .await;
 
                     if let Err(e) = result {
-                        utils::send_error_sse(&tx, &e, "internal_error");
+                        utils::send_error_sse(&tx, &e, "internal_error").await;
                     }
 
-                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
                 });
             }
             context::ExecutionResult::Embedding { .. } => {
@@ -214,8 +211,9 @@ impl StreamingProcessor {
                     &tx,
                     "Embeddings not supported in streaming mode",
                     "invalid_request_error",
-                );
-                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                )
+                .await;
+                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
             }
             // Batch results exist only on the completions pipeline.
             context::ExecutionResult::Batch { .. } => {
@@ -223,8 +221,9 @@ impl StreamingProcessor {
                     &tx,
                     "Batched results not supported in chat streaming",
                     "invalid_request_error",
-                );
-                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                )
+                .await;
+                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
             }
         }
 
@@ -241,7 +240,7 @@ impl StreamingProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         self.process_streaming_chunks_inner(
@@ -268,7 +267,7 @@ impl StreamingProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         pd_timing: Option<context::PdTiming>,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
@@ -473,6 +472,7 @@ impl StreamingProcessor {
                             .build();
                         Self::format_sse_chunk_into(&mut sse_buffer, &first_chunk);
                         tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                            .await
                             .map_err(|_| "Failed to send first chunk".to_string())?;
                         is_firsts.insert(index, false);
                     }
@@ -499,6 +499,7 @@ impl StreamingProcessor {
                         if let Some(chunk) = reasoning_chunk {
                             Self::format_sse_chunk_into(&mut sse_buffer, &chunk);
                             tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                                .await
                                 .map_err(|_| "Failed to send reasoning chunk".to_string())?;
                         }
                         delta = normal_text;
@@ -550,6 +551,7 @@ impl StreamingProcessor {
                             for chunk in tool_chunks {
                                 Self::format_sse_chunk_into(&mut sse_buffer, &chunk);
                                 tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                                    .await
                                     .map_err(|_| "Failed to send tool call chunk".to_string())?;
                             }
 
@@ -574,6 +576,7 @@ impl StreamingProcessor {
                                 .build();
                         Self::format_sse_chunk_into(&mut sse_buffer, &content_chunk);
                         tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                            .await
                             .map_err(|_| "Failed to send content chunk".to_string())?;
                     }
                 }
@@ -599,6 +602,7 @@ impl StreamingProcessor {
                                         format!("Failed to serialize content chunk: {e}")
                                     })?;
                                 tx.send(Ok(sse_chunk))
+                                    .await
                                     .map_err(|_| "Failed to send flushed content".to_string())?;
                             }
                         }
@@ -654,6 +658,7 @@ impl StreamingProcessor {
                         .encode_data(&tool_chunk)
                         .map_err(|e| format!("Failed to serialize tool chunk: {e}"))?;
                     tx.send(Ok(sse_chunk))
+                        .await
                         .map_err(|_| "Failed to send unstreamed tool args".to_string())?;
                 }
             }
@@ -680,6 +685,7 @@ impl StreamingProcessor {
                 .encode_data(&finish_chunk)
                 .map_err(|e| format!("Failed to serialize finish chunk: {e}"))?;
             tx.send(Ok(sse_chunk))
+                .await
                 .map_err(|_| "Failed to send finish chunk".to_string())?;
         }
 
@@ -710,6 +716,7 @@ impl StreamingProcessor {
                     .encode_data(&usage_chunk)
                     .map_err(|e| format!("Failed to serialize usage chunk: {e}"))?;
                 tx.send(Ok(sse_chunk))
+                    .await
                     .map_err(|_| "Failed to send usage chunk".to_string())?;
             }
         }
@@ -762,7 +769,7 @@ impl StreamingProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         pd_timing: context::PdTiming,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
@@ -813,7 +820,7 @@ impl StreamingProcessor {
     ///
     /// Note: Caller should attach load guards to the returned response using
     /// `WorkerLoadGuard::attach_to_response()` for proper RAII lifecycle management.
-    pub fn process_streaming_generate(
+    pub async fn process_streaming_generate(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
         generate_request: Arc<GenerateRequest>,
@@ -822,7 +829,7 @@ impl StreamingProcessor {
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Response {
         // Create SSE channel
-        let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
+        let (tx, rx) = sse_channel();
 
         // Build context once, clone for spawned task
         let ctx = GenerateStreamContext {
@@ -856,10 +863,10 @@ impl StreamingProcessor {
                             .await;
 
                     if let Err(e) = result {
-                        utils::send_error_sse(&tx, &e, "internal_error");
+                        utils::send_error_sse(&tx, &e, "internal_error").await;
                     }
 
-                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
                 });
             }
             context::ExecutionResult::PrefillDecode {
@@ -886,10 +893,10 @@ impl StreamingProcessor {
                     .await;
 
                     if let Err(e) = result {
-                        utils::send_error_sse(&tx, &e, "internal_error");
+                        utils::send_error_sse(&tx, &e, "internal_error").await;
                     }
 
-                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
                 });
             }
             context::ExecutionResult::Embedding { .. } => {
@@ -897,8 +904,9 @@ impl StreamingProcessor {
                     &tx,
                     "Embeddings not supported in streaming generate",
                     "invalid_request_error",
-                );
-                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                )
+                .await;
+                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
             }
             // Batch results exist only on the completions pipeline.
             context::ExecutionResult::Batch { .. } => {
@@ -906,8 +914,9 @@ impl StreamingProcessor {
                     &tx,
                     "Batched results not supported in streaming generate",
                     "invalid_request_error",
-                );
-                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                )
+                .await;
+                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
             }
         }
 
@@ -921,7 +930,7 @@ impl StreamingProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         mut stream: ProtoStream,
         ctx: GenerateStreamContext,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         let start_time = Instant::now();
@@ -988,6 +997,7 @@ impl StreamingProcessor {
                         .encode_data(&chunk_response)
                         .map_err(|e| format!("Failed to serialize generate chunk: {e}"))?;
                     tx.send(Ok(sse_data))
+                        .await
                         .map_err(|_| "Failed to send chunk".to_string())?;
                 }
                 ProtoResponseVariant::Complete(complete) => {
@@ -1021,6 +1031,7 @@ impl StreamingProcessor {
                         .encode_data(&finish_response)
                         .map_err(|e| format!("Failed to serialize generate finish: {e}"))?;
                     tx.send(Ok(sse_data))
+                        .await
                         .map_err(|_| "Failed to send finish chunk".to_string())?;
 
                     // Continue to process all completions if n>1
@@ -1057,7 +1068,7 @@ impl StreamingProcessor {
         mut prefill_stream: ProtoStream,
         decode_stream: ProtoStream,
         ctx: GenerateStreamContext,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         pd_timing: context::PdTiming,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
@@ -1113,7 +1124,7 @@ impl StreamingProcessor {
         mut stream: ProtoStream,
         ctx: GenerateStreamContext,
         input_token_logprobs: Option<Vec<Vec<Option<f64>>>>,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         pd_timing: Option<context::PdTiming>,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
@@ -1217,6 +1228,7 @@ impl StreamingProcessor {
                         .encode_data(&chunk_response)
                         .map_err(|e| format!("Failed to serialize generate chunk: {e}"))?;
                     tx.send(Ok(sse_data))
+                        .await
                         .map_err(|_| "Failed to send chunk".to_string())?;
                 }
                 ProtoResponseVariant::Complete(complete) => {
@@ -1264,6 +1276,7 @@ impl StreamingProcessor {
                         .encode_data(&finish_response)
                         .map_err(|e| format!("Failed to serialize generate finish: {e}"))?;
                     tx.send(Ok(sse_data))
+                        .await
                         .map_err(|_| "Failed to send finish chunk".to_string())?;
 
                     // Continue to process all completions if n>1
@@ -1633,13 +1646,14 @@ impl StreamingProcessor {
     }
 
     /// Send a `MessageStreamEvent` through the SSE channel using a reusable buffer.
-    fn send_messages_event(
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+    async fn send_messages_event(
+        tx: &SseSender,
         buffer: &mut Vec<u8>,
         event: &MessageStreamEvent,
     ) -> Result<(), String> {
         Self::format_messages_sse_into(buffer, event)?;
         tx.send(Ok(Bytes::from(buffer.clone())))
+            .await
             .map_err(|_| "Client disconnected".to_string())
     }
 
@@ -1699,7 +1713,7 @@ impl StreamingProcessor {
     ///
     /// Parallel to [`Self::process_streaming_response`] for chat, but emits
     /// Anthropic SSE format (`event: {type}\ndata: {json}\n\n`).
-    pub fn process_messages_streaming_response(
+    pub async fn process_messages_streaming_response(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
         messages_request: Arc<CreateMessageRequest>,
@@ -1719,7 +1733,7 @@ impl StreamingProcessor {
             false, // ignore_eos — not available in Messages API
         );
 
-        let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
+        let (tx, rx) = sse_channel();
 
         match execution_result {
             context::ExecutionResult::Single { stream } => {
@@ -1751,7 +1765,7 @@ impl StreamingProcessor {
                             },
                         };
                         let mut buf = Vec::with_capacity(256);
-                        let _ = Self::send_messages_event(&tx, &mut buf, &error_event);
+                        let _ = Self::send_messages_event(&tx, &mut buf, &error_event).await;
                     }
                     // No data: [DONE] — Anthropic uses message_stop instead
                 });
@@ -1790,7 +1804,7 @@ impl StreamingProcessor {
                             },
                         };
                         let mut buf = Vec::with_capacity(256);
-                        let _ = Self::send_messages_event(&tx, &mut buf, &error_event);
+                        let _ = Self::send_messages_event(&tx, &mut buf, &error_event).await;
                     }
                 });
             }
@@ -1802,7 +1816,7 @@ impl StreamingProcessor {
                     },
                 };
                 let mut buf = Vec::with_capacity(256);
-                let _ = Self::send_messages_event(&tx, &mut buf, &error_event);
+                let _ = Self::send_messages_event(&tx, &mut buf, &error_event).await;
             }
             // Batch results exist only on the completions pipeline.
             context::ExecutionResult::Batch { .. } => {
@@ -1813,7 +1827,7 @@ impl StreamingProcessor {
                     },
                 };
                 let mut buf = Vec::with_capacity(256);
-                let _ = Self::send_messages_event(&tx, &mut buf, &error_event);
+                let _ = Self::send_messages_event(&tx, &mut buf, &error_event).await;
             }
         }
 
@@ -1832,7 +1846,7 @@ impl StreamingProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<CreateMessageRequest>,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         let start_time = Instant::now();
@@ -1998,7 +2012,8 @@ impl StreamingProcessor {
             &MessageStreamEvent::MessageStart {
                 message: start_message,
             },
-        )?;
+        )
+        .await?;
 
         // Phase 2: Main streaming loop
         while let Some(response) = grpc_stream.next().await {
@@ -2065,7 +2080,8 @@ impl StreamingProcessor {
                                         signature: String::new(),
                                     },
                                 },
-                            )?;
+                            )
+                            .await?;
                             thinking_block_open = true;
                         }
                         Self::send_messages_event(
@@ -2077,7 +2093,8 @@ impl StreamingProcessor {
                                     thinking: reasoning_chunk_text,
                                 },
                             },
-                        )?;
+                        )
+                        .await?;
                     }
 
                     // Transition: reasoning ended, close thinking block
@@ -2088,7 +2105,8 @@ impl StreamingProcessor {
                             &MessageStreamEvent::ContentBlockStop {
                                 index: current_block_index,
                             },
-                        )?;
+                        )
+                        .await?;
                         thinking_block_open = false;
                         current_block_index += 1;
                     }
@@ -2107,7 +2125,8 @@ impl StreamingProcessor {
                                         &MessageStreamEvent::ContentBlockStop {
                                             index: current_block_index,
                                         },
-                                    )?;
+                                    )
+                                    .await?;
                                     text_block_open = false;
                                     current_block_index += 1;
                                 }
@@ -2133,7 +2152,8 @@ impl StreamingProcessor {
                                             input: Value::Object(serde_json::Map::new()),
                                         },
                                     },
-                                )?;
+                                )
+                                .await?;
                                 tool_block_open = true;
                             }
                             // Emit arguments delta
@@ -2147,7 +2167,8 @@ impl StreamingProcessor {
                                             partial_json: normal_text,
                                         },
                                     },
-                                )?;
+                                )
+                                .await?;
                             }
                         } else if let Some(ref mut parser) = streaming_tool_parser {
                             // Regular/required tool choice: use incremental parser
@@ -2169,7 +2190,8 @@ impl StreamingProcessor {
                                                         citations: None,
                                                     },
                                                 },
-                                            )?;
+                                            )
+                                            .await?;
                                             text_block_open = true;
                                         }
                                         Self::send_messages_event(
@@ -2179,7 +2201,8 @@ impl StreamingProcessor {
                                                 index: current_block_index,
                                                 delta: ContentBlockDelta::TextDelta { text },
                                             },
-                                        )?;
+                                        )
+                                        .await?;
                                     }
 
                                     // Emit tool call events
@@ -2195,7 +2218,8 @@ impl StreamingProcessor {
                                                     &MessageStreamEvent::ContentBlockStop {
                                                         index: current_block_index,
                                                     },
-                                                )?;
+                                                )
+                                                .await?;
                                                 text_block_open = false;
                                                 current_block_index += 1;
                                             }
@@ -2206,7 +2230,8 @@ impl StreamingProcessor {
                                                     &MessageStreamEvent::ContentBlockStop {
                                                         index: current_block_index,
                                                     },
-                                                )?;
+                                                )
+                                                .await?;
                                                 current_block_index += 1;
                                             }
 
@@ -2227,7 +2252,7 @@ impl StreamingProcessor {
                                                         input: Value::Object(serde_json::Map::new()),
                                                     },
                                                 },
-                                            )?;
+                                            ).await?;
                                             tool_block_open = true;
                                         }
 
@@ -2242,7 +2267,8 @@ impl StreamingProcessor {
                                                         partial_json: tool_call_item.parameters,
                                                     },
                                                 },
-                                            )?;
+                                            )
+                                            .await?;
                                         }
                                     }
                                 }
@@ -2267,7 +2293,8 @@ impl StreamingProcessor {
                                         citations: None,
                                     },
                                 },
-                            )?;
+                            )
+                            .await?;
                             text_block_open = true;
                         }
                         Self::send_messages_event(
@@ -2277,7 +2304,8 @@ impl StreamingProcessor {
                                 index: current_block_index,
                                 delta: ContentBlockDelta::TextDelta { text: normal_text },
                             },
-                        )?;
+                        )
+                        .await?;
                     }
                 }
                 ProtoResponseVariant::Complete(complete) => {
@@ -2295,7 +2323,8 @@ impl StreamingProcessor {
                                             citations: None,
                                         },
                                     },
-                                )?;
+                                )
+                                .await?;
                                 text_block_open = true;
                             }
                             Self::send_messages_event(
@@ -2305,7 +2334,8 @@ impl StreamingProcessor {
                                     index: current_block_index,
                                     delta: ContentBlockDelta::TextDelta { text },
                                 },
-                            )?;
+                            )
+                            .await?;
                         }
                     }
 
@@ -2338,7 +2368,8 @@ impl StreamingProcessor {
                                 &MessageStreamEvent::ContentBlockStop {
                                     index: current_block_index,
                                 },
-                            )?;
+                            )
+                            .await?;
                             text_block_open = false;
                             current_block_index += 1;
                         }
@@ -2349,7 +2380,8 @@ impl StreamingProcessor {
                                 &MessageStreamEvent::ContentBlockStop {
                                     index: current_block_index,
                                 },
-                            )?;
+                            )
+                            .await?;
                             current_block_index += 1;
                         }
 
@@ -2370,7 +2402,8 @@ impl StreamingProcessor {
                                     input: Value::Object(serde_json::Map::new()),
                                 },
                             },
-                        )?;
+                        )
+                        .await?;
                         tool_block_open = true;
                     }
 
@@ -2384,7 +2417,8 @@ impl StreamingProcessor {
                                     partial_json: tool_call_item.parameters,
                                 },
                             },
-                        )?;
+                        )
+                        .await?;
                     }
                 }
             }
@@ -2398,7 +2432,8 @@ impl StreamingProcessor {
                 &MessageStreamEvent::ContentBlockStop {
                     index: current_block_index,
                 },
-            )?;
+            )
+            .await?;
             current_block_index += 1;
         }
 
@@ -2409,7 +2444,8 @@ impl StreamingProcessor {
                 &MessageStreamEvent::ContentBlockStop {
                     index: current_block_index,
                 },
-            )?;
+            )
+            .await?;
             current_block_index += 1;
         }
 
@@ -2420,7 +2456,8 @@ impl StreamingProcessor {
                 &MessageStreamEvent::ContentBlockStop {
                     index: current_block_index,
                 },
-            )?;
+            )
+            .await?;
         }
 
         // Phase 4: Emit message_delta with stop_reason and usage
@@ -2456,10 +2493,11 @@ impl StreamingProcessor {
                     server_tool_use: None,
                 },
             },
-        )?;
+        )
+        .await?;
 
         // Phase 5: Emit message_stop
-        Self::send_messages_event(tx, &mut sse_buffer, &MessageStreamEvent::MessageStop)?;
+        Self::send_messages_event(tx, &mut sse_buffer, &MessageStreamEvent::MessageStop).await?;
 
         // Mark stream completed
         grpc_stream.mark_completed();
@@ -2505,7 +2543,7 @@ impl StreamingProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<CreateMessageRequest>,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Result<(), String> {
         // Consume prefill stream (Messages API does not expose prompt logprobs)
@@ -2547,7 +2585,7 @@ impl StreamingProcessor {
     /// write typed SSE events (with prompt-major index offsets) into one
     /// channel, and the coordinator emits the single aggregated usage chunk,
     /// metrics record, and `[DONE]`.
-    pub fn process_completion_streaming_response(
+    pub async fn process_completion_streaming_response(
         self: Arc<Self>,
         execution_result: context::ExecutionResult,
         completion_request: Arc<CompletionRequest>,
@@ -2555,13 +2593,13 @@ impl StreamingProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         reservation: Option<Arc<SharedReservationHandle>>,
     ) -> Response {
-        let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
+        let (tx, rx) = sse_channel();
 
         let units = match Self::completion_stream_units(execution_result) {
             Ok(units) => units,
             Err(message) => {
-                utils::send_error_sse(&tx, message, "invalid_request_error");
-                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                utils::send_error_sse(&tx, message, "invalid_request_error").await;
+                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
                 return build_sse_response(rx);
             }
         };
@@ -2645,7 +2683,7 @@ impl StreamingProcessor {
 
             match outcomes {
                 Err(e) => {
-                    utils::send_error_sse(&tx, &e, "internal_error");
+                    utils::send_error_sse(&tx, &e, "internal_error").await;
                 }
                 Ok(outcomes) => {
                     let mut total_prompt = 0u32;
@@ -2702,7 +2740,7 @@ impl StreamingProcessor {
                         };
                         let mut sse_buffer = Vec::with_capacity(256);
                         Self::format_completion_sse_into(&mut sse_buffer, &usage_chunk);
-                        let _ = tx.send(Ok(Bytes::from(sse_buffer)));
+                        let _ = tx.send(Ok(Bytes::from(sse_buffer))).await;
                     }
                     Metrics::record_streaming_metrics(StreamingMetricsParams {
                         router_type: metrics_labels::ROUTER_GRPC,
@@ -2717,7 +2755,7 @@ impl StreamingProcessor {
                 }
             }
 
-            let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+            let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n"))).await;
         });
 
         build_sse_response(rx)
@@ -2775,7 +2813,7 @@ impl StreamingProcessor {
         completion_request: Arc<CompletionRequest>,
         prompt_text: &str,
         index_offset: u32,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
     ) -> Result<CompletionStreamOutcome, String> {
         let mut first_token_time: Option<Instant> = None;
 
@@ -2873,6 +2911,7 @@ impl StreamingProcessor {
 
                         Self::format_completion_sse_into(&mut sse_buffer, &stream_resp);
                         tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                            .await
                             .map_err(|_| "Channel closed".to_string())?;
                     }
 
@@ -2899,6 +2938,7 @@ impl StreamingProcessor {
                             };
                             Self::format_completion_sse_into(&mut sse_buffer, &suffix_chunk);
                             tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                                .await
                                 .map_err(|_| "Channel closed".to_string())?;
                         }
 
@@ -2918,6 +2958,7 @@ impl StreamingProcessor {
                         };
                         Self::format_completion_sse_into(&mut sse_buffer, &final_chunk);
                         tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                            .await
                             .map_err(|_| "Channel closed".to_string())?;
                     }
                 }
@@ -2954,6 +2995,7 @@ impl StreamingProcessor {
                         };
                         Self::format_completion_sse_into(&mut sse_buffer, &echo_chunk);
                         tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                            .await
                             .map_err(|_| "Channel closed".to_string())?;
                         *is_first = false;
                     }
@@ -2977,6 +3019,7 @@ impl StreamingProcessor {
                                 };
                                 Self::format_completion_sse_into(&mut sse_buffer, &stream_resp);
                                 tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                                    .await
                                     .map_err(|_| "Channel closed".to_string())?;
                             }
                         }
@@ -2999,6 +3042,7 @@ impl StreamingProcessor {
                         };
                         Self::format_completion_sse_into(&mut sse_buffer, &stream_resp);
                         tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                            .await
                             .map_err(|_| "Channel closed".to_string())?;
                     }
 
@@ -3044,6 +3088,7 @@ impl StreamingProcessor {
                     };
                     Self::format_completion_sse_into(&mut sse_buffer, &final_chunk);
                     tx.send(Ok(Bytes::from(sse_buffer.clone())))
+                        .await
                         .map_err(|_| "Channel closed".to_string())?;
                 }
                 ProtoResponseVariant::None => continue,
@@ -3082,7 +3127,7 @@ impl StreamingProcessor {
         original_request: Arc<CompletionRequest>,
         prompt_text: &str,
         index_offset: u32,
-        tx: &UnboundedSender<Result<Bytes, io::Error>>,
+        tx: &SseSender,
     ) -> Result<CompletionStreamOutcome, String> {
         while let Some(response) = prefill_stream.next().await {
             let gen_response =

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::HashMap,
-    io,
     sync::{Arc, OnceLock},
 };
 
@@ -22,24 +21,33 @@ use openai_protocol::{
     generate::GenerateFinishReason,
 };
 use serde_json::{json, Value};
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::Semaphore;
 use tracing::error;
 use uuid::Uuid;
 
 use crate::routers::{
+    common::sse,
     error,
     grpc::{context::RequestContext, multimodal::PlaceholderTokens, ProcessedMessages},
 };
 
 /// Type alias for the SSE channel sender used across streaming endpoints.
-pub(crate) type SseSender = mpsc::UnboundedSender<Result<Bytes, io::Error>>;
+///
+/// Re-exports the bounded [`crate::routers::common::sse::SseSender`] so the gRPC
+/// streaming paths share one definition with the rest of the gateway and cannot
+/// drift back to an unbounded channel. Bounded => `send` is async and applies
+/// backpressure to a slow client.
+pub(crate) type SseSender = sse::SseSender;
 
 /// Send an SSE error event with a typed error body.
 ///
 /// Produces `data: {"error":{"message":"...","type":"..."}}\n\n` using
 /// `serde_json` so that quotes, newlines, and other special characters in the
 /// error message are properly escaped.
-pub(crate) fn send_error_sse(tx: &SseSender, message: impl ToString, error_type: &str) {
+///
+/// `async` because the sender is bounded: awaits if the buffer is full so the
+/// terminal error frame still applies backpressure rather than being dropped.
+pub(crate) async fn send_error_sse(tx: &SseSender, message: impl ToString, error_type: &str) {
     let chunk = format!(
         "data: {}\n\n",
         json!({
@@ -49,7 +57,7 @@ pub(crate) fn send_error_sse(tx: &SseSender, message: impl ToString, error_type:
             }
         })
     );
-    let _ = tx.send(Ok(Bytes::from(chunk)));
+    let _ = tx.send(Ok(Bytes::from(chunk))).await;
 }
 
 /// Resolve tokenizer from registry and cache it in request context.

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -21,7 +21,7 @@ use reqwest::Client;
 use serde::Serialize;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error, warn};
 
 use crate::{
@@ -37,7 +37,7 @@ use crate::{
         common::{
             header_utils,
             retry::{is_retryable_status, RetryExecutor},
-            sse::SseEncoder,
+            sse::{SseEncoder, SSE_CHANNEL_BUFFER},
         },
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},
@@ -964,7 +964,7 @@ impl PDRouter {
     ) -> Response {
         use crate::worker::AttachedBody;
 
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(SSE_CHANNEL_BUFFER);
 
         #[expect(
             clippy::disallowed_methods,
@@ -997,7 +997,7 @@ impl PDRouter {
                             chunk
                         };
 
-                        if tx.send(Ok(result)).is_err() {
+                        if tx.send(Ok(result)).await.is_err() {
                             break;
                         }
 
@@ -1009,14 +1009,14 @@ impl PDRouter {
                         if let Some(ref url) = decode_url {
                             error!("Stream error from decode server {}: {}", url, e);
                         }
-                        let _ = tx.send(Err(format!("Stream error: {e}")));
+                        let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                         break;
                     }
                 }
             }
         });
 
-        let stream = UnboundedReceiverStream::new(rx);
+        let stream = ReceiverStream::new(rx);
         let body = Body::from_stream(stream);
 
         let mut response = Response::new(body);
@@ -1856,8 +1856,8 @@ mod tests {
         assert_eq!(prefill_ref.load(), 0);
         assert_eq!(decode_ref.load(), 0);
 
-        let (tx, rx) = mpsc::unbounded_channel();
-        let stream = UnboundedReceiverStream::new(rx);
+        let (tx, rx) = mpsc::channel(SSE_CHANNEL_BUFFER);
+        let stream = ReceiverStream::new(rx);
 
         {
             let guards = vec![
@@ -1882,7 +1882,7 @@ mod tests {
             assert_eq!(prefill_ref.load(), 1);
             assert_eq!(decode_ref.load(), 1);
 
-            tx.send(Bytes::from("test data")).unwrap();
+            tx.send(Bytes::from("test data")).await.unwrap();
 
             sleep(Duration::from_millis(10)).await;
 

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -29,7 +29,7 @@ use reqwest::{
     Client,
 };
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::error;
 
 use crate::{
@@ -50,6 +50,7 @@ use crate::{
                 ws::handle_realtime_ws, RealtimeLabels, RealtimeRegistry,
             },
             retry::{is_retryable_status, RetryExecutor},
+            sse::SSE_CHANNEL_BUFFER,
             worker_selection::{SelectWorkerRequest, WorkerSelector},
         },
         error::{self, extract_error_code_from_response},
@@ -1069,7 +1070,9 @@ impl Router {
             response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
 
             let stream = res.bytes_stream();
-            let (tx, rx) = mpsc::unbounded_channel();
+            // Bounded channel applies backpressure: a slow client makes the
+            // relay await on `send` instead of buffering the whole response.
+            let (tx, rx) = mpsc::channel(SSE_CHANNEL_BUFFER);
 
             // Spawn task to forward stream
             #[expect(
@@ -1081,19 +1084,19 @@ impl Router {
                 while let Some(chunk) = stream.next().await {
                     match chunk {
                         Ok(bytes) => {
-                            if tx.send(Ok(bytes)).is_err() {
+                            if tx.send(Ok(bytes)).await.is_err() {
                                 break;
                             }
                         }
                         Err(e) => {
-                            let _ = tx.send(Err(format!("Stream error: {e}")));
+                            let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                             break;
                         }
                     }
                 }
             });
 
-            let stream = UnboundedReceiverStream::new(rx);
+            let stream = ReceiverStream::new(rx);
             let body = Body::from_stream(stream);
 
             let mut response = Response::new(body);

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -11,7 +11,7 @@ use futures_util::StreamExt;
 use openai_protocol::chat::ChatCompletionRequest;
 use serde_json::to_value;
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 
 use super::{
     context::{ComponentRefs, PayloadState, RequestContext, SharedComponents, WorkerSelection},
@@ -26,6 +26,7 @@ use crate::{
         common::{
             header_utils::{apply_provider_headers, extract_auth_header},
             retry::{is_retryable_status, RetryExecutor},
+            sse::SSE_CHANNEL_BUFFER,
             worker_selection::{SelectWorkerRequest, WorkerSelector},
         },
         error,
@@ -193,26 +194,26 @@ pub(super) async fn route_chat(
 
                 if is_streaming {
                     let stream = resp.bytes_stream();
-                    let (tx, rx) = mpsc::unbounded_channel();
+                    let (tx, rx) = mpsc::channel(SSE_CHANNEL_BUFFER);
                     #[expect(clippy::disallowed_methods, reason = "fire-and-forget stream relay; gateway shutdown need not wait for individual stream forwarding")]
                     tokio::spawn(async move {
                         let mut s = stream;
                         while let Some(chunk) = s.next().await {
                             match chunk {
                                 Ok(bytes) => {
-                                    if tx.send(Ok(bytes)).is_err() {
+                                    if tx.send(Ok(bytes)).await.is_err() {
                                         break;
                                     }
                                 }
                                 Err(e) => {
-                                    let _ = tx.send(Err(format!("Stream error: {e}")));
+                                    let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                                     break;
                                 }
                             }
                         }
                     });
                     let mut response =
-                        Response::new(Body::from_stream(UnboundedReceiverStream::new(rx)));
+                        Response::new(Body::from_stream(ReceiverStream::new(rx)));
                     *response.status_mut() = status;
                     response
                         .headers_mut()

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -8,7 +8,7 @@
 //! - Payload transformation for MCP tool interception
 //! - Metadata injection for MCP operations
 
-use std::{collections::HashSet, io};
+use std::collections::HashSet;
 
 use axum::http::HeaderMap;
 use bytes::Bytes;
@@ -18,7 +18,6 @@ use openai_protocol::{
 };
 use serde_json::{json, to_value, Value};
 use smg_mcp::{McpServerBinding, McpToolSession, ToolExecutionInput, ToolExecutionResult};
-use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
 use super::tool_handler::FunctionCallInProgress;
@@ -32,6 +31,7 @@ use crate::{
                 self, extract_embedded_openai_responses, mcp_response_item_id, FormatRegistry,
                 ResponseFormat, ResponseTransformer,
             },
+            sse::SseSender,
         },
         error,
         openai::responses::utils,
@@ -171,7 +171,7 @@ pub(crate) async fn execute_streaming_tool_calls(
     pending_calls: Vec<FunctionCallInProgress>,
     session: &McpToolSession<'_>,
     format_registry: &FormatRegistry,
-    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+    tx: &SseSender,
     state: &mut ToolLoopState,
     sequence_number: &mut u64,
     model_id: &str,
@@ -228,7 +228,9 @@ pub(crate) async fn execute_streaming_tool_calls(
                     &mcp_call_item,
                     response_format,
                     sequence_number,
-                ) {
+                )
+                .await
+                {
                     return false;
                 }
                 state.record_call(
@@ -243,7 +245,7 @@ pub(crate) async fn execute_streaming_tool_calls(
             }
         };
 
-        if !send_tool_call_intermediate_event(tx, &call, response_format, sequence_number) {
+        if !send_tool_call_intermediate_event(tx, &call, response_format, sequence_number).await {
             return false;
         }
 
@@ -303,7 +305,9 @@ pub(crate) async fn execute_streaming_tool_calls(
             &mcp_call_item,
             response_format,
             sequence_number,
-        ) {
+        )
+        .await
+        {
             return false;
         }
 
@@ -442,8 +446,8 @@ pub(crate) fn build_resume_payload(
 
 /// Send mcp_list_tools events to client at the start of streaming
 /// Returns false if client disconnected
-pub(crate) fn send_mcp_list_tools_events(
-    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+pub(crate) async fn send_mcp_list_tools_events(
+    tx: &SseSender,
     session: &McpToolSession<'_>,
     server_label: &str,
     output_index: usize,
@@ -475,7 +479,7 @@ pub(crate) fn send_mcp_list_tools_events(
         OutputItemEvent::ADDED,
         event1_payload
     );
-    if tx.send(Ok(Bytes::from(event1))).is_err() {
+    if tx.send(Ok(Bytes::from(event1))).await.is_err() {
         return false; // Client disconnected
     }
 
@@ -492,7 +496,7 @@ pub(crate) fn send_mcp_list_tools_events(
         McpEvent::LIST_TOOLS_IN_PROGRESS,
         event2_payload
     );
-    if tx.send(Ok(Bytes::from(event2))).is_err() {
+    if tx.send(Ok(Bytes::from(event2))).await.is_err() {
         return false;
     }
 
@@ -509,7 +513,7 @@ pub(crate) fn send_mcp_list_tools_events(
         McpEvent::LIST_TOOLS_COMPLETED,
         event3_payload
     );
-    if tx.send(Ok(Bytes::from(event3))).is_err() {
+    if tx.send(Ok(Bytes::from(event3))).await.is_err() {
         return false;
     }
 
@@ -526,13 +530,13 @@ pub(crate) fn send_mcp_list_tools_events(
         OutputItemEvent::DONE,
         event4_payload
     );
-    tx.send(Ok(Bytes::from(event4))).is_ok()
+    tx.send(Ok(Bytes::from(event4))).await.is_ok()
 }
 
 /// Send intermediate event during tool execution (searching/interpreting).
 /// Returns false if client disconnected.
-fn send_tool_call_intermediate_event(
-    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+async fn send_tool_call_intermediate_event(
+    tx: &SseSender,
     call: &FunctionCallInProgress,
     response_format: ResponseFormat,
     sequence_number: &mut u64,
@@ -555,15 +559,15 @@ fn send_tool_call_intermediate_event(
     *sequence_number += 1;
 
     let event = format!("event: {event_type}\ndata: {event_payload}\n\n");
-    tx.send(Ok(Bytes::from(event))).is_ok()
+    tx.send(Ok(Bytes::from(event))).await.is_ok()
 }
 
 /// Send tool call completion events after tool execution.
 /// Handles mcp_call, web_search_call, code_interpreter_call, file_search_call,
 /// and image_generation_call items.
 /// Returns false if client disconnected.
-fn send_tool_call_completion_events(
-    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+async fn send_tool_call_completion_events(
+    tx: &SseSender,
     call: &FunctionCallInProgress,
     tool_call_item: &Value,
     response_format: ResponseFormat,
@@ -593,7 +597,7 @@ fn send_tool_call_completion_events(
     *sequence_number += 1;
 
     let completed_event = format!("event: {completed_event_type}\ndata: {completed_payload}\n\n");
-    if tx.send(Ok(Bytes::from(completed_event))).is_err() {
+    if tx.send(Ok(Bytes::from(completed_event))).await.is_err() {
         return false;
     }
 
@@ -611,7 +615,7 @@ fn send_tool_call_completion_events(
         OutputItemEvent::DONE,
         done_payload
     );
-    tx.send(Ok(Bytes::from(done_event))).is_ok()
+    tx.send(Ok(Bytes::from(done_event))).await.is_ok()
 }
 
 fn stable_streaming_tool_item_id(
@@ -1644,9 +1648,7 @@ mod tests {
     // L1054-L1072).
     // ========================================================================
 
-    fn drain_channel(
-        rx: &mut mpsc::UnboundedReceiver<Result<bytes::Bytes, std::io::Error>>,
-    ) -> Vec<String> {
+    fn drain_channel(rx: &mut mpsc::Receiver<Result<bytes::Bytes, std::io::Error>>) -> Vec<String> {
         let mut events = Vec::new();
         while let Ok(chunk) = rx.try_recv() {
             let bytes = chunk.expect("no io errors in unit-test channel");
@@ -1667,8 +1669,8 @@ mod tests {
         block.to_string()
     }
 
-    #[test]
-    fn image_generation_completion_events_fire_before_output_item_done() {
+    #[tokio::test]
+    async fn image_generation_completion_events_fire_before_output_item_done() {
         // Gap B lock test: after the tool executes, the completion
         // emitter must push `response.image_generation_call.completed`
         // onto the wire BEFORE `response.output_item.done`. If a future
@@ -1690,7 +1692,7 @@ mod tests {
             "result": "BASE64",
         });
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(4);
         let mut sequence_number: u64 = 0;
 
         let ok = super::send_tool_call_completion_events(
@@ -1699,7 +1701,8 @@ mod tests {
             &tool_call_item,
             ResponseFormat::ImageGenerationCall,
             &mut sequence_number,
-        );
+        )
+        .await;
         assert!(ok, "send_tool_call_completion_events should not disconnect");
         drop(tx);
 
@@ -1725,8 +1728,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn web_search_completion_events_fire_before_output_item_done() {
+    #[tokio::test]
+    async fn web_search_completion_events_fire_before_output_item_done() {
         // Same ordering contract for the pre-existing web_search_call path,
         // so the invariant applies uniformly across every hosted-tool
         // ResponseFormat we emit.
@@ -1747,7 +1750,7 @@ mod tests {
             "action": {"type": "search"}
         });
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(4);
         let mut sequence_number: u64 = 0;
 
         let ok = super::send_tool_call_completion_events(
@@ -1756,7 +1759,8 @@ mod tests {
             &tool_call_item,
             ResponseFormat::WebSearchCall,
             &mut sequence_number,
-        );
+        )
+        .await;
         assert!(ok);
         drop(tx);
 
@@ -1777,8 +1781,8 @@ mod tests {
         assert!(completed_idx < done_idx);
     }
 
-    #[test]
-    fn code_interpreter_completion_events_fire_before_output_item_done() {
+    #[tokio::test]
+    async fn code_interpreter_completion_events_fire_before_output_item_done() {
         // The suppression gate in `tool_handler.rs` drops the upstream
         // umbrella `output_item.done` for every tool-call item type. This
         // test locks the downstream half of the contract for
@@ -1803,7 +1807,7 @@ mod tests {
             "code": "print('hi')",
         });
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(4);
         let mut sequence_number: u64 = 0;
 
         let ok = super::send_tool_call_completion_events(
@@ -1812,7 +1816,8 @@ mod tests {
             &tool_call_item,
             ResponseFormat::CodeInterpreterCall,
             &mut sequence_number,
-        );
+        )
+        .await;
         assert!(ok);
         drop(tx);
 
@@ -1849,8 +1854,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn file_search_completion_events_fire_before_output_item_done() {
+    #[tokio::test]
+    async fn file_search_completion_events_fire_before_output_item_done() {
         // Lock the ordering contract for the hosted `file_search_call`
         // format so the gate's suppression covers every tool-call item
         // type listed in `TOOL_CALL_ITEM_TYPES`.
@@ -1871,7 +1876,7 @@ mod tests {
             "queries": ["needle"],
         });
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::channel::<Result<bytes::Bytes, std::io::Error>>(4);
         let mut sequence_number: u64 = 0;
 
         let ok = super::send_tool_call_completion_events(
@@ -1880,7 +1885,8 @@ mod tests {
             &tool_call_item,
             ResponseFormat::FileSearchCall,
             &mut sequence_number,
-        );
+        )
+        .await;
         assert!(ok);
         drop(tx);
 

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -25,8 +25,7 @@ use openai_protocol::{
 };
 use serde_json::{json, Value};
 use smg_mcp::{McpOrchestrator, McpServerBinding, McpToolSession};
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::warn;
 
 use super::{
@@ -49,7 +48,7 @@ use crate::{
             },
             mcp_utils::DEFAULT_MAX_ITERATIONS,
             persistence_utils::persist_conversation_items,
-            sse::SseEncoder,
+            sse::{sse_channel, SseEncoder, SseSender},
         },
         error,
         openai::{
@@ -213,21 +212,21 @@ fn build_mcp_tools_value(original_body: &ResponsesRequest) -> Option<Value> {
 /// Send an SSE event to the client channel
 /// Returns false if the client disconnected
 #[inline]
-fn send_sse_event(
-    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+async fn send_sse_event(
+    tx: &SseSender,
     enc: &mut SseEncoder,
     event_name: &str,
     data: &Value,
 ) -> bool {
     match enc.encode_event(event_name, data) {
-        Ok(bytes) => tx.send(Ok(bytes)).is_ok(),
+        Ok(bytes) => tx.send(Ok(bytes)).await.is_ok(),
         Err(e) => {
             // Unreachable in practice (static event name + Value); fall back to
             // manual framing like send_final_response_event rather than treating
             // an encode error as a client disconnect.
             warn!("failed to encode SSE event '{event_name}', falling back: {e}");
             let block = format!("event: {event_name}\ndata: {data}\n\n");
-            tx.send(Ok(Bytes::from(block))).is_ok()
+            tx.send(Ok(Bytes::from(block))).await.is_ok()
         }
     }
 }
@@ -244,10 +243,10 @@ fn map_event_name(event_name: &str) -> &str {
 
 /// Send buffered function call arguments as a synthetic delta event.
 /// Returns false if client disconnected.
-fn send_buffered_arguments(
+async fn send_buffered_arguments(
     parsed_data: &mut Value,
     handler: &StreamingToolHandler,
-    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+    tx: &SseSender,
     enc: &mut SseEncoder,
     sequence_number: &mut u64,
     mapped_output_index: &mut Option<usize>,
@@ -307,7 +306,7 @@ fn send_buffered_arguments(
         }
     }
 
-    if !send_sse_event(tx, enc, McpEvent::CALL_ARGUMENTS_DELTA, &delta_event) {
+    if !send_sse_event(tx, enc, McpEvent::CALL_ARGUMENTS_DELTA, &delta_event).await {
         return false;
     }
 
@@ -326,10 +325,10 @@ pub(super) struct SseEventData<'a> {
 
 /// Forward and transform a streaming event to the client.
 /// Returns false if client disconnected.
-pub(super) fn forward_streaming_event(
+pub(super) async fn forward_streaming_event(
     event: SseEventData<'_>,
     handler: &mut StreamingToolHandler,
-    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+    tx: &SseSender,
     enc: &mut SseEncoder,
     ctx: &StreamingEventContext<'_>,
     sequence_number: &mut u64,
@@ -352,7 +351,7 @@ pub(super) fn forward_streaming_event(
             Ok(v) => v,
             Err(_) => {
                 let chunk = format!("{raw_block}\n\n");
-                return tx.send(Ok(Bytes::from(chunk))).is_ok();
+                return tx.send(Ok(Bytes::from(chunk))).await.is_ok();
             }
         },
     };
@@ -373,6 +372,7 @@ pub(super) fn forward_streaming_event(
             sequence_number,
             &mut mapped_output_index,
         )
+        .await
     {
         return false;
     }
@@ -414,12 +414,12 @@ pub(super) fn forward_streaming_event(
         Err(_) => Bytes::from(format!("{raw_block}\n\n")),
     };
 
-    if tx.send(Ok(final_bytes)).is_err() {
+    if tx.send(Ok(final_bytes)).await.is_err() {
         return false;
     }
 
     if event_name == Some(OutputItemEvent::ADDED)
-        && !maybe_inject_tool_in_progress(&parsed_data, tx, enc, sequence_number)
+        && !maybe_inject_tool_in_progress(&parsed_data, tx, enc, sequence_number).await
     {
         return false;
     }
@@ -431,9 +431,9 @@ pub(super) fn forward_streaming_event(
 /// Handles mcp_call, web_search_call, code_interpreter_call, file_search_call,
 /// and image_generation_call items.
 /// Returns false if client disconnected.
-fn maybe_inject_tool_in_progress(
+async fn maybe_inject_tool_in_progress(
     parsed_data: &Value,
-    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+    tx: &SseSender,
     enc: &mut SseEncoder,
     sequence_number: &mut u64,
 ) -> bool {
@@ -463,14 +463,14 @@ fn maybe_inject_tool_in_progress(
     });
     *sequence_number += 1;
 
-    send_sse_event(tx, enc, event_type, &event)
+    send_sse_event(tx, enc, event_type, &event).await
 }
 
 /// Send final response.completed event to client
 /// Returns false if client disconnected
-pub(super) fn send_final_response_event(
+pub(super) async fn send_final_response_event(
     handler: &StreamingToolHandler,
-    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+    tx: &SseSender,
     enc: &mut SseEncoder,
     sequence_number: &mut u64,
     state: &ToolLoopState,
@@ -513,7 +513,7 @@ pub(super) fn send_final_response_event(
     *sequence_number += 1;
 
     match enc.encode_event(ResponseEvent::COMPLETED, &completed_payload) {
-        Ok(bytes) => tx.send(Ok(bytes)).is_ok(),
+        Ok(bytes) => tx.send(Ok(bytes)).await.is_ok(),
         Err(e) => {
             warn!("failed to encode response.completed via SseEncoder, falling back: {e}");
             let completed_event = format!(
@@ -521,7 +521,7 @@ pub(super) fn send_final_response_event(
                 ResponseEvent::COMPLETED,
                 completed_payload
             );
-            tx.send(Ok(Bytes::from(completed_event))).is_ok()
+            tx.send(Ok(Bytes::from(completed_event))).await.is_ok()
         }
     }
 }
@@ -570,7 +570,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
     let preserved_headers = preserve_response_headers(response.headers());
     let mut upstream_stream = response.bytes_stream();
 
-    let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
+    let (tx, rx) = sse_channel();
 
     let should_store = req.original_body.store.unwrap_or(true);
     let original_request = req.original_body;
@@ -608,7 +608,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
 
                         if receiver_connected {
                             let chunk_to_send = format!("{block_cow}\n\n");
-                            if tx.send(Ok(Bytes::from(chunk_to_send))).is_err() {
+                            if tx.send(Ok(Bytes::from(chunk_to_send))).await.is_err() {
                                 receiver_connected = false;
                             }
                         }
@@ -625,7 +625,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
                 Err(err) => {
                     upstream_failed = true;
                     let io_err = io::Error::other(err);
-                    let _ = tx.send(Err(io_err));
+                    let _ = tx.send(Err(io_err)).await;
                     break;
                 }
             }
@@ -664,7 +664,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
         }
     });
 
-    let body_stream = UnboundedReceiverStream::new(rx);
+    let body_stream = ReceiverStream::new(rx);
     let mut response = Response::new(Body::from_stream(body_stream));
     *response.status_mut() = status_code;
 
@@ -692,7 +692,7 @@ pub(super) fn handle_streaming_with_tool_interception(
 ) -> Response {
     let payload = req.payload;
 
-    let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
+    let (tx, rx) = sse_channel();
     let should_store = req.original_body.store.unwrap_or(true);
     let original_request = req.original_body;
     let previous_response_id = req.previous_response_id;
@@ -765,7 +765,8 @@ pub(super) fn handle_streaming_with_tool_interception(
                         &mut sse_encoder,
                         "error",
                         &json!({"error": {"message": e.to_string()}}),
-                    );
+                    )
+                    .await;
                     return;
                 }
             };
@@ -779,7 +780,8 @@ pub(super) fn handle_streaming_with_tool_interception(
                     &mut sse_encoder,
                     "error",
                     &json!({"error": {"message": format!("Upstream error {}: {}", status, body)}}),
-                );
+                )
+                .await;
                 return;
             }
 
@@ -847,7 +849,9 @@ pub(super) fn handle_streaming_with_tool_interception(
                                             &mut sse_encoder,
                                             &streaming_ctx,
                                             &mut sequence_number,
-                                        ) {
+                                        )
+                                        .await
+                                        {
                                             return;
                                         }
                                     }
@@ -865,7 +869,9 @@ pub(super) fn handle_streaming_with_tool_interception(
                                                     list_tools_index,
                                                     &mut sequence_number,
                                                     server_key,
-                                                ) {
+                                                )
+                                                .await
+                                                {
                                                     // Client disconnected
                                                     return;
                                                 }
@@ -919,6 +925,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                                             &streaming_ctx,
                                             &mut sequence_number,
                                         )
+                                        .await
                                     {
                                         return;
                                     }
@@ -938,7 +945,8 @@ pub(super) fn handle_streaming_with_tool_interception(
                             &mut sse_encoder,
                             "error",
                             &json!({"error": {"message": format!("Stream error: {}", e)}}),
-                        );
+                        )
+                        .await;
                         return;
                     }
                 }
@@ -958,7 +966,9 @@ pub(super) fn handle_streaming_with_tool_interception(
                     &mut sequence_number,
                     &state,
                     &streaming_ctx,
-                ) {
+                )
+                .await
+                {
                     return;
                 }
 
@@ -1001,7 +1011,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                     }
                 }
 
-                let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes())));
+                let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes()))).await;
                 return;
             }
 
@@ -1030,8 +1040,9 @@ pub(super) fn handle_streaming_with_tool_interception(
                     &mut sse_encoder,
                     "error",
                     &json!({"error": {"message": "Exceeded max_tool_calls limit"}}),
-                );
-                let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes())));
+                )
+                .await;
+                let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes()))).await;
                 return;
             }
 
@@ -1073,15 +1084,15 @@ pub(super) fn handle_streaming_with_tool_interception(
                         &mut sse_encoder,
                         "error",
                         &json!({"error": {"message": format!("Failed to build resume payload: {}", e)}}),
-                    );
-                    let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes())));
+                    ).await;
+                    let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes()))).await;
                     return;
                 }
             }
         }
     });
 
-    let body_stream = UnboundedReceiverStream::new(rx);
+    let body_stream = ReceiverStream::new(rx);
     let mut response = Response::new(Body::from_stream(body_stream));
     *response.status_mut() = StatusCode::OK;
     response


### PR DESCRIPTION
## Description

### Problem

Every SSE / streaming HTTP response body was fed by an **unbounded** `mpsc` channel. The backend read loop pushed frames at full engine speed while hyper drained the body only at the client's TCP rate, so a slow (or deliberately slow-reading) client made the gateway **buffer the entire response in RAM** — an unbounded-memory / slowloris OOM vector, quadratic on `/generate`. Audit finding F004 and its ~14 siblings, re-verified against `main`.

### Solution

Introduce a shared bounded SSE channel in `common/sse.rs` (`SSE_CHANNEL_BUFFER = 32`, mirroring the existing `STREAM_RELAY_BUFFER`; `SseSender`/`SseReceiver`; `sse_channel()`), route every response-body channel through it with **await-on-send** so a slow client applies backpressure to the backend read loop instead of growing memory. `build_sse_response` takes the bounded receiver + `ReceiverStream`. Producers that write body frames became `async` and await their sends; the five gRPC streaming entry points and the emitter/helper chains thread `.await` up to their async `execute()` callers. `send_error_sse` became `async`.

## Changes

- `common/sse.rs`: shared bounded channel API + `build_sse_response`.
- gRPC (chat / generate / messages / completion / responses + harmony), OpenAI responses, HTTP + PD relay paths: bounded channels, awaited sends, `ReceiverStream`; producer methods made `async` with `.await` threaded to stage callers. 17 files.

Note: parsers on these paths are per-request (not pooled), so holding a request's own async parser guard across its awaited send only backpressures that request — no cross-request stall and no sync-guard-across-`.await`.

## Test Plan

- `cargo test -p smg --lib` — 1448 passed, 0 failed
- `cargo clippy -p smg --all-targets -- -D warnings` — clean (`--all-features` needs opencv locally; covered by CI)
- `cargo +nightly fmt -p smg -- --check` — clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (via CI; `--all-features` needs opencv locally)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
