### PR TITLE
fix(pd): defer decode-leg abort until the KV handoff completes

### DIFF
--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -43,6 +43,8 @@ prost-build = "0.14.4"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+# Mock-server harness for the abort-on-drop behavioral tests.
+tokio-stream = { version = "0.1", features = ["net"] }
 
 [lints]
 workspace = true

--- a/crates/grpc_client/src/abort_on_drop.rs
+++ b/crates/grpc_client/src/abort_on_drop.rs
@@ -26,6 +26,11 @@ use std::{
 use tonic::Streaming;
 use tracing::{debug, warn};
 
+/// Upper bound on how long a deferred abort waits for the stream's first
+/// item before aborting anyway. Bounds the detached drain task when the
+/// backend never produces output (e.g. its upstream handoff peer died).
+const DEFERRED_ABORT_MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Bridge between the generic [`AbortOnDropStream`] and an engine-specific
 /// client. Implementors provide an async function that the wrapper calls
 /// from `Drop` to release backend resources.
@@ -44,25 +49,50 @@ pub trait AbortOnDropClient: Clone + Send + Sync + 'static {
 ///
 /// `T` is the engine-specific stream item (typically `proto::GenerateResponse`).
 /// `C` is the engine client implementing [`AbortOnDropClient`].
-pub struct AbortOnDropStream<T, C: AbortOnDropClient> {
-    inner: Streaming<T>,
+pub struct AbortOnDropStream<T: Send + 'static, C: AbortOnDropClient> {
+    /// `Some` while the wrapper owns the stream; `Drop` may `take()` it into
+    /// a detached drain task when the abort is deferred.
+    inner: Option<Streaming<T>>,
     request_id: String,
     client: C,
     aborted: Arc<AtomicBool>,
+    /// When set, a drop that happens before the stream yielded its first
+    /// item drains the stream in the background until that first item (or a
+    /// terminal event / [`DEFERRED_ABORT_MAX_WAIT`]) before sending the
+    /// abort. For workers whose request must not be torn down mid-handoff —
+    /// e.g. a disaggregated decode leg receiving KV state from its prefill
+    /// peer — an early abort can kill the transfer while the peer is still
+    /// writing; the first generated item is the proof the handoff completed.
+    defer_abort_until_first_item: bool,
+    /// Whether `poll_next` has yielded at least one item (data or error).
+    saw_item: bool,
     _marker: PhantomData<fn() -> T>,
 }
 
-impl<T, C: AbortOnDropClient> AbortOnDropStream<T, C> {
+impl<T: Send + 'static, C: AbortOnDropClient> AbortOnDropStream<T, C> {
     /// Wrap a streaming response so it auto-aborts on drop.
     pub fn new(stream: Streaming<T>, request_id: String, client: C) -> Self {
         debug!("Created AbortOnDropStream for request {}", request_id);
         Self {
-            inner: stream,
+            inner: Some(stream),
             request_id,
             client,
             aborted: Arc::new(AtomicBool::new(false)),
+            defer_abort_until_first_item: false,
+            saw_item: false,
             _marker: PhantomData,
         }
+    }
+
+    /// Defer the abort-on-drop until the stream has produced its first item.
+    ///
+    /// Default behavior (off) aborts immediately on drop. See the field docs
+    /// for when deferral is required; `mark_completed` still suppresses the
+    /// abort entirely in either mode.
+    #[must_use]
+    pub fn defer_abort_until_first_item(mut self) -> Self {
+        self.defer_abort_until_first_item = true;
+        self
     }
 
     /// Suppress the abort-on-drop. Call after the stream completes
@@ -76,7 +106,7 @@ impl<T, C: AbortOnDropClient> AbortOnDropStream<T, C> {
     }
 }
 
-impl<T, C: AbortOnDropClient> Drop for AbortOnDropStream<T, C> {
+impl<T: Send + 'static, C: AbortOnDropClient> Drop for AbortOnDropStream<T, C> {
     fn drop(&mut self) {
         // Atomically claim the "send abort" responsibility. If
         // `mark_completed` already ran, `compare_exchange` fails and we
@@ -93,15 +123,46 @@ impl<T, C: AbortOnDropClient> Drop for AbortOnDropStream<T, C> {
         let request_id_for_log = request_id.clone();
         let client = self.client.clone();
 
+        // Deferred mode, dropped before the first item: keep the stream
+        // alive in the background until the backend produces its first item
+        // (or terminates, or the wait cap fires), THEN abort. The request
+        // still dies — the deferral only moves the abort past the window
+        // where tearing it down would interrupt an in-flight handoff.
+        let drain = if self.defer_abort_until_first_item && !self.saw_item {
+            self.inner.take()
+        } else {
+            None
+        };
+
         #[expect(
             clippy::disallowed_methods,
             reason = "fire-and-forget abort on Drop is intentional"
         )]
         tokio::spawn(async move {
-            debug!(
-                "Stream dropped without completion for request {}, sending abort",
-                request_id_for_log
-            );
+            if let Some(mut stream) = drain {
+                debug!(
+                    "Stream dropped before first item for request {}, draining before abort",
+                    request_id_for_log
+                );
+                let first_item = tokio::time::timeout(DEFERRED_ABORT_MAX_WAIT, async {
+                    // `Streaming::message` resolves on the next message,
+                    // stream end, or transport error — any of which ends the
+                    // protected window.
+                    let _ = stream.message().await;
+                })
+                .await;
+                if first_item.is_err() {
+                    warn!(
+                        "Deferred abort for request {} timed out waiting for the first item",
+                        request_id_for_log
+                    );
+                }
+            } else {
+                debug!(
+                    "Stream dropped without completion for request {}, sending abort",
+                    request_id_for_log
+                );
+            }
             if let Err(e) = client.abort_for_drop(request_id).await {
                 warn!(
                     "Failed to send abort on drop for request {}: {}",
@@ -116,13 +177,29 @@ impl<T, C: AbortOnDropClient> Drop for AbortOnDropStream<T, C> {
 // pinned reference to any field. Marking the wrapper `Unpin` lets us
 // use `Pin<&mut Self>::deref_mut` to reach `inner` without needing
 // `pin-project` machinery.
-impl<T, C: AbortOnDropClient> Unpin for AbortOnDropStream<T, C> {}
+impl<T: Send + 'static, C: AbortOnDropClient> Unpin for AbortOnDropStream<T, C> {}
 
-impl<T, C: AbortOnDropClient> futures::Stream for AbortOnDropStream<T, C> {
+impl<T: Send + 'static, C: AbortOnDropClient> futures::Stream for AbortOnDropStream<T, C> {
     type Item = Result<T, tonic::Status>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.inner).poll_next(cx)
+        let this = &mut *self;
+        match this.inner.as_mut() {
+            Some(inner) => {
+                let polled = Pin::new(inner).poll_next(cx);
+                if matches!(polled, Poll::Ready(Some(_))) {
+                    // Any yielded item — data or error — ends the deferred
+                    // window: the backend has responded, so its handoff
+                    // state is resolved either way.
+                    this.saw_item = true;
+                }
+                polled
+            }
+            // Only reachable if polled after Drop took the stream, which
+            // cannot happen for an owned value; return end-of-stream rather
+            // than panicking to keep the impl total.
+            None => Poll::Ready(None),
+        }
     }
 }
 

--- a/crates/grpc_client/tests/abort_on_drop_deferred.rs
+++ b/crates/grpc_client/tests/abort_on_drop_deferred.rs
@@ -1,0 +1,246 @@
+//! Behavioral tests for `AbortOnDropStream`'s deferred-abort mode, driven
+//! through the real `VllmEngineClient` against an in-process mock engine.
+//!
+//! The deferral contract: with `defer_abort_until_first_item`, dropping the
+//! stream before the backend produced any response holds the abort until the
+//! first response arrives (the disaggregated decode leg uses this so a client
+//! disconnect can never tear down a request mid-KV-handoff); dropping after
+//! the first response — or without the deferral — aborts promptly, and
+//! `mark_completed` suppresses the abort entirely.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use futures::StreamExt;
+use smg_grpc_client::{vllm_proto as proto, VllmEngineClient};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
+use tonic::{transport::Server, Request, Response, Status};
+
+type GenerateTx = mpsc::Sender<Result<proto::GenerateResponse, Status>>;
+
+#[derive(Default)]
+struct MockState {
+    /// Sender feeding the currently open generate stream.
+    generate_tx: Mutex<Option<GenerateTx>>,
+    /// Request ids passed to Abort.
+    aborted: Mutex<Vec<String>>,
+}
+
+impl MockState {
+    fn lock_tx(&self) -> std::sync::MutexGuard<'_, Option<GenerateTx>> {
+        self.generate_tx
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn aborted_ids(&self) -> Vec<String> {
+        self.aborted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+#[derive(Clone, Default)]
+struct MockEngine {
+    state: Arc<MockState>,
+}
+
+#[tonic::async_trait]
+impl proto::vllm_engine_server::VllmEngine for MockEngine {
+    type GenerateStream = ReceiverStream<Result<proto::GenerateResponse, Status>>;
+
+    async fn generate(
+        &self,
+        _request: Request<proto::GenerateRequest>,
+    ) -> Result<Response<Self::GenerateStream>, Status> {
+        let (tx, rx) = mpsc::channel(4);
+        *self.state.lock_tx() = Some(tx);
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    async fn abort(
+        &self,
+        request: Request<proto::AbortRequest>,
+    ) -> Result<Response<proto::AbortResponse>, Status> {
+        self.state
+            .aborted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extend(request.into_inner().request_ids);
+        Ok(Response::new(proto::AbortResponse::default()))
+    }
+
+    async fn embed(
+        &self,
+        _request: Request<proto::EmbedRequest>,
+    ) -> Result<Response<proto::EmbedResponse>, Status> {
+        Err(Status::unimplemented("unused in tests"))
+    }
+
+    async fn health_check(
+        &self,
+        _request: Request<proto::HealthCheckRequest>,
+    ) -> Result<Response<proto::HealthCheckResponse>, Status> {
+        Err(Status::unimplemented("unused in tests"))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<proto::GetModelInfoRequest>,
+    ) -> Result<Response<proto::GetModelInfoResponse>, Status> {
+        Err(Status::unimplemented("unused in tests"))
+    }
+
+    async fn get_server_info(
+        &self,
+        _request: Request<proto::GetServerInfoRequest>,
+    ) -> Result<Response<proto::GetServerInfoResponse>, Status> {
+        Err(Status::unimplemented("unused in tests"))
+    }
+
+    async fn get_loads(
+        &self,
+        _request: Request<proto::GetLoadsRequest>,
+    ) -> Result<Response<proto::GetLoadsResponse>, Status> {
+        Err(Status::unimplemented("unused in tests"))
+    }
+
+    type GetTokenizerStream =
+        ReceiverStream<Result<smg_grpc_client::common_proto::GetTokenizerChunk, Status>>;
+
+    async fn get_tokenizer(
+        &self,
+        _request: Request<smg_grpc_client::common_proto::GetTokenizerRequest>,
+    ) -> Result<Response<Self::GetTokenizerStream>, Status> {
+        Err(Status::unimplemented("unused in tests"))
+    }
+
+    type SubscribeKvEventsStream =
+        ReceiverStream<Result<smg_grpc_client::common_proto::KvEventBatch, Status>>;
+
+    async fn subscribe_kv_events(
+        &self,
+        _request: Request<smg_grpc_client::common_proto::SubscribeKvEventsRequest>,
+    ) -> Result<Response<Self::SubscribeKvEventsStream>, Status> {
+        Err(Status::unimplemented("unused in tests"))
+    }
+}
+
+async fn spawn_mock() -> Result<(String, Arc<MockState>), Box<dyn std::error::Error>> {
+    let mock = MockEngine::default();
+    let state = Arc::clone(&mock.state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "mock server for one test; lives until the test process exits"
+    )]
+    tokio::spawn(
+        Server::builder()
+            .add_service(proto::vllm_engine_server::VllmEngineServer::new(mock))
+            .serve_with_incoming(TcpListenerStream::new(listener)),
+    );
+    Ok((format!("http://{addr}"), state))
+}
+
+fn chunk() -> proto::GenerateResponse {
+    proto::GenerateResponse::default()
+}
+
+/// Wait (bounded) until the mock has recorded at least one abort.
+async fn wait_for_abort(state: &MockState) -> Vec<String> {
+    for _ in 0..100 {
+        let ids = state.aborted_ids();
+        if !ids.is_empty() {
+            return ids;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    state.aborted_ids()
+}
+
+fn generate_request(id: &str) -> proto::GenerateRequest {
+    proto::GenerateRequest {
+        request_id: id.to_string(),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn default_mode_aborts_immediately_on_drop() {
+    let (endpoint, state) = spawn_mock().await.unwrap();
+    let client = VllmEngineClient::connect(&endpoint).await.unwrap();
+
+    let stream = client.generate(generate_request("imm-1")).await.unwrap();
+    drop(stream);
+
+    assert_eq!(wait_for_abort(&state).await, ["imm-1"]);
+}
+
+#[tokio::test]
+async fn deferred_mode_holds_abort_until_first_item() {
+    let (endpoint, state) = spawn_mock().await.unwrap();
+    let client = VllmEngineClient::connect(&endpoint).await.unwrap();
+
+    let stream = client
+        .generate(generate_request("def-1"))
+        .await
+        .unwrap()
+        .defer_abort_until_first_item();
+    drop(stream);
+
+    // No abort while the backend hasn't produced anything.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        state.aborted_ids().is_empty(),
+        "abort must be held until the first response"
+    );
+
+    // The backend produces its first response (handoff complete) — the
+    // deferred abort now fires.
+    let tx = state.lock_tx().clone().unwrap();
+    tx.send(Ok(chunk())).await.unwrap();
+    assert_eq!(wait_for_abort(&state).await, ["def-1"]);
+}
+
+#[tokio::test]
+async fn deferred_mode_aborts_immediately_after_first_item_was_consumed() {
+    let (endpoint, state) = spawn_mock().await.unwrap();
+    let client = VllmEngineClient::connect(&endpoint).await.unwrap();
+
+    let mut stream = client
+        .generate(generate_request("def-2"))
+        .await
+        .unwrap()
+        .defer_abort_until_first_item();
+
+    let tx = state.lock_tx().clone().unwrap();
+    tx.send(Ok(chunk())).await.unwrap();
+    let first = stream.next().await;
+    assert!(matches!(first, Some(Ok(_))));
+
+    // The protected window is over — dropping now aborts promptly.
+    drop(stream);
+    assert_eq!(wait_for_abort(&state).await, ["def-2"]);
+}
+
+#[tokio::test]
+async fn mark_completed_suppresses_abort_in_deferred_mode() {
+    let (endpoint, state) = spawn_mock().await.unwrap();
+    let client = VllmEngineClient::connect(&endpoint).await.unwrap();
+
+    let stream = client
+        .generate(generate_request("done-1"))
+        .await
+        .unwrap()
+        .defer_abort_until_first_item();
+    stream.mark_completed();
+    drop(stream);
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(state.aborted_ids().is_empty());
+}

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -538,6 +538,16 @@ impl RequestExecutionStage {
             )
         })?;
 
+        // A client disconnect drops both leg streams, which normally fires an
+        // immediate abort to each worker. The decode leg must not be aborted
+        // while it is still receiving the KV handoff from prefill — tearing
+        // the request down mid-transfer can crash or leak on the engine — so
+        // its abort is deferred until the first decode response (the proof
+        // the handoff completed). The prefill leg keeps the immediate abort:
+        // if prefill is still running there is nothing to hand off yet, and
+        // stopping it promptly frees capacity.
+        let decode_stream = decode_stream.defer_abort_until_first_item();
+
         Ok(ExecutionResult::PrefillDecode {
             prefill: prefill_stream,
             decode: Box::new(decode_stream),
@@ -816,6 +826,13 @@ impl RequestExecutionStage {
             runtime,
             kv_window_start.elapsed(),
         );
+
+        // Prefill has completed and its KV blocks are held pending decode's
+        // transfer; aborting decode mid-transfer on a client disconnect can
+        // crash or leak on the engine side. Defer the abort until the first
+        // decode response proves the handoff finished (see the parallel PD
+        // path for the same invariant).
+        let decode_stream = decode_stream.defer_abort_until_first_item();
 
         Ok(ExecutionResult::Single {
             stream: decode_stream,

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -2024,6 +2024,26 @@ impl ProtoStream {
             Self::Zmq(stream) => stream.mark_completed(),
         }
     }
+
+    /// Defer the abort-on-drop until the stream yields its first response.
+    ///
+    /// Used for the disaggregated decode leg: aborting a decode request while
+    /// it is still receiving the KV handoff from its prefill peer can tear
+    /// down the transfer mid-write; the first response proves the handoff
+    /// completed, after which the (deferred) abort is safe. No-op for ZMQ
+    /// streams — the ZMQ adapter owns its own lifecycle and the ZMQ lane does
+    /// not serve disaggregated requests.
+    #[must_use]
+    pub fn defer_abort_until_first_item(self) -> Self {
+        match self {
+            Self::Sglang(stream) => Self::Sglang(stream.defer_abort_until_first_item()),
+            Self::Vllm(stream) => Self::Vllm(stream.defer_abort_until_first_item()),
+            Self::Trtllm(stream) => Self::Trtllm(stream.defer_abort_until_first_item()),
+            Self::Mlx(stream) => Self::Mlx(stream.defer_abort_until_first_item()),
+            Self::TokenSpeed(stream) => Self::TokenSpeed(stream.defer_abort_until_first_item()),
+            Self::Zmq(stream) => Self::Zmq(stream),
+        }
+    }
 }
 
 /// Unified EmbedRequest that works with all backends


### PR DESCRIPTION
## Description

### Problem

When a client disconnects mid-request in disaggregated (PD) mode, both leg streams drop and every engine stream wrapper fires an immediate `Abort` to its worker. For the decode leg this can land while the worker is still receiving KV state from its prefill peer — tearing the request down mid-transfer, which can crash the engine or leak the KV blocks the prefill worker is holding for the handoff.

### Solution

An opt-in deferred mode on `AbortOnDropStream`: if the wrapper is dropped before the stream yielded its first item, the stream is drained in a detached task until the first response, a terminal event, or a 30s cap — and only then is the abort sent. The first decode response is the proof the handoff completed. The request still dies either way; the deferral only moves the abort past the transfer window. Both PD execution paths (parallel/bootstrap and sequential with connector-relayed KV params) opt their decode leg in. The prefill leg deliberately keeps the immediate abort — before a handoff exists, stopping prefill promptly just frees capacity.

## Changes

- `AbortOnDropStream`: `defer_abort_until_first_item()` builder, first-item tracking in the `Stream` impl, and a bounded background drain in `Drop` (`DEFERRED_ABORT_MAX_WAIT` = 30s). Default behavior is unchanged; `mark_completed` still suppresses the abort entirely in either mode.
- `ProtoStream::defer_abort_until_first_item()` fanning to each engine variant (no-op for ZMQ, which owns its own lifecycle and serves no disaggregated requests).
- Both `execute_parallel_pd` and `execute_sequential_pd` defer the decode leg, with the invariant documented at each site.

## Test Plan

- New behavioral suite drives the real `VllmEngineClient` against an in-process mock engine: default mode aborts immediately on drop; deferred mode holds the abort until the backend's first response then fires; a drop after the first consumed item aborts promptly; `mark_completed` suppresses the abort.
- `cargo test -p smg-grpc-client` (69) and `cargo test -p smg --lib` (1474) green; `cargo clippy -p smg-grpc-client -p smg --all-targets -- -D warnings` zero errors; `cargo +nightly fmt` clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>