### PR TITLE
feat(router): route pre-tokenized HTTP requests on the token tree

### DIFF
--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -46,6 +46,13 @@ pub trait GenerationRequest: Send + Sync {
 
     /// Extract text content for routing decisions
     fn extract_text_for_routing(&self) -> String;
+
+    /// Token IDs for routing when the request is already tokenized.
+    /// Some(_) routes on the token radix tree instead of the decimal-string
+    /// rendering of the same IDs.
+    fn routing_tokens(&self) -> Option<&[i32]> {
+        None
+    }
 }
 
 // ============================================================================

--- a/crates/protocols/src/generate.rs
+++ b/crates/protocols/src/generate.rs
@@ -235,6 +235,14 @@ impl GenerationRequest for GenerateRequest {
         // No text input found
         String::new()
     }
+
+    fn routing_tokens(&self) -> Option<&[i32]> {
+        // Mirrors extract_text_for_routing priority: explicit text wins.
+        match (&self.text, &self.input_ids) {
+            (None, Some(InputIds::Single(ids))) => Some(ids),
+            _ => None,
+        }
+    }
 }
 
 // ============================================================================
@@ -304,4 +312,39 @@ pub enum GenerateFinishReason {
 pub enum GenerateFinishType {
     Length,
     Stop,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req() -> GenerateRequest {
+        serde_json::from_value(serde_json::json!({"model": "m"})).expect("minimal request")
+    }
+
+    #[test]
+    fn routing_tokens_from_single_input_ids() {
+        let mut r = req();
+        r.input_ids = Some(InputIds::Single(vec![1, 2, 3]));
+        assert_eq!(r.routing_tokens(), Some(&[1, 2, 3][..]));
+    }
+
+    #[test]
+    fn routing_tokens_text_takes_priority() {
+        let mut r = req();
+        r.text = Some("hello".to_string());
+        r.input_ids = Some(InputIds::Single(vec![1, 2, 3]));
+        assert_eq!(r.routing_tokens(), None);
+        assert_eq!(r.extract_text_for_routing(), "hello");
+    }
+
+    #[test]
+    fn routing_tokens_none_for_batch_and_empty() {
+        let mut r = req();
+        r.input_ids = Some(InputIds::Batch(vec![vec![1], vec![2]]));
+        assert_eq!(r.routing_tokens(), None);
+
+        let r = req();
+        assert_eq!(r.routing_tokens(), None);
+    }
 }

--- a/model_gateway/src/policies/bucket.rs
+++ b/model_gateway/src/policies/bucket.rs
@@ -182,9 +182,12 @@ impl LoadBalancingPolicy for BucketPolicy {
             return None;
         }
 
-        let char_count = match info.request_text {
-            None => 0,
-            Some(text) => text.chars().count(),
+        // Request-size signal: token count for pre-tokenized requests, else
+        // chars. Boundaries adapt to whichever unit the traffic carries.
+        let char_count = match (info.tokens, info.request_text) {
+            (Some(tokens), _) => tokens.len(),
+            (None, Some(text)) => text.chars().count(),
+            (None, None) => 0,
         };
 
         // Determine the model for this set of workers (router pre-filters by model)

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -62,6 +62,7 @@ struct PDRequestContext<'a> {
     is_stream: bool,
     return_logprob: bool,
     request_text: Option<String>,
+    routing_tokens: Option<Vec<u32>>,
     model_id: &'a str,
     headers: Option<HeaderMap>,
 }
@@ -329,6 +330,7 @@ impl PDRouter {
                         let (prefill, decode) = match self
                             .select_pd_pair(
                                 context.request_text.as_deref(),
+                                context.routing_tokens.as_deref(),
                                 context.model_id,
                                 context.headers.as_ref(),
                             )
@@ -376,8 +378,12 @@ impl PDRouter {
 
                         let dp_rank_policy_opt = self.policy_registry.get_dp_rank_policy();
                         if let Some(dp_rank_policy) = dp_rank_policy_opt.as_ref() {
-                            let estimated_cost: isize = match context.request_text.as_ref() {
-                                Some(text) => {
+                            let estimated_cost: isize = match (
+                                context.routing_tokens.as_deref(),
+                                context.request_text.as_ref(),
+                            ) {
+                                (Some(tokens), _) => (tokens.len() as isize).max(1),
+                                (None, Some(text)) => {
                                     // Calculate token count using a simple heuristic
                                     // In a real implementation, we would use the tokenizer
                                     // For now, use a simple words-to-tokens ratio
@@ -386,7 +392,7 @@ impl PDRouter {
                                     let token_count = (word_count as f64 * 1.3).ceil() as isize;
                                     token_count.max(1)
                                 }
-                                None => 1, // Use at least 1 to avoid no-op
+                                (None, None) => 1, // Use at least 1 to avoid no-op
                             };
                             let policy_prefill_rank =
                                 dp_rank_policy.select_dp_rank(prefill.as_ref(), estimated_cost);
@@ -808,6 +814,7 @@ impl PDRouter {
     async fn select_pd_pair(
         &self,
         request_text: Option<&str>,
+        tokens: Option<&[u32]>,
         model_id: &str,
         headers: Option<&HeaderMap>,
     ) -> Result<(Arc<dyn Worker>, Arc<dyn Worker>), String> {
@@ -857,6 +864,7 @@ impl PDRouter {
             &prefill_workers,
             &prefill_policy,
             request_text,
+            tokens,
             headers,
             hash_ring.clone(),
             "prefill",
@@ -867,6 +875,7 @@ impl PDRouter {
             &decode_workers,
             &decode_policy,
             request_text,
+            tokens,
             headers,
             hash_ring,
             "decode",
@@ -900,6 +909,7 @@ impl PDRouter {
         workers: &[Arc<dyn Worker>],
         policy: &Arc<dyn LoadBalancingPolicy>,
         request_text: Option<&str>,
+        tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
         hash_ring: Option<Arc<HashRing>>,
         worker_type: &str,
@@ -930,7 +940,7 @@ impl PDRouter {
                 &available_workers,
                 &SelectWorkerInfo {
                     request_text,
-                    tokens: None, // HTTP doesn't have tokens, use gRPC for PrefixHash
+                    tokens,
                     headers,
                     hash_ring,
                     leg,
@@ -1321,7 +1331,10 @@ impl RouterTrait for PDRouter {
         // Note: This endpoint actually causes the model to generate tokens, so we only test one pair
 
         // Select a random worker pair using the policy
-        let (prefill, decode) = match self.select_pd_pair(None, UNKNOWN_MODEL_ID, None).await {
+        let (prefill, decode) = match self
+            .select_pd_pair(None, None, UNKNOWN_MODEL_ID, None)
+            .await
+        {
             Ok(pair) => pair,
             Err(e) => {
                 return error::service_unavailable(
@@ -1419,10 +1432,13 @@ impl RouterTrait for PDRouter {
         let is_stream = body.stream;
         let return_logprob = body.return_logprob.unwrap_or(false);
 
-        let request_text = if self.policies_need_request_text() {
-            body.text.as_deref().map(|s| s.to_string())
+        let (request_text, routing_tokens) = if self.policies_need_request_text() {
+            match body.routing_tokens() {
+                Some(ids) => (None, Some(ids.iter().map(|&id| id as u32).collect())),
+                None => (body.text.as_deref().map(|s| s.to_string()), None),
+            }
         } else {
-            None
+            (None, None)
         };
 
         let batch_size = Self::get_generate_batch_size(body);
@@ -1433,6 +1449,7 @@ impl RouterTrait for PDRouter {
             is_stream,
             return_logprob,
             request_text,
+            routing_tokens,
             model_id,
             headers: headers.cloned(),
         };
@@ -1465,6 +1482,7 @@ impl RouterTrait for PDRouter {
             is_stream,
             return_logprob,
             request_text,
+            routing_tokens: None,
             model_id,
             headers: headers.cloned(),
         };
@@ -1500,6 +1518,7 @@ impl RouterTrait for PDRouter {
             is_stream,
             return_logprob,
             request_text,
+            routing_tokens: None,
             model_id,
             headers: headers.cloned(),
         };
@@ -1527,6 +1546,7 @@ impl RouterTrait for PDRouter {
             is_stream: false,
             return_logprob: false,
             request_text: req_text,
+            routing_tokens: None,
             model_id,
             headers: headers.cloned(),
         };
@@ -1698,7 +1718,9 @@ mod tests {
             .worker_registry
             .register_or_replace(Arc::from(decode_worker));
 
-        let result = router.select_pd_pair(None, UNKNOWN_MODEL_ID, None).await;
+        let result = router
+            .select_pd_pair(None, None, UNKNOWN_MODEL_ID, None)
+            .await;
 
         assert!(result.is_ok());
         let (prefill, _decode) = result.unwrap();
@@ -1723,14 +1745,14 @@ mod tests {
         }
 
         let (prefill, decode) = router
-            .select_pd_pair(None, "GLM-5.2-Coding", None)
+            .select_pd_pair(None, None, "GLM-5.2-Coding", None)
             .await
             .expect("alias should select a PD pair");
         assert_eq!(prefill.url(), "http://prefill");
         assert_eq!(decode.url(), "http://decode");
 
         assert!(router
-            .select_pd_pair(None, "GLM-5.2-Unknown", None)
+            .select_pd_pair(None, None, "GLM-5.2-Unknown", None)
             .await
             .is_err());
     }
@@ -1739,7 +1761,9 @@ mod tests {
     async fn test_empty_worker_lists() {
         let router = create_test_pd_router();
 
-        let result = router.select_pd_pair(None, UNKNOWN_MODEL_ID, None).await;
+        let result = router
+            .select_pd_pair(None, None, UNKNOWN_MODEL_ID, None)
+            .await;
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("No prefill workers available"));
@@ -1798,6 +1822,7 @@ mod tests {
             is_stream: true,
             return_logprob: false,
             request_text: None,
+            routing_tokens: None,
             model_id: UNKNOWN_MODEL_ID,
             headers: None,
         };

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -197,6 +197,7 @@ impl Router {
         &self,
         model_id: &str,
         text: Option<&str>,
+        tokens: Option<&[u32]>,
         headers: Option<&HeaderMap>,
     ) -> Option<Arc<dyn Worker>> {
         // UNKNOWN_MODEL_ID means caller didn't specify a model — find any available worker
@@ -233,7 +234,7 @@ impl Router {
             &available,
             &SelectWorkerInfo {
                 request_text: text,
-                tokens: None, // HTTP doesn't have tokens, use gRPC for PrefixHash
+                tokens,
                 headers,
                 hash_ring,
                 leg: crate::policies::WorkerLeg::Single,
@@ -323,7 +324,14 @@ impl Router {
     ) -> Response {
         let start = Instant::now();
         let is_stream = typed_req.is_stream();
-        let text = typed_req.extract_text_for_routing();
+        // Pre-tokenized requests route on the token tree; the decimal-string
+        // rendering is only materialized when there are no tokens.
+        let routing_tokens: Option<Vec<u32>> = typed_req
+            .routing_tokens()
+            .map(|ids| ids.iter().map(|&id| id as u32).collect());
+        let text = routing_tokens
+            .is_none()
+            .then(|| typed_req.extract_text_for_routing());
         // Resolve once, here, so every registry, policy and metrics lookup
         // below is keyed by the canonical model ID. Only `get_by_model`
         // understands aliases; retry configs, hash rings and policies do not,
@@ -361,7 +369,8 @@ impl Router {
                         model_id,
                         canonical_model.as_deref(),
                         is_stream,
-                        &text,
+                        text.as_deref(),
+                        routing_tokens.as_deref(),
                     )
                     .await;
 
@@ -425,9 +434,10 @@ impl Router {
         model_id: &str,
         canonical_model: Option<&str>,
         is_stream: bool,
-        text: &str,
+        text: Option<&str>,
+        tokens: Option<&[u32]>,
     ) -> Response {
-        let worker = match self.select_worker_for_model(model_id, Some(text), headers) {
+        let worker = match self.select_worker_for_model(model_id, text, tokens, headers) {
             Some(w) => w,
             None => {
                 // Distinguish "no workers for this model" from "workers exist but unavailable"


### PR DESCRIPTION
## Description

### Problem

HTTP `/generate` requests that carry `input_ids` are routed on the string radix tree over a space-joined decimal rendering of the token IDs (`extract_text_for_routing`). Every token costs ~6 characters of tree budget, so at the same `max_tree_size` the affinity recency window is ~6x shorter than the token tree gives gRPC traffic, tree walks operate on 6x longer sequences, and the router materializes a large routing string per request (hundreds of KB for long contexts) that exists only to be re-parsed as a prefix key. On the PD path it is worse: `/generate` passes only `body.text`, so pre-tokenized requests select prefill/decode workers with no affinity signal at all.

### Solution

Expose the tokens and route on them. `GenerationRequest` gains `routing_tokens() -> Option<&[i32]>` (default `None`; `GenerateRequest` returns `Some` for single `input_ids` with the same text-first priority as `extract_text_for_routing`). The HTTP regular and PD routers thread the tokens into `SelectWorkerInfo.tokens`, which `cache_aware` and `prefix_hash` already consume via the existing (gRPC-proven) token-tree path — including its single-descent `match_and_insert_with`. When tokens are present the string rendering is never materialized.

## Changes

- `crates/protocols`: `routing_tokens()` on `GenerationRequest` (defaulted), implemented for `GenerateRequest`; batch and text-carrying requests keep today's string behavior
- `routers/http/router.rs`: compute tokens once per request, skip the routing-string materialization when present, thread through `route_typed_request_once` / `select_worker_for_model` into `SelectWorkerInfo`
- `routers/http/pd_router.rs`: `routing_tokens` on `PDRequestContext`, threaded through `select_pd_pair` / `pick_worker_by_policy_arc` for both legs; dp-rank estimated cost uses the exact token count instead of the words-per-token heuristic
- `policies/bucket.rs`: request-size signal prefers token count over char count (adaptive boundaries absorb the unit change)
- Mixed traffic note: text-carrying and token-carrying requests for the same model build affinity in their respective trees (both are always initialized per model at worker registration); they do not cross-match, same as HTTP-vs-gRPC today

## Test Plan

- New protocols unit tests: `routing_tokens` from single `input_ids`, text-priority over tokens, `None` for batch/empty
- Existing token-tree policy tests cover the selection path this now feeds (`test_no_monitor_uses_token_tree`, `test_empty_indexer_falls_through_to_token_tree`, ...)
- `cargo test -p smg -p openai-protocol`: 26 suites, 0 failures (includes integration test binaries)
- `cargo clippy --all-targets -- -D warnings` clean locally (default features; `--all-features` needs system OpenCV and is covered by CI)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>