### PR TITLE
perf(kv_index): skip string-tree eviction walk when no tenant is over budget

### DIFF
--- a/crates/kv_index/src/string_tree.rs
+++ b/crates/kv_index/src/string_tree.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Reverse,
-    collections::{BinaryHeap, HashMap},
+    collections::{BinaryHeap, HashMap, HashSet},
     hash::{BuildHasherDefault, Hasher},
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -950,6 +950,18 @@ impl Tree {
     }
 
     pub fn evict_tenant_by_size(&self, max_size: usize) {
+        // Eviction can only touch tenants over budget; skip the
+        // full-tree walk and heap construction when there are none.
+        let over_budget: HashSet<TenantId> = self
+            .tenant_char_count
+            .iter()
+            .filter(|entry| *entry.value() > max_size)
+            .map(|entry| Arc::clone(entry.key()))
+            .collect();
+        if over_budget.is_empty() {
+            return;
+        }
+
         // Calculate used size and collect leaves
         let mut stack = vec![Arc::clone(&self.root)];
         let mut pq = BinaryHeap::new();
@@ -959,8 +971,11 @@ impl Tree {
                 stack.push(Arc::clone(child.value()));
             }
 
-            // Add leaves to priority queue
+            // Add over-budget tenants' leaves to priority queue
             for tenant in Tree::leaf_of(&curr) {
+                if !over_budget.contains(tenant.as_ref()) {
+                    continue;
+                }
                 if let Some(timestamp) = curr.tenant_last_access_time.get(tenant.as_ref()) {
                     pq.push(Reverse(EvictionEntry {
                         timestamp: *timestamp,
@@ -2785,6 +2800,33 @@ mod tests {
 
         let sizes = tree.get_used_size_per_tenant();
         assert!(sizes.is_empty());
+    }
+
+    #[test]
+    fn test_eviction_no_op_when_under_budget() {
+        let tree = Tree::new();
+
+        tree.insert_text("hello", "tenant1");
+        tree.insert_text("world", "tenant2");
+
+        let sizes_before = tree.get_used_size_per_tenant();
+        let counts_before = get_maintained_counts(&tree);
+
+        // Both tenants under budget: nothing may change.
+        tree.evict_tenant_by_size(100);
+
+        // At budget (count == max_size) is not over budget: still a no-op.
+        tree.evict_tenant_by_size(5);
+
+        assert_eq!(tree.get_used_size_per_tenant(), sizes_before);
+        assert_eq!(get_maintained_counts(&tree), counts_before);
+
+        let (matched, tenant) = tree.prefix_match_legacy("hello");
+        assert_eq!(matched, "hello");
+        assert_eq!(tenant, "tenant1");
+        let (matched, tenant) = tree.prefix_match_legacy("world");
+        assert_eq!(matched, "world");
+        assert_eq!(tenant, "tenant2");
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

`StringTree::evict_tenant_by_size` performs a full-tree DFS on every eviction cycle: it builds a per-node leaf map (allocating a `HashMap` per node and scanning every child's tenant map) and pushes every `(leaf, tenant)` pair into a `BinaryHeap` before any budget check runs. The over-budget filter only executes at pop time, so a completely under-budget tree still pays the full O(nodes x tenants-on-leaves) walk and heap construction — and the cache-aware eviction loop runs this every `eviction_interval_secs` for every model's tree.

The token tree already avoids this: `TokenTree::evict_tenant_by_size` filters `tenant_token_count` for offenders first and returns without touching the tree when none exceed the cap.

### Solution

Port the token tree's offender pre-filter to the string tree: consult `tenant_char_count` first and return immediately when no tenant exceeds `max_size`. When offenders exist, run the existing walk but push only over-budget tenants' leaves into the heap.

This preserves eviction semantics exactly. Char counts only decrease during eviction, so a tenant under budget at walk start could never be evicted — its heap entries were always skipped by the pop-time budget check. The heap orders by timestamp only, so filtering out non-offender entries cannot reorder offender pops; the new-leaf re-push path only ever re-pushes the tenant currently being evicted; and the pop-time budget check is retained to stop eviction once an offender drops to `max_size`.

If budget semantics later change from per-tenant to global-total, the pre-filter concept carries over unchanged: a single global-total comparison before the walk is the equivalent guard.

## Changes

- `crates/kv_index/src/string_tree.rs`
  - `evict_tenant_by_size`: collect over-budget tenants from `tenant_char_count` up front; return early when the set is empty; skip non-offender tenants when populating the eviction heap
  - Add `test_eviction_no_op_when_under_budget`: under-budget and exactly-at-budget evictions leave per-tenant computed sizes, maintained counts, and prefix matches untouched

## Test Plan

- `cargo test -p kv-index`: 207 passed, 0 failed. Existing eviction tests pass unchanged as the semantics lock: `test_simple_eviction` (LRU order with a mixed under/over-budget tenant pair), `test_advanced_eviction`, `test_eviction_zero_max_size`, `test_eviction_single_tenant_all_entries`, `test_tenant_char_count` (post-eviction count consistency), `test_concurrent_operations_with_eviction`
- New `test_eviction_no_op_when_under_budget` locks in the no-op path, including the `count == max_size` boundary
- `cargo test -p smg --lib policies::cache_aware` (eviction-loop consumer): 27 passed, 0 failed

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>