### PR TITLE
fix(kv_index): purge tree tenants when a worker is removed

### DIFF
--- a/crates/kv_index/src/lib.rs
+++ b/crates/kv_index/src/lib.rs
@@ -69,7 +69,7 @@ pub trait RadixTree: Send + Sync {
     /// * `max_units` - Maximum units (chars/tokens) to retain for this tenant
     fn evict(&self, tenant: &TenantId, max_units: usize);
 
-    // No `remove_tenant`: stale entries are reclaimed via LRU eviction.
+    // Tenant purge lives on the concrete trees (`remove_tenant_all`), not the trait.
 
     /// Get the current size (in units) for a tenant.
     fn tenant_size(&self, tenant: &TenantId) -> usize;

--- a/crates/kv_index/src/string_tree.rs
+++ b/crates/kv_index/src/string_tree.rs
@@ -1119,10 +1119,6 @@ impl Tree {
         }
     }
 
-    // TODO: Implement efficient remove_tenant with reverse index.
-    // See lib.rs for design options. Current naive O(n) traversal removed.
-    // For now, stale entries are cleaned up by LRU eviction.
-
     pub fn get_tenant_char_count(&self) -> HashMap<String, usize> {
         self.tenant_char_count
             .iter()
@@ -1168,9 +1164,10 @@ impl Tree {
         self.evict_tenant_entries(tenant, current_count - max_chars);
     }
 
-    /// Remove a tenant from all nodes in the tree, including root.
-    /// Used for mesh eviction propagation — when a remote node reports
-    /// that a worker evicted all its cached prefixes.
+    /// Remove a tenant from all nodes in the tree (including root), detach
+    /// nodes the removal emptied, and drop the tenant's char-count entry.
+    /// Used for mesh eviction propagation and worker removal — size-based
+    /// eviction never fires for a tenant whose count no longer grows.
     pub fn remove_tenant_all(&self, tenant_id: &TenantId) {
         // collect_tenant_nodes skips root (root is never LRU-evicted),
         // but global removal must include it.
@@ -1180,9 +1177,27 @@ impl Tree {
         self.collect_tenant_nodes(&self.root, tenant_id, &mut nodes);
         for (node, _) in &nodes {
             self.remove_tenant_from_node(node, tenant_id);
+            Self::detach_empty_ancestors(node);
         }
         if let Some((_, count)) = self.tenant_char_count.remove(tenant_id) {
             self.total_char_count.fetch_sub(count, Ordering::Relaxed);
+        }
+    }
+
+    /// Detach `node` from its parent when it has no tenants and no children
+    /// (the `evict_tenant_by_size` empty-node rule), walking up so ancestors
+    /// emptied by the detach are removed too. The root (no parent) is never
+    /// detached.
+    fn detach_empty_ancestors(node: &NodeRef) {
+        let mut current = Arc::clone(node);
+        while current.children.is_empty() && current.tenant_last_access_time.is_empty() {
+            let Some(parent) = current.parent.read().as_ref().and_then(Weak::upgrade) else {
+                break;
+            };
+            if let Some(fc) = current.text.read().first_char() {
+                parent.children.remove(&fc);
+            }
+            current = parent;
         }
     }
 
@@ -3575,5 +3590,45 @@ mod tests {
                 "prefix {j} not fully cached after concurrent stress (route loss)"
             );
         }
+    }
+
+    #[test]
+    fn test_remove_tenant_all_purges_tenant_and_keeps_others() {
+        let tree = Tree::new();
+        tree.insert_text("hello world", "tenant1");
+        tree.insert_text("hello there", "tenant2");
+
+        tree.remove_tenant_all(&Arc::from("tenant1"));
+
+        // Count entry is gone (not merely zero), root entry included.
+        assert!(!tree.get_tenant_char_count().contains_key("tenant1"));
+        assert!(!tree.root.tenant_last_access_time.contains_key("tenant1"));
+
+        // tenant1's sole-owner branch ("world") is detached from the split node.
+        assert_eq!(tree.root.children.len(), 1);
+        let split = Arc::clone(tree.root.children.iter().next().unwrap().value());
+        assert_eq!(split.text.read().as_str(), "hello ");
+        assert_eq!(split.children.len(), 1);
+
+        // tenant2 still matches its full prefix.
+        let r = tree.match_prefix_with_counts("hello there");
+        assert_eq!(r.matched_char_count, "hello there".chars().count());
+        assert_eq!(r.tenant.as_ref(), "tenant2");
+    }
+
+    #[test]
+    fn test_remove_tenant_all_sole_owner_detaches_subtree() {
+        let tree = Tree::new();
+        // Chain root -> "solo" -> " prefix chain", owned by tenant1 only.
+        tree.insert_text("solo", "tenant1");
+        tree.insert_text("solo prefix chain", "tenant1");
+        assert!(!tree.root.children.is_empty());
+
+        tree.remove_tenant_all(&Arc::from("tenant1"));
+
+        assert!(tree.root.children.is_empty());
+        assert!(!tree.get_tenant_char_count().contains_key("tenant1"));
+        let r = tree.match_prefix_with_counts("solo prefix chain");
+        assert_eq!(r.matched_char_count, 0);
     }
 }

--- a/crates/kv_index/src/token_tree.rs
+++ b/crates/kv_index/src/token_tree.rs
@@ -1570,9 +1570,42 @@ impl TokenTree {
         self.total_token_count.store(0, Ordering::Relaxed);
     }
 
-    // TODO: Implement efficient remove_tenant with reverse index.
-    // See lib.rs for design options. Current naive O(n) traversal removed.
-    // For now, stale entries are cleaned up by LRU eviction.
+    /// Remove a tenant from every node (including the root), detach nodes
+    /// the removal emptied, and drop the tenant's token-count entry.
+    /// Size-based eviction never fires for a tenant whose count no longer
+    /// grows, so removed workers must be purged eagerly.
+    pub fn remove_tenant_all(&self, tenant_id: &TenantId) {
+        self.root.tenant_last_access_time.remove(tenant_id.as_ref());
+
+        let mut nodes: Vec<NodeRef> = Vec::new();
+        self.collect_tenant_nodes(&self.root, tenant_id, &mut nodes);
+        for node in &nodes {
+            self.remove_tenant_and_cleanup(node, tenant_id);
+        }
+        if let Some((_, count)) = self.tenant_token_count.remove(tenant_id.as_ref()) {
+            self.total_token_count.fetch_sub(count, Ordering::Relaxed);
+        }
+    }
+
+    /// Collect every node owning `tenant_id`. The root is excluded (never
+    /// detached); the caller drops its entry directly.
+    fn collect_tenant_nodes(
+        &self,
+        node: &NodeRef,
+        tenant_id: &TenantId,
+        result: &mut Vec<NodeRef>,
+    ) {
+        if !Arc::ptr_eq(node, &self.root)
+            && node
+                .tenant_last_access_time
+                .contains_key(tenant_id.as_ref())
+        {
+            result.push(Arc::clone(node));
+        }
+        for child in &node.children {
+            self.collect_tenant_nodes(child.value(), tenant_id, result);
+        }
+    }
 
     /// Evict cache entries until the tree-wide token total is at or under
     /// `max_size`. Matches the StringTree API.
@@ -3686,11 +3719,65 @@ mod tests {
         assert_consistent(&tree);
         assert!(tree.total_token_size() <= total / 2);
 
+        // Tenant purge.
+        tree.remove_tenant_all(&Arc::from("tenant2"));
+        assert_consistent(&tree);
+
         // No-op eviction and reset.
         tree.evict_tenant_by_size(usize::MAX);
         assert_consistent(&tree);
         tree.clear();
         assert_consistent(&tree);
         assert_eq!(tree.total_token_size(), 0);
+    }
+
+    #[test]
+    fn test_remove_tenant_all_purges_tenant_and_keeps_others() {
+        let tree = TokenTree::new();
+
+        // Shared first page; a distinct second page per tenant.
+        let mut tokens1 = make_tokens(1, 1);
+        tokens1.extend(make_tokens(100, 1));
+        let mut tokens2 = make_tokens(1, 1);
+        tokens2.extend(make_tokens(200, 1));
+        tree.insert_tokens(&tokens1, "tenant1");
+        tree.insert_tokens(&tokens2, "tenant2");
+
+        tree.remove_tenant_all(&Arc::from("tenant1"));
+
+        // Count entry is gone (not merely zero), root entry included.
+        assert!(!tree.get_tenant_token_counts().contains_key("tenant1"));
+        assert!(!tree.root.tenant_last_access_time.contains_key("tenant1"));
+
+        // tenant1's path only matches the shared page, now owned by tenant2.
+        let r = tree.match_prefix_with_counts(&tokens1);
+        assert_eq!(r.matched_token_count, PAGE_SIZE);
+        assert_eq!(r.tenant.as_ref(), "tenant2");
+
+        // tenant1's sole-owner branch is detached from the shared node.
+        assert_eq!(tree.root.children.len(), 1);
+        let shared = Arc::clone(tree.root.children.iter().next().unwrap().value());
+        assert_eq!(shared.children.len(), 1);
+
+        // tenant2 still matches its full prefix.
+        let r = tree.match_prefix_with_counts(&tokens2);
+        assert_eq!(r.matched_token_count, 2 * PAGE_SIZE);
+        assert_eq!(r.tenant.as_ref(), "tenant2");
+    }
+
+    #[test]
+    fn test_remove_tenant_all_sole_owner_detaches_subtree() {
+        let tree = TokenTree::new();
+        // Chain root -> [page] -> [2 pages], all owned by tenant1 only.
+        tree.insert_tokens(&make_tokens(500, 1), "tenant1");
+        tree.insert_tokens(&make_tokens(500, 3), "tenant1");
+        assert!(!tree.root.children.is_empty());
+
+        tree.remove_tenant_all(&Arc::from("tenant1"));
+
+        assert!(tree.root.children.is_empty());
+        assert!(!tree.get_tenant_token_counts().contains_key("tenant1"));
+        let r = tree.match_prefix_with_counts(&make_tokens(500, 3));
+        assert_eq!(r.matched_token_count, 0);
     }
 }

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -51,7 +51,7 @@ use std::{
 };
 
 use dashmap::DashMap;
-use kv_index::{compute_request_content_hashes, PositionalIndexer, TokenTree, Tree};
+use kv_index::{compute_request_content_hashes, PositionalIndexer, TenantId, TokenTree, Tree};
 use openai_protocol::worker::WorkerLoadResponse;
 use parking_lot::RwLock;
 use rand::RngExt;
@@ -545,28 +545,21 @@ impl CacheAwarePolicy {
     }
 
     /// Remove a worker from the trees
-    ///
-    /// Note: Currently a no-op. Stale entries are cleaned up by LRU eviction.
-    /// Worker registry removes workers first, so routing will skip them anyway.
-    /// TODO: Implement efficient remove_tenant in kv_index with reverse index.
-    #[expect(
-        clippy::unused_self,
-        reason = "no-op stub; will use self once remove_tenant is implemented"
-    )]
-    pub fn remove_worker(&self, _worker: &dyn Worker) {
-        // No-op: rely on LRU eviction to clean up stale entries
+    pub fn remove_worker(&self, worker: &dyn Worker) {
+        self.remove_worker_by_url(worker.url());
     }
 
-    /// Remove a worker by URL (removes from all model trees for backward compatibility)
-    ///
-    /// Note: Currently a no-op. Stale entries are cleaned up by LRU eviction.
-    /// TODO: Implement efficient remove_tenant in kv_index with reverse index.
-    #[expect(
-        clippy::unused_self,
-        reason = "no-op stub; will use self once remove_tenant is implemented"
-    )]
-    pub fn remove_worker_by_url(&self, _url: &str) {
-        // No-op: rely on LRU eviction to clean up stale entries
+    /// Remove a worker by URL, purging its tenant from every model's string
+    /// and token tree. A removed worker's tenant count never grows again, so
+    /// size-based eviction alone would retain its subtree forever.
+    pub fn remove_worker_by_url(&self, url: &str) {
+        let tenant: TenantId = Arc::from(url);
+        for tree_ref in self.string_trees.iter() {
+            tree_ref.value().remove_tenant_all(&tenant);
+        }
+        for tree_ref in self.token_trees.iter() {
+            tree_ref.value().remove_tenant_all(&tenant);
+        }
     }
 
     /// Run cache eviction to prevent unbounded growth
@@ -1728,6 +1721,80 @@ mod tests {
             )
             .unwrap();
         assert_eq!(idx, 1);
+    }
+
+    #[test]
+    fn test_remove_worker_purges_tree_tenants() {
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        });
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .health_config(no_health_check())
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .health_config(no_health_check())
+                    .build(),
+            ),
+        ];
+        policy.init_workers(&workers);
+
+        // Distinct cold inputs spread across both workers (min-load
+        // tie-breaks by processed count), populating both trees.
+        for text in ["purge me please", "keep me around"] {
+            policy
+                .select_worker(
+                    &workers,
+                    &SelectWorkerInfo {
+                        request_text: Some(text),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+        }
+        let tokens_a: Vec<u32> = (0..32).collect();
+        let tokens_b: Vec<u32> = (1000..1032).collect();
+        for tokens in [&tokens_a, &tokens_b] {
+            policy
+                .select_worker(
+                    &workers,
+                    &SelectWorkerInfo {
+                        tokens: Some(tokens),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+        }
+
+        let model_key = normalize_model_key(workers[0].model_id()).to_string();
+        let string_tree = Arc::clone(policy.string_trees.get(&model_key).unwrap().value());
+        let token_tree = Arc::clone(policy.token_trees.get(&model_key).unwrap().value());
+
+        let char_counts = string_tree.get_tenant_char_count();
+        let token_counts = token_tree.get_tenant_token_counts();
+        for url in ["http://w1:8000", "http://w2:8000"] {
+            assert!(char_counts.contains_key(url), "precondition: {url} routed");
+            assert!(token_counts.contains_key(url), "precondition: {url} routed");
+        }
+
+        policy.remove_worker(workers[0].as_ref());
+
+        let char_counts = string_tree.get_tenant_char_count();
+        assert!(!char_counts.contains_key("http://w1:8000"));
+        assert!(char_counts.contains_key("http://w2:8000"));
+        let token_counts = token_tree.get_tenant_token_counts();
+        assert!(!token_counts.contains_key("http://w1:8000"));
+        assert!(token_counts.contains_key("http://w2:8000"));
+
+        policy.remove_worker_by_url("http://w2:8000");
+        assert!(string_tree.get_tenant_char_count().is_empty());
+        assert!(token_tree.get_tenant_token_counts().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

`CacheAwarePolicy::remove_worker` / `remove_worker_by_url` are no-op stubs that rely on LRU eviction to reclaim a removed worker's radix-tree state. But `evict_tenant_by_size` only evicts tenants whose per-tenant count exceeds `max_tree_size`, and a removed worker's counter never grows again — so its subtree (up to the budget) is retained forever, its tenant entries keep shared nodes non-empty (pinning other tenants' evicted paths), and node splits keep copying the dead tenant into new intermediate nodes. On a large fleet with heavy pod churn this is a steady router RSS leak.

### Solution

Purge the worker's tenant eagerly when it is removed:

- The token tree gains `remove_tenant_all`, mirroring the string tree's (previously caller-less) API: remove the tenant from every node including the root, detach nodes the removal emptied via the existing eviction ancestor cleanup, and drop the `tenant_token_count` entry, debiting the tree-wide token total by the removed count.
- The string tree's `remove_tenant_all` now also detaches nodes the removal emptied (same empty-node rule as `evict_tenant_by_size`) instead of leaving unreachable empty nodes behind, and keeps dropping the `tenant_char_count` entry (which also debits the tree-wide char total).
- `remove_worker` / `remove_worker_by_url` purge the worker's URL from every model's string and token tree. `hash_index` needs no per-worker purge: its entries are keyed by node-path hash and carry no tenant.

## Changes

- `crates/kv_index/src/token_tree.rs`: add `TokenTree::remove_tenant_all` + `collect_tenant_nodes`, reusing `remove_tenant_and_cleanup` for empty-node detachment
- `crates/kv_index/src/string_tree.rs`: `remove_tenant_all` detaches emptied nodes via new `detach_empty_ancestors` (mirrors the eviction empty-node rule)
- `model_gateway/src/policies/cache_aware.rs`: implement `remove_worker` / `remove_worker_by_url` (previously no-op stubs)
- Tests: per-tree purge tests (count entry gone, surviving tenant still matches its full prefix, sole-owner branches detached) and a policy-level add/route/remove test asserting tenant counts empty for the removed URL in both trees; the token tree's total-vs-tenant-sum consistency test gains a tenant-purge step (matching the string tree's)

## Test Plan

- `cargo test -p kv-index` — 220 passed, 0 failed (includes 4 new `remove_tenant_all` tests covering both trees)
- `cargo test -p smg --lib policies` — 132 passed, 0 failed (includes new `test_remove_worker_purges_tree_tenants`)
- `cargo test -p smg` — all test binaries pass
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
