### PR TITLE
feat(tool_parser): day-0 tool-calling support for Qwen3.8

### DIFF
--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -319,6 +319,18 @@ mod tests {
     }
 
     #[test]
+    fn test_factory_routes_dotted_qwen3_generations_to_qwen3() {
+        let factory = ParserFactory::new();
+        // The dotted generations keep <think> reasoning; the qwen3 substring
+        // pattern must keep matching their ids.
+        assert_eq!(
+            factory.create("Qwen/Qwen3.8-2.4T-A95B").model_type(),
+            "qwen3"
+        );
+        assert_eq!(factory.create("Qwen/Qwen3.6-35B-A3B").model_type(), "qwen3");
+    }
+
+    #[test]
     fn test_factory_creates_kimi() {
         let factory = ParserFactory::new();
         let parser = factory.create("kimi-chat");

--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -374,6 +374,14 @@ impl ParserFactory {
         registry.map_model("Qwen3.5*", "qwen_xml");
         registry.map_model("qwen3.5*", "qwen_xml");
         registry.map_model("qwen/qwen3.5*", "qwen_xml");
+        registry.map_model("Qwen/Qwen3.6*", "qwen_xml");
+        registry.map_model("Qwen3.6*", "qwen_xml");
+        registry.map_model("qwen3.6*", "qwen_xml");
+        registry.map_model("qwen/qwen3.6*", "qwen_xml");
+        registry.map_model("Qwen/Qwen3.8*", "qwen_xml");
+        registry.map_model("Qwen3.8*", "qwen_xml");
+        registry.map_model("qwen3.8*", "qwen_xml");
+        registry.map_model("qwen/qwen3.8*", "qwen_xml");
         registry.map_model("Qwen/Qwen3-Coder*", "qwen_xml");
         registry.map_model("Qwen3-Coder*", "qwen_xml");
         registry.map_model("qwen3-coder*", "qwen_xml");

--- a/crates/tool_parser/tests/tool_parser_qwen_dotted.rs
+++ b/crates/tool_parser/tests/tool_parser_qwen_dotted.rs
@@ -1,0 +1,59 @@
+//! Qwen3.6 / Qwen3.8 family resolution tests.
+//!
+//! The dotted Qwen3.x generations from 3.5 onward render tool calls in the
+//! XML-parameter format (verified against each family's own published chat
+//! template), so their ids must resolve to the `qwen_xml` parser instead of
+//! falling through the generic `qwen*` glob to the JSON-style parser. These
+//! tests pin the mapping; the grammar itself is covered by the qwen_xml suite.
+
+use tool_parser::ParserFactory;
+
+#[tokio::test]
+async fn qwen36_and_qwen38_resolve_to_qwen_xml() {
+    let factory = ParserFactory::new();
+    for model in [
+        "Qwen/Qwen3.8-2.4T-A95B",
+        "qwen3.8-2.4t-a95b",
+        "Qwen/Qwen3.6-35B-A3B",
+        "qwen3.6-35b-a3b",
+    ] {
+        assert_eq!(
+            factory.registry().resolve_model_to_parser(model).as_deref(),
+            Some("qwen_xml"),
+            "{model} must resolve to the XML tool parser"
+        );
+    }
+}
+
+#[tokio::test]
+async fn earlier_qwen_families_keep_their_parsers() {
+    let factory = ParserFactory::new();
+    // The dotted 3.5 mapping is unchanged.
+    assert_eq!(
+        factory
+            .registry()
+            .resolve_model_to_parser("Qwen/Qwen3.5-122B-A10B")
+            .as_deref(),
+        Some("qwen_xml")
+    );
+    // Pre-3.5 families keep the JSON-style parser.
+    for model in ["Qwen/Qwen2.5-72B-Instruct", "Qwen/Qwen3-32B", "qwen-max"] {
+        assert_eq!(
+            factory.registry().resolve_model_to_parser(model).as_deref(),
+            Some("qwen"),
+            "{model} must keep the JSON-style qwen parser"
+        );
+    }
+}
+
+#[tokio::test]
+async fn qwen38_parses_xml_tool_call_end_to_end() {
+    let factory = ParserFactory::new();
+    let parser = factory.get_pooled("Qwen/Qwen3.8-2.4T-A95B");
+    let input = "<tool_call>\n<function=get_weather>\n<parameter=city>\nSanta Clara\n</parameter>\n</function>\n</tool_call>";
+    let (_normal, tools) = parser.lock().await.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["city"], "Santa Clara");
+}


### PR DESCRIPTION
## Description

Day-0 tool-calling support for **Qwen3.8** (released today), plus the same fix for Qwen3.6: both families now map to the `qwen_xml` tool-call parser.

## Problem

Both families publish chat templates that render assistant tool calls as XML function/parameter blocks — `<tool_call>` wrapping `<function=NAME>` and per-argument `<parameter=KEY>` tags (verifiable in each model's `chat_template.jinja` on Hugging Face, e.g. `Qwen/Qwen3.8-2.4T-A95B`). The parser mapping table only covers the `qwen3.5*` and `qwen3-coder*` stems, so ids like `Qwen/Qwen3.8-2.4T-A95B` fell through to the generic `qwen*` glob and got the JSON-style `qwen` parser: native tool-call output came back unparsed inside `content` with `tool_calls: null`.

## Solution

Add the dotted `qwen3.6*` / `qwen3.8*` stems (same variant style as the existing `qwen3.5*` block) to the `qwen_xml` mapping. Reasoning auto-detection already routes these ids correctly via the `qwen3` pattern; a test now pins that too.

## Changes

- `crates/tool_parser/src/factory.rs`: 8 mapping entries for the two families
- `crates/tool_parser/tests/tool_parser_qwen_dotted.rs`: resolution pins (new families → `qwen_xml`; 3.5 unchanged; pre-3.5 keep `qwen`) + end-to-end XML parse
- `crates/reasoning_parser/src/factory.rs`: test pinning dotted generations → `qwen3` reasoning

## Test Plan

- [x] `cargo test -p tool-parser -p reasoning-parser` — all green including new tests
- [x] `cargo clippy -p tool-parser -p reasoning-parser --all-targets -- -D warnings` — clean
- [x] nightly `cargo fmt`