### PR TITLE
feat(observability): jemalloc global allocator with stats gauges

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -81,6 +81,10 @@ jobs:
         if: matrix.os == 'windows'
         run: choco install protoc -y
 
+      - name: Pin jemalloc page size for cross-built aarch64 wheels
+        if: matrix.platform == 'linux' && matrix.target == 'aarch64' && matrix.manylinux == '2_28'
+        run: echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> "$GITHUB_ENV"
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -89,7 +93,7 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           args: --release --out dist --features vendored-openssl --interpreter ${{ matrix.interpreter || '3.9 3.10 3.11 3.12 3.13 3.14' }}
           rust-toolchain: stable
-          docker-options: -e CI -e CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc -e CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+          docker-options: -e CI -e JEMALLOC_SYS_WITH_LG_PAGE -e CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc -e CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
           before-script-linux: |
             # Install build dependencies (perl/make for vendored OpenSSL, protoc for gRPC)
             if command -v yum &> /dev/null; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ serde_tuple = "1.1.3"
 zeromq = { version = "0.6.0", default-features = false, features = ["tokio-runtime", "all-transport"] }
 chrono = { version = "0.4" }
 dashmap = "6.2.1"
+tikv-jemallocator = { version = "0.6", features = ["stats", "profiling", "background_threads_runtime_support", "disable_initial_exec_tls"] }
+tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 http = "1.4.2"
 lru = "0.18.0"
 num-traits = "0.2"

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -64,3 +64,6 @@ codegen-units = 256
 
 [lints]
 workspace = true
+
+[target.'cfg(all(not(target_env = "msvc"), not(target_env = "musl")))'.dependencies]
+tikv-jemallocator = { workspace = true }

--- a/bindings/golang/src/lib.rs
+++ b/bindings/golang/src/lib.rs
@@ -13,6 +13,13 @@
 //! All functions marked with `#[no_mangle]` and `extern "C"` must be called
 //! with valid pointers and follow the documented memory management rules.
 
+// Jemalloc for all Rust-side allocations in the cdylib. Prefixed symbols
+// leave the host process's allocator untouched; disable_initial_exec_tls is
+// required for a dlopen'd shared library.
+#[cfg(all(not(target_env = "msvc"), not(target_env = "musl")))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 // Re-export error types
 // Re-export client stream function (defined in client.rs but used by stream)
 pub use client::sgl_client_chat_completion_stream;

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -46,3 +46,6 @@ strip = true
 
 [lints]
 workspace = true
+
+[target.'cfg(all(not(target_env = "msvc"), not(target_env = "musl")))'.dependencies]
+tikv-jemallocator = { workspace = true }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2,6 +2,13 @@ use std::collections::HashMap;
 
 use once_cell::sync::OnceCell;
 use pyo3::prelude::*;
+
+// Jemalloc for all Rust-side allocations in the extension. Prefixed symbols
+// leave CPython's allocators untouched; disable_initial_exec_tls is required
+// for a dlopen'd cdylib.
+#[cfg(all(not(target_env = "msvc"), not(target_env = "musl")))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use smg::*;
 use smg_auth as auth;
 

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -235,3 +235,7 @@ path = "benches/scheduler_load.rs"
 
 [lints]
 workspace = true
+
+[target.'cfg(all(not(target_env = "msvc"), not(target_env = "musl")))'.dependencies]
+tikv-jemallocator = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true }

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1,6 +1,13 @@
 use std::collections::HashMap;
 
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+
+// Jemalloc as the global allocator: glibc malloc retains freed pages badly
+// under the gateway's allocation churn. Prefixed symbols only — vendored C
+// libraries keep their own malloc.
+#[cfg(all(not(target_env = "msvc"), not(target_env = "musl")))]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use openai_protocol::worker::TransportMode;
 use rand::{distr::Alphanumeric, RngExt};
 use smg::{

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -183,6 +183,9 @@ impl Default for PrometheusConfig {
 pub(crate) const UPKEEP_INTERVAL_SECS: u64 = 5 * 60;
 
 pub(crate) fn init_metrics() {
+    #[cfg(all(not(target_env = "msvc"), not(target_env = "musl")))]
+    allocator_stats::describe();
+
     // Layer 1: HTTP metrics
     describe_counter!(
         "smg_http_requests_total",
@@ -507,7 +510,78 @@ pub fn start_prometheus(config: PrometheusConfig) -> PrometheusHandle {
         )
         .expect("failed to set event loop delay buckets")
         .install_recorder()
+        .inspect(|_| {
+            #[cfg(all(not(target_env = "msvc"), not(target_env = "musl")))]
+            allocator_stats::start_reporting();
+        })
         .expect("failed to install Prometheus recorder")
+}
+
+#[cfg(all(not(target_env = "msvc"), not(target_env = "musl")))]
+pub(crate) mod allocator_stats {
+    use metrics::{describe_gauge, gauge};
+
+    pub(crate) fn describe() {
+        describe_gauge!(
+            "smg_allocator_allocated_bytes",
+            "Bytes in live allocations (jemalloc stats.allocated)"
+        );
+        describe_gauge!(
+            "smg_allocator_active_bytes",
+            "Bytes in active pages (jemalloc stats.active)"
+        );
+        describe_gauge!(
+            "smg_allocator_resident_bytes",
+            "Bytes resident per the allocator (jemalloc stats.resident)"
+        );
+        describe_gauge!(
+            "smg_allocator_metadata_bytes",
+            "Allocator metadata bytes (jemalloc stats.metadata)"
+        );
+    }
+
+    fn record() {
+        use tikv_jemalloc_ctl::{epoch, stats};
+        if epoch::advance().is_err() {
+            return;
+        }
+        if let Ok(v) = stats::allocated::read() {
+            gauge!("smg_allocator_allocated_bytes").set(v as f64);
+        }
+        if let Ok(v) = stats::active::read() {
+            gauge!("smg_allocator_active_bytes").set(v as f64);
+        }
+        if let Ok(v) = stats::resident::read() {
+            gauge!("smg_allocator_resident_bytes").set(v as f64);
+        }
+        if let Ok(v) = stats::metadata::read() {
+            gauge!("smg_allocator_metadata_bytes").set(v as f64);
+        }
+    }
+
+    /// Gauges are truthful when jemalloc is the global allocator, which every
+    /// shipped artifact declares.
+    pub(crate) fn start_reporting() {
+        record();
+        // Plain thread: metrics must not depend on a runtime being alive.
+        let _ = std::thread::Builder::new()
+            .name("smg-allocator-stats".into())
+            .spawn(|| loop {
+                std::thread::sleep(std::time::Duration::from_secs(60));
+                record();
+            });
+    }
+
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        fn jemalloc_stats_readable() {
+            use tikv_jemalloc_ctl::{epoch, stats};
+            epoch::advance().expect("epoch advance");
+            stats::allocated::read().expect("stats.allocated readable");
+            stats::resident::read().expect("stats.resident readable");
+        }
+    }
 }
 
 /// Label constants for consistent metric labeling


### PR DESCRIPTION
## Description

### Problem

The gateway runs on the system allocator (glibc ptmalloc2), which retains and fragments freed pages badly under the router's allocation churn (per-request token vectors, JSON bodies, SSE chunks, radix-tree nodes). Under sustained load this can present as steady RSS growth — and eventually OOM kills in memory-limited deployments — and with no allocator introspection there is no way to tell live-data growth from allocator retention from outside the process, so a sizing problem is indistinguishable from a leak.

### Solution

Adopt `tikv-jemallocator` as the global allocator in all three shipped artifacts, and export jemalloc's own accounting as Prometheus gauges so allocated-vs-resident is a dashboard read.

## Changes

- `#[global_allocator] tikv_jemallocator::Jemalloc` in the `smg` binary, the Python extension, and the Go cdylib — cfg-gated off `msvc`/`musl` (musllinux wheels keep the system allocator)
- Prefixed jemalloc symbols only: CPython, cgo hosts, and vendored C libraries (openssl, opencv) keep their own malloc — no interposition
- `disable_initial_exec_tls`: required for dlopen'd cdylibs (the py-polars pattern)
- `stats` + `profiling` compiled in; profiling is runtime-off (`_RJEM_MALLOC_CONF=prof:true` to enable) so heap attribution needs a restart, not a rebuild
- New gauges refreshed every 60s from a dedicated thread: `smg_allocator_allocated_bytes` (live), `smg_allocator_active_bytes`, `smg_allocator_resident_bytes`, `smg_allocator_metadata_bytes`
- Wheel CI: `JEMALLOC_SYS_WITH_LG_PAGE=16` pinned for the cross-built linux/aarch64 manylinux_2_28 lane (64K-page ARM hosts); macOS lanes build natively and auto-detect

## Test Plan

- `jemalloc_stats_readable` unit test exercises the epoch/stats surface
- `cargo clippy --all-targets -- -D warnings` clean; `cargo test -p smg --lib observability` green (57 passed)
- `cargo build -p smg-python` and `-p smg-golang` both build with the allocator declared

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
