### PR TITLE
fix(anthropic): emit Anthropic-native tool_use ids on the Messages surface

### DIFF
--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -752,7 +752,7 @@ impl ResponseProcessor {
                 };
 
                 content_blocks.push(messages::ContentBlock::ToolUse {
-                    id: tc.id.clone(),
+                    id: utils::message_utils::anthropic_tool_use_id(&tc.id),
                     name: tc.function.name.clone(),
                     input,
                 });

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -2160,7 +2160,7 @@ impl StreamingProcessor {
                                     &MessageStreamEvent::ContentBlockStart {
                                         index: current_block_index,
                                         content_block: ContentBlock::ToolUse {
-                                            id: tool_call_id,
+                                            id: message_utils::anthropic_tool_use_id(&tool_call_id),
                                             name: tool_name,
                                             input: Value::Object(serde_json::Map::new()),
                                         },
@@ -2260,7 +2260,9 @@ impl StreamingProcessor {
                                                 &MessageStreamEvent::ContentBlockStart {
                                                     index: current_block_index,
                                                     content_block: ContentBlock::ToolUse {
-                                                        id: tool_call_id,
+                                                        id: message_utils::anthropic_tool_use_id(
+                                                            &tool_call_id,
+                                                        ),
                                                         name: name.clone(),
                                                         input: Value::Object(serde_json::Map::new()),
                                                     },
@@ -2410,7 +2412,7 @@ impl StreamingProcessor {
                             &MessageStreamEvent::ContentBlockStart {
                                 index: current_block_index,
                                 content_block: ContentBlock::ToolUse {
-                                    id: tool_call_id,
+                                    id: message_utils::anthropic_tool_use_id(&tool_call_id),
                                     name: name.clone(),
                                     input: Value::Object(serde_json::Map::new()),
                                 },

--- a/model_gateway/src/routers/grpc/utils/message_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/message_utils.rs
@@ -470,11 +470,58 @@ pub(crate) fn get_history_tool_calls_count_messages(request: &CreateMessageReque
         .count()
 }
 
+/// Anthropic-native id for a `tool_use` content block.
+///
+/// The Messages surface should expose `toolu_`-prefixed ids — strict Anthropic
+/// SDKs and ecosystem tooling pattern-match the prefix. Parsed tool calls carry
+/// the standard OpenAI `call_{uuid}` id, so swap the prefix and keep the
+/// suffix: deterministic, so the non-streaming builder and every streaming
+/// `content_block_start` site emit the same id for the same call, and clients
+/// echo it back opaquely just as before.
+///
+/// Any other id shape passes through unchanged — model families whose id
+/// format is load-bearing in the prompt (rendered into history or correlated
+/// verbatim by the reference server) must keep their native shape.
+pub(crate) fn anthropic_tool_use_id(id: &str) -> String {
+    match id.strip_prefix("call_") {
+        Some(suffix) => format!("toolu_{suffix}"),
+        None => id.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use messages::{InputMessage, Role, TextBlock};
 
     use super::*;
+
+    #[test]
+    fn anthropic_tool_use_id_swaps_standard_prefix() {
+        assert_eq!(
+            anthropic_tool_use_id("call_0123456789abcdef01234567"),
+            "toolu_0123456789abcdef01234567"
+        );
+        // Deterministic: same input, same output.
+        assert_eq!(
+            anthropic_tool_use_id("call_0123456789abcdef01234567"),
+            anthropic_tool_use_id("call_0123456789abcdef01234567"),
+        );
+    }
+
+    #[test]
+    fn anthropic_tool_use_id_passes_other_shapes_through() {
+        // Prompt-visible / reference-correlated id formats keep their shape.
+        assert_eq!(anthropic_tool_use_id("Bash_3"), "Bash_3");
+        assert_eq!(
+            anthropic_tool_use_id("functions.get_weather:2"),
+            "functions.get_weather:2"
+        );
+        // Already-native ids are untouched.
+        assert_eq!(
+            anthropic_tool_use_id("toolu_0123456789abcdef01234567"),
+            "toolu_0123456789abcdef01234567"
+        );
+    }
 
     #[test]
     fn test_simple_user_message() {


### PR DESCRIPTION
## Description

### Problem

The gRPC-terminating `/v1/messages` path builds `tool_use` content blocks with the parsed tool call's OpenAI-format id (`call_{24-uuid}`). Anthropic-native clients, strict SDK types, and ecosystem tooling pattern-match the `toolu_` prefix — an Anthropic response carrying `call_*` ids reads as malformed to them, even though correlation still works by opaque equality.

### Solution

Derive the block id deterministically from the parsed id at the Anthropic surface only: standard `call_` ids become `toolu_` with the same suffix. Applied at the non-streaming block builder and every streaming `content_block_start` site, so one request always exposes exactly one id per call across both paths. Determinism (rather than fresh minting) is what makes the four construction sites trivially consistent.

Ids in any other shape pass through unchanged — model families whose id format is load-bearing in the prompt (rendered into history or correlated verbatim by their reference servers) keep their native shape. Clients echo whatever id they were given, and inbound handling already treats ids as opaque, so round-tripping is unchanged. The chat/completions surface is untouched.

## Changes

- `message_utils::anthropic_tool_use_id`: `call_*` → `toolu_*` prefix swap, everything else identity.
- Applied in the non-streaming Messages response builder and the three streaming `ContentBlockStart` sites.

## Test Plan

- Unit tests: standard-prefix swap, determinism, pass-through for prompt-visible id shapes and already-native ids.
- `cargo test -p smg --lib`: 1476 passed. `cargo +nightly fmt` clean; `cargo clippy -p smg --all-targets -- -D warnings` clean locally (`--all-features` via CI).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>