### PR TITLE
chore(ci): hard-block internal-only references from a public repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,12 @@ repos:
         stages: [commit-msg]
         always_run: true
 
+      - id: no-internal-refs
+        name: No internal-only references
+        description: Reject internal hostnames, tracker ids, corporate emails, and AI attribution
+        entry: scripts/check-no-internal-refs.sh
+        language: system
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,18 @@ Signed-off-by: Your Name <your.email@example.com>
   have the right to submit it.
 - **No AI attribution.** `Co-Authored-By: Claude` / `noreply@anthropic.com` and
   similar are rejected by the `no-ai-co-author` pre-commit hook.
+- **No internal-only references.** This repository is public. Internal
+  hostnames, tracker identifiers (`D…`/`T…`/`S…`), and corporate email addresses
+  are rejected by the `no-internal-refs` pre-commit hook, which also runs in CI
+  over every file — so `--no-verify` does not get a leak past review. Describe
+  behaviour and constraints from first principles instead of naming an internal
+  system. Codenames are deliberately not listed in the hook (writing them down
+  here would be the leak); point `SMG_INTERNAL_REF_PATTERNS` at a file of extra
+  regexes outside the repository to catch your own.
+
+  Agents can be stopped a step earlier, before the text reaches disk, by wiring
+  `scripts/claude-hooks/block-internal-refs.sh` as a `PreToolUse` hook for
+  `Write|Edit` in your own Claude Code settings.
 
 ---
 

--- a/scripts/check-no-internal-refs.sh
+++ b/scripts/check-no-internal-refs.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Reject content that only makes sense inside a private network from a public
+# repository: internal hostnames, internal-tracker identifiers, corporate email
+# addresses, and AI-tool attribution.
+#
+# Codenames for internal systems are deliberately NOT listed here — writing them
+# down in a public file is the very leak this guard exists to prevent. Point
+# SMG_INTERNAL_REF_PATTERNS at a file of extra extended-regex patterns (one per
+# line, `#` comments allowed) to add them from outside the repository.
+#
+# Usage: check-no-internal-refs.sh <file>...
+
+set -uo pipefail
+
+patterns=(
+  # Internal hostnames and short links.
+  '\b(fburl|internalfb|intern\.[a-z0-9-]+\.fb)\.com\b'
+  '\bphabricator\.[a-z0-9.-]+\b'
+  # Corporate email addresses; commit authorship must use the public identity.
+  '[A-Za-z0-9._%+-]+@(fb|meta)\.com\b'
+  # Internal tracker identifiers: Phabricator diffs, tasks, SEVs.
+  '\b(D[0-9]{7,}|T[0-9]{6,}|S[0-9]{6,})\b'
+  # AI-tool attribution, in code and in generated text alike.
+  '(Generated|Co-[Aa]uthored)[ -][Ww]ith [Cc]laude'
+  'noreply@anthropic\.com'
+  '🤖 Generated'
+)
+
+if [[ -n "${SMG_INTERNAL_REF_PATTERNS:-}" ]]; then
+  if [[ ! -r "${SMG_INTERNAL_REF_PATTERNS}" ]]; then
+    echo "check-no-internal-refs: cannot read SMG_INTERNAL_REF_PATTERNS=${SMG_INTERNAL_REF_PATTERNS}" >&2
+    exit 1
+  fi
+  while IFS= read -r line; do
+    [[ -z "${line}" || "${line}" == \#* ]] && continue
+    patterns+=("${line}")
+  done <"${SMG_INTERNAL_REF_PATTERNS}"
+fi
+
+# One alternation over all patterns keeps this a single pass per file.
+combined="$(
+  IFS='|'
+  echo "${patterns[*]}"
+)"
+
+# Files that state or enforce the policy have to quote the strings they ban.
+is_policy_text() {
+  case "${1#./}" in
+    scripts/check-no-internal-refs.sh | .pre-commit-config.yaml | \
+      .github/workflows/pr-naming-check.yml | CONTRIBUTING.md) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+status=0
+for file in "$@"; do
+  is_policy_text "${file}" && continue
+  # Binary files have no prose to leak.
+  grep -Iq . "${file}" 2>/dev/null || continue
+  if matches="$(grep -nEI "${combined}" "${file}")"; then
+    while IFS= read -r match; do
+      echo "${file}:${match}"
+    done <<<"${matches}"
+    status=1
+  fi
+done
+
+if [[ "${status}" -ne 0 ]]; then
+  cat >&2 <<'EOF'
+
+ERROR: internal-only references found in files bound for a public repository.
+
+Rewrite the flagged lines so they stand on their own: describe the behaviour or
+the constraint from first principles instead of naming an internal system,
+ticket, or host. Use the GitHub noreply address for authorship.
+
+To extend this guard with codenames that must not be written down here, set
+SMG_INTERNAL_REF_PATTERNS to a file of extra regexes outside the repository.
+EOF
+fi
+
+exit "${status}"

--- a/scripts/claude-hooks/block-internal-refs.sh
+++ b/scripts/claude-hooks/block-internal-refs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook: refuse a Write/Edit whose new text carries
+# internal-only references, so the text never reaches disk. `git commit
+# --no-verify` cannot get around this one, because there is nothing to commit.
+#
+# Reads the tool-call JSON on stdin; exit 2 blocks the call and returns stderr
+# to the model.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+checker="${repo_root}/scripts/check-no-internal-refs.sh"
+[[ -x "${checker}" ]] || exit 0
+
+payload="$(cat)"
+text="$(jq -r '[.tool_input.content, .tool_input.new_string] | map(select(. != null)) | join("\n")' <<<"${payload}" 2>/dev/null)"
+[[ -z "${text}" ]] && exit 0
+
+scratch="$(mktemp)"
+trap 'rm -f "${scratch}"' EXIT
+printf '%s\n' "${text}" >"${scratch}"
+
+if ! findings="$("${checker}" "${scratch}" 2>/dev/null)"; then
+  target="$(jq -r '.tool_input.file_path // "the edited file"' <<<"${payload}")"
+  {
+    echo "Blocked: this edit would write internal-only references into ${target}."
+    echo "${findings//${scratch}:/line }"
+    echo "Rewrite the flagged lines from first principles — describe the behaviour"
+    echo "or constraint without naming an internal system, ticket, or host."
+  } >&2
+  exit 2
+fi


### PR DESCRIPTION
## Description

### Problem

Nothing mechanically stops an internal hostname, a tracker id, or a
corporate email address from being committed to a public repository. The
only guard today is prose in `CONTRIBUTING.md` and `AGENTS.md`, which a
contributor -- or an agent -- has to read and remember. `no-ai-co-author`
already proves the pattern works for commit messages; file content has no
equivalent.

### Solution

`scripts/check-no-internal-refs.sh` scans file content for structural
leaks: internal hostnames, `D…`/`T…`/`S…` tracker identifiers, `@fb.com`
and `@meta.com` addresses, and AI-tool attribution. It runs as the
`no-internal-refs` pre-commit hook, and because that hook is absent from
the CI skip list, `pre-commit run --all-files` enforces it on every PR --
so `--no-verify` cannot land a leak.

Internal codenames are deliberately not written into the hook: listing
them in a public file is the leak the guard exists to prevent. The script
reads extra patterns from the file named by `SMG_INTERNAL_REF_PATTERNS`,
which lives outside the repository.

Files that state or enforce the policy have to quote the strings they ban,
so the script skips that short, explicit list rather than weakening the
patterns for everyone.

## Changes

- Add `scripts/check-no-internal-refs.sh` plus the `no-internal-refs`
  pre-commit hook.
- Add `scripts/claude-hooks/block-internal-refs.sh`, an optional
  `PreToolUse` hook that refuses a `Write`/`Edit` before the text reaches
  disk. Opt-in via personal Claude Code settings; not wired up here.
- Document both in `CONTRIBUTING.md`.

## Test Plan

- `pre-commit run no-internal-refs --all-files` passes on the tree as it
  stands, confirming no existing violations and no false positives across
  every tracked file.
- A file containing `// see T1234567 for context` fails the hook with the
  offending line printed.
- Structural patterns verified individually: tracker id, internal short
  link, and corporate email each trip the guard.
- An external pattern file supplied through `SMG_INTERNAL_REF_PATTERNS`
  flags a codename that the in-repo patterns ignore; the same file passes
  without that variable set.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>
