### PR TITLE
chore(e2e): switch xAI e2e model to grok-4.20-0309-non-reasoning

### DIFF
--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -339,7 +339,7 @@ THIRD_PARTY_MODELS: dict[str, dict] = {
     },
     "xai": {
         "description": "xAI API",
-        "model": "grok-4-fast",
+        "model": "grok-4.20-0309-non-reasoning",
         "api_key_env": "XAI_API_KEY",
     },
     "anthropic": {


### PR DESCRIPTION
## Description

### Problem

The xAI e2e backend is pinned to `grok-4-fast`.

### Solution

Change the model to `grok-4.20-0309-non-reasoning`.

## Changes

- `e2e_test/infra/model_specs.py`: set the `xai` entry's `model` to `grok-4.20-0309-non-reasoning`.

## Test Plan

Not run locally — the gateway build requires rustc 1.93.0 and the build machine has 1.88.0. Relies on `TestStateManagementCloudXai` in CI.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)