### PR TITLE
fix(logging): stop ERROR-flooding on expected probe 503s

### DIFF
--- a/model_gateway/src/health.rs
+++ b/model_gateway/src/health.rs
@@ -65,6 +65,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     config::{RouterConfig, RoutingMode},
+    middleware::ProbeResponse,
     observability::inflight_tracker::InFlightRequestTracker,
     worker::{event::WorkerEvent, ConnectionMode, WorkerRegistry, WorkerType},
 };
@@ -220,41 +221,47 @@ impl ProbeState {
     /// during shutdown (liveness intentionally stays OK — see module docs).
     pub fn readiness_response(&self) -> Response {
         if self.inflight_tracker.is_draining() {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(json!({
-                    "status": "not ready",
-                    "reason": "draining"
-                })),
-            )
-                .into_response();
+            return mark_probe(
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({
+                        "status": "not ready",
+                        "reason": "draining"
+                    })),
+                )
+                    .into_response(),
+            );
         }
 
         let snapshot = self.readiness.load();
         if snapshot.workers_ready && snapshot.tokenizers_ready {
-            (
-                StatusCode::OK,
-                Json(json!({
-                    "status": "ready",
-                    "healthy_workers": snapshot.healthy_workers,
-                    "total_workers": snapshot.total_workers
-                })),
+            mark_probe(
+                (
+                    StatusCode::OK,
+                    Json(json!({
+                        "status": "ready",
+                        "healthy_workers": snapshot.healthy_workers,
+                        "total_workers": snapshot.total_workers
+                    })),
+                )
+                    .into_response(),
             )
-                .into_response()
         } else {
             let reason = if snapshot.workers_ready {
                 "tokenizer not yet registered"
             } else {
                 "insufficient healthy workers"
             };
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(json!({
-                    "status": "not ready",
-                    "reason": reason
-                })),
+            mark_probe(
+                (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({
+                        "status": "not ready",
+                        "reason": reason
+                    })),
+                )
+                    .into_response(),
             )
-                .into_response()
         }
     }
 }
@@ -263,7 +270,15 @@ impl ProbeState {
 /// deliberately stays OK while draining: the process is healthy, it is
 /// just not accepting new work.
 pub fn liveness_response() -> Response {
-    (StatusCode::OK, "OK").into_response()
+    mark_probe((StatusCode::OK, "OK").into_response())
+}
+
+/// Attach the [`ProbeResponse`] logging marker: probe statuses (503 "not
+/// ready" included) are expected states polled on a tight interval, and the
+/// HTTP logging layer demotes marked responses to DEBUG.
+fn mark_probe(mut response: Response) -> Response {
+    response.extensions_mut().insert(ProbeResponse);
+    response
 }
 
 /// Spawn the readiness maintainer: recomputes the snapshot on every
@@ -742,6 +757,32 @@ mod tests {
             StatusCode::OK,
             "liveness must stay OK while draining"
         );
+    }
+
+    /// Every probe response — ready and not-ready alike — must carry the
+    /// [`ProbeResponse`] marker, or the HTTP logging layer floods ERROR with
+    /// expected not-ready 503s on every poll (two lines per 2s in the e2e
+    /// gateway logs before this marker existed).
+    #[tokio::test]
+    async fn probe_responses_carry_the_logging_marker() {
+        let inflight_tracker = InFlightRequestTracker::new();
+        let state = ProbeState::new(inflight_tracker.clone());
+
+        // Not ready (initial snapshot), ready is irrelevant to the marker:
+        // check the 503 path, the liveness 200 path, and the draining path.
+        let not_ready = state.readiness_response();
+        assert_eq!(not_ready.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(not_ready.extensions().get::<ProbeResponse>().is_some());
+
+        assert!(liveness_response()
+            .extensions()
+            .get::<ProbeResponse>()
+            .is_some());
+
+        inflight_tracker.begin_drain();
+        let draining = state.readiness_response();
+        assert_eq!(draining.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(draining.extensions().get::<ProbeResponse>().is_some());
     }
 
     async fn get_probe(router: &Router, path: &str) -> (StatusCode, String) {

--- a/model_gateway/src/middleware/logging.rs
+++ b/model_gateway/src/middleware/logging.rs
@@ -7,8 +7,11 @@
 use std::time::Duration;
 
 use axum::{extract::Request, response::Response};
-use tower_http::trace::{MakeSpan, OnRequest, OnResponse, TraceLayer};
-use tracing::{error, field::Empty, info, info_span, warn, Span};
+use tower_http::{
+    classify::ServerErrorsFailureClass,
+    trace::{MakeSpan, OnFailure, OnRequest, OnResponse, TraceLayer},
+};
+use tracing::{debug, error, field::Empty, info, info_span, warn, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use super::{metrics::matched_path_label, request_id::RequestId};
@@ -16,6 +19,22 @@ use crate::observability::{
     metrics::{method_to_static_str, Metrics},
     otel_trace::extract_trace_context_http,
 };
+
+/// Response-extension marker for orchestrator probe responses (`/health`,
+/// `/readiness`, `/liveness`): every status they return — 503 "not ready"
+/// included — is an expected operational state, reported to a machine that
+/// polls on a tight interval. The handler that produces the response owns
+/// that knowledge and attaches this marker; [`ResponseLogger`] logs marked
+/// responses at DEBUG instead of flooding ERROR/INFO once per poll.
+#[derive(Clone, Copy, Debug)]
+pub struct ProbeResponse;
+
+/// The probe routes on the main listener. Request-start logging for these is
+/// demoted alongside [`ProbeResponse`] — the paths are the request-side view
+/// of the same contract.
+fn is_probe_path(path: &str) -> bool {
+    matches!(path, "/health" | "/readiness" | "/liveness")
+}
 
 /// Custom span maker that includes request ID
 #[derive(Clone, Debug)]
@@ -66,11 +85,19 @@ impl<B> OnRequest<B> for RequestLogger {
         let path = matched_path_label(request.extensions());
         Metrics::record_http_request(method, path);
 
-        // Log the request start
-        info!(
-            target: "smg::request",
-            "started processing request"
-        );
+        // Log the request start. Probe polls arrive every couple of seconds
+        // forever; keep them out of the INFO access log.
+        if is_probe_path(request.uri().path()) {
+            debug!(
+                target: "smg::request",
+                "started processing request"
+            );
+        } else {
+            info!(
+                target: "smg::request",
+                "started processing request"
+            );
+        }
     }
 }
 
@@ -90,7 +117,14 @@ impl<B> OnResponse<B> for ResponseLogger {
 
         // Log the response completion
         let _enter = span.enter();
-        if status.is_server_error() {
+        if response.extensions().get::<ProbeResponse>().is_some() {
+            // A probe's 503 means "not ready yet" — an expected state a poller
+            // reads every couple of seconds, not a server malfunction.
+            debug!(
+                target: "smg::response",
+                "finished probe request"
+            );
+        } else if status.is_server_error() {
             error!(
                 target: "smg::response",
                 "request failed with server error"
@@ -109,6 +143,34 @@ impl<B> OnResponse<B> for ResponseLogger {
     }
 }
 
+/// Failure handler that logs only what [`ResponseLogger`] cannot see.
+///
+/// The default `OnFailure` ERRORs on every 5xx *status*, duplicating the
+/// line `ResponseLogger` already emits with more span context — that pair
+/// is the double ERROR per failed request in the logs. A status is not a
+/// transport failure; the one thing `ResponseLogger` genuinely cannot
+/// observe is a body/stream error after the response head went out, so
+/// only that arm logs here.
+#[derive(Clone, Debug)]
+pub struct StreamFailureLogger;
+
+impl OnFailure<ServerErrorsFailureClass> for StreamFailureLogger {
+    fn on_failure(&mut self, failure: ServerErrorsFailureClass, _latency: Duration, span: &Span) {
+        match failure {
+            // Already logged by ResponseLogger with status + latency.
+            ServerErrorsFailureClass::StatusCode(_) => {}
+            ServerErrorsFailureClass::Error(error) => {
+                let _enter = span.enter();
+                error!(
+                    target: "smg::response",
+                    error,
+                    "response stream failed after the head was sent"
+                );
+            }
+        }
+    }
+}
+
 /// Create a configured TraceLayer for HTTP logging
 /// Note: Actual request/response logging with request IDs is done in RequestIdService
 pub fn create_logging_layer() -> TraceLayer<
@@ -116,9 +178,13 @@ pub fn create_logging_layer() -> TraceLayer<
     RequestSpan,
     RequestLogger,
     ResponseLogger,
+    tower_http::trace::DefaultOnBodyChunk,
+    tower_http::trace::DefaultOnEos,
+    StreamFailureLogger,
 > {
     TraceLayer::new_for_http()
         .make_span_with(RequestSpan)
         .on_request(RequestLogger)
         .on_response(ResponseLogger)
+        .on_failure(StreamFailureLogger)
 }

--- a/model_gateway/src/middleware/mod.rs
+++ b/model_gateway/src/middleware/mod.rs
@@ -19,7 +19,10 @@ pub use auth::{auth_middleware, deny_all_middleware, AuthConfig};
 pub use concurrency::{
     concurrency_limit_middleware, ConcurrencyLimiter, QueueProcessor, QueuedRequest, TokenGuardBody,
 };
-pub use logging::{create_logging_layer, RequestLogger, RequestSpan, ResponseLogger};
+pub use logging::{
+    create_logging_layer, ProbeResponse, RequestLogger, RequestSpan, ResponseLogger,
+    StreamFailureLogger,
+};
 pub use metrics::{HttpMetricsLayer, HttpMetricsMiddleware};
 pub use request_id::{RequestId, RequestIdLayer, RequestIdMiddleware};
 pub use storage_context::storage_context_middleware;


### PR DESCRIPTION
## Description

### Problem

While workers load (60–90s per engine on the ZMQ lanes), every readiness poll produces two ERROR lines in the gateway log:

```
ERROR smg::response: request failed with server error
ERROR tower_http::trace::on_failure: response failed classification=Status code: 503 Service Unavailable
```

One poll every ~2 seconds means hundreds of ERROR lines per engine start, all describing one expected state: "not ready yet". Two distinct defects stack:

1. **Every 5xx is logged twice.** `ResponseLogger` logs each response, and the TraceLayer's unconfigured default `on_failure` logs the same 5xx again with less context.
2. **A probe's 503 is not a server malfunction.** `/readiness` answering "not ready" to a poller is the endpoint working as designed, but the logger classifies by status code alone.

### Solution

Two owners, each logging only what it alone can see:

- **`StreamFailureLogger`** replaces the default `on_failure`: the status-code arm is silent (`ResponseLogger` already owns it with full span context), and only a body/stream error after the response head went out — the one failure `ResponseLogger` cannot observe — logs at ERROR. Halves the lines for every real 5xx too.
- **`ProbeResponse` response-extension marker**: the probe handlers (`liveness_response`, all three `readiness_response` exits including draining) attach it, and `ResponseLogger` logs marked responses at DEBUG regardless of status. The handler that produced the 503 owns the knowledge that it is expected — no path table in the response logger. Request-start lines for the three probe paths drop to DEBUG for the same reason.

Overhead goes down, not up: probe polls that used to format and emit two events now short-circuit at tracing's cached interest check, real 5xx responses emit one event instead of two, and the additions are one 3-literal path match per request plus one TypeId extension lookup per response.

Readiness behaviour, status codes, and response bodies are byte-identical — only log classification changes.

## Changes

- `model_gateway/src/middleware/logging.rs`: `ProbeResponse` marker, `StreamFailureLogger`, DEBUG demotion for marked responses and probe request-starts.
- `model_gateway/src/health.rs`: `mark_probe` attaches the marker in `liveness_response` and every `readiness_response` exit.
- `model_gateway/src/middleware/mod.rs`: export the new types.

## Test Plan

- New `probe_responses_carry_the_logging_marker` covers all three response producers, including the draining path — the marker is the contract the demotion rests on.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; pre-commit clean.
- Observable effect: a ZMQ e2e gateway log during engine warmup drops from two ERROR lines per poll to none (DEBUG-filtered). Any e2e lane on this PR shows it — the flood was visible in every `e2e-*-zmq` gateway log.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
