### PR TITLE
fix(policies): propagate operator config to hinted per-model policies

### DIFF
--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -258,6 +258,20 @@ impl CacheAwarePolicy {
         self.populate_hash_index.load(Ordering::Relaxed)
     }
 
+    /// Test-only view of the effective config so registry tests can
+    /// assert operator tunables propagated.
+    #[cfg(test)]
+    pub(crate) fn config_for_test(&self) -> &CacheAwareConfig {
+        &self.config
+    }
+
+    /// Test-only: whether a KV event monitor is attached, so registry
+    /// tests can assert injection at publication.
+    #[cfg(test)]
+    pub(crate) fn kv_event_monitor_is_set_for_test(&self) -> bool {
+        self.kv_monitor.read().is_some()
+    }
+
     /// Test-only view onto the populate flag so integration tests
     /// outside this file can assert wiring flipped it. Not part of
     /// the public API.

--- a/model_gateway/src/policies/least_load.rs
+++ b/model_gateway/src/policies/least_load.rs
@@ -134,6 +134,17 @@ impl LeastLoadPolicy {
         }
     }
 
+    /// Test-only view of the tunables so registry tests can assert
+    /// operator values propagated.
+    #[cfg(test)]
+    pub(crate) fn params_for_test(&self) -> (f64, u32, f64) {
+        (
+            self.kv_pressure_weight,
+            self.mean_prefill_tokens,
+            self.default_throughput,
+        )
+    }
+
     /// Expected-wait score for a worker (lower is better).
     ///
     /// `inflight` maps worker URL -> token-work dispatched since its last poll.

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -37,6 +37,11 @@ pub struct PolicyRegistry {
     /// Default policy instance (cached, immutable after creation)
     default_policy: Arc<dyn LoadBalancingPolicy>,
 
+    /// Operator config the default policy was built from; hinted per-model
+    /// policies of the same type are built from it so they inherit the
+    /// operator's tunables.
+    default_policy_config: PolicyConfig,
+
     /// Prefill policy for PD mode (set once at startup, lock-free reads via OnceLock)
     prefill_policy: Arc<OnceLock<Arc<dyn LoadBalancingPolicy>>>,
 
@@ -95,6 +100,7 @@ impl PolicyRegistry {
             model_policies: Arc::new(DashMap::new()),
             model_worker_counts: Arc::new(DashMap::new()),
             default_policy,
+            default_policy_config,
             prefill_policy: Arc::new(OnceLock::new()),
             decode_policy: Arc::new(OnceLock::new()),
             encode_policy: Arc::new(OnceLock::new()),
@@ -270,9 +276,20 @@ impl PolicyRegistry {
             model_id
         );
 
-        // Store policy for this model (DashMap handles concurrent inserts)
-        self.model_policies
-            .insert(model_id.to_string(), Arc::clone(&policy));
+        // Inject and publish under the integration guards so a concurrent
+        // setter cannot fall between them: it either wrote before the reads
+        // here, or its propagation scan runs after the insert and finds
+        // this policy.
+        {
+            let monitor = self.kv_event_monitor.read();
+            let load_rx = self.load_rx.read();
+            let mesh = self.mesh_tree_sync.read();
+            Self::maybe_inject_monitor(&policy, monitor.as_ref());
+            Self::maybe_inject_load_rx(&policy, load_rx.as_ref());
+            Self::maybe_inject_mesh_tree_sync(&policy, mesh.as_ref());
+            self.model_policies
+                .insert(model_id.to_string(), Arc::clone(&policy));
+        }
 
         policy
     }
@@ -385,35 +402,27 @@ impl PolicyRegistry {
         Arc::clone(&self.default_policy)
     }
 
-    /// Create a policy from a type string (delegates to PolicyFactory)
+    /// Create a policy from a type string. A hint naming the operator's
+    /// default policy type is built from that config so it inherits the
+    /// operator's tunables; other types are built with their defaults.
+    /// Integration injection happens at publication in
+    /// [`Self::on_worker_added`].
     fn create_policy_from_type(&self, policy_type: &str) -> Arc<dyn LoadBalancingPolicy> {
-        if policy_type == "cache_aware" {
-            let cache_aware = CacheAwarePolicy::new();
-            {
-                let guard = self.kv_event_monitor.read();
-                if let Some(ref monitor) = *guard {
-                    cache_aware.set_kv_event_monitor(Some(Arc::clone(monitor)));
-                }
-            }
-            {
-                let guard = self.load_rx.read();
-                if let Some(ref rx) = *guard {
-                    cache_aware.set_load_receiver(Some(rx.clone()));
-                }
-            }
-            {
-                let guard = self.mesh_tree_sync.read();
-                if let Some(ref adapter) = *guard {
-                    cache_aware.set_mesh_tree_sync(Some(Arc::clone(adapter)));
-                }
-            }
-            Arc::new(cache_aware)
+        if Self::hint_matches_config(policy_type, self.default_policy_config.name()) {
+            Self::create_policy_from_config(&self.default_policy_config)
+        } else if let Some(policy) = PolicyFactory::create_by_name(policy_type) {
+            policy
         } else {
-            PolicyFactory::create_by_name(policy_type).unwrap_or_else(|| {
-                warn!("Unknown policy type '{}', using default", policy_type);
-                Arc::clone(&self.default_policy)
-            })
+            warn!("Unknown policy type '{}', using default", policy_type);
+            Arc::clone(&self.default_policy)
         }
+    }
+
+    /// Whether a policy hint names `config_name`, accepting the same
+    /// underscore-stripped aliases as [`PolicyFactory::create_by_name`].
+    fn hint_matches_config(policy_type: &str, config_name: &str) -> bool {
+        let hint = policy_type.to_lowercase();
+        hint == config_name || hint == config_name.replace('_', "")
     }
 
     /// Create a policy from a PolicyConfig (delegates to PolicyFactory)
@@ -703,7 +712,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        policies::{CacheAwareConfig, SelectWorkerInfo},
+        policies::{CacheAwareConfig, LeastLoadPolicy, SelectWorkerInfo},
         worker::{BasicWorkerBuilder, Worker, WorkerType},
     };
 
@@ -883,6 +892,139 @@ mod tests {
         // Get default directly
         let default = registry.get_default_policy();
         assert_eq!(default.name(), "round_robin");
+    }
+
+    #[test]
+    fn hinted_policy_inherits_operator_cache_aware_config() {
+        let registry = PolicyRegistry::new(PolicyConfig::CacheAware {
+            cache_threshold: 0.9,
+            balance_abs_threshold: 64,
+            balance_rel_threshold: 2.5,
+            eviction_interval_secs: 0,
+            max_tree_size: 4096,
+            block_size: 32,
+            balance_token_usage_threshold: 0.5,
+            overload_token_usage_threshold: 0.8,
+        });
+
+        // Hinted policy is a fresh per-model instance, not the shared default.
+        let policy = registry.on_worker_added("llama-3", Some("cache_aware"));
+        assert!(!Arc::ptr_eq(&policy, &registry.get_default_policy()));
+
+        let config = policy
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .unwrap()
+            .config_for_test();
+        assert_eq!(config.cache_threshold, 0.9);
+        assert_eq!(config.balance_abs_threshold, 64);
+        assert_eq!(config.balance_rel_threshold, 2.5);
+        assert_eq!(config.eviction_interval_secs, 0);
+        assert_eq!(config.max_tree_size, 4096);
+        assert_eq!(config.block_size, 32);
+        assert_eq!(config.balance_token_usage_threshold, 0.5);
+        assert_eq!(config.overload_token_usage_threshold, 0.8);
+
+        // Aliases accepted by create_by_name inherit too.
+        let alias = registry.on_worker_added("llama-4", Some("CacheAware"));
+        let alias_config = alias
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .unwrap()
+            .config_for_test();
+        assert_eq!(alias_config.max_tree_size, 4096);
+    }
+
+    #[test]
+    fn hinted_policy_inherits_operator_least_load_config() {
+        let registry = PolicyRegistry::new(PolicyConfig::LeastLoad {
+            load_check_interval_secs: 10,
+            kv_pressure_weight: 0.4,
+            mean_prefill_tokens: 2048,
+            default_throughput: 555.0,
+        });
+
+        let policy = registry.on_worker_added("llama-3", Some("least_load"));
+        assert!(!Arc::ptr_eq(&policy, &registry.get_default_policy()));
+        let least_load = policy.as_any().downcast_ref::<LeastLoadPolicy>().unwrap();
+        assert_eq!(least_load.params_for_test(), (0.4, 2048, 555.0));
+    }
+
+    /// An integration setter racing policy publication must never be
+    /// missed: publication injects and inserts under the integration
+    /// guards, so the setter either wrote first (its value is injected)
+    /// or its propagation scan runs after the insert.
+    #[test]
+    fn hinted_policy_publication_races_integration_setter() {
+        use std::sync::Barrier;
+
+        use crate::worker::KvEventMonitor;
+
+        const ADDERS: usize = 4;
+
+        let registry = Arc::new(PolicyRegistry::new(PolicyConfig::CacheAware {
+            cache_threshold: 0.5,
+            balance_abs_threshold: 32,
+            balance_rel_threshold: 1.5,
+            eviction_interval_secs: 0,
+            max_tree_size: 128,
+            block_size: 16,
+            balance_token_usage_threshold: 1.0,
+            overload_token_usage_threshold: 1.0,
+        }));
+
+        for round in 0..64 {
+            let monitor = Arc::new(KvEventMonitor::new(Some(4)));
+            let barrier = Arc::new(Barrier::new(ADDERS + 1));
+            let handles: Vec<_> = (0..ADDERS)
+                .map(|k| {
+                    let registry = Arc::clone(&registry);
+                    let barrier = Arc::clone(&barrier);
+                    std::thread::spawn(move || {
+                        barrier.wait();
+                        registry
+                            .on_worker_added(&format!("model-{round}-{k}"), Some("cache_aware"));
+                    })
+                })
+                .collect();
+            barrier.wait();
+            registry.set_kv_event_monitor(Some(monitor));
+            for handle in handles {
+                handle.join().unwrap();
+            }
+            for entry in registry.model_policies.iter() {
+                let cache_aware = entry
+                    .value()
+                    .as_any()
+                    .downcast_ref::<CacheAwarePolicy>()
+                    .unwrap();
+                assert!(
+                    cache_aware.kv_event_monitor_is_set_for_test(),
+                    "policy for {} missed the concurrently-set monitor",
+                    entry.key()
+                );
+            }
+            registry.set_kv_event_monitor(None);
+            registry.clear();
+        }
+    }
+
+    #[test]
+    fn hinted_policy_without_operator_config_uses_type_defaults() {
+        let registry = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        let policy = registry.on_worker_added("llama-3", Some("cache_aware"));
+        let config = policy
+            .as_any()
+            .downcast_ref::<CacheAwarePolicy>()
+            .unwrap()
+            .config_for_test();
+        let defaults = CacheAwareConfig::default();
+        assert_eq!(config.cache_threshold, defaults.cache_threshold);
+        assert_eq!(config.max_tree_size, defaults.max_tree_size);
+        assert_eq!(
+            config.eviction_interval_secs,
+            defaults.eviction_interval_secs
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

`PolicyRegistry` builds policies on two paths. The default policy flows through `PolicyFactory::create_from_config`, which carries the operator's CLI tunables (`--cache-threshold`, `--balance-abs-threshold`, `--balance-rel-threshold`, `--eviction-interval`, `--max-tree-size`, token-usage thresholds, `least_load` weights, ...). But when a model gets its own policy from a worker `policy` label hint, `create_policy_from_type` constructed it with hardcoded defaults: `CacheAwarePolicy::new()` (eviction every 30s, max tree size 10000, cache threshold 0.5) or `PolicyFactory::create_by_name` defaults for `least_load`/`bucket`/`manual`/`prefix_hash`. Any deployment using worker-hinted per-model policies silently ran configuration nobody chose.

Additionally, only the exact `cache_aware` hint received the KV-event-monitor / load-receiver / mesh injections; the `cacheaware`/`CacheAware` aliases accepted by `create_by_name` missed them.

### Solution

Store the operator's default `PolicyConfig` on the registry at construction. `create_policy_from_type` builds a hinted policy from that config whenever the hint names the operator-configured policy type (accepting the same underscore-stripped aliases as `create_by_name`), so hinted per-model policies inherit the operator's tunables while remaining fresh per-model instances. Hints for other policy types keep type defaults, since no operator config exists for them. The cache-aware injections now apply to every instance created here regardless of construction path. PD prefill/decode/encode legs already flow through `create_from_config` and are unchanged.

Injection and publication are also atomic with respect to the integration setters: `on_worker_added` injects the KV-event monitor, load receiver, and mesh adapter and inserts into `model_policies` while holding the integration read guards, so a concurrent `set_kv_event_monitor` / `set_load_receiver` / `set_mesh_tree_sync` either lands before the guard read (its value is injected) or blocks until after the insert (its propagation scan finds the policy). Previously a setter in that window missed the new policy on both paths — it could miss an enabled monitor or keep a detached mesh adapter.

## Changes

- `model_gateway/src/policies/registry.rs`: store `default_policy_config`; build matching hinted policies from it in `create_policy_from_type`; inject KV-monitor/load-receiver/mesh and publish into `model_policies` under the integration read guards in `on_worker_added`
- `model_gateway/src/policies/cache_aware.rs`: test-only `config_for_test` / `kv_event_monitor_is_set_for_test` accessors
- `model_gateway/src/policies/least_load.rs`: test-only `params_for_test` accessor
- Registry tests: hinted `cache_aware` (including alias form) and `least_load` policies carry the operator's values; a hint with no matching operator config keeps type defaults; policy publication racing an integration setter never loses the setter's value

## Test Plan

```
cargo +nightly fmt --all
cargo clippy --all-targets -- -D warnings
cargo test -p smg --lib policies      # 129 passed
cargo test -p smg                     # all 23 test targets pass
```

New regression tests fail on main (hinted policies came back with `CacheAwareConfig::default()` / `LeastLoadPolicy::new()` values):

- `policies::registry::tests::hinted_policy_inherits_operator_cache_aware_config`
- `policies::registry::tests::hinted_policy_inherits_operator_least_load_config`

`policies::registry::tests::hinted_policy_without_operator_config_uses_type_defaults` pins the fallback rule, and `policies::registry::tests::hinted_policy_publication_races_integration_setter` pins the atomic inject-and-publish ordering.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
