### PR TITLE
feat(observability): per-model cache tree size gauges

### DIFF
--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -314,6 +314,18 @@ pub(crate) fn init_metrics() {
         "smg_manual_policy_cache_entries",
         "Number of routing entries in manual policy cache"
     );
+    describe_gauge!(
+        "smg_cache_tree_chars",
+        "Cache-aware string tree cached characters by model (summed across tenants)"
+    );
+    describe_gauge!(
+        "smg_cache_tree_tokens",
+        "Cache-aware token tree cached tokens by model (summed across tenants)"
+    );
+    describe_gauge!(
+        "smg_cache_tree_tenants",
+        "Cache-aware tree tenant count by model and tree (string/token)"
+    );
 
     // Layer 3: Worker resilience metrics (circuit breaker)
     describe_gauge!(
@@ -1158,6 +1170,24 @@ impl Metrics {
         gauge!("smg_manual_policy_cache_entries").set(count as f64);
     }
 
+    /// Set cache-aware string-tree cached characters for a model
+    pub fn set_cache_tree_chars(model_id: &str, chars: usize) {
+        let model = intern_model_label(model_id);
+        gauge!("smg_cache_tree_chars", "model" => model).set(chars as f64);
+    }
+
+    /// Set cache-aware token-tree cached tokens for a model
+    pub fn set_cache_tree_tokens(model_id: &str, tokens: usize) {
+        let model = intern_model_label(model_id);
+        gauge!("smg_cache_tree_tokens", "model" => model).set(tokens as f64);
+    }
+
+    /// Set cache-aware tree tenant count for a model and tree kind ("string"/"token")
+    pub fn set_cache_tree_tenants(model_id: &str, tree: &'static str, count: usize) {
+        let model = intern_model_label(model_id);
+        gauge!("smg_cache_tree_tenants", "model" => model, "tree" => tree).set(count as f64);
+    }
+
     /// Record consistent hashing policy execution branch for routing decisions
     pub fn record_worker_consistent_hashing_policy_branch(branch: &'static str) {
         counter!(
@@ -1760,6 +1790,33 @@ mod tests {
             &pd_labels,
             "4",
         );
+    }
+
+    #[test]
+    fn cache_tree_setters_emit_per_model_gauges() {
+        let rendered = render_with_recorder(|| {
+            Metrics::set_cache_tree_chars("m", 120);
+            Metrics::set_cache_tree_tokens("m", 64);
+            Metrics::set_cache_tree_tenants("m", "string", 3);
+            Metrics::set_cache_tree_tenants("m", "token", 2);
+        });
+
+        assert_metric(&rendered, "smg_cache_tree_chars", &["model=\"m\""], "120");
+        assert_metric(&rendered, "smg_cache_tree_tokens", &["model=\"m\""], "64");
+        // Two tenant series (one per tree kind); series order within the
+        // family is exporter-defined, so match each line independently.
+        for (tree, value) in [("string", "3"), ("token", "2")] {
+            let label = format!("tree=\"{tree}\"");
+            assert!(
+                rendered.lines().any(|l| {
+                    l.starts_with("smg_cache_tree_tenants{")
+                        && l.contains("model=\"m\"")
+                        && l.contains(&label)
+                        && l.ends_with(&format!(" {value}"))
+                }),
+                "smg_cache_tree_tenants {tree} series missing; rendered:\n{rendered}"
+            );
+        }
     }
 
     #[test]

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -64,6 +64,7 @@ use super::{
 };
 use crate::{
     mesh::adapters::tree_sync::{RepairEntry, TreeDelta, TreeRepairPage, TreeSyncAdapter},
+    observability::metrics::Metrics,
     worker::{KvEventMonitor, Worker},
 };
 
@@ -145,6 +146,20 @@ struct PerModelHashIndex {
     token_tree: DashMap<u64, Vec<u32>>,
 }
 
+/// Total cached characters across tenants and the tenant count for one
+/// model's string tree. O(tenants): sums the tree's maintained counters.
+fn string_tree_totals(tree: &Tree) -> (usize, usize) {
+    let counts = tree.get_tenant_char_count();
+    (counts.values().sum(), counts.len())
+}
+
+/// Total cached tokens across tenants and the tenant count for one
+/// model's token tree. O(tenants): sums the tree's maintained counters.
+fn token_tree_totals(tree: &TokenTree) -> (usize, usize) {
+    let counts = tree.get_tenant_token_counts();
+    (counts.values().sum(), counts.len())
+}
+
 impl CacheAwarePolicy {
     pub fn new() -> Self {
         Self::with_config(CacheAwareConfig::default())
@@ -167,10 +182,16 @@ impl CacheAwarePolicy {
                 "Eviction",
                 move || {
                     // Evict string trees (HTTP)
+                    let mut total_chars: usize = 0;
                     for tree_ref in string_trees_clone.iter() {
                         let model_id = tree_ref.key();
                         let tree = tree_ref.value();
                         tree.evict_tenant_by_size(max_tree_size);
+
+                        let (chars, tenants) = string_tree_totals(tree);
+                        total_chars += chars;
+                        Metrics::set_cache_tree_chars(model_id, chars);
+                        Metrics::set_cache_tree_tenants(model_id, "string", tenants);
 
                         debug!(
                             "String tree eviction completed for model {}, max_size: {}",
@@ -178,10 +199,16 @@ impl CacheAwarePolicy {
                         );
                     }
                     // Evict token trees (gRPC)
+                    let mut total_tokens: usize = 0;
                     for tree_ref in token_trees_clone.iter() {
                         let model_id = tree_ref.key();
                         let tree = tree_ref.value();
                         tree.evict_tenant_by_size(max_tree_size);
+
+                        let (tokens, tenants) = token_tree_totals(tree);
+                        total_tokens += tokens;
+                        Metrics::set_cache_tree_tokens(model_id, tokens);
+                        Metrics::set_cache_tree_tenants(model_id, "token", tenants);
 
                         debug!(
                             "Token tree eviction completed for model {}, max_size: {}",
@@ -214,14 +241,18 @@ impl CacheAwarePolicy {
                         hash_total += per_model.string_tree.len() + per_model.token_tree.len();
                     }
 
-                    // Log tree sizes — model counts + hash-index total.
+                    // Log tree sizes — model counts, aggregate sizes +
+                    // hash-index total, from the per-tenant counters.
                     // DO NOT call tree.snapshot() here — it clones all
                     // edge text (~170 MB) every cycle.
                     tracing::info!(
-                        "Tree memory: string_trees={} models, token_trees={} models, \
+                        "Tree memory: string_trees={} models / {} chars, \
+                         token_trees={} models / {} tokens, \
                          hash_index={} models / {} entries",
                         string_trees_clone.len(),
+                        total_chars,
                         token_trees_clone.len(),
+                        total_tokens,
                         hash_index_clone.len(),
                         hash_total,
                     );
@@ -1423,6 +1454,54 @@ mod tests {
             let idx = policy.select_worker(&workers, &info).unwrap();
             assert_eq!(idx, 1); // Should always pick worker2
         }
+    }
+
+    // ---- tree size aggregation (per-model gauges + eviction-cycle log) ----
+
+    #[test]
+    fn string_tree_totals_sums_tenant_chars() {
+        let tree = Tree::new();
+        assert_eq!(string_tree_totals(&tree), (0, 0));
+
+        // Worker registration (empty insert) registers a zero-char tenant.
+        tree.insert_text("", "http://w1:8000");
+        assert_eq!(string_tree_totals(&tree), (0, 1));
+
+        tree.insert_text("hello", "http://w1:8000");
+        assert_eq!(string_tree_totals(&tree), (5, 1));
+
+        // A shared path counts its chars for every tenant on it.
+        tree.insert_text("hello", "http://w2:8000");
+        assert_eq!(string_tree_totals(&tree), (10, 2));
+
+        // "help!" shares "hel", adds only "p!" for w1.
+        tree.insert_text("help!", "http://w1:8000");
+        assert_eq!(string_tree_totals(&tree), (12, 2));
+    }
+
+    #[test]
+    fn token_tree_totals_sums_tenant_tokens() {
+        let tree = TokenTree::new();
+        assert_eq!(token_tree_totals(&tree), (0, 0));
+
+        // Worker registration (empty insert) aligns to zero pages —
+        // no tenant entry.
+        tree.insert_tokens(&[], "http://w1:8000");
+        assert_eq!(token_tree_totals(&tree), (0, 0));
+
+        let page = tree.page_size();
+        let page_a: Vec<u32> = (0..page as u32).collect();
+        tree.insert_tokens(&page_a, "http://w1:8000");
+        assert_eq!(token_tree_totals(&tree), (page, 1));
+
+        // A shared page counts its tokens for every tenant on it.
+        tree.insert_tokens(&page_a, "http://w2:8000");
+        assert_eq!(token_tree_totals(&tree), (2 * page, 2));
+
+        // A disjoint page adds only for its tenant.
+        let page_b: Vec<u32> = (1000..1000 + page as u32).collect();
+        tree.insert_tokens(&page_b, "http://w1:8000");
+        assert_eq!(token_tree_totals(&tree), (3 * page, 2));
     }
 
     // ---- is_imbalanced: 3-term trigger (overload ∨ KV-spread ∨ count) ----


### PR DESCRIPTION
## Description

### Problem

Cache-aware tree growth is otherwise invisible in operation. The only periodic output is the eviction-cycle info log, which reports model counts only (`string_trees=N models`), and the per-tenant tree size APIs (`get_tenant_char_count`, `get_tenant_token_counts`) have no callers. Tree-driven memory growth shows up neither on `/metrics` nor in logs, so it cannot be attributed to the trees.

### Solution

Piggyback on the eviction cycle, which already iterates every model's trees: after each tree's eviction pass, sum its per-tenant size counters (O(tenants) reads of maintained counters — no new task, no new locks, no tree walk) and set per-model gauges. Labels are model-only via the bounded model-label interner; tenant/worker never becomes a label, so large worker pools cannot explode series cardinality — per-tenant sizes are aggregated instead. The periodic info log now carries the aggregate char/token totals, so logs alone tell the story.

## Changes

- New gauges, registered in `init_metrics` and set each eviction cycle:
  - `smg_cache_tree_chars{model}` — string-tree cached characters, summed across tenants
  - `smg_cache_tree_tokens{model}` — token-tree cached tokens, summed across tenants
  - `smg_cache_tree_tenants{model, tree}` — tenant count per tree kind (`string`/`token`)
- `Metrics::set_cache_tree_chars/_tokens/_tenants` setters following the existing policy-gauge pattern
- `string_tree_totals`/`token_tree_totals` aggregation helpers in `cache_aware.rs`
- Eviction-cycle log upgraded: `Tree memory: string_trees={} models / {} chars, token_trees={} models / {} tokens, hash_index={} models / {} entries`

## Test Plan

- `cargo test -p smg --lib policies` — 127 passed, includes new aggregation tests on trees with known contents:
  - `string_tree_totals_sums_tenant_chars` (empty registration insert, shared path counted per tenant, split adds only the new suffix)
  - `token_tree_totals_sums_tenant_tokens` (sub-page inserts excluded, shared page counted per tenant, disjoint page adds only for its tenant)
- `cargo test -p smg --lib cache_tree_setters` — renders a Prometheus scrape via the local-recorder harness and asserts all three series with model/tree labels and values
- Full `cargo test -p smg` — all 23 test targets ok, 0 failures

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
