### PR TITLE
fix(router): cancel upstream stream relays when the client disconnects

### DIFF
--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -870,16 +870,29 @@ impl Router {
             tokio::spawn(async move {
                 let mut stream = stream;
                 let mut stream_failed = false;
-                while let Some(chunk) = stream.next().await {
-                    match chunk {
-                        Ok(bytes) => {
-                            if tx.send(Ok(bytes)).await.is_err() {
+                let mut client_disconnected = false;
+                loop {
+                    tokio::select! {
+                        chunk = stream.next() => match chunk {
+                            Some(Ok(bytes)) => {
+                                if tx.send(Ok(bytes)).await.is_err() {
+                                    client_disconnected = true;
+                                    break;
+                                }
+                            }
+                            Some(Err(e)) => {
+                                stream_failed = true;
+                                let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                                 break;
                             }
-                        }
-                        Err(e) => {
-                            stream_failed = true;
-                            let _ = tx.send(Err(format!("Stream error: {e}"))).await;
+                            None => break,
+                        },
+                        // Client gone with no chunk in flight (long prefill,
+                        // stalled upstream): break so the reqwest stream drops,
+                        // closing the upstream connection and letting the
+                        // engine abort generation.
+                        () = tx.closed() => {
+                            client_disconnected = true;
                             break;
                         }
                     }
@@ -899,6 +912,13 @@ impl Router {
                         metrics_labels::CONNECTION_HTTP,
                         error_type_from_status(effective_status),
                     );
+                }
+                // A client disconnect gets no terminal router metric: it is
+                // neither a completed request (duration) nor a router or
+                // worker failure (error). Worker-level attribution above
+                // still applies — the header status is a worker fact.
+                if client_disconnected {
+                    return;
                 }
                 if effective_status.is_success() {
                     Metrics::record_router_duration(
@@ -1073,17 +1093,25 @@ impl Router {
             )]
             tokio::spawn(async move {
                 let mut stream = stream;
-                while let Some(chunk) = stream.next().await {
-                    match chunk {
-                        Ok(bytes) => {
-                            if tx.send(Ok(bytes)).await.is_err() {
+                loop {
+                    tokio::select! {
+                        chunk = stream.next() => match chunk {
+                            Some(Ok(bytes)) => {
+                                if tx.send(Ok(bytes)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Some(Err(e)) => {
+                                let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                                 break;
                             }
-                        }
-                        Err(e) => {
-                            let _ = tx.send(Err(format!("Stream error: {e}"))).await;
-                            break;
-                        }
+                            None => break,
+                        },
+                        // Client gone with no chunk in flight (long prefill,
+                        // stalled upstream): break so the reqwest stream drops,
+                        // closing the upstream connection and letting the
+                        // engine abort generation.
+                        () = tx.closed() => break,
                     }
                 }
             });

--- a/model_gateway/tests/routing/mod.rs
+++ b/model_gateway/tests/routing/mod.rs
@@ -11,6 +11,7 @@ pub mod pd_routing_test;
 pub mod policy_registry_integration;
 pub mod power_of_two_test;
 pub mod service_discovery_test;
+pub mod stream_relay_disconnect_test;
 pub mod test_openai_routing;
 pub mod test_pd_routing;
 pub mod worker_management_test;

--- a/model_gateway/tests/routing/stream_relay_disconnect_test.rs
+++ b/model_gateway/tests/routing/stream_relay_disconnect_test.rs
@@ -1,0 +1,234 @@
+//! Client-disconnect propagation for the HTTP router's streaming relays.
+//!
+//! When a streaming client drops the response body, the relay must drop the
+//! upstream reqwest stream promptly — closing the worker connection so the
+//! engine aborts generation — instead of only noticing on the next upstream
+//! chunk, which may never arrive during a long prefill or a stalled upstream.
+
+use std::{
+    convert::Infallible,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use axum::{
+    response::sse::{Event, Sse},
+    routing::post,
+    Router as AxumRouter,
+};
+use futures_util::{stream, StreamExt};
+use http_body_util::BodyExt;
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    transcription::{AudioFile, TranscriptionRequest},
+};
+use serde_json::json;
+use smg::{
+    routers::{router::Router as HttpRouter, RouterTrait},
+    tenant::{RouteRequestMeta, TenantKey},
+    worker::{BasicWorkerBuilder, ModelCard, Worker},
+};
+use tokio::{net::TcpListener, sync::oneshot, time::timeout};
+
+use crate::common::test_app::create_test_app_context;
+
+/// Sends on drop, so the test observes the moment the upstream response body
+/// is dropped — i.e. the gateway actually closed the worker connection.
+struct DropSignal(Option<oneshot::Sender<()>>);
+
+impl Drop for DropSignal {
+    fn drop(&mut self) {
+        if let Some(tx) = self.0.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+/// Upstream that answers with SSE headers, optionally one chunk, then stalls
+/// forever. Returns the base URL and a receiver that completes when the
+/// stalled response body is dropped.
+#[expect(
+    clippy::disallowed_methods,
+    clippy::unwrap_used,
+    reason = "test infrastructure - panicking on failure is intentional"
+)]
+async fn spawn_stalling_upstream(send_first_chunk: bool) -> (String, oneshot::Receiver<()>) {
+    let (dropped_tx, dropped_rx) = oneshot::channel();
+    let signal = Arc::new(Mutex::new(Some(DropSignal(Some(dropped_tx)))));
+
+    let handler = move || {
+        let signal = Arc::clone(&signal);
+        async move {
+            let signal = signal.lock().unwrap().take();
+            let head =
+                send_first_chunk.then(|| Ok::<Event, Infallible>(Event::default().data("head")));
+            // `map` owns `signal`, so the DropSignal fires exactly when this
+            // body stream is dropped by the server end of the connection.
+            let body = stream::iter(head)
+                .chain(stream::pending::<Result<Event, Infallible>>())
+                .map(move |item| {
+                    let _held = &signal;
+                    item
+                });
+            Sse::new(body)
+        }
+    };
+
+    let app = AxumRouter::new()
+        .route("/v1/chat/completions", post(handler.clone()))
+        .route("/v1/audio/transcriptions", post(handler));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    (format!("http://{addr}"), dropped_rx)
+}
+
+/// Build an HTTP router whose only worker is the given upstream.
+#[expect(
+    clippy::unwrap_used,
+    reason = "test infrastructure - panicking on failure is intentional"
+)]
+async fn http_router_for(upstream_url: &str) -> HttpRouter {
+    let ctx = create_test_app_context().await;
+    let worker: Arc<dyn Worker> = Arc::new(
+        BasicWorkerBuilder::new(upstream_url)
+            .models(vec![ModelCard::new("mock-model")])
+            .health_config(openai_protocol::worker::HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            })
+            .build(),
+    );
+    ctx.worker_registry.register(worker);
+    HttpRouter::new(&ctx).await.unwrap()
+}
+
+fn tenant_meta() -> smg::middleware::TenantRequestMeta {
+    RouteRequestMeta::new(TenantKey::from("test-tenant"))
+}
+
+#[expect(
+    clippy::unwrap_used,
+    reason = "test infrastructure - panicking on failure is intentional"
+)]
+fn streaming_chat_request() -> ChatCompletionRequest {
+    serde_json::from_value(json!({
+        "model": "mock-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": true
+    }))
+    .unwrap()
+}
+
+/// Client disconnects while the upstream has produced no chunk yet (the
+/// prefill window). The relay must not wait for a first token that may be
+/// tens of seconds away — or never come.
+#[tokio::test]
+async fn chat_relay_closes_upstream_when_client_disconnects_during_prefill() {
+    let (upstream_url, dropped_rx) = spawn_stalling_upstream(false).await;
+    let router = http_router_for(&upstream_url).await;
+
+    let response = router
+        .route_chat(
+            None,
+            &tenant_meta(),
+            &streaming_chat_request(),
+            "mock-model",
+        )
+        .await;
+    assert_eq!(response.status(), 200);
+
+    // Client disconnect: the response body (and its relay channel receiver)
+    // is dropped before any chunk arrived.
+    drop(response);
+
+    timeout(Duration::from_secs(5), dropped_rx)
+        .await
+        .expect("upstream response body was not dropped: relay did not notice client disconnect")
+        .expect("drop signal sender vanished without firing");
+}
+
+/// Client disconnects mid-stream while the upstream is stalled between
+/// chunks. The relay is parked in `stream.next()` and must still notice.
+#[tokio::test]
+async fn chat_relay_closes_upstream_when_client_disconnects_mid_stream() {
+    let (upstream_url, mut dropped_rx) = spawn_stalling_upstream(true).await;
+    let router = http_router_for(&upstream_url).await;
+
+    let response = router
+        .route_chat(
+            None,
+            &tenant_meta(),
+            &streaming_chat_request(),
+            "mock-model",
+        )
+        .await;
+    assert_eq!(response.status(), 200);
+
+    let mut body = response.into_body();
+    let first = body.frame().await;
+    assert!(
+        matches!(first, Some(Ok(_))),
+        "expected a first streamed chunk, got {first:?}"
+    );
+
+    // Upstream must stay attached while the client is still reading.
+    assert!(
+        dropped_rx.try_recv().is_err(),
+        "upstream body dropped while the client was still connected"
+    );
+
+    drop(body);
+
+    timeout(Duration::from_secs(5), dropped_rx)
+        .await
+        .expect("upstream response body was not dropped: relay did not notice client disconnect")
+        .expect("drop signal sender vanished without firing");
+}
+
+/// Same contract for the transcription relay, which additionally carries
+/// stream-outcome attribution: a client disconnect must still drop the
+/// upstream stream promptly.
+#[tokio::test]
+async fn transcription_relay_closes_upstream_when_client_disconnects() {
+    let (upstream_url, mut dropped_rx) = spawn_stalling_upstream(true).await;
+    let router = http_router_for(&upstream_url).await;
+
+    let request = TranscriptionRequest {
+        model: "mock-model".to_string(),
+        stream: Some(true),
+        ..Default::default()
+    };
+    let audio = AudioFile {
+        bytes: bytes::Bytes::from_static(b"not real audio"),
+        file_name: "test.wav".to_string(),
+        content_type: Some("audio/wav".to_string()),
+    };
+
+    let response = router
+        .route_audio_transcriptions(None, &tenant_meta(), &request, audio, "mock-model")
+        .await;
+    assert_eq!(response.status(), 200);
+
+    let mut body = response.into_body();
+    let first = body.frame().await;
+    assert!(
+        matches!(first, Some(Ok(_))),
+        "expected a first streamed chunk, got {first:?}"
+    );
+    assert!(
+        dropped_rx.try_recv().is_err(),
+        "upstream body dropped while the client was still connected"
+    );
+
+    drop(body);
+
+    timeout(Duration::from_secs(5), dropped_rx)
+        .await
+        .expect("upstream response body was not dropped: relay did not notice client disconnect")
+        .expect("drop signal sender vanished without firing");
+}


### PR DESCRIPTION
## Description

### Problem

The HTTP router's streaming proxy relays (`send_typed_request`'s SSE branch and the transcription relay in `model_gateway/src/routers/http/router.rs`) forward upstream chunks through a bounded channel and only notice a client disconnect when the next `tx.send` fails. While parked in `stream.next().await` they never observe the channel closing, so:

- A client that disconnects during a long prefill (no chunks flowing yet — tens of seconds on big-context workloads) keeps the upstream request alive, and the engine keeps computing for a dead client until first token.
- A silent or hung upstream pins the relay task, the upstream connection, and the channel for up to the full request timeout (1800s default).

### Solution

`tokio::select!` between `stream.next()` and `tx.closed()` in both relay loops. When the client goes away (the response body — and with it the channel receiver — is dropped), the relay breaks immediately, dropping the reqwest stream and closing the upstream connection; engines abort generation natively when the connection closes. A `closed()`-arm exit and an in-flight chunk-forward `tx.send` failure are treated as the same client-disconnect outcome.

Attribution on the client-disconnect exit (the transcription relay owns stream-completion attribution):

- Worker-level bookkeeping is unchanged: the circuit breaker still records the header status, and `worker_error` still fires for a 5xx header — both are facts about the worker, independent of the client leaving.
- No terminal router metric is recorded: a client abort is neither a completed request (recording `router_request_duration` would skew the histogram with short aborted streams) nor a router/worker failure (recording `router_error` would alert on client behavior). This matches the other client-abort paths: the typed streaming path records its terminal router metrics at header time and treats mid-stream aborts as benign, and the gRPC streaming tasks and the Anthropic MCP loop treat client disconnects as clean terminations rather than errors.

Normal exits (stream completed, mid-stream upstream error, 5xx header under `stream=true`) are attributed exactly as before.

## Changes

- `model_gateway/src/routers/http/router.rs`: both stream relay loops (`send_typed_request` SSE branch, transcription streaming branch) select on `tx.closed()` and break so the reqwest stream drops promptly; the transcription relay classifies a client disconnect as a distinct outcome (worker attribution kept, terminal router metrics skipped).
- `model_gateway/tests/routing/stream_relay_disconnect_test.rs` (new): a mock axum upstream returns SSE headers, optionally one chunk, then stalls forever, holding a drop guard that fires the moment the gateway drops the upstream response body. Tests drop the client body during prefill and mid-stream (chat) and mid-stream (transcription), asserting the upstream is released promptly instead of hanging on the stall.

## Test Plan

- `cargo test -p smg --test routing_tests stream_relay` — the 3 new tests pass in ~0.05s.
- Reverting the `router.rs` change makes all 3 fail on their 5s timeouts (the relay never notices the disconnect while the upstream stalls), confirming the tests capture the bug.
- `cargo test -p smg --lib` — 1486 passed.
- `cargo test -p smg --test routing_tests` — 105 passed.
- `cargo test -p smg --test api_tests` — 106 passed.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

