### PR TITLE
fix(responses): persist harmony /v1/responses assistant message and reasoning

### DIFF
--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -683,9 +683,27 @@ impl ResponseStreamEventEmitter {
             .output_items
             .iter()
             .filter_map(|item| {
-                item.item_data
-                    .as_ref()
-                    .and_then(|data| serde_json::from_value(data.clone()).ok())
+                let data = item.item_data.as_ref()?;
+                match serde_json::from_value::<ResponseOutputItem>(data.clone()) {
+                    Ok(parsed) => Some(parsed),
+                    Err(e) => {
+                        // Data loss: a hand-built item that does not round-trip
+                        // into the typed enum is silently missing from the
+                        // persisted response. Make it loud instead of invisible.
+                        let item_type = data
+                            .get("type")
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("unknown");
+                        warn!(
+                            error = %e,
+                            item_type,
+                            output_index = item.output_index,
+                            "finalize: dropping persisted /v1/responses output item that \
+                             failed typed parse"
+                        );
+                        None
+                    }
+                }
             })
             .collect();
 
@@ -726,12 +744,19 @@ impl ResponseStreamEventEmitter {
         // Allocate output index and generate ID
         let (output_index, item_id) = self.allocate_output_index(OutputItemKind::Reasoning);
 
-        // Build reasoning item structure
+        // Build reasoning item structure. Typed `ResponseOutputItem::Reasoning`
+        // requires `content: Vec<ResponseReasoningContent>` — a bare scalar fails
+        // the typed round-trip in `finalize()` and drops the item from the
+        // persisted response.
+        let content = match &reasoning_content {
+            Some(text) => json!([{ "type": "reasoning_text", "text": text }]),
+            None => json!([]),
+        };
         let item = json!({
             "id": item_id,
             "type": "reasoning",
             "summary": [],
-            "content": reasoning_content,
+            "content": content,
             "encrypted_content": null,
             "status": null
         });
@@ -826,7 +851,10 @@ impl ResponseStreamEventEmitter {
                         }
 
                         if self.has_emitted_output_item_added {
-                            // Build complete message item for output_item.done
+                            // Build complete message item for output_item.done.
+                            // Typed `ResponseOutputItem::Message` requires `status`;
+                            // without it the item fails the typed round-trip in
+                            // `finalize()` and is dropped from the persisted response.
                             let item = json!({
                                 "id": item_id,
                                 "type": "message",
@@ -834,7 +862,8 @@ impl ResponseStreamEventEmitter {
                                 "content": [{
                                     "type": "output_text",
                                     "text": std::mem::take(&mut self.accumulated_text)
-                                }]
+                                }],
+                                "status": "completed"
                             });
                             let event = self.emit_output_item_done(output_index, &item);
                             self.send_event(&event, tx)?;
@@ -1051,5 +1080,64 @@ mod tests {
         );
         assert!(usage.get("prompt_tokens").is_none());
         assert!(usage.get("completion_tokens").is_none());
+    }
+
+    #[test]
+    fn hand_built_reasoning_and_message_items_round_trip_into_typed_output() {
+        // The exact shapes the emitter now builds must deserialize into the typed
+        // `ResponseOutputItem`, or `finalize()` silently drops them from the
+        // persisted response.
+        let reasoning = json!({
+            "id": "rs_1",
+            "type": "reasoning",
+            "summary": [],
+            "content": [{ "type": "reasoning_text", "text": "thinking" }],
+            "encrypted_content": null,
+            "status": null
+        });
+        assert!(
+            matches!(
+                serde_json::from_value::<ResponseOutputItem>(reasoning),
+                Ok(ResponseOutputItem::Reasoning { .. })
+            ),
+            "reasoning item must deserialize into the typed enum"
+        );
+
+        let message = json!({
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "text": "hello" }],
+            "status": "completed"
+        });
+        assert!(
+            matches!(
+                serde_json::from_value::<ResponseOutputItem>(message),
+                Ok(ResponseOutputItem::Message { .. })
+            ),
+            "message item must deserialize into the typed enum"
+        );
+    }
+
+    #[test]
+    fn finalize_preserves_reasoning_item_built_by_the_emitter() {
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_test".to_string(), "test-model".to_string(), 1);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        emitter
+            .emit_reasoning_item(&tx, Some("thinking".to_string()))
+            .expect("emit reasoning item");
+
+        let wire = serde_json::to_value(emitter.finalize(None)).expect("serialize finalized");
+        let output = wire
+            .get("output")
+            .and_then(|o| o.as_array())
+            .expect("output array present");
+        assert!(
+            output
+                .iter()
+                .any(|item| item.get("type").and_then(|t| t.as_str()) == Some("reasoning")),
+            "reasoning item must survive finalize (not be silently dropped); got {output:?}"
+        );
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -1125,7 +1125,9 @@ impl HarmonyStreamingProcessor {
                             emitter.emit_content_part_done(output_index, item_id, content_index);
                         emitter.send_event_best_effort(&event, tx);
 
-                        // Emit output_item.done
+                        // Emit output_item.done. Typed `ResponseOutputItem::Message`
+                        // requires `status`; without it the persisted response drops
+                        // this assistant message in finalize()'s typed round-trip.
                         let item = json!({
                             "id": item_id,
                             "type": "message",
@@ -1133,7 +1135,8 @@ impl HarmonyStreamingProcessor {
                             "content": [{
                                 "type": "output_text",
                                 "text": accumulated_final_text.clone()
-                            }]
+                            }],
+                            "status": "completed"
                         });
                         let event = emitter.emit_output_item_done(output_index, &item);
 


### PR DESCRIPTION
## Description

### Problem

`ResponseStreamEventEmitter::finalize()` rebuilds the persisted `ResponsesResponse.output` by re-parsing each stored item's hand-built JSON into the typed `ResponseOutputItem` and **silently dropping** any that fail (`serde_json::from_value(..).ok()`, no log). Two hand-built items never round-tripped: the assistant **message** omitted the required `status` field, and the **reasoning** item set `content` to a bare scalar instead of `Vec<ResponseReasoningContent>`. So every `store=true` harmony `/v1/responses` request persisted a response **missing the assistant message text and reasoning** — deterministic, invisible data loss that breaks retrieval and `previous_response_id` continuation. The client-facing SSE copy uses the raw untyped item and was correct — only the persisted copy was lossy. Audit CRITICAL, re-verified against `main`.

### Solution

Fix the two hand-built shapes so they round-trip: reasoning `content` → `[{"type":"reasoning_text","text":…}]` (or `[]`); add `"status": "completed"` to the done message items (both the emitter's `process_chunk` path and the harmony streaming done path). Harden `finalize()`: replace the bare `.ok()` with a `warn!` (item type + output_index + serde error) so future shape drift is loud instead of silent data loss.

## Changes

- `grpc/common/responses/streaming.rs`: reasoning content shape; message `status`; logged `finalize()`.
- `grpc/harmony/streaming.rs`: `status` on the harmony done-message item.
- Tests: both shapes deserialize into the typed enum; a reasoning item built by the emitter survives `finalize()`.

## Test Plan

- `cargo test -p smg --lib grpc::common::responses::streaming` — 3 pass (2 new)
- `cargo clippy -p smg --all-targets -- -D warnings` — clean (`--all-features` needs opencv locally; covered by CI)
- `cargo +nightly fmt -p smg -- --check` — clean

Note: touches `harmony/streaming.rs`, which #2097 also edits; a trivial rebase may be needed depending on merge order (different regions — a `json!` literal here vs. `.await`/signature changes there).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (via CI; `--all-features` needs opencv locally)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
