### PR TITLE
feat(grpc): add a client for vLLM's first-party gRPC services

### DIFF
--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -43,6 +43,8 @@ prost-build = "0.14.4"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+# Mock-server harness for the native-endpoint client tests.
+tokio-stream = { version = "0.1", features = ["net"] }
 
 [lints]
 workspace = true

--- a/crates/grpc_client/build.rs
+++ b/crates/grpc_client/build.rs
@@ -7,6 +7,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=proto/vllm_engine.proto");
     println!("cargo:rerun-if-changed=proto/trtllm_service.proto");
     println!("cargo:rerun-if-changed=proto/mlx_engine.proto");
+    println!("cargo:rerun-if-changed=proto/vllm_native/inference.proto");
+    println!("cargo:rerun-if-changed=proto/vllm_native/control.proto");
 
     // Pass 1: compile shared message types (no gRPC service generation)
     tonic_prost_build::configure()
@@ -61,6 +63,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "proto/tokenspeed_scheduler.proto",
             ],
             &["proto"],
+        )?;
+
+    // Pass 4: vLLM's first-party gRPC services (vendored from upstream, see
+    // proto/vllm_native/README.md). Compiled separately: the `vllm` package
+    // is unrelated to our own `vllm.grpc.engine` protocol above.
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile_protos(
+            &[
+                "proto/vllm_native/inference.proto",
+                "proto/vllm_native/control.proto",
+            ],
+            &["proto/vllm_native"],
         )?;
 
     Ok(())

--- a/crates/grpc_client/proto/vllm_native/README.md
+++ b/crates/grpc_client/proto/vllm_native/README.md
@@ -1,0 +1,15 @@
+# Vendored vLLM native gRPC protocol
+
+- Source repository: `vllm-project/vllm` (Apache-2.0)
+- Upstream path: `rust/proto/{inference,control}.proto`
+- Vendored at commit: `466855a2bfc57e58f7e2d03ee2deba79ceab2617`
+- SHA-256:
+  - `inference.proto`: `6152c306583166ecd691c9c715cab950523e8d1ed2db3dc2bcb538f6ca90e56f`
+  - `control.proto`: `390c88e94f1b68421c54c6d9440f2088d2709a432549c7a0fe94d35ce7b37476`
+
+These are vLLM's first-party gRPC services (`vllm.Inference` for generation,
+`vllm.Control` for server/model info, abort, and KV event source discovery),
+served by the engine itself — no injected servicer required. Files are vendored
+byte-for-byte with upstream license headers retained. Update the commit and
+checksums together when re-vendoring; the client in `src/vllm_native.rs` is
+written against this revision.

--- a/crates/grpc_client/proto/vllm_native/control.proto
+++ b/crates/grpc_client/proto/vllm_native/control.proto
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+syntax = "proto3";
+package vllm;
+
+service Control {
+  rpc GetServerInfo (GetServerInfoRequest) returns (ServerInfo) {}
+  rpc GetModelInfo (GetModelInfoRequest) returns (ModelInfo) {}
+  rpc Abort (AbortRequest) returns (AbortResponse) {}
+  rpc GetKvEventSources (GetKvEventSourcesRequest) returns (GetKvEventSourcesResponse) {}
+}
+
+message GetServerInfoRequest {}
+
+message ServerInfo {
+  string engine_version = 1;
+  string api_version = 2;
+  string instance_id = 3;
+  ParallelismInfo parallelism = 4;
+  uint32 max_model_len = 5;
+  uint32 kv_block_size = 6;
+  uint64 total_kv_blocks = 7;
+  uint64 max_running_requests = 8;
+  uint64 max_batched_tokens = 9;
+}
+
+message ParallelismInfo {
+  uint32 tensor_parallel_size = 1;
+  uint32 pipeline_parallel_size = 2;
+  uint32 data_parallel_size = 3;
+  uint32 data_parallel_rank = 4;
+  uint32 decode_context_parallel_size = 5;
+}
+
+message GetModelInfoRequest {}
+
+message ModelInfo {
+  string model_id = 1;
+  string served_model_name = 2;
+  repeated string served_model_aliases = 3;
+
+  bool supports_text_input = 20;
+  bool supports_token_ids_input = 21;
+  bool supports_multimodal = 23;
+  string reasoning_parser = 24;
+  string tool_call_parser = 25;
+}
+
+message AbortRequest {
+  repeated string request_ids = 1;
+}
+
+message AbortResponse {}
+
+// ======================================================================================
+// KV discovery
+// ======================================================================================
+
+message GetKvEventSourcesRequest {}
+message GetKvEventSourcesResponse { repeated KvEventSource sources = 1; }
+
+message KvEventSource {
+  string transport = 1;
+  string endpoint = 2;
+  string topic = 3;
+  string replay_endpoint = 4;
+  optional uint32 data_parallel_rank = 5;
+  string encoding = 6;
+  uint32 schema_version = 7;
+  uint32 buffer_steps = 8;
+  uint32 hwm = 9;
+  uint32 max_queue_size = 10;
+}

--- a/crates/grpc_client/proto/vllm_native/inference.proto
+++ b/crates/grpc_client/proto/vllm_native/inference.proto
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+syntax = "proto3";
+package vllm;
+
+import "google/protobuf/struct.proto";
+
+
+service Inference {
+  // Generates text given a prompt
+  rpc Generate (GenerateRequest) returns (GenerateResponse) {}
+  // Generates text given a prompt, streaming the outputs
+  rpc GenerateStream (GenerateRequest) returns (stream GenerateResponse) {}
+}
+
+// ======================================================================================
+// Generate Request
+// ======================================================================================
+
+message GenerateRequest {
+  string request_id = 1;
+  string model = 2;
+
+  oneof prompt {
+    string text = 3;
+    TokenIds token_ids = 4;
+  }
+
+  // Temperature, defaults to model-specific default or 0
+  optional float temperature = 5;
+  // Parameters controlling random sampling, not applicable if temperature == 0
+  RandomSampling sampling = 6;
+  // Parameters for conditionally penalizing/boosting
+  // candidate tokens during decoding
+  DecodingParameters decoding = 7;
+  // Parameters controlling when generation should stop
+  StoppingCriteria stopping = 8;
+  // Flags to control what is returned in the response
+  ResponseOptions response = 9;
+  // Parameters controlling KV cache/distribution
+  KVCacheParameters kv = 10;
+
+  // Truncate prompt tokens; default (0) means no truncation
+  uint32 truncate_prompt_tokens = 11;
+
+  int32 priority = 12;
+
+  optional string session_id = 13;
+
+  // Multimodal inputs aligned with placeholder markers in token_ids.
+  repeated MediaItem media = 14;
+}
+
+message RandomSampling {
+  uint32 num_sequences = 1;  // "n", default (0) means 1
+  uint32 top_k = 2;  // 0 means default
+  float top_p = 3;  // 0 means default
+  float min_p = 4;  // 0 means default
+  optional int64 seed = 5;
+}
+
+message DecodingParameters {
+  // Penalties
+  float presence_penalty = 1;  // Default (0.0) means no penalty
+  float frequency_penalty = 2;  // Default (0.0) means no penalty
+  float repetition_penalty = 3;  // Default (0.0) means no penalty
+  map<uint32, float> logit_bias = 4;
+  repeated uint32 allowed_token_ids = 5;
+
+  message StringChoices {
+    repeated string choices = 1;
+  }
+
+  // Control structured outputs
+  oneof structured_output {
+    string json = 6;
+    string regex = 7;
+    StringChoices choice = 8;
+    string grammar = 9;
+    bool json_object = 10;
+    string structural_tag = 11;
+  }
+}
+
+message StoppingCriteria {
+  // Default (0) is currently 20
+  uint32 max_new_tokens = 1;
+  // Default (0) means no minimum
+  uint32 min_new_tokens = 2;
+
+  repeated uint32 stop_token_ids = 3;
+  repeated string stop_strings = 4;
+  bool include_stop_strings = 5;
+
+  bool ignore_eos = 6;
+}
+
+message ResponseOptions {
+  // Prompt options
+  bool prompt_token_ids = 1;
+  bool prompt_logprobs = 2;
+  optional CandidateTokens prompt_candidates = 3;
+
+  // Output options; output_text defaults to true
+  optional bool output_text = 4;
+  bool output_token_ids = 5;
+  bool output_logprobs = 6;
+  optional CandidateTokens output_candidates = 7;
+}
+
+message KVCacheParameters {
+  bool bypass_prefix_cache = 1;
+  string cache_salt = 2;
+
+  // KV Connector transfer parameters
+  google.protobuf.Struct kv_transfer_params = 3;
+
+  // Encoder cache connector transfer parameters
+  google.protobuf.Struct ec_transfer_params = 4;
+}
+
+// Controls which extra candidate tokens at each position should be returned
+message CandidateTokens {
+  oneof select {
+    uint32 top_n = 1;
+    TokenIds token_ids = 2;
+    bool all = 3;
+  }
+}
+
+// ======================================================================================
+// Generate Response
+// ======================================================================================
+
+message GenerateResponse {
+  // Only present in first response
+  optional PromptInfo prompt_info = 1;
+  SequenceOutput outputs = 2;
+}
+
+message SequenceOutput {
+  // Index of output sequence for num_sequences > 1.
+  uint32 index = 1;
+
+  string text = 2;
+  uint32 num_tokens = 3;  // Number of tokens in this chunk
+  repeated uint32 token_ids = 4;  // If requested
+  repeated float logprobs = 5;  // If requested
+  repeated uint32 ranks = 6;  // If logprobs were requested
+  repeated CandidateTokenInfo candidate_tokens = 7; // If requested
+
+  // Only present in final output for this sequence
+  optional FinishInfo finish_info = 8;
+}
+
+// Prompt info, returned in the first response
+message PromptInfo {
+  uint32 num_prompt_tokens = 1;
+  repeated uint32 token_ids = 2;  // If requested
+  repeated float logprobs = 3;  // If requested
+  repeated uint32 ranks = 4;  // If logprobs were requested
+  repeated CandidateTokenInfo candidate_tokens = 5;
+}
+
+// Finish info, returned in the final response
+message FinishInfo {
+  uint32 num_output_tokens = 1;
+
+  enum FinishReason {
+    NOT_FINISHED = 0;  // Possibly more tokens to be streamed
+    LENGTH = 1;  // Finished due to length constraint
+    STOP = 2;  // Stop string/token or EOS encountered
+    ABORTED = 3;  // Request aborted/cancelled
+  }
+
+  FinishReason finish_reason = 2;
+  // One of these will be set when finish_reason == STOP
+  oneof stop_reason {
+    uint32 stop_token_id = 3;
+    uint32 eos_token_id = 4;
+    string stop_string = 5;
+  }
+
+  google.protobuf.Struct kv_transfer_params = 6;
+  //uint64 seed = 7;
+  google.protobuf.Struct ec_transfer_params = 8;
+}
+
+// Info for candidate tokens other than the input/sampled
+// token at a given position
+message CandidateTokenInfo {
+  message TokenInfo {
+    uint32 id = 1;
+    float logprob = 2;
+    uint32 rank = 3;
+    //    string text = 4;
+    //    bytes token_bytes = 5;
+  }
+  // Candidate token infos at this position
+  repeated TokenInfo tokens = 1;
+}
+
+// Token ids used for prompt
+message TokenIds {
+  repeated uint32 ids = 1;
+}
+
+// ======================================================================================
+// Media
+// ======================================================================================
+
+enum Modality {
+  MODALITY_UNSPECIFIED = 0;
+  MODALITY_IMAGE = 1;
+  MODALITY_VIDEO = 2;
+  MODALITY_AUDIO = 3;
+}
+
+message MediaItem {
+  Modality modality = 1;
+  oneof source {
+    string url = 2;       // http:// or https://
+    string data_uri = 3;  // data:
+    bytes raw_bytes = 4;
+  }
+  string mime_type = 5;
+  string uuid = 6;
+}

--- a/crates/grpc_client/src/lib.rs
+++ b/crates/grpc_client/src/lib.rs
@@ -22,6 +22,7 @@ pub mod tokenspeed_encoder;
 pub mod tokenspeed_scheduler;
 pub mod trtllm_service;
 pub mod vllm_engine;
+pub mod vllm_native;
 
 // Re-export clients
 use std::sync::Arc;

--- a/crates/grpc_client/src/vllm_native.rs
+++ b/crates/grpc_client/src/vllm_native.rs
@@ -1,0 +1,184 @@
+//! Client for vLLM's first-party gRPC services.
+//!
+//! vLLM serves two native gRPC services from the engine process itself
+//! (vendored protos: `proto/vllm_native/`, see its README for provenance):
+//!
+//! - `vllm.Inference` — `Generate` / `GenerateStream`
+//! - `vllm.Control` — `GetServerInfo`, `GetModelInfo`, `Abort`,
+//!   `GetKvEventSources`
+//!
+//! Connecting to these directly removes the injected Python servicer from the
+//! serving path for engines that expose them. This module is the transport
+//! layer only — worker detection and routing-pipeline integration land
+//! separately; nothing constructs this client in production yet.
+//!
+//! Notable protocol properties, load-bearing for the follow-up wiring:
+//!
+//! - `ModelInfo` declares the engine's own `tool_call_parser` /
+//!   `reasoning_parser` names — a native source for per-model parser
+//!   overrides (today those come from worker labels).
+//! - `ServerInfo` carries `kv_block_size`, `total_kv_blocks`, scheduler
+//!   limits, and full parallelism info (including decode-context-parallel
+//!   size), so capacity and block-size registration need no side channel.
+//! - `GetKvEventSources` returns per-data-parallel-rank event endpoints with
+//!   replay endpoints — the discovery half of event-driven cache-aware
+//!   routing without a subscription shim.
+//! - Data-parallel rank targeting is out-of-band: requests carry the
+//!   `x-data-parallel-rank` metadata header rather than a body field.
+//! - Cancellation is explicit (`Control.Abort` with request ids); dropping a
+//!   response stream does not abort the engine-side request by itself.
+
+use std::{future::Future, pin::Pin};
+
+use tonic::{transport::Channel, Request, Streaming};
+use tracing::{debug, warn};
+
+use crate::{AbortOnDropClient, BoxedTraceInjector};
+
+// Include the generated protobuf code. Unlike the sibling proto modules this
+// one contains enums, whose generated `as_str_name(&self)` trips the
+// pass-by-value lint — silence it for generated code only.
+#[expect(clippy::allow_attributes)]
+pub mod proto {
+    #![allow(
+        clippy::all,
+        clippy::absolute_paths,
+        clippy::trivially_copy_pass_by_ref,
+        unused_qualifications
+    )]
+    tonic::include_proto!("vllm");
+}
+
+/// Metadata key selecting a data-parallel rank for a request.
+pub const DATA_PARALLEL_RANK_METADATA_KEY: &str = "x-data-parallel-rank";
+
+/// Streaming `generate_stream()` response that auto-aborts on drop. Concrete
+/// alias for the generic `crate::AbortOnDropStream`.
+pub type AbortOnDropStream = crate::AbortOnDropStream<proto::GenerateResponse, VllmNativeClient>;
+
+/// Client for vLLM's first-party `Inference` + `Control` gRPC services.
+///
+/// Both service clients share one HTTP/2 channel.
+#[derive(Clone)]
+pub struct VllmNativeClient {
+    inference: proto::inference_client::InferenceClient<Channel>,
+    control: proto::control_client::ControlClient<Channel>,
+    trace_injector: BoxedTraceInjector,
+}
+
+impl AbortOnDropClient for VllmNativeClient {
+    fn abort_for_drop(
+        self,
+        request_id: String,
+    ) -> Pin<Box<dyn Future<Output = Result<(), tonic::Status>> + Send>> {
+        Box::pin(async move {
+            let mut control = self.control;
+            control
+                .abort(Request::new(proto::AbortRequest {
+                    request_ids: vec![request_id],
+                }))
+                .await
+                .map(|_| ())
+        })
+    }
+}
+
+impl VllmNativeClient {
+    /// Create a new client and connect to the engine's gRPC listener.
+    pub async fn connect(endpoint: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Self::connect_with_trace_injector(endpoint, std::sync::Arc::new(crate::NoopTraceInjector))
+            .await
+    }
+
+    /// Create a new client with a custom trace injector.
+    pub async fn connect_with_trace_injector(
+        endpoint: &str,
+        trace_injector: BoxedTraceInjector,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        debug!("Connecting to vLLM native gRPC server at {endpoint}");
+        let channel = crate::channel::connect_channel(endpoint).await?;
+        Ok(Self {
+            inference: proto::inference_client::InferenceClient::new(channel.clone()),
+            control: proto::control_client::ControlClient::new(channel),
+            trace_injector,
+        })
+    }
+
+    /// Set or replace the trace injector.
+    #[must_use]
+    pub fn with_trace_injector(mut self, trace_injector: BoxedTraceInjector) -> Self {
+        self.trace_injector = trace_injector;
+        self
+    }
+
+    /// Engine/server capabilities: versions, parallelism, KV block size and
+    /// capacity, scheduler limits.
+    pub async fn get_server_info(&self) -> Result<proto::ServerInfo, tonic::Status> {
+        let mut request = Request::new(proto::GetServerInfoRequest {});
+        if let Err(e) = self.trace_injector.inject(request.metadata_mut()) {
+            warn!("Failed to inject trace context: {e}");
+        }
+        let mut client = self.control.clone();
+        Ok(client.get_server_info(request).await?.into_inner())
+    }
+
+    /// Model identity and capabilities, including the engine's own
+    /// `tool_call_parser` / `reasoning_parser` declarations.
+    pub async fn get_model_info(&self) -> Result<proto::ModelInfo, tonic::Status> {
+        let mut request = Request::new(proto::GetModelInfoRequest {});
+        if let Err(e) = self.trace_injector.inject(request.metadata_mut()) {
+            warn!("Failed to inject trace context: {e}");
+        }
+        let mut client = self.control.clone();
+        Ok(client.get_model_info(request).await?.into_inner())
+    }
+
+    /// Per-data-parallel-rank KV event source descriptors (transport,
+    /// endpoint, topic, replay endpoint).
+    pub async fn get_kv_event_sources(
+        &self,
+    ) -> Result<proto::GetKvEventSourcesResponse, tonic::Status> {
+        let mut request = Request::new(proto::GetKvEventSourcesRequest {});
+        if let Err(e) = self.trace_injector.inject(request.metadata_mut()) {
+            warn!("Failed to inject trace context: {e}");
+        }
+        let mut client = self.control.clone();
+        Ok(client.get_kv_event_sources(request).await?.into_inner())
+    }
+
+    /// Abort in-flight requests by id. Idempotent server-side.
+    pub async fn abort(&self, request_ids: Vec<String>) -> Result<(), tonic::Status> {
+        let mut request = Request::new(proto::AbortRequest { request_ids });
+        if let Err(e) = self.trace_injector.inject(request.metadata_mut()) {
+            warn!("Failed to inject trace context: {e}");
+        }
+        let mut client = self.control.clone();
+        client.abort(request).await.map(|_| ())
+    }
+
+    /// Streaming generation. `data_parallel_rank`, when set, rides the
+    /// `x-data-parallel-rank` metadata header (the protocol carries no body
+    /// field for it). The returned stream is raw; wrap it in
+    /// [`AbortOnDropStream`] at the call site that owns cancellation policy —
+    /// dropping the raw stream does NOT abort the engine-side request.
+    pub async fn generate_stream(
+        &self,
+        generate_request: proto::GenerateRequest,
+        data_parallel_rank: Option<u32>,
+    ) -> Result<Streaming<proto::GenerateResponse>, tonic::Status> {
+        let mut request = Request::new(generate_request);
+        if let Err(e) = self.trace_injector.inject(request.metadata_mut()) {
+            warn!("Failed to inject trace context: {e}");
+        }
+        if let Some(rank) = data_parallel_rank {
+            request.metadata_mut().insert(
+                DATA_PARALLEL_RANK_METADATA_KEY,
+                rank.to_string()
+                    .parse()
+                    .map_err(|_| tonic::Status::internal("invalid dp rank metadata"))?,
+            );
+        }
+        let mut client = self.inference.clone();
+        Ok(client.generate_stream(request).await?.into_inner())
+    }
+}

--- a/crates/grpc_client/tests/vllm_native_client.rs
+++ b/crates/grpc_client/tests/vllm_native_client.rs
@@ -1,0 +1,245 @@
+//! Round-trip tests for the vLLM native-endpoint client against an in-process
+//! mock server implementing the vendored `vllm.Inference` / `vllm.Control`
+//! services.
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+use smg_grpc_client::vllm_native::{proto, VllmNativeClient, DATA_PARALLEL_RANK_METADATA_KEY};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{transport::Server, Request, Response, Status};
+
+#[derive(Default)]
+struct MockState {
+    /// dp-rank metadata observed on the last GenerateStream call.
+    seen_dp_rank: Mutex<Option<String>>,
+    /// Request ids passed to Abort.
+    aborted: Mutex<Vec<String>>,
+    /// Whether any RPC arrived at all.
+    touched: AtomicBool,
+}
+
+#[derive(Clone, Default)]
+struct MockVllm {
+    state: Arc<MockState>,
+}
+
+#[tonic::async_trait]
+impl proto::control_server::Control for MockVllm {
+    async fn get_server_info(
+        &self,
+        _request: Request<proto::GetServerInfoRequest>,
+    ) -> Result<Response<proto::ServerInfo>, Status> {
+        self.state.touched.store(true, Ordering::Relaxed);
+        Ok(Response::new(proto::ServerInfo {
+            engine_version: "0.0-test".to_string(),
+            api_version: "1".to_string(),
+            instance_id: "mock-1".to_string(),
+            parallelism: Some(proto::ParallelismInfo {
+                tensor_parallel_size: 1,
+                pipeline_parallel_size: 1,
+                data_parallel_size: 2,
+                data_parallel_rank: 0,
+                decode_context_parallel_size: 1,
+            }),
+            max_model_len: 4096,
+            kv_block_size: 16,
+            total_kv_blocks: 1000,
+            max_running_requests: 8,
+            max_batched_tokens: 8192,
+        }))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<proto::GetModelInfoRequest>,
+    ) -> Result<Response<proto::ModelInfo>, Status> {
+        Ok(Response::new(proto::ModelInfo {
+            model_id: "mock/model".to_string(),
+            served_model_name: "mock-model".to_string(),
+            served_model_aliases: vec![],
+            supports_text_input: true,
+            supports_token_ids_input: true,
+            supports_multimodal: false,
+            reasoning_parser: "basic".to_string(),
+            tool_call_parser: "json".to_string(),
+        }))
+    }
+
+    async fn abort(
+        &self,
+        request: Request<proto::AbortRequest>,
+    ) -> Result<Response<proto::AbortResponse>, Status> {
+        self.state
+            .aborted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extend(request.into_inner().request_ids);
+        Ok(Response::new(proto::AbortResponse {}))
+    }
+
+    async fn get_kv_event_sources(
+        &self,
+        _request: Request<proto::GetKvEventSourcesRequest>,
+    ) -> Result<Response<proto::GetKvEventSourcesResponse>, Status> {
+        Ok(Response::new(proto::GetKvEventSourcesResponse {
+            sources: vec![proto::KvEventSource {
+                transport: "zmq".to_string(),
+                endpoint: "tcp://127.0.0.1:5557".to_string(),
+                topic: String::new(),
+                replay_endpoint: "tcp://127.0.0.1:5558".to_string(),
+                data_parallel_rank: Some(0),
+                encoding: "msgpack".to_string(),
+                schema_version: 1,
+                buffer_steps: 64,
+                hwm: 1000,
+                max_queue_size: 10_000,
+            }],
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl proto::inference_server::Inference for MockVllm {
+    async fn generate(
+        &self,
+        _request: Request<proto::GenerateRequest>,
+    ) -> Result<Response<proto::GenerateResponse>, Status> {
+        Err(Status::unimplemented("unary generate unused in tests"))
+    }
+
+    type GenerateStreamStream =
+        futures::stream::Iter<std::vec::IntoIter<Result<proto::GenerateResponse, Status>>>;
+
+    async fn generate_stream(
+        &self,
+        request: Request<proto::GenerateRequest>,
+    ) -> Result<Response<Self::GenerateStreamStream>, Status> {
+        *self
+            .state
+            .seen_dp_rank
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = request
+            .metadata()
+            .get(DATA_PARALLEL_RANK_METADATA_KEY)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        let _ = request.into_inner();
+        let chunk = |text: &str, tokens: u32| proto::GenerateResponse {
+            prompt_info: None,
+            outputs: Some(proto::SequenceOutput {
+                index: 0,
+                text: text.to_string(),
+                num_tokens: tokens,
+                ..Default::default()
+            }),
+        };
+        let chunks = vec![Ok(chunk("hel", 1)), Ok(chunk("lo", 1))];
+        Ok(Response::new(futures::stream::iter(chunks)))
+    }
+}
+
+async fn spawn_mock() -> Result<(String, Arc<MockState>), Box<dyn std::error::Error>> {
+    let mock = MockVllm::default();
+    let state = Arc::clone(&mock.state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "mock server for one test; lives until the test process exits"
+    )]
+    tokio::spawn(
+        Server::builder()
+            .add_service(proto::control_server::ControlServer::new(mock.clone()))
+            .add_service(proto::inference_server::InferenceServer::new(mock))
+            .serve_with_incoming(TcpListenerStream::new(listener)),
+    );
+    Ok((format!("http://{addr}"), state))
+}
+
+#[tokio::test]
+async fn control_surface_round_trips() {
+    let (endpoint, state) = spawn_mock().await.unwrap();
+    let client = VllmNativeClient::connect(&endpoint).await.unwrap();
+
+    let server_info = client.get_server_info().await.unwrap();
+    assert_eq!(server_info.kv_block_size, 16);
+    assert_eq!(
+        server_info.parallelism.as_ref().unwrap().data_parallel_size,
+        2
+    );
+    assert!(state.touched.load(Ordering::Relaxed));
+
+    let model_info = client.get_model_info().await.unwrap();
+    assert_eq!(model_info.served_model_name, "mock-model");
+    // The engine declares its own parser names — the native source for
+    // per-model parser overrides.
+    assert_eq!(model_info.tool_call_parser, "json");
+    assert_eq!(model_info.reasoning_parser, "basic");
+
+    let sources = client.get_kv_event_sources().await.unwrap();
+    assert_eq!(sources.sources.len(), 1);
+    assert_eq!(sources.sources[0].transport, "zmq");
+    assert_eq!(sources.sources[0].data_parallel_rank, Some(0));
+}
+
+#[tokio::test]
+async fn generate_stream_carries_dp_rank_metadata() {
+    let (endpoint, state) = spawn_mock().await.unwrap();
+    let client = VllmNativeClient::connect(&endpoint).await.unwrap();
+
+    let request = proto::GenerateRequest {
+        request_id: "req-1".to_string(),
+        model: "mock-model".to_string(),
+        ..Default::default()
+    };
+
+    let mut stream = client
+        .generate_stream(request.clone(), Some(1))
+        .await
+        .unwrap();
+    let mut text = String::new();
+    while let Some(chunk) = stream.message().await.unwrap() {
+        text.push_str(&chunk.outputs.unwrap().text);
+    }
+    assert_eq!(text, "hello");
+    assert_eq!(
+        state
+            .seen_dp_rank
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_deref(),
+        Some("1")
+    );
+
+    // Without a rank, no metadata header is sent.
+    let mut stream = client.generate_stream(request, None).await.unwrap();
+    while stream.message().await.unwrap().is_some() {}
+    assert_eq!(
+        state
+            .seen_dp_rank
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_deref(),
+        None
+    );
+}
+
+#[tokio::test]
+async fn abort_reaches_the_control_service() {
+    let (endpoint, state) = spawn_mock().await.unwrap();
+    let client = VllmNativeClient::connect(&endpoint).await.unwrap();
+
+    client.abort(vec!["req-9".to_string()]).await.unwrap();
+    assert_eq!(
+        state
+            .aborted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_slice(),
+        ["req-9"]
+    );
+}


### PR DESCRIPTION
## Description

### Problem

For vLLM workers, the serving path runs through the injected Python servicer even though vLLM now ships first-party gRPC services from the engine process itself: `vllm.Inference` (Generate/GenerateStream) and `vllm.Control` (GetServerInfo, GetModelInfo, Abort, GetKvEventSources). Talking to those directly would drop a process and a translation layer from the path — and the Control surface natively answers questions the gateway currently derives from labels and probes: the engine's own tool/reasoning parser declarations, KV block size and capacity, scheduler limits, full parallelism info (including decode-context-parallel size), and per-data-parallel-rank KV event source endpoints with replay support.

### Solution

Groundwork slice: the transport layer only. Vendored upstream protos (byte-exact, with provenance commit + SHA-256 checksums documented in `proto/vllm_native/README.md`), a dual-service client sharing one HTTP/2 channel, `AbortOnDrop` integration (cancellation on this protocol is explicit via `Control.Abort` — dropping a stream does not abort the engine-side request, which is documented on the API), and data-parallel rank targeting via the `x-data-parallel-rank` metadata header (the protocol carries no body field for it). Worker detection and routing-pipeline integration land as follow-ups; nothing constructs this client in production yet.

## Changes

- `proto/vllm_native/{inference,control}.proto` vendored from upstream `vllm-project/vllm` @ `466855a2` (`rust/proto/`), license headers retained; README pins commit + checksums.
- `build.rs`: separate codegen pass (the upstream `vllm` package is unrelated to this crate's own `vllm.grpc.engine` protocol).
- `src/vllm_native.rs`: `VllmNativeClient` — connect / trace-injector / `get_server_info` / `get_model_info` / `get_kv_event_sources` / `abort` / `generate_stream(request, dp_rank)`, plus `AbortOnDropClient` and the `AbortOnDropStream` alias following the crate's house pattern.
- First integration-test harness for this crate: an in-process tonic mock implementing both services.

## Test Plan

- Mock-server round trips: Control surface (server info incl. parallelism, model info incl. engine-declared parser names, KV event sources), streaming generation with and without the dp-rank metadata header (presence asserted server-side), abort delivery.
- `cargo test -p smg-grpc-client` (68 tests) green; `cargo clippy -p smg-grpc-client --all-targets -- -D warnings` zero errors; `cargo check -p smg` unaffected; `cargo +nightly fmt` clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>