### PR TITLE
feat(parsers): route the Nemotron-3 family to its tool and reasoning parsers

### DIFF
--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -230,6 +230,10 @@ impl ParserFactory {
         registry.register_pattern("nemotron-nano", "nano_v3");
         registry.register_pattern("nemotron-super", "nano_v3");
         registry.register_pattern("nano-v3", "nano_v3");
+        // Generation-qualified names (Nemotron-3-Super, Nemotron-3.5-Lightning)
+        // contain neither "nemotron-nano" nor "nemotron-super" — the `-3`/`-3.5`
+        // infix breaks the substring — so match the generation prefix directly.
+        registry.register_pattern("nemotron-3", "nano_v3");
 
         // Inkling checkpoints use the model-family name in their ID or config.
         registry.register_pattern("inkling", "inkling");
@@ -393,6 +397,14 @@ mod tests {
 
         let nemotron_nano = factory.create("nemotron-nano-4b");
         assert_eq!(nemotron_nano.model_type(), "nano_v3");
+
+        // Generation-qualified names: the -3/-3.5 infix breaks the
+        // nemotron-nano/nemotron-super substrings, so they match via the
+        // generation prefix instead.
+        let lightning = factory.create("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4");
+        assert_eq!(lightning.model_type(), "nano_v3");
+        let super_3 = factory.create("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8");
+        assert_eq!(super_3.model_type(), "nano_v3");
 
         let nemotron_super = factory.create("NVIDIA-Nemotron/nemotron-super");
         assert_eq!(nemotron_super.model_type(), "nano_v3");

--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -318,6 +318,9 @@ impl ParserFactory {
         registry.register_parser("qwen", || Box::new(QwenParser::new()));
         registry.register_parser("qwen_xml", || Box::new(QwenXmlParser::new()));
         registry.register_parser("qwen_coder", || Box::new(QwenXmlParser::new()));
+        // Nemotron-3 family emits the same XML-parameter format as Qwen3-Coder;
+        // named alias so operators can select it explicitly per model.
+        registry.register_parser("nemotron", || Box::new(QwenXmlParser::new()));
         registry.register_parser("pythonic", || Box::new(PythonicParser::new()));
         registry.register_parser("llama", || Box::new(LlamaParser::new()));
         registry.register_parser("deepseek", || Box::new(DeepSeekParser::new()));
@@ -378,6 +381,14 @@ impl ParserFactory {
         // Qwen3 and earlier (including Qwen2.5-Coder) use JSON format
         registry.map_model("qwen*", "qwen");
         registry.map_model("Qwen*", "qwen");
+
+        // Nemotron-3 generation (Nano/Super/Ultra/3.5-Lightning): the chat
+        // template renders tool calls in the Qwen3-Coder XML-parameter format
+        // (`<tool_call>\n<function=name>\n<parameter=key>value</parameter>...`)
+        // and tool results as `<tool_response>` blocks. Scoped to `nemotron-3`
+        // so earlier Nemotron families with different formats never match
+        // (matching is case-insensitive substring, so one spelling suffices).
+        registry.map_model("nemotron-3*", "qwen_xml");
 
         // Llama models
         registry.map_model("llama-4*", "pythonic");

--- a/crates/tool_parser/tests/tool_parser_nemotron.rs
+++ b/crates/tool_parser/tests/tool_parser_nemotron.rs
@@ -1,0 +1,62 @@
+//! Nemotron-3 family resolution tests.
+//!
+//! The Nemotron-3 generation (Nano/Super/Ultra/3.5-Lightning) renders tool
+//! calls in the same XML-parameter format as Qwen3-Coder, so the family maps
+//! to the `qwen_xml` parser; `nemotron` is also a named alias for explicit
+//! selection. These tests pin the mapping and prove an end-to-end parse for a
+//! representative model ID; the grammar itself is covered by the qwen_xml
+//! suite.
+
+use tool_parser::ParserFactory;
+
+const LIGHTNING_ID: &str = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4";
+
+#[tokio::test]
+async fn nemotron_3_family_resolves_and_parses() {
+    let factory = ParserFactory::new();
+
+    for model in [
+        LIGHTNING_ID,
+        "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
+        "nemotron-3-nano-omni",
+        "nemotron-3-ultra",
+    ] {
+        assert!(
+            factory.registry().has_parser_for_model(model),
+            "{model} must resolve to a tool parser"
+        );
+    }
+
+    let parser = factory.get_pooled(LIGHTNING_ID);
+    let input = "<tool_call>\n<function=get_weather>\n<parameter=city>\nSanta Clara\n</parameter>\n<parameter=units>\ncelsius\n</parameter>\n</function>\n</tool_call>";
+    let (_normal_text, tools) = parser.lock().await.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["city"], "Santa Clara");
+}
+
+#[tokio::test]
+async fn nemotron_named_alias_is_registered() {
+    let factory = ParserFactory::new();
+    assert!(factory.registry().has_parser("nemotron"));
+}
+
+#[tokio::test]
+async fn earlier_nemotron_families_do_not_match_the_generation_glob() {
+    let factory = ParserFactory::new();
+
+    // Pre-3 families use different formats; the `nemotron-3` stem must not
+    // capture them. (They may resolve via unrelated globs — llama-*, etc. —
+    // but never to qwen_xml through the nemotron mapping.)
+    for model in ["nemotron-4-340b-instruct", "nemotron-mini-4b"] {
+        let matched = factory
+            .registry()
+            .resolve_model_to_parser(model)
+            .unwrap_or_default();
+        assert_ne!(
+            matched, "qwen_xml",
+            "{model} must not match the nemotron-3 mapping"
+        );
+    }
+}


### PR DESCRIPTION
## Description

### Problem

Nemotron-3-generation models (Nano/Super/Ultra, 3.5-Lightning) had no tool-parser mapping, so their tool-call output came back verbatim in `content` with `tool_calls: null`. Reasoning auto-detection also missed the generation-qualified names: `NVIDIA-Nemotron-3-Super` contains neither of the registered `nemotron-nano`/`nemotron-super` substrings — the `-3`/`-3.5` infix breaks them.

### Solution

Per the family's HuggingFace chat templates, these models emit tool calls in exactly the Qwen3-Coder XML-parameter format (`<tool_call>` / `<function=name>` / `<parameter=key>` blocks, `<tool_response>` results, `<think>` reasoning with an `enable_thinking` toggle). So no new parser is needed — route the family to the existing `qwen_xml` tool parser and the existing `nano_v3` reasoning parser.

## Changes

- `tool_parser`: `nemotron-3*` → `qwen_xml` (single glob — matching is case-insensitive substring, so one spelling covers all id forms; scoped to the -3 generation so earlier Nemotron families with different formats never match). New `nemotron` named alias for explicit selection (auto-appears in Python bindings choices).
- `reasoning_parser`: `nemotron-3` pattern → `nano_v3`, beside the existing entries.

## Test Plan

- New resolution suite: full HF ids (`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4`, `...-3-Super-...`) resolve and parse a representative XML tool call end to end; the `nemotron` alias is registered; pre-3 Nemotron ids never resolve to `qwen_xml` via this mapping.
- Reasoning factory test extended with both generation-qualified ids.
- `cargo test -p tool-parser -p reasoning-parser` all green; `cargo clippy --all-targets -- -D warnings` clean; `cargo +nightly fmt` clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>