### PR TITLE
fix(grpc): bound the detached drop-abort RPC with a local deadline

### DIFF
--- a/crates/grpc_client/src/abort_on_drop.rs
+++ b/crates/grpc_client/src/abort_on_drop.rs
@@ -30,7 +30,7 @@ use tracing::{debug, warn};
 /// Upper bound on how long a deferred abort waits for the stream's first
 /// item before aborting anyway. Bounds the detached drain task when the
 /// backend never produces output (e.g. its upstream handoff peer died).
-const DEFERRED_ABORT_MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+const DEFERRED_ABORT_MAX_WAIT: Duration = Duration::from_secs(30);
 
 /// Bridge between the generic [`AbortOnDropStream`] and an engine-specific
 /// client. Implementors provide an async function that the wrapper calls
@@ -273,6 +273,11 @@ mod tests {
 
         // Short real deadline keeps the test fast; it returns only because the
         // timeout fires against the never-resolving abort.
-        abort_within(Duration::from_millis(10), HangingClient, "req-1".to_string()).await;
+        abort_within(
+            Duration::from_millis(10),
+            HangingClient,
+            "req-1".to_string(),
+        )
+        .await;
     }
 }

--- a/crates/grpc_client/src/abort_on_drop.rs
+++ b/crates/grpc_client/src/abort_on_drop.rs
@@ -21,6 +21,7 @@ use std::{
         Arc,
     },
     task::{Context, Poll},
+    time::Duration,
 };
 
 use tonic::Streaming;
@@ -120,7 +121,6 @@ impl<T: Send + 'static, C: AbortOnDropClient> Drop for AbortOnDropStream<T, C> {
         }
 
         let request_id = self.request_id.clone();
-        let request_id_for_log = request_id.clone();
         let client = self.client.clone();
 
         // Deferred mode, dropped before the first item: keep the stream
@@ -142,7 +142,7 @@ impl<T: Send + 'static, C: AbortOnDropClient> Drop for AbortOnDropStream<T, C> {
             if let Some(mut stream) = drain {
                 debug!(
                     "Stream dropped before first item for request {}, draining before abort",
-                    request_id_for_log
+                    request_id
                 );
                 let first_item = tokio::time::timeout(DEFERRED_ABORT_MAX_WAIT, async {
                     // `Streaming::message` resolves on the next message,
@@ -154,22 +154,41 @@ impl<T: Send + 'static, C: AbortOnDropClient> Drop for AbortOnDropStream<T, C> {
                 if first_item.is_err() {
                     warn!(
                         "Deferred abort for request {} timed out waiting for the first item",
-                        request_id_for_log
+                        request_id
                     );
                 }
-            } else {
-                debug!(
-                    "Stream dropped without completion for request {}, sending abort",
-                    request_id_for_log
-                );
             }
-            if let Err(e) = client.abort_for_drop(request_id).await {
-                warn!(
-                    "Failed to send abort on drop for request {}: {}",
-                    request_id_for_log, e
-                );
-            }
+            abort_with_deadline(client, request_id).await;
         });
+    }
+}
+
+/// Send the drop-abort RPC under a local deadline.
+///
+/// The abort runs in a detached task that no caller can cancel, so without a
+/// bound a wedged backend (whose gRPC layer answers pings while its handler
+/// hangs) would let these tasks accumulate without limit — precisely during the
+/// mass-disconnect a backend brownout causes. See [`crate::ABORT_RPC_DEADLINE`].
+async fn abort_with_deadline<C: AbortOnDropClient>(client: C, request_id: String) {
+    abort_within(crate::ABORT_RPC_DEADLINE, client, request_id).await;
+}
+
+/// Deadline-bounded abort, parameterized on `deadline` for testability.
+async fn abort_within<C: AbortOnDropClient>(deadline: Duration, client: C, request_id: String) {
+    debug!(
+        "Stream dropped without completion for request {}, sending abort",
+        request_id
+    );
+    match tokio::time::timeout(deadline, client.abort_for_drop(request_id.clone())).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => warn!(
+            "Failed to send abort on drop for request {}: {}",
+            request_id, e
+        ),
+        Err(_elapsed) => warn!(
+            "Abort-on-drop RPC for request {} timed out after {:?}; giving up",
+            request_id, deadline
+        ),
     }
 }
 
@@ -229,5 +248,31 @@ mod tests {
         // `Send + Sync` regardless of `T`.
         fn assert_send_sync<X: Send + Sync>() {}
         assert_send_sync::<AbortOnDropStream<(), DummyClient>>();
+    }
+
+    /// A backend whose abort handler is wedged (answers the transport but never
+    /// completes the RPC) must not hang the detached drop-abort task forever.
+    /// The abort here never resolves, so the only way `abort_within` can return
+    /// is the deadline firing — an unbounded await would deadlock this test.
+    #[tokio::test]
+    async fn abort_within_gives_up_on_a_hung_backend() {
+        #[derive(Clone)]
+        struct HangingClient;
+
+        impl AbortOnDropClient for HangingClient {
+            fn abort_for_drop(
+                self,
+                _request_id: String,
+            ) -> Pin<Box<dyn Future<Output = Result<(), tonic::Status>> + Send>> {
+                Box::pin(async {
+                    std::future::pending::<()>().await;
+                    Ok(())
+                })
+            }
+        }
+
+        // Short real deadline keeps the test fast; it returns only because the
+        // timeout fires against the never-resolving abort.
+        abort_within(Duration::from_millis(10), HangingClient, "req-1".to_string()).await;
     }
 }

--- a/crates/grpc_client/src/lib.rs
+++ b/crates/grpc_client/src/lib.rs
@@ -76,6 +76,13 @@ pub const FLUSH_RPC_DEADLINE_MARGIN: std::time::Duration = std::time::Duration::
 /// a long time while the backend serializes large traces.
 pub const PROFILE_RPC_DEADLINE: std::time::Duration = std::time::Duration::from_secs(630);
 
+/// Local deadline for the fire-and-forget abort RPC issued from
+/// [`abort_on_drop::AbortOnDropStream`]'s `Drop`. The abort is a tiny unary RPC,
+/// but it runs in a detached task no caller can cancel; bounding it stops those
+/// tasks from accumulating without limit against a wedged backend — which is
+/// exactly when streams are mass-dropped (clients time out and disconnect).
+pub const ABORT_RPC_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Shared admin-op implementations (`flush_cache`, `start_profile`,
 /// `stop_profile`) for engine clients whose protos expose the common
 /// admin RPCs (request/response messages live in `common.proto`).


### PR DESCRIPTION
## Description

### Problem

`AbortOnDropStream::drop` spawns a fire-and-forget task that awaits `abort_for_drop()` — the per-request `Abort` RPC — with **no deadline**, and this single `Drop` path is shared by all five engine clients (mlx / sglang / trtllm / vllm / tokenspeed). During a backend brownout — precisely when HTTP clients time out and mass-drop their `generate()` streams — every drop spawns an abort task that can pend **forever** if the servicer's HTTP/2 layer answers keepalive pings while its handler is wedged. The detached tasks accumulate without bound until the backend recovers or the gateway restarts. The crate's own admin ops already wrap every RPC in a local deadline; the abort path — the one RPC no caller can cancel — was the omission. Audit abort-RPC-no-deadline family (F008/F009/F012/F013/F106/F125/F131/F196/F197/F298), re-verified against `main`.

### Solution

Add `ABORT_RPC_DEADLINE` (10s) alongside the crate's existing deadline constants, and wrap the abort in `tokio::time::timeout(ABORT_RPC_DEADLINE, ..)` in the one central spawned `Drop` task (extracted into `abort_within`, parameterized on the deadline for testability). Fixing it centrally covers all five engines at once.

## Changes

- `crates/grpc_client/src/lib.rs`: add `ABORT_RPC_DEADLINE`.
- `crates/grpc_client/src/abort_on_drop.rs`: bound the drop-spawned abort via `abort_within`; add a deterministic hung-backend test.

## Test Plan

- `cargo test -p smg-grpc-client` — all pass, incl. new `abort_within_gives_up_on_a_hung_backend` (a never-resolving abort returns only because the deadline fires)
- `cargo clippy -p smg-grpc-client --all-targets --all-features -- -D warnings` — clean
- `cargo +nightly fmt -p smg-grpc-client -- --check` — clean

Follow-up (separate PR): the `get_loads()` load-poll RPC (`monitor.rs::fetch_backend_load`) has the same missing-deadline issue on a different path.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
