### PR TITLE
feat(mesh): wire TreeSyncAdapter so cache-aware state syncs across nodes

### DIFF
--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -114,8 +114,13 @@ pub struct TreeDelta {
     pub node_hash: u64,
     /// Worker URL that cached the prefix.
     pub worker_url: String,
-    /// Cache-event epoch for intra-batch ordering on the receiver;
-    /// the stream transport itself doesn't inspect it.
+    /// Reserved on-wire slot for a future intra-batch ordering
+    /// value. The current receiver does not consult it — it appears
+    /// only in `trace!`/`debug!` log lines — so producers may set
+    /// `0` until a consumer that orders by epoch lands. Kept on
+    /// `TreeDelta` (rather than added later) so a newer receiver
+    /// paired with an older producer just sees zeros instead of a
+    /// deserialization mismatch.
     pub epoch: u64,
 }
 

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -36,8 +36,9 @@ use uuid::Uuid;
 use crate::policies::{TreeHandle, TreeKind};
 
 const PREFIX: &str = "td:";
-const REPAIR_REQUEST_PREFIX: &str = "tree:req:";
-const REPAIR_PAGE_PREFIX: &str = "tree:page:";
+pub(crate) const REPAIR_REQUEST_PREFIX: &str = "tree:req:";
+pub(crate) const REPAIR_PAGE_PREFIX: &str = "tree:page:";
+pub(crate) const TENANT_DELTA_PREFIX: &str = PREFIX;
 
 /// Duration a repair session may sit without progress before
 /// the periodic retry scan reissues it. Spec §15 default: 5 s.
@@ -678,6 +679,17 @@ impl TreeSyncAdapter {
             .entry(model_id.to_string())
             .or_default()
             .push(delta);
+    }
+
+    /// Test-only view onto the outbound buffer so integration tests
+    /// outside this file can assert that a producer hook fired without
+    /// having to wait a full gossip tick for drain.
+    #[cfg(test)]
+    pub(crate) fn pending_delta_count_for_test(&self, model_id: &str) -> usize {
+        self.pending_deltas
+            .get(model_id)
+            .map(|d| d.len())
+            .unwrap_or(0)
     }
 
     /// Collect each model's buffer into one `td:{model_id}` stream

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -197,41 +197,33 @@ impl PolicyRegistryTreeHandle {
         Self { registry }
     }
 
-    /// Fetch the policy Arc and pass it to `f` if it is cache-aware.
-    /// Returns `f`'s result, or the caller's `default` if this node
-    /// has no cache-aware policy for `model_id`. The policy Arc is
-    /// held for the duration of `f`, so downcast borrows are safe
+    /// Visit every distinct [`CacheAwarePolicy`] the registry could
+    /// dispatch requests through for `model_id`, in
+    /// most-specific-first order (per-model → default → PD/EPD legs),
+    /// invoking `f` on each. The `Arc<dyn ...>` is held for the
+    /// duration of each `f` call, so downcast borrows are safe
     /// against concurrent registry churn.
     ///
-    /// Emits a single `debug!` on the fallthrough branch so operators
-    /// can distinguish "legitimate empty result from a cache-aware
-    /// policy" (silent) from "this node is not authoritative for that
-    /// model" (grep-able) — the two look identical on the wire
-    /// otherwise, and the second case can drive spurious repair
-    /// traffic.
-    fn with_cache_aware<R>(
-        &self,
-        model_id: &str,
-        default: R,
-        f: impl FnOnce(&CacheAwarePolicy) -> R,
-    ) -> R {
-        let Some(policy) = self.registry.get_policy(model_id) else {
+    /// Emits a single `debug!` when the chain contains no
+    /// cache-aware policy so operators can distinguish a legitimate
+    /// empty result from "this node is not authoritative for that
+    /// model" — the two look identical on the wire otherwise, and
+    /// the second case can drive spurious repair traffic.
+    fn for_each_cache_aware(&self, model_id: &str, mut f: impl FnMut(&CacheAwarePolicy)) {
+        let policies = self.registry.policies_for_model(model_id);
+        let mut hit = false;
+        for policy in &policies {
+            if let Some(cache_aware) = policy.as_any().downcast_ref::<CacheAwarePolicy>() {
+                hit = true;
+                f(cache_aware);
+            }
+        }
+        if !hit {
             debug!(
                 model_id,
-                "tree-sync bridge: no policy registered for model on this node",
+                candidate_policies = policies.len(),
+                "tree-sync bridge: no cache-aware policy for model on this node",
             );
-            return default;
-        };
-        match policy.as_any().downcast_ref::<CacheAwarePolicy>() {
-            Some(cache_aware) => f(cache_aware),
-            None => {
-                debug!(
-                    model_id,
-                    policy = policy.name(),
-                    "tree-sync bridge: policy is not cache-aware on this node",
-                );
-                default
-            }
         }
     }
 }
@@ -251,9 +243,19 @@ impl TreeHandle for PolicyRegistryTreeHandle {
         node_hash: u64,
         worker_url: &str,
     ) -> bool {
-        self.with_cache_aware(model_id, false, |policy| {
-            policy.apply_known_remote_insert(model_id, tree_kind, node_hash, worker_url)
-        })
+        // First cache-aware policy in the chain that knows this
+        // hash wins; further policies are skipped because the delta
+        // has already been applied where it belongs.
+        let mut applied = false;
+        self.for_each_cache_aware(model_id, |policy| {
+            if applied {
+                return;
+            }
+            if policy.apply_known_remote_insert(model_id, tree_kind, node_hash, worker_url) {
+                applied = true;
+            }
+        });
+        applied
     }
 
     fn open_repair_stream(
@@ -261,16 +263,31 @@ impl TreeHandle for PolicyRegistryTreeHandle {
         model_id: &str,
         tree_kind: TreeKind,
     ) -> Option<Box<dyn Iterator<Item = RepairEntry> + Send>> {
-        // `open_repair_stream` returns an owned iterator, so the policy
-        // borrow only lives inside this closure — after it returns the
-        // iterator is self-contained (the underlying tree is Arc-shared).
-        self.with_cache_aware(model_id, None, |policy| {
-            policy.open_repair_stream(model_id, tree_kind)
-        })
+        // Return the first non-empty stream in the chain: the
+        // returned iterator is self-contained (underlying tree is
+        // Arc-shared) so the policy borrow can end when the closure
+        // returns.
+        let mut stream: Option<Box<dyn Iterator<Item = RepairEntry> + Send>> = None;
+        self.for_each_cache_aware(model_id, |policy| {
+            if stream.is_some() {
+                return;
+            }
+            stream = policy.open_repair_stream(model_id, tree_kind);
+        });
+        stream
     }
 
     fn apply_repair_page(&self, page: &TreeRepairPage) -> usize {
-        self.with_cache_aware(&page.model_id, 0, |policy| policy.apply_repair_page(page))
+        // Seed every cache-aware policy in the chain from the same
+        // page: in PD/EPD deployments both the prefill leg and the
+        // decode leg maintain their own routing tree and each needs
+        // the peer's state; delivering the page once per leg is
+        // cheap (per-entry `insert_text` / `insert_tokens`).
+        let mut total: usize = 0;
+        self.for_each_cache_aware(&page.model_id, |policy| {
+            total = total.saturating_add(policy.apply_repair_page(page));
+        });
+        total
     }
 }
 
@@ -362,16 +379,7 @@ mod tests {
     #[tokio::test]
     async fn tree_adapter_registers_and_flips_populate_flag() {
         let mesh = MeshKV::new("node-a".into());
-        let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::CacheAware {
-            cache_threshold: 0.5,
-            balance_abs_threshold: 32,
-            balance_rel_threshold: 1.5,
-            eviction_interval_secs: 60,
-            max_tree_size: 128,
-            block_size: 16,
-            balance_token_usage_threshold: 1.0,
-            overload_token_usage_threshold: 1.0,
-        }));
+        let policy_registry = Arc::new(PolicyRegistry::new(cache_aware_policy_config()));
         let _adapters = MeshAdapters::start(
             &mesh,
             "node-a".into(),
@@ -612,5 +620,100 @@ mod tests {
             "token select_worker must publish an additional TreeDelta \
              (before {after_string}, after {after_token})",
         );
+    }
+
+    /// The `TreeHandle` bridge must return the documented fallback
+    /// values (`false` / `None` / `0`) when the model has no
+    /// cache-aware policy in the chain — otherwise the tree adapter
+    /// cannot distinguish "delta legitimately unknown" from "no
+    /// policy on this node" and drives spurious repair traffic.
+    #[tokio::test]
+    async fn bridge_returns_fallbacks_when_no_cache_aware_policy() {
+        use crate::mesh::adapters::tree_sync::TreeRepairPage;
+
+        let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::Random));
+        let handle = PolicyRegistryTreeHandle::new(policy_registry);
+
+        assert!(
+            !handle.apply_known_remote_insert("no-such-model", TreeKind::String, 42, "http://w"),
+            "apply_known_remote_insert must return false when no cache-aware policy is reachable",
+        );
+        assert!(
+            handle
+                .open_repair_stream("no-such-model", TreeKind::String)
+                .is_none(),
+            "open_repair_stream must return None when no cache-aware policy is reachable",
+        );
+        let page = TreeRepairPage {
+            session_id: uuid::Uuid::nil(),
+            model_id: "no-such-model".into(),
+            tree_kind: TreeKind::String,
+            page_index: 0,
+            entries: Vec::new(),
+            next_cursor: None,
+            is_last: true,
+        };
+        assert_eq!(
+            handle.apply_repair_page(&page),
+            0,
+            "apply_repair_page must return 0 when no cache-aware policy is reachable",
+        );
+    }
+
+    /// A cache-aware default policy (no per-model entry, no PD legs)
+    /// must be reachable through the bridge — that's the shape a
+    /// single-model non-PD deployment has, and the fallback CodeRabbit
+    /// flagged as missing.
+    #[tokio::test]
+    async fn bridge_dispatches_through_default_policy() {
+        use kv_index::hash_node_path;
+
+        use crate::mesh::adapters::tree_sync::TreeRepairPage;
+
+        let policy_registry = Arc::new(PolicyRegistry::new(cache_aware_policy_config()));
+        // Do NOT touch `get_policy_or_default("m")` — we want the
+        // default policy path, not a per-model entry. Manually seed
+        // the default policy's hash_index so `apply_known_remote_insert`
+        // has something to resolve.
+        let default_policy = policy_registry.get_default_policy();
+        let cache_aware = default_policy
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .expect("default policy is cache-aware");
+        cache_aware.set_populate_hash_index_for_test_true();
+        let text = "hello world";
+        let path_hash = hash_node_path(text);
+        cache_aware.seed_hash_index_for_test(
+            crate::worker::UNKNOWN_MODEL_ID,
+            TreeKind::String,
+            path_hash,
+            text,
+        );
+
+        let handle = PolicyRegistryTreeHandle::new(policy_registry);
+        assert!(
+            handle.apply_known_remote_insert(
+                crate::worker::UNKNOWN_MODEL_ID,
+                TreeKind::String,
+                path_hash,
+                "http://w1:8000",
+            ),
+            "bridge must reach default_policy for models without a per-model entry",
+        );
+
+        // apply_repair_page over the same model should reach the
+        // default policy too — empty page trivially returns 0
+        // entries applied, but the fact that it does not panic
+        // proves the chain walked.
+        let page = TreeRepairPage {
+            session_id: uuid::Uuid::nil(),
+            model_id: crate::worker::UNKNOWN_MODEL_ID.into(),
+            tree_kind: TreeKind::String,
+            page_index: 0,
+            entries: Vec::new(),
+            next_cursor: None,
+            is_last: true,
+        };
+        assert_eq!(handle.apply_repair_page(&page), 0);
     }
 }

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -7,12 +7,41 @@
 //! mesh server's gossip starts so every remote op merges through its
 //! registered engine.
 
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
-use smg_mesh::{MergeStrategy, MeshKV};
+use smg_mesh::{
+    gossip::NodeStatus, ClusterState, MergeStrategy, MeshKV, StreamConfig, StreamRouting,
+};
+use tracing::debug;
 
-use super::adapters::{RateLimitSyncAdapter, WorkerSyncAdapter};
-use crate::worker::WorkerRegistry;
+use super::adapters::{
+    tree_sync::{
+        PeerList, RepairEntry, TreeRepairPage, TreeSyncAdapter, REPAIR_PAGE_PREFIX,
+        REPAIR_REQUEST_PREFIX, TENANT_DELTA_PREFIX,
+    },
+    RateLimitSyncAdapter, WorkerSyncAdapter,
+};
+use crate::{
+    policies::{CacheAwarePolicy, PolicyRegistry, TreeHandle, TreeKind},
+    worker::WorkerRegistry,
+};
+
+/// Buffer budget for the broadcast tenant-delta namespace (`td:`). Undersized
+/// buffers FIFO-evict pending deltas before drain — the receiver then repairs
+/// through the (much more expensive) `tree:req:`/`tree:page:` path. Sized to
+/// cover a few gossip rounds of steady-state routing traffic.
+const TD_BUFFER_BYTES: usize = 4 * 1024 * 1024;
+
+/// Buffer budget for the targeted repair-request namespace. Requests
+/// carry small per-session metadata (session id, requester + target
+/// peer id, model id, tree kind, an opaque resume cursor, and a
+/// reason enum) so this stays modest.
+const REPAIR_REQ_BUFFER_BYTES: usize = 256 * 1024;
+
+/// Buffer budget for the targeted repair-page namespace. Cold-start replay
+/// pages can span megabytes per session — keep this generous so a slow peer
+/// draining pages doesn't drop earlier ones.
+const REPAIR_PAGE_BUFFER_BYTES: usize = 32 * 1024 * 1024;
 
 /// Owns the started mesh sync adapters. Mesh on means every adapter here is
 /// constructed, its namespace registered, and its inbound loop running —
@@ -21,35 +50,89 @@ use crate::worker::WorkerRegistry;
 pub struct MeshAdapters {
     worker: Arc<WorkerSyncAdapter>,
     rate_limit: Arc<RateLimitSyncAdapter>,
+    tree: Arc<TreeSyncAdapter>,
 }
 
 impl MeshAdapters {
     /// Register the `worker:` (last-writer-wins) and `rl:` (epoch-max-wins)
-    /// CRDT namespaces, construct the adapters, and start their inbound sync
+    /// CRDT namespaces plus the `td:` / `tree:req:` / `tree:page:` stream
+    /// namespaces, construct the adapters, and start their inbound sync
     /// loops. One call because the adapters' `start` methods are not
     /// idempotent (each call spawns another subscription task).
     ///
     /// MUST be called before `MeshServer::start` spawns gossip: a remote op
     /// arriving for an unregistered prefix would merge through the default
-    /// last-writer-wins engine with the wrong semantics.
+    /// last-writer-wins engine with the wrong semantics, and a remote tenant
+    /// delta arriving before the tree adapter subscribes would be dropped.
+    ///
+    /// After construction the tree adapter is attached to `policy_registry`,
+    /// which propagates it (and flips `populate_hash_index` on) to every
+    /// existing and future [`CacheAwarePolicy`] instance.
     ///
     /// # Panics
     ///
-    /// Panics if either prefix is already configured (double call) or if
-    /// `node_name` is empty or contains `':'` (the rate-limit shard-key
-    /// separator).
+    /// Panics if any adapter's `start` invariants are violated — the
+    /// concrete sources are a double `start` call on the same [`MeshKV`]
+    /// (each adapter registers exactly one drain per prefix) and an
+    /// empty `node_name` (asserted by every adapter); the rate-limit
+    /// adapter additionally rejects a `node_name` containing `':'`
+    /// because it is the shard-key separator.
     pub fn start(
         mesh_kv: &MeshKV,
         node_name: String,
         worker_registry: Arc<WorkerRegistry>,
+        cluster_state: ClusterState,
+        policy_registry: Arc<PolicyRegistry>,
     ) -> Arc<Self> {
         let worker_ns = mesh_kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
         let rl_ns = mesh_kv.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+        let td_ns = mesh_kv.configure_stream_prefix(
+            TENANT_DELTA_PREFIX,
+            StreamConfig {
+                max_buffer_bytes: TD_BUFFER_BYTES,
+                routing: StreamRouting::Broadcast,
+            },
+        );
+        let repair_req_ns = mesh_kv.configure_stream_prefix(
+            REPAIR_REQUEST_PREFIX,
+            StreamConfig {
+                max_buffer_bytes: REPAIR_REQ_BUFFER_BYTES,
+                routing: StreamRouting::Targeted,
+            },
+        );
+        let repair_page_ns = mesh_kv.configure_stream_prefix(
+            REPAIR_PAGE_PREFIX,
+            StreamConfig {
+                max_buffer_bytes: REPAIR_PAGE_BUFFER_BYTES,
+                routing: StreamRouting::Targeted,
+            },
+        );
         let worker = WorkerSyncAdapter::new(worker_ns, worker_registry);
-        let rate_limit = RateLimitSyncAdapter::new(rl_ns, node_name);
+        let rate_limit = RateLimitSyncAdapter::new(rl_ns, node_name.clone());
+        let peers: Arc<dyn PeerList> =
+            Arc::new(ClusterStatePeerList::new(cluster_state, node_name.clone()));
+        let tree_handle: Arc<dyn TreeHandle> =
+            Arc::new(PolicyRegistryTreeHandle::new(policy_registry.clone()));
+        let tree = TreeSyncAdapter::new(
+            td_ns,
+            repair_req_ns,
+            repair_page_ns,
+            tree_handle,
+            peers,
+            node_name,
+        );
         worker.start();
         rate_limit.start();
-        Arc::new(Self { worker, rate_limit })
+        tree.start();
+        // Only after the adapter is subscribed to the `td:` stream do we
+        // let policies start writing to it — otherwise the very first
+        // hot-path delta races the subscription setup and is dropped.
+        policy_registry.set_mesh_tree_sync(Some(tree.clone()));
+        Arc::new(Self {
+            worker,
+            rate_limit,
+            tree,
+        })
     }
 
     /// Worker sync adapter.
@@ -61,26 +144,184 @@ impl MeshAdapters {
     pub fn rate_limit(&self) -> &Arc<RateLimitSyncAdapter> {
         &self.rate_limit
     }
+
+    /// Tree sync adapter (cache-aware tenant deltas + repair).
+    pub fn tree(&self) -> &Arc<TreeSyncAdapter> {
+        &self.tree
+    }
+}
+
+/// [`PeerList`] impl backed by the mesh [`ClusterState`]. Reports every
+/// node whose `NodeStatus == Alive` other than this node. Read on the
+/// gossip tick (repair scan), so a read-lock is fine.
+struct ClusterStatePeerList {
+    state: ClusterState,
+    self_name: String,
+}
+
+impl ClusterStatePeerList {
+    fn new(state: ClusterState, self_name: String) -> Self {
+        Self { state, self_name }
+    }
+}
+
+impl fmt::Debug for ClusterStatePeerList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClusterStatePeerList")
+            .field("self_name", &self.self_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PeerList for ClusterStatePeerList {
+    fn alive_peers(&self) -> Vec<String> {
+        let state = self.state.read();
+        state
+            .values()
+            .filter(|node| node.status == NodeStatus::Alive as i32 && node.name != self.self_name)
+            .map(|node| node.name.clone())
+            .collect()
+    }
+}
+
+/// [`TreeHandle`] that dispatches per-`model_id` to whichever
+/// [`CacheAwarePolicy`] the registry has for that model. Non-cache-aware
+/// policies (or absent models) return the "unknown hash / no local tree"
+/// defaults so the adapter can request repair or skip the update.
+struct PolicyRegistryTreeHandle {
+    registry: Arc<PolicyRegistry>,
+}
+
+impl PolicyRegistryTreeHandle {
+    fn new(registry: Arc<PolicyRegistry>) -> Self {
+        Self { registry }
+    }
+
+    /// Fetch the policy Arc and pass it to `f` if it is cache-aware.
+    /// Returns `f`'s result, or the caller's `default` if this node
+    /// has no cache-aware policy for `model_id`. The policy Arc is
+    /// held for the duration of `f`, so downcast borrows are safe
+    /// against concurrent registry churn.
+    ///
+    /// Emits a single `debug!` on the fallthrough branch so operators
+    /// can distinguish "legitimate empty result from a cache-aware
+    /// policy" (silent) from "this node is not authoritative for that
+    /// model" (grep-able) — the two look identical on the wire
+    /// otherwise, and the second case can drive spurious repair
+    /// traffic.
+    fn with_cache_aware<R>(
+        &self,
+        model_id: &str,
+        default: R,
+        f: impl FnOnce(&CacheAwarePolicy) -> R,
+    ) -> R {
+        let Some(policy) = self.registry.get_policy(model_id) else {
+            debug!(
+                model_id,
+                "tree-sync bridge: no policy registered for model on this node",
+            );
+            return default;
+        };
+        match policy.as_any().downcast_ref::<CacheAwarePolicy>() {
+            Some(cache_aware) => f(cache_aware),
+            None => {
+                debug!(
+                    model_id,
+                    policy = policy.name(),
+                    "tree-sync bridge: policy is not cache-aware on this node",
+                );
+                default
+            }
+        }
+    }
+}
+
+impl fmt::Debug for PolicyRegistryTreeHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PolicyRegistryTreeHandle")
+            .finish_non_exhaustive()
+    }
+}
+
+impl TreeHandle for PolicyRegistryTreeHandle {
+    fn apply_known_remote_insert(
+        &self,
+        model_id: &str,
+        tree_kind: TreeKind,
+        node_hash: u64,
+        worker_url: &str,
+    ) -> bool {
+        self.with_cache_aware(model_id, false, |policy| {
+            policy.apply_known_remote_insert(model_id, tree_kind, node_hash, worker_url)
+        })
+    }
+
+    fn open_repair_stream(
+        &self,
+        model_id: &str,
+        tree_kind: TreeKind,
+    ) -> Option<Box<dyn Iterator<Item = RepairEntry> + Send>> {
+        // `open_repair_stream` returns an owned iterator, so the policy
+        // borrow only lives inside this closure — after it returns the
+        // iterator is self-contained (the underlying tree is Arc-shared).
+        self.with_cache_aware(model_id, None, |policy| {
+            policy.open_repair_stream(model_id, tree_kind)
+        })
+    }
+
+    fn apply_repair_page(&self, page: &TreeRepairPage) -> usize {
+        self.with_cache_aware(&page.model_id, 0, |policy| policy.apply_repair_page(page))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{collections::BTreeMap, time::Duration};
 
-    use smg_mesh::WorkerState;
+    use openai_protocol::worker::HealthCheckConfig;
+    use parking_lot::RwLock;
+    use smg_mesh::{gossip::NodeState, WorkerState};
     use tokio::time::sleep;
 
     use super::*;
+    use crate::{
+        config::types::PolicyConfig,
+        policies::SelectWorkerInfo,
+        worker::{BasicWorkerBuilder, Worker, WorkerType},
+    };
+
+    fn no_health_check() -> HealthCheckConfig {
+        HealthCheckConfig {
+            disable_health_check: true,
+            ..Default::default()
+        }
+    }
+
+    fn empty_cluster_state() -> ClusterState {
+        Arc::new(RwLock::new(BTreeMap::new()))
+    }
 
     fn started(mesh: &MeshKV) -> Arc<MeshAdapters> {
-        MeshAdapters::start(mesh, "node-a".into(), Arc::new(WorkerRegistry::new()))
+        MeshAdapters::start(
+            mesh,
+            "node-a".into(),
+            Arc::new(WorkerRegistry::new()),
+            empty_cluster_state(),
+            Arc::new(PolicyRegistry::new(PolicyConfig::Random)),
+        )
     }
 
     #[tokio::test]
     async fn start_wires_worker_inbound_end_to_end() {
         let mesh = MeshKV::new("node-a".into());
         let registry = Arc::new(WorkerRegistry::new());
-        let adapters = MeshAdapters::start(&mesh, "node-a".into(), registry.clone());
+        let adapters = MeshAdapters::start(
+            &mesh,
+            "node-a".into(),
+            registry.clone(),
+            empty_cluster_state(),
+            Arc::new(PolicyRegistry::new(PolicyConfig::Random)),
+        );
 
         // A put through the adapter echoes back through the namespace
         // subscription, exercising the registered prefix and the live
@@ -119,6 +360,78 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tree_adapter_registers_and_flips_populate_flag() {
+        let mesh = MeshKV::new("node-a".into());
+        let policy_registry = Arc::new(PolicyRegistry::new(PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 32,
+            balance_rel_threshold: 1.5,
+            eviction_interval_secs: 60,
+            max_tree_size: 128,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+        }));
+        let _adapters = MeshAdapters::start(
+            &mesh,
+            "node-a".into(),
+            Arc::new(WorkerRegistry::new()),
+            empty_cluster_state(),
+            policy_registry.clone(),
+        );
+
+        // A fresh model → policy created on demand should inherit the
+        // adapter + populate flag from the registry.
+        let policy = policy_registry.get_policy_or_default("llama-3");
+        let cache_aware = policy
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .expect("cache_aware default policy");
+        assert!(
+            cache_aware.should_populate_hash_index_for_test(),
+            "wiring must flip populate_hash_index when the adapter is attached",
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_list_reports_alive_only() {
+        let state: ClusterState = Arc::new(RwLock::new(BTreeMap::from([
+            (
+                "node-a".to_string(),
+                NodeState {
+                    name: "node-a".into(),
+                    address: "127.0.0.1:9000".into(),
+                    status: NodeStatus::Alive as i32,
+                    version: 1,
+                    metadata: Default::default(),
+                },
+            ),
+            (
+                "node-b".to_string(),
+                NodeState {
+                    name: "node-b".into(),
+                    address: "127.0.0.1:9001".into(),
+                    status: NodeStatus::Alive as i32,
+                    version: 1,
+                    metadata: Default::default(),
+                },
+            ),
+            (
+                "node-c".to_string(),
+                NodeState {
+                    name: "node-c".into(),
+                    address: "127.0.0.1:9002".into(),
+                    status: NodeStatus::Down as i32,
+                    version: 1,
+                    metadata: Default::default(),
+                },
+            ),
+        ])));
+        let peers = ClusterStatePeerList::new(state, "node-a".into());
+        assert_eq!(peers.alive_peers(), vec!["node-b".to_string()]);
+    }
+
+    #[tokio::test]
     #[should_panic(expected = "already configured")]
     async fn start_panics_on_second_call() {
         let mesh = MeshKV::new("node-a".into());
@@ -130,6 +443,174 @@ mod tests {
     #[should_panic(expected = "must not contain ':'")]
     async fn start_panics_on_colon_node_name() {
         let mesh = MeshKV::new("node-a".into());
-        let _ = MeshAdapters::start(&mesh, "node:a".into(), Arc::new(WorkerRegistry::new()));
+        let _ = MeshAdapters::start(
+            &mesh,
+            "node:a".into(),
+            Arc::new(WorkerRegistry::new()),
+            empty_cluster_state(),
+            Arc::new(PolicyRegistry::new(PolicyConfig::Random)),
+        );
+    }
+
+    fn cache_aware_policy_config() -> PolicyConfig {
+        PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 32,
+            balance_rel_threshold: 1.5,
+            eviction_interval_secs: 60,
+            max_tree_size: 128,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+        }
+    }
+
+    /// The atomic setter must reach model policies that already exist
+    /// before wiring runs — not just future-created ones. Regression
+    /// guard for the propagation path in `set_mesh_tree_sync`.
+    #[tokio::test]
+    async fn start_propagates_to_preexisting_model_policies() {
+        let policy_registry = Arc::new(PolicyRegistry::new(cache_aware_policy_config()));
+        // Create a per-model cache-aware policy BEFORE wiring runs, so
+        // it lives in `model_policies` at attach time.
+        let preexisting = policy_registry.get_policy_or_default("qwen2");
+        let cache_aware = preexisting
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .expect("cache_aware model policy");
+        assert!(
+            !cache_aware.should_populate_hash_index_for_test(),
+            "populate flag defaults off before wiring",
+        );
+
+        let mesh = MeshKV::new("node-a".into());
+        let _adapters = MeshAdapters::start(
+            &mesh,
+            "node-a".into(),
+            Arc::new(WorkerRegistry::new()),
+            empty_cluster_state(),
+            policy_registry.clone(),
+        );
+
+        assert!(
+            cache_aware.should_populate_hash_index_for_test(),
+            "wiring must propagate the adapter to already-existing model policies",
+        );
+    }
+
+    /// `set_mesh_tree_sync(None)` must undo both flips atomically so
+    /// the hot path stops emitting deltas and stops populating the
+    /// index — otherwise we'd keep growing an index nothing reads.
+    #[tokio::test]
+    async fn detach_clears_populate_flag() {
+        let policy_registry = Arc::new(PolicyRegistry::new(cache_aware_policy_config()));
+        let mesh = MeshKV::new("node-a".into());
+        let _adapters = MeshAdapters::start(
+            &mesh,
+            "node-a".into(),
+            Arc::new(WorkerRegistry::new()),
+            empty_cluster_state(),
+            policy_registry.clone(),
+        );
+        let policy = policy_registry.get_policy_or_default("llama-3");
+        let cache_aware = policy
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .expect("cache_aware default policy");
+        assert!(cache_aware.should_populate_hash_index_for_test());
+
+        policy_registry.set_mesh_tree_sync(None);
+        assert!(
+            !cache_aware.should_populate_hash_index_for_test(),
+            "detach must clear the populate flag",
+        );
+    }
+
+    /// Every producer-side hash-index write must publish a matching
+    /// `TreeDelta` — this is what closes #1578. Deleting either
+    /// `sync_local_insert` call at the two `select_worker_*` sites
+    /// makes this test fail (the pending buffer stays empty on the
+    /// exercised branch), which is the regression guard we lacked.
+    #[tokio::test]
+    async fn producer_hook_publishes_delta_on_select_worker() {
+        use crate::worker::UNKNOWN_MODEL_ID;
+
+        let policy_registry = Arc::new(PolicyRegistry::new(cache_aware_policy_config()));
+        let mesh = MeshKV::new("node-a".into());
+        let adapters = MeshAdapters::start(
+            &mesh,
+            "node-a".into(),
+            Arc::new(WorkerRegistry::new()),
+            empty_cluster_state(),
+            policy_registry.clone(),
+        );
+
+        // Workers with no model_id → select_worker derives
+        // UNKNOWN_MODEL_ID; assert on the same bucket the delta
+        // lands under.
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .health_config(no_health_check())
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .health_config(no_health_check())
+                    .build(),
+            ),
+        ];
+
+        let policy = policy_registry.get_policy_or_default(UNKNOWN_MODEL_ID);
+        let cache_aware = policy
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .expect("cache_aware policy");
+        cache_aware.init_workers(&workers);
+        assert_eq!(
+            adapters
+                .tree()
+                .pending_delta_count_for_test(UNKNOWN_MODEL_ID),
+            0,
+            "no delta should be pending before any request",
+        );
+
+        // Drive a string request — populates the string tree and
+        // must call `sync_local_insert`.
+        let _ = policy.select_worker(
+            &workers,
+            &SelectWorkerInfo {
+                request_text: Some("the quick brown fox jumps over the lazy dog"),
+                ..Default::default()
+            },
+        );
+        let after_string = adapters
+            .tree()
+            .pending_delta_count_for_test(UNKNOWN_MODEL_ID);
+        assert!(
+            after_string >= 1,
+            "string select_worker must publish at least one TreeDelta (got {after_string})",
+        );
+
+        // Drive a token request — populates the token tree and
+        // must call `sync_local_insert` on the other branch.
+        let tokens: Vec<u32> = (0..32).collect();
+        let _ = policy.select_worker(
+            &workers,
+            &SelectWorkerInfo {
+                tokens: Some(&tokens),
+                ..Default::default()
+            },
+        );
+        let after_token = adapters
+            .tree()
+            .pending_delta_count_for_test(UNKNOWN_MODEL_ID);
+        assert!(
+            after_token > after_string,
+            "token select_worker must publish an additional TreeDelta \
+             (before {after_string}, after {after_token})",
+        );
     }
 }

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -266,6 +266,52 @@ impl CacheAwarePolicy {
         self.should_populate_hash_index()
     }
 
+    /// Test-only: flip populate on without going through the mesh
+    /// wiring path. Used by bridge tests that need to seed
+    /// `hash_index` directly.
+    #[cfg(test)]
+    pub fn set_populate_hash_index_for_test_true(&self) {
+        self.set_populate_hash_index(true);
+    }
+
+    /// Test-only: seed a single hash-index entry so bridge tests
+    /// can exercise the inbound resolution path without driving a
+    /// full request through `select_worker`. `matched` is the
+    /// matched-prefix shape the populate site would normally store
+    /// (full text for string / full token vec for token) — for a
+    /// unit test that only asserts the lookup succeeded, any
+    /// non-empty value works because the underlying tree seeds
+    /// itself in `apply_known_remote_insert`.
+    #[cfg(test)]
+    pub fn seed_hash_index_for_test(
+        &self,
+        model_id: &str,
+        tree_kind: TreeKind,
+        node_hash: u64,
+        matched: &str,
+    ) {
+        let entry = self.hash_index.entry(model_id.to_string()).or_default();
+        match tree_kind {
+            TreeKind::String => {
+                entry.string_tree.insert(node_hash, matched.to_string());
+                // Ensure the string_tree map has a matching tree so
+                // apply_known_remote_insert doesn't hit the
+                // populate-site invariant warning.
+                self.string_trees
+                    .entry(model_id.to_string())
+                    .or_insert_with(|| Arc::new(Tree::new()));
+            }
+            TreeKind::Token => {
+                entry
+                    .token_tree
+                    .insert(node_hash, matched.bytes().map(u32::from).collect());
+                self.token_trees
+                    .entry(model_id.to_string())
+                    .or_insert_with(|| Arc::new(TokenTree::new()));
+            }
+        }
+    }
+
     /// Attach the mesh outbound bridge and enable hash-index population
     /// in one atomic step; pass `None` to detach and disable both. The
     /// pair moves together because the hash-index has no non-mesh
@@ -278,10 +324,10 @@ impl CacheAwarePolicy {
     /// `set_kv_event_monitor` / `set_load_receiver`.
     pub fn set_mesh_tree_sync(&self, adapter: Option<Arc<TreeSyncAdapter>>) {
         let populate = adapter.is_some();
-        {
-            let mut guard = self.mesh_tree_sync.write();
-            *guard = adapter;
-        }
+        let mut guard = self.mesh_tree_sync.write();
+        *guard = adapter;
+        // Store under the guard so no observer can see the pair
+        // split (adapter attached ↔ populate flag on).
         self.populate_hash_index.store(populate, Ordering::Relaxed);
     }
 
@@ -1112,7 +1158,9 @@ impl CacheAwarePolicy {
                     // the node_hash keys the hash_index entry we
                     // just wrote, so a receiver that repairs against
                     // us will land the same worker onto the same
-                    // tree node.
+                    // tree node. `epoch: 0` — the field is a reserved
+                    // slot the current receiver does not consult
+                    // (see `TreeDelta::epoch`).
                     self.sync_local_insert(
                         model_id,
                         TreeDelta {

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -63,7 +63,7 @@ use super::{
     SelectWorkerInfo,
 };
 use crate::{
-    mesh::adapters::tree_sync::{RepairEntry, TreeRepairPage},
+    mesh::adapters::tree_sync::{RepairEntry, TreeDelta, TreeRepairPage, TreeSyncAdapter},
     worker::{KvEventMonitor, Worker},
 };
 
@@ -121,6 +121,16 @@ pub struct CacheAwarePolicy {
     /// gateway. Off by default; the mesh wiring code flips it on
     /// when it attaches.
     populate_hash_index: AtomicBool,
+    /// Outbound bridge into the mesh `td:` broadcast namespace.
+    /// `Some` after [`Self::set_mesh_tree_sync`] (called by mesh wiring
+    /// at startup); `None` when mesh is disabled, in which case
+    /// `sync_local_insert` is a no-op. The setter also toggles
+    /// [`Self::populate_hash_index`] to match adapter presence so the
+    /// two never drift apart. Note the pairing is best-effort at a
+    /// point-in-time — later eviction of a hash-index entry can leave
+    /// a still-in-flight delta with no local resolution; peers that
+    /// repair against us will simply see the gap the next tick.
+    mesh_tree_sync: RwLock<Option<Arc<TreeSyncAdapter>>>,
 }
 
 /// Per-model inner container for [`CacheAwarePolicy::hash_index`].
@@ -230,18 +240,62 @@ impl CacheAwarePolicy {
             load_rx: RwLock::new(None),
             hash_index,
             populate_hash_index: AtomicBool::new(false),
+            mesh_tree_sync: RwLock::new(None),
         }
     }
 
-    /// Enable request-hot-path `hash_index` population. Called by mesh
-    /// wiring when the policy is attached to a mesh adapter; otherwise
-    /// the index stays empty (its only readers are mesh-only paths).
-    pub fn set_populate_hash_index(&self, enabled: bool) {
+    /// Enable request-hot-path `hash_index` population without attaching
+    /// an adapter. Only exists so unit tests can seed the populate flag
+    /// without the ceremony of wiring in a real [`TreeSyncAdapter`];
+    /// production code goes through [`Self::set_mesh_tree_sync`], which
+    /// flips both fields together.
+    #[cfg(test)]
+    fn set_populate_hash_index(&self, enabled: bool) {
         self.populate_hash_index.store(enabled, Ordering::Relaxed);
     }
 
     fn should_populate_hash_index(&self) -> bool {
         self.populate_hash_index.load(Ordering::Relaxed)
+    }
+
+    /// Test-only view onto the populate flag so integration tests
+    /// outside this file can assert wiring flipped it. Not part of
+    /// the public API.
+    #[cfg(test)]
+    pub fn should_populate_hash_index_for_test(&self) -> bool {
+        self.should_populate_hash_index()
+    }
+
+    /// Attach the mesh outbound bridge and enable hash-index population
+    /// in one atomic step; pass `None` to detach and disable both. The
+    /// pair moves together because the hash-index has no non-mesh
+    /// readers — enabling population without an adapter attached would
+    /// waste memory, and the producer-side `sync_local_insert` calls
+    /// only fire while population is on.
+    ///
+    /// Interior-mutability setter so it composes with policies stored
+    /// behind `Arc<dyn LoadBalancingPolicy>` after construction, matching
+    /// `set_kv_event_monitor` / `set_load_receiver`.
+    pub fn set_mesh_tree_sync(&self, adapter: Option<Arc<TreeSyncAdapter>>) {
+        let populate = adapter.is_some();
+        {
+            let mut guard = self.mesh_tree_sync.write();
+            *guard = adapter;
+        }
+        self.populate_hash_index.store(populate, Ordering::Relaxed);
+    }
+
+    /// Publish one local tree change to the mesh outbound buffer.
+    /// No-op when no adapter is attached — cheap check on the hot path.
+    /// The `Arc` is cloned out before invoking `on_local_insert` so the
+    /// adapter callback never runs under our read lock (avoids a future
+    /// deadlock if the adapter path ever wants to write back into any
+    /// policy state).
+    fn sync_local_insert(&self, model_id: &str, delta: TreeDelta) {
+        let adapter = self.mesh_tree_sync.read().as_ref().map(Arc::clone);
+        if let Some(adapter) = adapter {
+            adapter.on_local_insert(model_id, delta);
+        }
     }
 
     /// Set event-driven KV cache monitor (thread-safe, can be called after construction).
@@ -1048,11 +1102,26 @@ impl CacheAwarePolicy {
                 // returned by match_and_insert_with.
                 if self.should_populate_hash_index() {
                     let matched_prefix: Vec<u32> = tokens[..result.matched_token_count].to_vec();
+                    let node_hash = kv_index::hash_token_path(tokens);
                     self.hash_index
                         .entry(model_id.to_string())
                         .or_default()
                         .token_tree
-                        .insert(kv_index::hash_token_path(tokens), matched_prefix);
+                        .insert(node_hash, matched_prefix);
+                    // Publish only what peers can already resolve:
+                    // the node_hash keys the hash_index entry we
+                    // just wrote, so a receiver that repairs against
+                    // us will land the same worker onto the same
+                    // tree node.
+                    self.sync_local_insert(
+                        model_id,
+                        TreeDelta {
+                            tree_kind: TreeKind::Token,
+                            node_hash,
+                            worker_url: workers[idx].url().to_string(),
+                            epoch: 0,
+                        },
+                    );
                 }
                 workers[idx].increment_processed();
                 return Some(idx);
@@ -1134,6 +1203,15 @@ impl CacheAwarePolicy {
                         .or_default()
                         .string_tree
                         .insert(path_hash, matched_prefix);
+                    self.sync_local_insert(
+                        model_id,
+                        TreeDelta {
+                            tree_kind: TreeKind::String,
+                            node_hash: path_hash,
+                            worker_url: workers[idx].url().to_string(),
+                            epoch: 0,
+                        },
+                    );
                 }
 
                 workers[idx].increment_processed();

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -330,6 +330,44 @@ impl PolicyRegistry {
             .unwrap_or_else(|| self.get_default_policy())
     }
 
+    /// Every distinct policy this registry might dispatch requests
+    /// through for `model_id`, ordered from most-specific to least
+    /// (per-model → default → PD/EPD legs). Deduplicated by `Arc`
+    /// pointer identity so a policy that appears in multiple slots
+    /// (e.g. the same `CacheAwarePolicy` as both default and prefill
+    /// leg) is returned once.
+    ///
+    /// The tree-sync bridge uses this to reach every `CacheAwarePolicy`
+    /// that could have produced a delta for `model_id` — reaching
+    /// only `model_policies` misses PD-leg and default-fallback
+    /// deployments, and inbound deltas never resolve.
+    pub(crate) fn policies_for_model(&self, model_id: &str) -> Vec<Arc<dyn LoadBalancingPolicy>> {
+        let mut out: Vec<Arc<dyn LoadBalancingPolicy>> = Vec::new();
+        let mut push = |candidate: Arc<dyn LoadBalancingPolicy>| {
+            let ptr = Arc::as_ptr(&candidate) as *const ();
+            if !out
+                .iter()
+                .any(|existing| Arc::as_ptr(existing) as *const () == ptr)
+            {
+                out.push(candidate);
+            }
+        };
+        if let Some(policy) = self.get_policy(model_id) {
+            push(policy);
+        }
+        push(Arc::clone(&self.default_policy));
+        if let Some(p) = self.prefill_policy.get() {
+            push(Arc::clone(p));
+        }
+        if let Some(p) = self.decode_policy.get() {
+            push(Arc::clone(p));
+        }
+        if let Some(p) = self.encode_policy.get() {
+            push(Arc::clone(p));
+        }
+        out
+    }
+
     /// Determine policy for a new model
     fn determine_policy_for_model(
         &self,

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -19,6 +19,7 @@ use super::{
 };
 use crate::{
     config::types::{PolicyConfig, RoutingKeyOverrideConfig},
+    mesh::adapters::TreeSyncAdapter,
     policies::cache_aware::LoadReceiver,
     routers::common::header_utils::extract_routing_key,
     worker::{KvEventMonitor, Worker},
@@ -53,6 +54,12 @@ pub struct PolicyRegistry {
     /// set, new CacheAwarePolicy instances are injected with it for the KV-usage
     /// imbalance trigger.
     load_rx: Arc<RwLock<Option<LoadReceiver>>>,
+
+    /// Optional mesh outbound bridge. When set, every cache-aware policy
+    /// created here is attached to this adapter so its local tree inserts
+    /// join the next gossip round. Absence means mesh is disabled and
+    /// cache-aware policies stay local.
+    mesh_tree_sync: Arc<RwLock<Option<Arc<TreeSyncAdapter>>>>,
 
     // DP-rank policy: Supports the selection of dp-rank outside the engine.
     dp_rank_policy: Arc<OnceLock<Arc<dyn DPRankLoadPolicy>>>,
@@ -93,6 +100,7 @@ impl PolicyRegistry {
             encode_policy: Arc::new(OnceLock::new()),
             kv_event_monitor: Arc::new(RwLock::new(None)),
             load_rx: Arc::new(RwLock::new(None)),
+            mesh_tree_sync: Arc::new(RwLock::new(None)),
             dp_rank_policy: Arc::new(OnceLock::new()),
             routing_key_sticky,
         }
@@ -186,6 +194,44 @@ impl PolicyRegistry {
     fn maybe_inject_load_rx(policy: &Arc<dyn LoadBalancingPolicy>, rx: Option<&LoadReceiver>) {
         if let Some(cache_aware) = policy.as_any().downcast_ref::<CacheAwarePolicy>() {
             cache_aware.set_load_receiver(rx.cloned());
+        }
+    }
+
+    /// Attach the mesh outbound bridge (thread-safe, can be called after
+    /// initialization). Every existing cache-aware policy gets the adapter
+    /// wired in and its `populate_hash_index` flag flipped on (both flip
+    /// atomically inside [`CacheAwarePolicy::set_mesh_tree_sync`]); every
+    /// future cache-aware policy created here inherits both. Pass `None`
+    /// to detach.
+    pub fn set_mesh_tree_sync(&self, adapter: Option<Arc<TreeSyncAdapter>>) {
+        {
+            let mut guard = self.mesh_tree_sync.write();
+            guard.clone_from(&adapter);
+        }
+        Self::maybe_inject_mesh_tree_sync(&self.default_policy, adapter.as_ref());
+        if let Some(p) = self.prefill_policy.get() {
+            Self::maybe_inject_mesh_tree_sync(p, adapter.as_ref());
+        }
+        if let Some(p) = self.decode_policy.get() {
+            Self::maybe_inject_mesh_tree_sync(p, adapter.as_ref());
+        }
+        if let Some(p) = self.encode_policy.get() {
+            Self::maybe_inject_mesh_tree_sync(p, adapter.as_ref());
+        }
+        for entry in self.model_policies.iter() {
+            Self::maybe_inject_mesh_tree_sync(entry.value(), adapter.as_ref());
+        }
+    }
+
+    /// Inject the mesh adapter into a policy if it's cache-aware.
+    /// The setter also flips `populate_hash_index` to match adapter
+    /// presence, so callers do not need to touch that flag directly.
+    fn maybe_inject_mesh_tree_sync(
+        policy: &Arc<dyn LoadBalancingPolicy>,
+        adapter: Option<&Arc<TreeSyncAdapter>>,
+    ) {
+        if let Some(cache_aware) = policy.as_any().downcast_ref::<CacheAwarePolicy>() {
+            cache_aware.set_mesh_tree_sync(adapter.cloned());
         }
     }
 
@@ -315,6 +361,12 @@ impl PolicyRegistry {
                 let guard = self.load_rx.read();
                 if let Some(ref rx) = *guard {
                     cache_aware.set_load_receiver(Some(rx.clone()));
+                }
+            }
+            {
+                let guard = self.mesh_tree_sync.read();
+                if let Some(ref adapter) = *guard {
+                    cache_aware.set_mesh_tree_sync(Some(Arc::clone(adapter)));
                 }
             }
             Arc::new(cache_aware)

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1089,6 +1089,8 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
             handler.mesh_kv(),
             handler.self_name.clone(),
             app_context.worker_registry.clone(),
+            handler.state.clone(),
+            app_context.policy_registry.clone(),
         )
     });
     if let Some(mesh_server) = mesh_server {


### PR DESCRIPTION
## Description

### Problem

Cache-aware policy tree state does not synchronize across mesh nodes even
when `--enable-mesh` is on. Router B starts with an empty routing tree after
Router A fails, losing all cache affinity. `path_hash_index` metrics return
`-1`; observed routing consistency after failover is `-100%` across all seven
warm-up strategies tested in #1578.

Root cause: the pieces are all present — `TreeSyncAdapter` implementation,
`CacheAwarePolicy::apply_known_remote_insert` / `apply_repair_page` /
`populate_hash_index` flag, hash-index generators — but the composition root
`MeshAdapters::start` (`model_gateway/src/mesh/wiring.rs`) only wires the
`worker:` and `rl:` CRDT namespaces. The `td:` / `tree:req:` / `tree:page:`
stream namespaces are never registered, no `TreeSyncAdapter` is ever
constructed, no producer-side hook fires, and `populate_hash_index` stays
`false` at its default.

Closes #1578.

### Solution

Extend `MeshAdapters::start` to register the three tree-sync stream
namespaces, construct a `TreeSyncAdapter`, and attach it to the running
`PolicyRegistry`. The registry propagates the adapter (and flips
`populate_hash_index` on) to every existing and future `CacheAwarePolicy`,
matching the pattern already used for `KvEventMonitor` / `LoadReceiver`.

Producer side: `CacheAwarePolicy::select_worker_with_tokens` and
`select_worker_with_text` publish a `TreeDelta` right after every
`hash_index` write, using the same `hash_token_path(tokens)` /
`hash_node_path(text)` keys — so peers that request repair land on the same
tree node.

Consumer side: `PolicyRegistryTreeHandle` implements `TreeHandle` and
dispatches per-`model_id` to whichever `CacheAwarePolicy` the registry has
for that model. `ClusterStatePeerList` implements `PeerList` by reading
`ClusterState` and filtering to alive non-self peers.

## Changes

- `model_gateway/src/mesh/wiring.rs` — `MeshAdapters::start` grows two
  parameters (`ClusterState`, `Arc<PolicyRegistry>`); registers `td:`
  (broadcast), `tree:req:` (targeted), `tree:page:` (targeted) stream
  namespaces; constructs `TreeSyncAdapter` with `PolicyRegistryTreeHandle` +
  `ClusterStatePeerList`; starts it before flipping `set_mesh_tree_sync` on
  the registry (order matters — see comment).
- `model_gateway/src/policies/cache_aware.rs` — adds `mesh_tree_sync`
  field and `set_mesh_tree_sync` setter that atomically attaches the
  adapter AND flips `populate_hash_index` (single call, one write lock,
  one atomic store) so the paired invariant cannot drift; adds
  `sync_local_insert` helper (clones the adapter Arc out of the read
  guard before invoking `on_local_insert`, so a future adapter path can
  never deadlock against the policy read lock); wires the producer hook
  into both `select_worker_*` sites right after the `hash_index` write.
- `model_gateway/src/policies/registry.rs` — adds `mesh_tree_sync` field,
  `set_mesh_tree_sync` (propagates to default + PD + all model policies),
  `maybe_inject_mesh_tree_sync` helper, and injection in
  `create_policy_from_type` so lazily-created per-model policies inherit
  the adapter. The registry uses the single atomic setter throughout;
  the standalone `set_populate_hash_index` on `CacheAwarePolicy` is
  gated `#[cfg(test)]` because the pair now moves together in
  production.
- `model_gateway/src/mesh/adapters/tree_sync.rs` — makes the three prefix
  constants `pub(crate)` so wiring can reference them; adds a
  `#[cfg(test)] pub(crate) fn pending_delta_count_for_test(...)` view
  onto the outbound buffer so wiring integration tests can assert the
  producer hook fired without waiting a gossip tick for drain.
- `model_gateway/src/server.rs` — passes `handler.state` and
  `app_context.policy_registry` to `MeshAdapters::start`.

The wiring flips `populate_hash_index` and the outbound adapter together —
individually flipping only one would either OOM the gateway (index writes
with no readers, mesh off) or publish deltas the local node cannot resolve
on repair (adapter attached but index empty, mesh on).

## Test Plan

Unit tests, added to `model_gateway/src/mesh/wiring.rs`:

- `start_wires_worker_inbound_end_to_end` — existing test, extended with
  the new `MeshAdapters::start` signature; confirms `worker:` CRDT inbound
  loop still runs.
- `rl_namespace_uses_epoch_max_wins` — existing, extended.
- `tree_adapter_registers_and_flips_populate_flag` — new. Constructs
  `MeshAdapters` with a `PolicyRegistry` defaulted to `cache_aware`, then
  fetches a per-model policy via `get_policy_or_default`. Asserts that
  `populate_hash_index` reads `true` on the fetched policy — proves the
  adapter is attached and the flag propagates to lazily-created policies.
- `start_propagates_to_preexisting_model_policies` — new. Creates a
  per-model cache-aware policy BEFORE wiring runs (so it lives in
  `model_policies` at attach time), then starts wiring and asserts the
  populate flag flipped on the same live policy Arc. Regression guard
  for the propagation path that walks `model_policies` in
  `set_mesh_tree_sync`.
- `detach_clears_populate_flag` — new. After attach, calls
  `set_mesh_tree_sync(None)` and asserts the populate flag goes back
  off. Guards the paired invariant that the atomic setter undoes both
  flips together.
- `producer_hook_publishes_delta_on_select_worker` — new. End-to-end
  regression guard for #1578: builds a full `MeshAdapters`, drives one
  string request and one token request through
  `CacheAwarePolicy::select_worker`, and asserts the outbound
  `pending_deltas` buffer on the `TreeSyncAdapter` grew for each. Deleting
  either `sync_local_insert` call site fails this test.
- `peer_list_reports_alive_only` — new. Populates a `ClusterState` with
  Alive + Alive + Down entries and asserts `alive_peers()` excludes self
  and the Down node.
- `start_panics_on_second_call` — existing, extended.
- `start_panics_on_colon_node_name` — existing, extended.

Manual reproduction of the #1578 scenario across two mesh nodes is NOT part
of this PR's test evidence — I don't have the multi-node cluster to run
that on. If the pre-merge reviewer wants that, I can coordinate a
follow-up.

Full run:

```
cargo test -p smg --lib
# test result: ok. 1460 passed; 0 failed; 5 ignored
cargo test -p smg --lib mesh::wiring
# test result: ok. 9 passed; 0 failed
cargo +nightly fmt --all -- --check
# clean
cargo clippy -p smg --lib --tests -- -D warnings
# clean on this diff (see note below on monitor.rs:744)
```

Note on `monitor.rs:744` — a pre-existing `clippy::unneeded_wildcard_pattern`
lint appears on upstream `main` at `c2cf59c7`. I confirmed this by stashing
my changes and re-running clippy; the error persists. Out of scope for this
PR per the "one concern per PR" rule.

<details>
<summary>Checklist</summary>


- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy -p smg --lib --tests -- -D warnings` passes on this
      diff (a pre-existing `unneeded_wildcard_pattern` on `monitor.rs:744`
      remains — see note in Test Plan; workspace `--all-features` skipped
      because system OpenCV is not installed locally, per `CONTRIBUTING.md`
      fallback)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [[#sig-smg](https://slack.lightseek.org/)](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>