### PR TITLE
feat(gateway): honor per-model parser overrides from model cards

### DIFF
--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -29,6 +29,7 @@ use super::{
         EncodeItemBootstrapInfo, ProtoEmbedComplete, ProtoEmbedRequest, ProtoGenerateRequest,
         ProtoRequest, ProtoStream,
     },
+    utils::ParserResolver,
 };
 use crate::{
     middleware::TenantRequestMeta,
@@ -144,10 +145,9 @@ pub(crate) struct SharedComponents {
     pub worker_registry: Arc<WorkerRegistry>,
     pub tool_parser_factory: ToolParserFactory,
     pub reasoning_parser_factory: ReasoningParserFactory,
-    /// Configured tool parser name (from CLI `--tool-call-parser`)
-    pub configured_tool_parser: Option<String>,
-    /// Configured reasoning parser name (from CLI `--reasoning-parser`)
-    pub configured_reasoning_parser: Option<String>,
+    /// Per-request parser-name resolution (model-card override → configured
+    /// CLI `--tool-call-parser`/`--reasoning-parser` names).
+    pub parser_resolver: ParserResolver,
     /// Multimodal processing components (initialized at router creation)
     pub multimodal: Option<Arc<MultimodalComponents>>,
 }

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -46,6 +46,7 @@ use super::{
         },
         streaming,
     },
+    utils,
     utils::error_type_from_status,
 };
 use crate::{
@@ -138,17 +139,20 @@ impl PipelineDeps {
         processor::ResponseProcessor,
         Arc<streaming::StreamingProcessor>,
     ) {
+        let parser_resolver = utils::ParserResolver::new(
+            self.worker_registry.clone(),
+            self.configured_tool_parser.clone(),
+            self.configured_reasoning_parser.clone(),
+        );
         let processor = processor::ResponseProcessor::new(
             self.tool_parser_factory.clone(),
             self.reasoning_parser_factory.clone(),
-            self.configured_tool_parser.clone(),
-            self.configured_reasoning_parser.clone(),
+            parser_resolver.clone(),
         );
         let streaming_processor = Arc::new(streaming::StreamingProcessor::new(
             self.tool_parser_factory.clone(),
             self.reasoning_parser_factory.clone(),
-            self.configured_tool_parser.clone(),
-            self.configured_reasoning_parser.clone(),
+            parser_resolver,
             backend,
         ));
         (processor, streaming_processor)
@@ -165,14 +169,12 @@ impl PipelineDeps {
         let processor = processor::ResponseProcessor::new(
             ToolParserFactory::default(),
             ReasoningParserFactory::default(),
-            None,
-            None,
+            utils::ParserResolver::disabled(),
         );
         let streaming_processor = Arc::new(streaming::StreamingProcessor::new(
             ToolParserFactory::default(),
             ReasoningParserFactory::default(),
-            None,
-            None,
+            utils::ParserResolver::disabled(),
             backend,
         ));
         (processor, streaming_processor)
@@ -1570,8 +1572,7 @@ mod alias_pipeline_tests {
             worker_registry,
             tool_parser_factory: ToolParserFactory::default(),
             reasoning_parser_factory: ReasoningParserFactory::default(),
-            configured_tool_parser: None,
-            configured_reasoning_parser: None,
+            parser_resolver: utils::ParserResolver::disabled(),
             multimodal: None,
         });
         let request: GenerateRequest = serde_json::from_value(json!({
@@ -1644,8 +1645,7 @@ mod rate_limit_reserve_tests {
             worker_registry,
             tool_parser_factory: ToolParserFactory::default(),
             reasoning_parser_factory: ReasoningParserFactory::default(),
-            configured_tool_parser: None,
-            configured_reasoning_parser: None,
+            parser_resolver: utils::ParserResolver::disabled(),
             multimodal: None,
         })
     }

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -38,22 +38,20 @@ use crate::routers::{
 pub(crate) struct ResponseProcessor {
     pub tool_parser_factory: ToolParserFactory,
     pub reasoning_parser_factory: ReasoningParserFactory,
-    pub configured_tool_parser: Option<String>,
-    pub configured_reasoning_parser: Option<String>,
+    /// Per-request parser-name resolution (model-card override → configured).
+    pub parser_resolver: utils::ParserResolver,
 }
 
 impl ResponseProcessor {
     pub fn new(
         tool_parser_factory: ToolParserFactory,
         reasoning_parser_factory: ReasoningParserFactory,
-        configured_tool_parser: Option<String>,
-        configured_reasoning_parser: Option<String>,
+        parser_resolver: utils::ParserResolver,
     ) -> Self {
         Self {
             tool_parser_factory,
             reasoning_parser_factory,
-            configured_tool_parser,
-            configured_reasoning_parser,
+            parser_resolver,
         }
     }
 
@@ -69,6 +67,11 @@ impl ResponseProcessor {
         history_tool_calls_count: usize,
         reasoning_parser_available: bool,
         tool_parser_available: bool,
+        // Resolved once per request by the caller: keeps every choice of one
+        // request on the same parser even if the worker registry changes
+        // between availability check and parsing.
+        reasoning_parser_name: Option<&str>,
+        tool_parser_name: Option<&str>,
     ) -> Result<ChatChoice, String> {
         stop_decoder.reset();
         // Decode tokens
@@ -109,7 +112,7 @@ impl ResponseProcessor {
             // across requests, so avoid serializing on the shared pooled mutex.
             if let Some(mut parser) = utils::create_reasoning_parser(
                 &self.reasoning_parser_factory,
-                self.configured_reasoning_parser.as_deref(),
+                reasoning_parser_name,
                 &original_request.model,
             ) {
                 // If the template injected `<think>` in the prefill (thinking toggle
@@ -151,7 +154,7 @@ impl ResponseProcessor {
             let has_structural_tag = self
                 .tool_parser_factory
                 .registry()
-                .has_structural_tag_for_parser(self.configured_tool_parser.as_deref());
+                .has_structural_tag_for_parser(tool_parser_name);
             let used_json_schema = if has_structural_tag {
                 false
             } else {
@@ -175,6 +178,7 @@ impl ResponseProcessor {
                     .parse_tool_calls(
                         &processed_text,
                         &original_request.model,
+                        tool_parser_name,
                         original_request.tools.as_deref().unwrap_or(&[]),
                         history_tool_calls_count,
                     )
@@ -241,6 +245,8 @@ impl ResponseProcessor {
         stop_decoder: &mut StopSequenceDecoder,
         request_logprobs: bool,
     ) -> Result<ChatCompletionResponse, axum::response::Response> {
+        let reasoning_parser_name = self.parser_resolver.reasoning_parser(&chat_request.model);
+        let tool_parser_name = self.parser_resolver.tool_parser(&chat_request.model);
         // Collect all responses from the execution result
         let all_responses =
             response_collection::collect_responses(execution_result, request_logprobs).await?;
@@ -251,7 +257,7 @@ impl ResponseProcessor {
         let reasoning_parser_available = chat_request.separate_reasoning
             && utils::check_reasoning_parser_availability(
                 &self.reasoning_parser_factory,
-                self.configured_reasoning_parser.as_deref(),
+                reasoning_parser_name.as_deref(),
                 &chat_request.model,
             );
 
@@ -264,7 +270,7 @@ impl ResponseProcessor {
             && chat_request.tools.is_some()
             && utils::check_tool_parser_availability(
                 &self.tool_parser_factory,
-                self.configured_tool_parser.as_deref(),
+                tool_parser_name.as_deref(),
                 &chat_request.model,
             );
 
@@ -296,6 +302,8 @@ impl ResponseProcessor {
                     history_tool_calls_count,
                     reasoning_parser_available,
                     tool_parser_available,
+                    reasoning_parser_name.as_deref(),
+                    tool_parser_name.as_deref(),
                 )
                 .await
             {
@@ -328,15 +336,14 @@ impl ResponseProcessor {
         &self,
         processed_text: &str,
         model: &str,
+        // Resolved once per request by the caller (see process_single_choice).
+        tool_parser_name: Option<&str>,
         tools: &[Tool],
         history_tool_calls_count: usize,
     ) -> (Option<Vec<ToolCall>>, String) {
         // Get pooled parser for this model
-        let pooled_parser = utils::get_tool_parser(
-            &self.tool_parser_factory,
-            self.configured_tool_parser.as_deref(),
-            model,
-        );
+        let pooled_parser =
+            utils::get_tool_parser(&self.tool_parser_factory, tool_parser_name, model);
 
         // Try parsing directly (parser will handle detection internally). Pass the
         // tool schemas so schema-aware parsers coerce argument types by their
@@ -502,6 +509,10 @@ impl ResponseProcessor {
         tokenizer: Arc<dyn Tokenizer>,
         stop_decoder: &mut StopSequenceDecoder,
     ) -> Result<Message, axum::response::Response> {
+        let reasoning_parser_name = self
+            .parser_resolver
+            .reasoning_parser(&messages_request.model);
+        let tool_parser_name = self.parser_resolver.tool_parser(&messages_request.model);
         // Collect all responses (no logprobs for Messages API)
         let all_responses = response_collection::collect_responses(execution_result, false).await?;
 
@@ -537,7 +548,7 @@ impl ResponseProcessor {
         // or when the selected parser needs structural special tokens (e.g. Inkling).
         let reasoning_requires_special_tokens = utils::reasoning_parser_requires_special_tokens(
             &self.reasoning_parser_factory,
-            self.configured_reasoning_parser.as_deref(),
+            reasoning_parser_name.as_deref(),
             &messages_request.model,
         );
         let separate_reasoning = reasoning_requires_special_tokens
@@ -551,7 +562,7 @@ impl ResponseProcessor {
         let reasoning_parser_available = separate_reasoning
             && utils::check_reasoning_parser_availability(
                 &self.reasoning_parser_factory,
-                self.configured_reasoning_parser.as_deref(),
+                reasoning_parser_name.as_deref(),
                 &messages_request.model,
             );
 
@@ -564,7 +575,7 @@ impl ResponseProcessor {
             && messages_request.tools.is_some()
             && utils::check_tool_parser_availability(
                 &self.tool_parser_factory,
-                self.configured_tool_parser.as_deref(),
+                tool_parser_name.as_deref(),
                 &messages_request.model,
             );
 
@@ -624,7 +635,7 @@ impl ResponseProcessor {
             // across requests, so avoid serializing on the shared pooled mutex.
             if let Some(mut parser) = utils::create_reasoning_parser(
                 &self.reasoning_parser_factory,
-                self.configured_reasoning_parser.as_deref(),
+                reasoning_parser_name.as_deref(),
                 &messages_request.model,
             ) {
                 // If thinking is effectively ON and template has a toggle, start in reasoning mode.
@@ -664,7 +675,7 @@ impl ResponseProcessor {
             let has_structural_tag = self
                 .tool_parser_factory
                 .registry()
-                .has_structural_tag_for_parser(self.configured_tool_parser.as_deref());
+                .has_structural_tag_for_parser(tool_parser_name.as_deref());
             let used_json_schema = !has_structural_tag
                 && matches!(
                     &messages_request.tool_choice,
@@ -694,6 +705,7 @@ impl ResponseProcessor {
                     .parse_tool_calls(
                         &processed_text,
                         &messages_request.model,
+                        tool_parser_name.as_deref(),
                         &chat_tools,
                         utils::message_utils::get_history_tool_calls_count_messages(
                             &messages_request,

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -239,7 +239,10 @@ impl ChatPreparationStage {
                 .tool_parser_factory
                 .registry()
                 .generate_tool_constraint(
-                    ctx.components.configured_tool_parser.as_deref(),
+                    ctx.components
+                        .parser_resolver
+                        .tool_parser(&request.model)
+                        .as_deref(),
                     tools,
                     tool_choice,
                 )
@@ -257,7 +260,10 @@ impl ChatPreparationStage {
         let preserve_reasoning_special_tokens = request.separate_reasoning
             && utils::reasoning_parser_requires_special_tokens(
                 &ctx.components.reasoning_parser_factory,
-                ctx.components.configured_reasoning_parser.as_deref(),
+                ctx.components
+                    .parser_resolver
+                    .reasoning_parser(&request.model)
+                    .as_deref(),
                 &request.model,
             );
 

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -267,7 +267,10 @@ impl MessagePreparationStage {
                 .tool_parser_factory
                 .registry()
                 .generate_tool_constraint(
-                    ctx.components.configured_tool_parser.as_deref(),
+                    ctx.components
+                        .parser_resolver
+                        .tool_parser(&request.model)
+                        .as_deref(),
                     &filtered_tools,
                     tool_choice,
                 )
@@ -290,7 +293,10 @@ impl MessagePreparationStage {
 
         let preserve_reasoning_special_tokens = utils::reasoning_parser_requires_special_tokens(
             &ctx.components.reasoning_parser_factory,
-            ctx.components.configured_reasoning_parser.as_deref(),
+            ctx.components
+                .parser_resolver
+                .reasoning_parser(&request.model)
+                .as_deref(),
             &request.model,
         );
 

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -79,8 +79,8 @@ struct CompletionStreamOutcome {
 pub(crate) struct StreamingProcessor {
     tool_parser_factory: ToolParserFactory,
     reasoning_parser_factory: ReasoningParserFactory,
-    configured_tool_parser: Option<String>,
-    configured_reasoning_parser: Option<String>,
+    /// Per-request parser-name resolution (model-card override → configured).
+    parser_resolver: utils::ParserResolver,
     backend_type: &'static str,
 }
 
@@ -101,15 +101,13 @@ impl StreamingProcessor {
     pub fn new(
         tool_parser_factory: ToolParserFactory,
         reasoning_parser_factory: ReasoningParserFactory,
-        configured_tool_parser: Option<String>,
-        configured_reasoning_parser: Option<String>,
+        parser_resolver: utils::ParserResolver,
         backend_type: &'static str,
     ) -> Self {
         Self {
             tool_parser_factory,
             reasoning_parser_factory,
-            configured_tool_parser,
-            configured_reasoning_parser,
+            parser_resolver,
             backend_type,
         }
     }
@@ -319,11 +317,15 @@ impl StreamingProcessor {
         let created = dispatch.created;
         let system_fingerprint = dispatch.weight_version.as_deref();
 
+        // Per-request effective parser names (model-card override → configured).
+        let reasoning_parser_name = self.parser_resolver.reasoning_parser(model);
+        let tool_parser_name = self.parser_resolver.tool_parser(model);
+
         // Check parser availability once upfront (log warning only once per request)
         let reasoning_parser_available = separate_reasoning
             && utils::check_reasoning_parser_availability(
                 &self.reasoning_parser_factory,
-                self.configured_reasoning_parser.as_deref(),
+                reasoning_parser_name.as_deref(),
                 model,
             );
 
@@ -344,7 +346,7 @@ impl StreamingProcessor {
         let has_structural_tag = self
             .tool_parser_factory
             .registry()
-            .has_structural_tag_for_parser(self.configured_tool_parser.as_deref());
+            .has_structural_tag_for_parser(tool_parser_name.as_deref());
         let used_json_schema = if has_structural_tag {
             false
         } else {
@@ -365,7 +367,7 @@ impl StreamingProcessor {
         let tool_parser_available = tools.is_some()
             && utils::check_tool_parser_availability(
                 &self.tool_parser_factory,
-                self.configured_tool_parser.as_deref(),
+                tool_parser_name.as_deref(),
                 model,
             );
 
@@ -490,6 +492,7 @@ impl StreamingProcessor {
                                 &mut reasoning_parsers,
                                 thinking_override,
                                 think_in_prefill,
+                                reasoning_parser_name.as_deref(),
                                 request_id,
                                 model,
                                 created,
@@ -537,6 +540,7 @@ impl StreamingProcessor {
                                     &mut tool_parsers,
                                     &mut has_tool_calls,
                                     tools_ref,
+                                    tool_parser_name.as_deref(),
                                     request_id,
                                     model,
                                     created,
@@ -1357,6 +1361,10 @@ impl StreamingProcessor {
         reasoning_parsers: &mut HashMap<u32, Arc<tokio::sync::Mutex<Box<dyn ReasoningParser>>>>,
         thinking_override: bool,
         think_in_prefill: bool,
+        // Resolved once per request by the caller: re-resolving here could
+        // disagree with the upfront availability check if the worker registry
+        // changed mid-stream, turning the `expect` below into a panic.
+        reasoning_parser_name: Option<&str>,
         request_id: &str,
         model: &str,
         created: u64,
@@ -1370,7 +1378,7 @@ impl StreamingProcessor {
         reasoning_parsers.entry(index).or_insert_with(|| {
             let mut parser = utils::create_reasoning_parser(
                 &self.reasoning_parser_factory,
-                self.configured_reasoning_parser.as_deref(),
+                reasoning_parser_name,
                 model,
             )
             .expect("Parser should be available - checked upfront");
@@ -1480,6 +1488,8 @@ impl StreamingProcessor {
         tool_parsers: &mut HashMap<u32, Arc<tokio::sync::Mutex<Box<dyn ToolParser>>>>,
         has_tool_calls: &mut HashMap<u32, bool>,
         tools: &[Tool],
+        // Resolved once per request by the caller (see process_reasoning_stream).
+        tool_parser_name: Option<&str>,
         request_id: &str,
         model: &str,
         created: u64,
@@ -1499,12 +1509,8 @@ impl StreamingProcessor {
                 utils::create_tool_parser(&self.tool_parser_factory, Some("json"), model)
                     .expect("JSON parser should be available")
             } else {
-                utils::create_tool_parser(
-                    &self.tool_parser_factory,
-                    self.configured_tool_parser.as_deref(),
-                    model,
-                )
-                .expect("Parser should be available - checked upfront")
+                utils::create_tool_parser(&self.tool_parser_factory, tool_parser_name, model)
+                    .expect("Parser should be available - checked upfront")
             };
             Arc::new(tokio::sync::Mutex::new(parser))
         });
@@ -1653,13 +1659,15 @@ impl StreamingProcessor {
         reasoning_parser: &mut Option<Arc<tokio::sync::Mutex<Box<dyn ReasoningParser>>>>,
         thinking_override: bool,
         think_in_prefill: bool,
+        // Resolved once per request by the caller (see process_reasoning_stream).
+        reasoning_parser_name: Option<&str>,
         model: &str,
     ) -> (String, String, bool) {
         // Lazily create parser
         if reasoning_parser.is_none() {
             if let Some(mut parser) = utils::create_reasoning_parser(
                 &self.reasoning_parser_factory,
-                self.configured_reasoning_parser.as_deref(),
+                reasoning_parser_name,
                 model,
             ) {
                 if thinking_override {
@@ -1884,11 +1892,15 @@ impl StreamingProcessor {
         // engine output (the backend has no stop-string detection over ZMQ).
         let mut stopped = false;
 
+        // Per-request effective parser names (model-card override → configured).
+        let reasoning_parser_name = self.parser_resolver.reasoning_parser(model);
+        let tool_parser_name = self.parser_resolver.tool_parser(model);
+
         // Check parser availability once upfront. Run parser when the user explicitly
         // enabled thinking, or when the selected parser needs structural special tokens.
         let reasoning_requires_special_tokens = utils::reasoning_parser_requires_special_tokens(
             &self.reasoning_parser_factory,
-            self.configured_reasoning_parser.as_deref(),
+            reasoning_parser_name.as_deref(),
             model,
         );
         let separate_reasoning = reasoning_requires_special_tokens
@@ -1902,7 +1914,7 @@ impl StreamingProcessor {
         let reasoning_parser_available = separate_reasoning
             && utils::check_reasoning_parser_availability(
                 &self.reasoning_parser_factory,
-                self.configured_reasoning_parser.as_deref(),
+                reasoning_parser_name.as_deref(),
                 model,
             );
 
@@ -1928,14 +1940,14 @@ impl StreamingProcessor {
             && tool_choice_enabled
             && utils::check_tool_parser_availability(
                 &self.tool_parser_factory,
-                self.configured_tool_parser.as_deref(),
+                tool_parser_name.as_deref(),
                 model,
             );
 
         let has_structural_tag = self
             .tool_parser_factory
             .registry()
-            .has_structural_tag_for_parser(self.configured_tool_parser.as_deref());
+            .has_structural_tag_for_parser(tool_parser_name.as_deref());
         let used_json_schema = !has_structural_tag
             && matches!(
                 &original_request.tool_choice,
@@ -1966,7 +1978,7 @@ impl StreamingProcessor {
                 let parser_name = if used_json_schema {
                     Some("json")
                 } else {
-                    self.configured_tool_parser.as_deref()
+                    tool_parser_name.as_deref()
                 };
                 utils::create_tool_parser(&self.tool_parser_factory, parser_name, model)
             } else {
@@ -2045,6 +2057,7 @@ impl StreamingProcessor {
                                 &mut reasoning_parser,
                                 thinking_override,
                                 think_in_prefill,
+                                reasoning_parser_name.as_deref(),
                                 model,
                             )
                             .await

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -33,6 +33,7 @@ use super::{
     multimodal::MultimodalComponents,
     pipeline::{Endpoint, PipelineDeps, RequestPipeline},
     regular::responses,
+    utils::ParserResolver,
 };
 use crate::{
     app_context::AppContext,
@@ -354,8 +355,11 @@ impl GrpcRouter {
             worker_registry: worker_registry.clone(),
             tool_parser_factory: tool_parser_factory.clone(),
             reasoning_parser_factory: reasoning_parser_factory.clone(),
-            configured_tool_parser: ctx.configured_tool_parser.clone(),
-            configured_reasoning_parser: ctx.configured_reasoning_parser.clone(),
+            parser_resolver: ParserResolver::new(
+                worker_registry.clone(),
+                ctx.configured_tool_parser.clone(),
+                ctx.configured_reasoning_parser.clone(),
+            ),
             multimodal,
         });
 

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use logprobs::{
 pub(crate) use metrics::{error_type_from_status, route_to_endpoint};
 pub(crate) use parsers::{
     check_reasoning_parser_availability, check_tool_parser_availability, create_reasoning_parser,
-    create_tool_parser, get_tool_parser, reasoning_parser_requires_special_tokens,
+    create_tool_parser, get_tool_parser, reasoning_parser_requires_special_tokens, ParserResolver,
 };
 // `pub` (not `pub(crate)`) so the Go bindings can reuse the gateway's reasoning
 // detection instead of duplicating it.

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -1,16 +1,113 @@
 //! Reasoning and tool parser helpers.
 
+use std::sync::Arc;
+
 use llm_tokenizer::{
     chat_template::{ThinkingKeyName, ThinkingToggle},
     traits::Tokenizer,
 };
-use openai_protocol::chat::thinking_from_reasoning_effort;
+use openai_protocol::{chat::thinking_from_reasoning_effort, model_card::ModelCard};
 use reasoning_parser::{ParserFactory as ReasoningParserFactory, ReasoningParser};
 use serde_json::Value;
 use tool_parser::{
     ParserFactory as ToolParserFactory, PooledParser as ToolPooledParser, ToolParser,
 };
 use tracing::warn;
+
+use crate::worker::WorkerRegistry;
+
+/// Per-request parser-name resolution.
+///
+/// Precedence: the model's `ModelCard` override (`tool_parser` /
+/// `reasoning_parser`, populated from worker labels or an explicit
+/// `WorkerSpec` card) → the process-wide configured name
+/// (`--tool-call-parser` / `--reasoning-parser`) → `None`, which lets the
+/// factory helpers fall back to their name-based auto-detection, unchanged.
+///
+/// Lookups borrow straight from worker metadata (no card clones); only the
+/// resolved name is cloned.
+#[derive(Clone)]
+pub(crate) struct ParserResolver {
+    /// `None` disables card lookups (parser-free endpoints, tests).
+    worker_registry: Option<Arc<WorkerRegistry>>,
+    configured_tool_parser: Option<String>,
+    configured_reasoning_parser: Option<String>,
+}
+
+impl ParserResolver {
+    pub(crate) fn new(
+        worker_registry: Arc<WorkerRegistry>,
+        configured_tool_parser: Option<String>,
+        configured_reasoning_parser: Option<String>,
+    ) -> Self {
+        Self {
+            worker_registry: Some(worker_registry),
+            configured_tool_parser,
+            configured_reasoning_parser,
+        }
+    }
+
+    /// Resolver that never consults model cards and carries no configured
+    /// names — preserves the parser-free endpoints' behavior.
+    pub(crate) fn disabled() -> Self {
+        Self {
+            worker_registry: None,
+            configured_tool_parser: None,
+            configured_reasoning_parser: None,
+        }
+    }
+
+    /// Effective tool-parser name for `model`, if any.
+    pub(crate) fn tool_parser(&self, model: &str) -> Option<String> {
+        self.card_parser(model, |card| card.tool_parser.as_ref())
+            .or_else(|| self.configured_tool_parser.clone())
+    }
+
+    /// Effective reasoning-parser name for `model`, if any.
+    pub(crate) fn reasoning_parser(&self, model: &str) -> Option<String> {
+        self.card_parser(model, |card| card.reasoning_parser.as_ref())
+            .or_else(|| self.configured_reasoning_parser.clone())
+    }
+
+    fn card_parser(
+        &self,
+        model: &str,
+        pick: impl Fn(&ModelCard) -> Option<&String>,
+    ) -> Option<String> {
+        let registry = self.worker_registry.as_ref()?;
+        // Cards built by the label pipeline agree across workers of one model;
+        // if they don't (mixed labels, e.g. mid rolling-upgrade), pick the
+        // lexicographically smallest so resolution is deterministic rather
+        // than registry-iteration-order dependent. Registration logs a
+        // warning for the conflict; here it's debug (per-request hot path).
+        let mut chosen: Option<String> = None;
+        let mut conflict = false;
+        for worker in registry.get_by_model(model).iter() {
+            let Some(name) = worker.metadata().spec.models.find(model).and_then(&pick) else {
+                continue;
+            };
+            match &chosen {
+                None => chosen = Some(name.clone()),
+                Some(existing) if existing != name => {
+                    conflict = true;
+                    if name < existing {
+                        chosen = Some(name.clone());
+                    }
+                }
+                Some(_) => {}
+            }
+        }
+        if conflict {
+            tracing::debug!(
+                model,
+                chosen = chosen.as_deref(),
+                "Workers for this model declare conflicting parser overrides; \
+                 using the lexicographically smallest"
+            );
+        }
+        chosen
+    }
+}
 
 /// Determine if thinking is effectively ON based on the template's thinking
 /// toggle and the user's request.
@@ -352,5 +449,88 @@ mod tests {
             Some("qwen3"),
             "served-model"
         ));
+    }
+}
+
+#[cfg(test)]
+mod parser_resolver_tests {
+    use super::*;
+    use crate::worker::{BasicWorkerBuilder, WorkerRegistry, WorkerType};
+
+    fn registry_with_card(card: ModelCard) -> Arc<WorkerRegistry> {
+        let registry = Arc::new(WorkerRegistry::new());
+        let worker = BasicWorkerBuilder::new("http://w1:8000")
+            .model(card)
+            .worker_type(WorkerType::Regular)
+            .build();
+        registry.register(Arc::new(worker));
+        registry
+    }
+
+    #[test]
+    fn card_override_wins_over_configured() {
+        let registry = registry_with_card(
+            ModelCard::new("m")
+                .with_tool_parser("json")
+                .with_reasoning_parser("basic"),
+        );
+        let resolver = ParserResolver::new(
+            registry,
+            Some("mistral".to_string()),
+            Some("deepseek_r1".to_string()),
+        );
+        assert_eq!(resolver.tool_parser("m").as_deref(), Some("json"));
+        assert_eq!(resolver.reasoning_parser("m").as_deref(), Some("basic"));
+    }
+
+    #[test]
+    fn falls_back_to_configured_without_card_override() {
+        let registry = registry_with_card(ModelCard::new("m"));
+        let resolver = ParserResolver::new(
+            registry,
+            Some("mistral".to_string()),
+            Some("deepseek_r1".to_string()),
+        );
+        assert_eq!(resolver.tool_parser("m").as_deref(), Some("mistral"));
+        assert_eq!(
+            resolver.reasoning_parser("m").as_deref(),
+            Some("deepseek_r1")
+        );
+        // Unknown model: no card, same configured fallback.
+        assert_eq!(resolver.tool_parser("other").as_deref(), Some("mistral"));
+    }
+
+    #[test]
+    fn no_override_and_no_configured_resolves_none() {
+        let registry = registry_with_card(ModelCard::new("m"));
+        let resolver = ParserResolver::new(registry, None, None);
+        assert_eq!(resolver.tool_parser("m"), None);
+        assert_eq!(resolver.reasoning_parser("m"), None);
+    }
+
+    #[test]
+    fn disabled_resolver_never_resolves() {
+        let resolver = ParserResolver::disabled();
+        assert_eq!(resolver.tool_parser("m"), None);
+        assert_eq!(resolver.reasoning_parser("m"), None);
+    }
+
+    #[test]
+    fn conflicting_overrides_resolve_deterministically() {
+        // Two same-model workers with different overrides: resolution must
+        // not depend on registration/iteration order — the lexicographically
+        // smallest name wins either way.
+        for (first, second) in [("zebra", "alpha"), ("alpha", "zebra")] {
+            let registry = Arc::new(WorkerRegistry::new());
+            for (i, name) in [first, second].iter().enumerate() {
+                let worker = BasicWorkerBuilder::new(format!("http://w{i}:8000"))
+                    .model(ModelCard::new("m").with_tool_parser(*name))
+                    .worker_type(WorkerType::Regular)
+                    .build();
+                registry.register(Arc::new(worker));
+            }
+            let resolver = ParserResolver::new(registry, None, None);
+            assert_eq!(resolver.tool_parser("m").as_deref(), Some("alpha"));
+        }
     }
 }

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -92,6 +92,30 @@ impl StepExecutor<WorkerWorkflowData> for CreateLocalWorkerStep {
             &app_context.router_config.model_aliases,
         );
 
+        // A parser override naming an unknown parser would silently ship
+        // unparsed output at serve time — fail registration loudly instead
+        // (mirrors the fail-fast AppContext applies to the global CLI names).
+        validate_parser_overrides(
+            &model_card,
+            &config.url,
+            app_context.tool_parser_factory.as_ref(),
+            app_context.reasoning_parser_factory.as_ref(),
+        )
+        .map_err(|message| WorkflowError::StepFailed {
+            step_id: StepId::new("create_worker"),
+            message,
+        })?;
+
+        // Mixed overrides across same-model workers are a misconfiguration
+        // (except transiently during rolling upgrades): resolution picks one
+        // deterministically, but only one family parses correctly. Warn, don't
+        // fail — failing would block rolling upgrades that change the parser.
+        warn_on_conflicting_parser_overrides(
+            &model_card,
+            &config.url,
+            &app_context.worker_registry,
+        );
+
         let runtime_type = match context.data.detected_runtime_type.as_deref() {
             Some(s) => s.parse::<RuntimeType>().unwrap_or(config.runtime_type),
             None => config.runtime_type,
@@ -263,6 +287,75 @@ fn resolve_model_id<'a>(config: &'a WorkerSpec, labels: &'a HashMap<String, Stri
         .unwrap_or(UNKNOWN_MODEL_ID)
 }
 
+/// Warn when a new worker's parser overrides disagree with an already
+/// registered worker serving the same model. Resolution stays deterministic
+/// (lexicographically smallest name wins), but only one format parses
+/// correctly — operators should see the conflict at deploy time.
+fn warn_on_conflicting_parser_overrides(
+    card: &ModelCard,
+    worker_url: &str,
+    registry: &crate::worker::WorkerRegistry,
+) {
+    for existing in registry.get_by_model(&card.id).iter() {
+        let Some(existing_card) = existing.metadata().spec.models.find(&card.id) else {
+            continue;
+        };
+        for (kind, new_name, existing_name) in [
+            ("tool_parser", &card.tool_parser, &existing_card.tool_parser),
+            (
+                "reasoning_parser",
+                &card.reasoning_parser,
+                &existing_card.reasoning_parser,
+            ),
+        ] {
+            if let (Some(new_name), Some(existing_name)) = (new_name, existing_name) {
+                if new_name != existing_name {
+                    tracing::warn!(
+                        model = %card.id,
+                        new_worker = worker_url,
+                        existing_worker = existing.url(),
+                        %kind,
+                        new = %new_name,
+                        existing = %existing_name,
+                        "Workers for one model declare conflicting parser \
+                         overrides; the lexicographically smallest name wins \
+                         at request time"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Reject parser-override names the registries don't know. Skipped when a
+/// factory is absent (parsers unused in that configuration).
+fn validate_parser_overrides(
+    card: &ModelCard,
+    worker_url: &str,
+    tool_parser_factory: Option<&tool_parser::ParserFactory>,
+    reasoning_parser_factory: Option<&reasoning_parser::ParserFactory>,
+) -> Result<(), String> {
+    if let (Some(name), Some(factory)) = (card.tool_parser.as_deref(), tool_parser_factory) {
+        if !factory.registry().has_parser(name) {
+            return Err(format!(
+                "worker {} declares unknown tool_parser '{}' for model '{}'",
+                worker_url, name, card.id
+            ));
+        }
+    }
+    if let (Some(name), Some(factory)) =
+        (card.reasoning_parser.as_deref(), reasoning_parser_factory)
+    {
+        if !factory.registry().has_parser(name) {
+            return Err(format!(
+                "worker {} declares unknown reasoning_parser '{}' for model '{}'",
+                worker_url, name, card.id
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn build_model_card(
     model_id: &str,
     config: &WorkerSpec,
@@ -324,6 +417,21 @@ fn build_model_card(
     if card.tokenizer_path.is_none() {
         card.tokenizer_path = labels
             .get("tokenizer_path")
+            .filter(|s| !s.is_empty())
+            .cloned();
+    }
+
+    // Per-model parser overrides: `tool_parser` / `reasoning_parser` labels
+    // (from backend metadata or WorkerSpec.labels) pin the parser for this
+    // model, overriding the process-wide `--tool-call-parser` /
+    // `--reasoning-parser` names on the gRPC serving path. An explicit card
+    // keeps its own values (same precedence as tokenizer_path above).
+    if card.tool_parser.is_none() {
+        card.tool_parser = labels.get("tool_parser").filter(|s| !s.is_empty()).cloned();
+    }
+    if card.reasoning_parser.is_none() {
+        card.reasoning_parser = labels
+            .get("reasoning_parser")
             .filter(|s| !s.is_empty())
             .cloned();
     }
@@ -607,5 +715,77 @@ mod tests {
         );
         assert!(card.aliases.contains(&"glm-5.2".to_string()));
         assert_eq!(card.aliases.len(), 2);
+    }
+
+    #[test]
+    fn parser_override_labels_flow_into_card() {
+        let spec = WorkerSpec::new("http://worker:8080");
+        let labels = HashMap::from([
+            ("tool_parser".to_string(), "json".to_string()),
+            ("reasoning_parser".to_string(), "basic".to_string()),
+            ("model_type".to_string(), "llama".to_string()),
+        ]);
+
+        let card = build_model_card("m", &spec, &labels, &HashMap::new());
+        assert_eq!(card.tool_parser.as_deref(), Some("json"));
+        assert_eq!(card.reasoning_parser.as_deref(), Some("basic"));
+
+        // Empty label values are treated as unset.
+        let labels = HashMap::from([("tool_parser".to_string(), String::new())]);
+        let card = build_model_card("m", &spec, &labels, &HashMap::new());
+        assert_eq!(card.tool_parser, None);
+    }
+
+    #[test]
+    fn explicit_card_parser_wins_over_labels() {
+        // A user-provided WorkerSpec card keeps its parser fields; labels
+        // only fill gaps (same precedence as tokenizer_path).
+        let mut spec = WorkerSpec::new("http://worker:8080");
+        spec.models = openai_protocol::worker::WorkerModels::Single(Box::new(
+            ModelCard::new("m").with_tool_parser("pythonic"),
+        ));
+        let labels = HashMap::from([
+            ("tool_parser".to_string(), "json".to_string()),
+            ("reasoning_parser".to_string(), "basic".to_string()),
+        ]);
+
+        let card = build_model_card("m", &spec, &labels, &HashMap::new());
+        assert_eq!(card.tool_parser.as_deref(), Some("pythonic"));
+        // The explicit card left reasoning unset — the label fills it.
+        assert_eq!(card.reasoning_parser.as_deref(), Some("basic"));
+    }
+
+    #[test]
+    fn unknown_parser_override_fails_validation() {
+        let tool_factory = tool_parser::ParserFactory::default();
+        let reasoning_factory = reasoning_parser::ParserFactory::default();
+
+        // No overrides → nothing to validate.
+        let card = ModelCard::new("m");
+        assert!(validate_parser_overrides(
+            &card,
+            "http://w:1",
+            Some(&tool_factory),
+            Some(&reasoning_factory)
+        )
+        .is_ok());
+
+        // Known tool parser passes; unknown names fail loudly.
+        let card = ModelCard::new("m").with_tool_parser("json");
+        assert!(validate_parser_overrides(&card, "http://w:1", Some(&tool_factory), None).is_ok());
+
+        let card = ModelCard::new("m").with_tool_parser("definitely-not-a-parser");
+        let err = validate_parser_overrides(&card, "http://w:1", Some(&tool_factory), None)
+            .expect_err("unknown tool parser must fail registration");
+        assert!(err.contains("definitely-not-a-parser"), "{err}");
+
+        let card = ModelCard::new("m").with_reasoning_parser("definitely-not-a-parser");
+        let err = validate_parser_overrides(&card, "http://w:1", None, Some(&reasoning_factory))
+            .expect_err("unknown reasoning parser must fail registration");
+        assert!(err.contains("definitely-not-a-parser"), "{err}");
+
+        // Absent factories skip validation (parsers unused in that config).
+        let card = ModelCard::new("m").with_tool_parser("definitely-not-a-parser");
+        assert!(validate_parser_overrides(&card, "http://w:1", None, None).is_ok());
     }
 }


### PR DESCRIPTION
## Description

### Problem

Parser selection on the gRPC serving path is process-global: one `--tool-call-parser` / `--reasoning-parser` name per router process. The tokenizer side is already per-model (`TokenizerRegistry`), so a gateway serving two model families selects the right tokenizer for each but not the right parsers — one family's tool calls come back unparsed in `content`. Meanwhile `ModelCard.tool_parser` / `ModelCard.reasoning_parser` exist in `crates/protocols` with builders and zero read sites.

### Solution

Wire the card fields end to end via the existing label pipeline: workers (or explicit `WorkerSpec` cards) declare per-model parser names; the gRPC path resolves per request with precedence card override → configured global → existing name-based auto-detection (unchanged). Unknown names fail worker registration loudly instead of shipping silently unparsed output.

## Changes

- `build_model_card` maps `tool_parser` / `reasoning_parser` labels into the card; explicit user-provided cards keep their own values (same precedence `tokenizer_path` uses).
- `CreateLocalWorkerStep` validates override names against the parser registries at registration (same fail-fast the global CLI names get in `AppContext`).
- A `ParserResolver` replaces the two `Option<String>`s threaded through `ResponseProcessor`, `StreamingProcessor`, chat/messages preparation stages, and `SharedComponents`; resolution borrows from worker metadata (no card clones on the hot path); conflicting same-model overrides resolve to the lexicographically smallest name (deterministic) with a loud registration-time warning, and resolved names are threaded through all downstream helpers so one request never mixes parsers even if the registry changes mid-stream.
- Parser-free endpoints (completion/embeddings/classify) keep a `disabled()` resolver — prior behavior byte-for-byte. Debug `/parse/*` endpoints keep their explicit per-request override.

## Test Plan

- `build_model_card`: label mapping, empty-label = unset, explicit-card precedence.
- `validate_parser_overrides`: known/unknown names, absent factories skip.
- `ParserResolver`: card override wins over configured, configured fallback without a card, none→none, disabled resolver, deterministic conflict resolution under both registration orders.
- `cargo test -p smg --lib`: 1456 passed. `cargo +nightly fmt` clean; `cargo clippy -p smg --all-targets -- -D warnings` clean locally (`--all-features` via CI).
- No behavior change without overrides: globals then auto-detection, as today.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
