### PR TITLE
fix(kv_index): enforce max_tree_size as a shared per-model tree budget

### DIFF
--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -174,8 +174,10 @@ class Router:
         eviction_interval_secs: Interval in seconds between cache eviction operations
             in cache-aware routing. Default: 60
         max_payload_size: Maximum payload size in bytes. Default: 256MB
-        max_tree_size: Maximum size of the approximation tree for cache-aware routing.
-            Default: 2^24
+        max_tree_size: Maximum total size of each model's approximation tree for
+            cache-aware routing (chars for HTTP, tokens for gRPC), shared across
+            all workers; eviction keeps every tree at or under this bound.
+            Default: 2^26
         dp_aware: Enable data parallelism aware schedule. Default: False
         dp_minimum_tokens_scheduler: Enable minimum tokens scheduler for data parallel group. Default: False
         enable_igw: Enable IGW (Inference-Gateway) mode for multi-model support. When

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -468,7 +468,10 @@ class RouterArgs:
             f"--{prefix}max-tree-size",
             type=int,
             default=RouterArgs.max_tree_size,
-            help="Maximum size of the approximation tree for cache-aware routing",
+            help="Maximum total size of each model's approximation tree for "
+            "cache-aware routing (chars for HTTP, tokens for gRPC), shared "
+            "across all workers; eviction keeps every tree at or under this "
+            "bound",
         )
         routing_group.add_argument(
             f"--{prefix}block-size",

--- a/crates/kv_index/src/string_tree.rs
+++ b/crates/kv_index/src/string_tree.rs
@@ -1,9 +1,9 @@
 use std::{
     cmp::Reverse,
-    collections::{BinaryHeap, HashMap, HashSet},
+    collections::{BinaryHeap, HashMap},
     hash::{BuildHasherDefault, Hasher},
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc, Weak,
     },
 };
@@ -268,7 +268,10 @@ struct Node {
 pub struct Tree {
     root: NodeRef,
     /// Per-tenant character count for size tracking. Using TenantId for consistency.
-    pub tenant_char_count: DashMap<TenantId, usize>,
+    tenant_char_count: DashMap<TenantId, usize>,
+    /// Tree-wide char total (sum of `tenant_char_count`); the budget
+    /// checked by `evict_tenant_by_size`
+    total_char_count: AtomicUsize,
 }
 
 // For the heap
@@ -387,6 +390,7 @@ impl Tree {
                 last_tenant: RwLock::new(None),
             }),
             tenant_char_count: DashMap::with_shard_amount(ROOT_SHARD_COUNT),
+            total_char_count: AtomicUsize::new(0),
         }
     }
 
@@ -448,10 +452,7 @@ impl Tree {
                     });
 
                     // Attach tenant to the new leaf node with timestamp
-                    self.tenant_char_count
-                        .entry(Arc::clone(&tenant_id))
-                        .and_modify(|count| *count += remaining_char_count)
-                        .or_insert(remaining_char_count);
+                    self.add_tenant_chars(&tenant_id, remaining_char_count);
                     new_node
                         .tenant_last_access_time
                         .insert(Arc::clone(&tenant_id), epoch);
@@ -506,10 +507,7 @@ impl Tree {
                             .tenant_last_access_time
                             .contains_key(tenant_id.as_ref())
                         {
-                            self.tenant_char_count
-                                .entry(Arc::clone(&tenant_id))
-                                .and_modify(|count| *count += matched_text_count)
-                                .or_insert(matched_text_count);
+                            self.add_tenant_chars(&tenant_id, matched_text_count);
                             new_node
                                 .tenant_last_access_time
                                 .insert(Arc::clone(&tenant_id), 0);
@@ -528,10 +526,7 @@ impl Tree {
                             .tenant_last_access_time
                             .contains_key(tenant_id.as_ref())
                         {
-                            self.tenant_char_count
-                                .entry(Arc::clone(&tenant_id))
-                                .and_modify(|count| *count += matched_node_text_count)
-                                .or_insert(matched_node_text_count);
+                            self.add_tenant_chars(&tenant_id, matched_node_text_count);
                             matched_node
                                 .tenant_last_access_time
                                 .insert(Arc::clone(&tenant_id), 0);
@@ -788,10 +783,7 @@ impl Tree {
                 .tenant_last_access_time
                 .contains_key(tenant_id.as_ref())
             {
-                self.tenant_char_count
-                    .entry(Arc::clone(&tenant_id))
-                    .and_modify(|count| *count += *char_count)
-                    .or_insert(*char_count);
+                self.add_tenant_chars(&tenant_id, *char_count);
                 node.tenant_last_access_time
                     .insert(Arc::clone(&tenant_id), 0);
             }
@@ -949,20 +941,18 @@ impl Tree {
             .collect()
     }
 
+    /// Evict cache entries until the tree-wide char total is at or under
+    /// `max_size`.
+    ///
+    /// The budget is shared across all tenants of this tree: eviction triggers
+    /// on the tree-wide total (no single tenant has to exceed anything) and
+    /// removes leaves in LRU order across tenants, least recently used first.
     pub fn evict_tenant_by_size(&self, max_size: usize) {
-        // Eviction can only touch tenants over budget; skip the
-        // full-tree walk and heap construction when there are none.
-        let over_budget: HashSet<TenantId> = self
-            .tenant_char_count
-            .iter()
-            .filter(|entry| *entry.value() > max_size)
-            .map(|entry| Arc::clone(entry.key()))
-            .collect();
-        if over_budget.is_empty() {
+        if self.total_char_size() <= max_size {
             return;
         }
 
-        // Calculate used size and collect leaves
+        // Collect leaves across all tenants
         let mut stack = vec![Arc::clone(&self.root)];
         let mut pq = BinaryHeap::new();
 
@@ -971,11 +961,13 @@ impl Tree {
                 stack.push(Arc::clone(child.value()));
             }
 
-            // Add over-budget tenants' leaves to priority queue
+            // Root is never eligible for eviction
+            if Arc::ptr_eq(&curr, &self.root) {
+                continue;
+            }
+
+            // Add leaves to priority queue
             for tenant in Tree::leaf_of(&curr) {
-                if !over_budget.contains(tenant.as_ref()) {
-                    continue;
-                }
                 if let Some(timestamp) = curr.tenant_last_access_time.get(tenant.as_ref()) {
                     pq.push(Reverse(EvictionEntry {
                         timestamp: *timestamp,
@@ -991,14 +983,16 @@ impl Tree {
             debug!("Tenant: {}, Size: {}", entry.key(), entry.value());
         }
 
-        // Process eviction
-        while let Some(Reverse(entry)) = pq.pop() {
+        // Process eviction until the tree-wide total obeys the budget
+        while self.total_char_size() > max_size {
+            let Some(Reverse(entry)) = pq.pop() else {
+                break;
+            };
             let EvictionEntry { tenant, node, .. } = entry;
 
-            if let Some(used_size) = self.tenant_char_count.get(tenant.as_ref()) {
-                if *used_size <= max_size {
-                    continue;
-                }
+            // Root is never eligible for eviction (re-enters via promotion)
+            if Arc::ptr_eq(&node, &self.root) {
+                continue;
             }
 
             // Verify this node is still a leaf for this tenant (may have changed)
@@ -1016,11 +1010,7 @@ impl Tree {
 
             // Decrement when removing tenant from node
             let node_len = node.text.read().char_count();
-            self.tenant_char_count
-                .entry(Arc::clone(&tenant))
-                .and_modify(|count| {
-                    *count = count.saturating_sub(node_len);
-                });
+            self.sub_tenant_chars(&tenant, node_len);
 
             // Remove tenant from node
             node.tenant_last_access_time.remove(tenant.as_ref());
@@ -1132,7 +1122,9 @@ impl Tree {
         for (node, _) in &nodes {
             self.remove_tenant_from_node(node, tenant_id);
         }
-        self.tenant_char_count.remove(tenant_id);
+        if let Some((_, count)) = self.tenant_char_count.remove(tenant_id) {
+            self.total_char_count.fetch_sub(count, Ordering::Relaxed);
+        }
     }
 
     /// Evict a specific number of chars for a tenant using LRU ordering.
@@ -1161,10 +1153,8 @@ impl Tree {
             }
         }
 
-        // Update tenant char count
-        self.tenant_char_count
-            .entry(tenant_id.clone())
-            .and_modify(|count| *count = count.saturating_sub(evicted));
+        // Update tenant char count and tree-wide total
+        self.sub_tenant_chars(tenant_id, evicted);
     }
 
     fn collect_tenant_nodes(
@@ -1198,7 +1188,38 @@ impl Tree {
         self.tenant_char_count.get(tenant).map(|v| *v).unwrap_or(0)
     }
 
-    /// Clear the tree to empty state.
+    /// Tree-wide char total (sum of per-tenant counts).
+    pub fn total_char_size(&self) -> usize {
+        self.total_char_count.load(Ordering::Relaxed)
+    }
+
+    /// Fold `chars` into a tenant's count and the tree-wide total.
+    fn add_tenant_chars(&self, tenant_id: &TenantId, chars: usize) {
+        if chars == 0 {
+            return;
+        }
+        self.tenant_char_count
+            .entry(Arc::clone(tenant_id))
+            .and_modify(|count| *count += chars)
+            .or_insert(chars);
+        self.total_char_count.fetch_add(chars, Ordering::Relaxed);
+    }
+
+    /// Subtract evicted `chars` from a tenant's count and the tree-wide
+    /// total, clamped to the tenant's current count so the two stay in sync.
+    fn sub_tenant_chars(&self, tenant_id: &TenantId, chars: usize) {
+        if chars == 0 {
+            return;
+        }
+        if let Some(mut count) = self.tenant_char_count.get_mut(tenant_id.as_ref()) {
+            let removed = chars.min(*count);
+            *count -= removed;
+            self.total_char_count.fetch_sub(removed, Ordering::Relaxed);
+        }
+    }
+
+    /// Clear the tree to empty state. Not synchronized with concurrent
+    /// mutation: callers must quiesce writers first.
     pub fn clear(&self) {
         // Clear root's children
         self.root.children.clear();
@@ -1206,6 +1227,7 @@ impl Tree {
         self.root.tenant_last_access_time.clear();
         // Clear tenant char counts
         self.tenant_char_count.clear();
+        self.total_char_count.store(0, Ordering::Relaxed);
         // Reset root text
         *self.root.text.write() = NodeText::new(String::new());
     }
@@ -1454,20 +1476,15 @@ impl Tree {
         }
 
         let mut idx = 0;
-        Self::restore_node(
-            &tree.root,
-            &snapshot.nodes,
-            &mut idx,
-            &tree.tenant_char_count,
-        );
+        tree.restore_node(&tree.root, &snapshot.nodes, &mut idx);
         tree
     }
 
     fn restore_node(
+        &self,
         target: &NodeRef,
         nodes: &[crate::snapshot::SnapshotNode],
         idx: &mut usize,
-        tenant_counts: &DashMap<TenantId, usize>,
     ) {
         if *idx >= nodes.len() {
             return;
@@ -1480,6 +1497,7 @@ impl Tree {
         *target.text.write() = NodeText::new(snap_node.edge.clone());
 
         // Set tenants
+        let edge_chars = snap_node.edge.chars().count();
         for (tenant_str, epoch) in &snap_node.tenants {
             let tenant_id = intern_tenant(tenant_str);
             target
@@ -1487,11 +1505,7 @@ impl Tree {
                 .insert(Arc::clone(&tenant_id), *epoch);
 
             // Track char counts
-            let edge_chars = snap_node.edge.chars().count();
-            tenant_counts
-                .entry(tenant_id)
-                .and_modify(|c| *c += edge_chars)
-                .or_insert(edge_chars);
+            self.add_tenant_chars(&tenant_id, edge_chars);
         }
 
         // Restore children
@@ -1525,7 +1539,7 @@ impl Tree {
                 last_tenant: RwLock::new(None),
             });
 
-            Self::restore_node(&child_node, nodes, idx, tenant_counts);
+            self.restore_node(&child_node, nodes, idx);
             target.children.insert(first_char, child_node);
         }
     }
@@ -1552,10 +1566,10 @@ impl Tree {
     /// (remote wins on newer epoch) and reconciles children using the
     /// three-case edge comparison.
     pub fn merge_tree(&self, remote: &Tree) {
-        Self::merge_nodes(&self.root, &remote.root, &self.tenant_char_count);
+        self.merge_nodes(&self.root, &remote.root);
     }
 
-    fn merge_nodes(local: &NodeRef, remote: &NodeRef, tenant_counts: &DashMap<TenantId, usize>) {
+    fn merge_nodes(&self, local: &NodeRef, remote: &NodeRef) {
         // Merge tenants at this node
         for entry in &remote.tenant_last_access_time {
             let tenant_id = Arc::clone(entry.key());
@@ -1578,10 +1592,7 @@ impl Tree {
 
                 if is_new {
                     let edge_chars = local.text.read().char_count();
-                    tenant_counts
-                        .entry(tenant_id)
-                        .and_modify(|c| *c += edge_chars)
-                        .or_insert(edge_chars);
+                    self.add_tenant_chars(&tenant_id, edge_chars);
                 }
             }
         }
@@ -1601,7 +1612,7 @@ impl Tree {
 
                 if shared == local_edge.chars().count() && shared == remote_edge.chars().count() {
                     // Case 1: exact match — recurse
-                    Self::merge_nodes(&local_child, &remote_child, tenant_counts);
+                    self.merge_nodes(&local_child, &remote_child);
                 } else if shared == local_edge.chars().count() {
                     // Case 2: local edge is a prefix of remote edge.
                     // Descend into local child. The remote child's edge
@@ -1626,10 +1637,7 @@ impl Tree {
                                 .insert(Arc::clone(&tid), epoch);
                             if is_new {
                                 let edge_chars = local_edge.chars().count();
-                                tenant_counts
-                                    .entry(tid)
-                                    .and_modify(|c| *c += edge_chars)
-                                    .or_insert(edge_chars);
+                                self.add_tenant_chars(&tid, edge_chars);
                             }
                         }
                     }
@@ -1659,11 +1667,11 @@ impl Tree {
                     if let Some(deeper_local) = local_child.children.get(&rem_first) {
                         let deeper_local = deeper_local.value().clone();
                         // Recurse: merge trimmed remote into the deeper local child
-                        Self::merge_nodes(&deeper_local, &trimmed_remote, tenant_counts);
+                        self.merge_nodes(&deeper_local, &trimmed_remote);
                     } else {
                         // No local child at this position — graft remote subtree
                         *trimmed_remote.parent.write() = Some(Arc::downgrade(&local_child));
-                        Self::accumulate_tenant_counts(&trimmed_remote, tenant_counts);
+                        self.accumulate_tenant_counts(&trimmed_remote);
                         local_child.children.insert(rem_first, trimmed_remote);
                     }
                 } else {
@@ -1713,10 +1721,7 @@ impl Tree {
                                 .tenant_last_access_time
                                 .insert(Arc::clone(&tid), epoch);
                             if is_new {
-                                tenant_counts
-                                    .entry(tid)
-                                    .and_modify(|c| *c += split_chars)
-                                    .or_insert(split_chars);
+                                self.add_tenant_chars(&tid, split_chars);
                             }
                         }
                     }
@@ -1747,7 +1752,7 @@ impl Tree {
                                 .children
                                 .insert(*child_entry.key(), child_clone);
                         }
-                        Self::accumulate_tenant_counts(&remote_subtree, tenant_counts);
+                        self.accumulate_tenant_counts(&remote_subtree);
                         split_node.children.insert(rem_first, remote_subtree);
                     }
 
@@ -1757,7 +1762,7 @@ impl Tree {
             } else {
                 // No local child at this char — copy entire remote subtree
                 let cloned = Self::clone_subtree(&remote_child, Some(local));
-                Self::accumulate_tenant_counts(&cloned, tenant_counts);
+                self.accumulate_tenant_counts(&cloned);
                 local.children.insert(rc, cloned);
             }
         }
@@ -1767,17 +1772,13 @@ impl Tree {
     /// tree-level `tenant_char_count` map.  Called after grafting a
     /// remote subtree into the local tree so that size tracking and
     /// eviction remain correct.
-    fn accumulate_tenant_counts(node: &NodeRef, tenant_counts: &DashMap<TenantId, usize>) {
+    fn accumulate_tenant_counts(&self, node: &NodeRef) {
         let edge_chars = node.text.read().char_count();
         for entry in &node.tenant_last_access_time {
-            let tid = Arc::clone(entry.key());
-            tenant_counts
-                .entry(tid)
-                .and_modify(|c| *c += edge_chars)
-                .or_insert(edge_chars);
+            self.add_tenant_chars(entry.key(), edge_chars);
         }
         for child_entry in &node.children {
-            Self::accumulate_tenant_counts(child_entry.value(), tenant_counts);
+            self.accumulate_tenant_counts(child_entry.value());
         }
     }
 
@@ -2263,13 +2264,14 @@ mod tests {
         assert_eq!(sizes_before.get("tenant1").unwrap(), &5); // "hello" = 5
         assert_eq!(sizes_before.get("tenant2").unwrap(), &10); // "hello" + "world" = 10
 
-        // Evict - should remove "hello" from tenant2 as it's the oldest
+        // Evict: the tree-wide total (15) exceeds max_size, so LRU leaves go
+        // first - tenant1's "hello" (oldest), then tenant2's "hello"
         tree.evict_tenant_by_size(max_size);
 
         tree.pretty_print();
 
         let sizes_after = tree.get_used_size_per_tenant();
-        assert_eq!(sizes_after.get("tenant1").unwrap(), &5); // Should be unchanged
+        assert_eq!(*sizes_after.get("tenant1").unwrap_or(&0), 0); // Oldest, evicted
         assert_eq!(sizes_after.get("tenant2").unwrap(), &5); // Only "world" remains
 
         let (matched, tenant) = tree.prefix_match_legacy("world");
@@ -2281,7 +2283,7 @@ mod tests {
     fn test_advanced_eviction() {
         let tree = Tree::new();
 
-        // Set limits for each tenant
+        // Tree-wide budget
         let max_size: usize = 100;
 
         // Define prefixes
@@ -2300,14 +2302,13 @@ mod tests {
         // Perform eviction
         tree.evict_tenant_by_size(max_size);
 
-        // Check sizes after eviction
+        // Check sizes after eviction: the tree-wide total obeys the budget
         let sizes_after = tree.get_used_size_per_tenant();
-        for (tenant, &size) in &sizes_after {
-            assert!(
-                size <= max_size,
-                "Tenant {tenant} exceeds size limit. Current size: {size}, Limit: {max_size}"
-            );
-        }
+        let total_after: usize = sizes_after.values().sum();
+        assert!(
+            total_after <= max_size,
+            "Tree total exceeds budget. Total: {total_after}, Limit: {max_size}"
+        );
     }
 
     #[test]
@@ -2318,7 +2319,7 @@ mod tests {
         let mut handles = vec![];
         let test_duration = Duration::from_secs(10);
         let start_time = Instant::now();
-        let max_size = 100; // Single max size for all tenants
+        let max_size = 100; // Tree-wide budget
 
         // Spawn eviction thread
         {
@@ -2373,16 +2374,15 @@ mod tests {
         // final eviction
         tree.evict_tenant_by_size(max_size);
 
-        // Final size check
+        // Final size check: the tree-wide total obeys the budget
         let final_sizes = tree.get_used_size_per_tenant();
         println!("Final sizes after test completion: {final_sizes:?}");
 
-        for &size in final_sizes.values() {
-            assert!(
-                size <= max_size,
-                "Tenant exceeds size limit. Final size: {size}, Limit: {max_size}"
-            );
-        }
+        let final_total: usize = final_sizes.values().sum();
+        assert!(
+            final_total <= max_size,
+            "Tree total exceeds budget. Final total: {final_total}, Limit: {max_size}"
+        );
     }
 
     #[test]
@@ -2800,33 +2800,6 @@ mod tests {
 
         let sizes = tree.get_used_size_per_tenant();
         assert!(sizes.is_empty());
-    }
-
-    #[test]
-    fn test_eviction_no_op_when_under_budget() {
-        let tree = Tree::new();
-
-        tree.insert_text("hello", "tenant1");
-        tree.insert_text("world", "tenant2");
-
-        let sizes_before = tree.get_used_size_per_tenant();
-        let counts_before = get_maintained_counts(&tree);
-
-        // Both tenants under budget: nothing may change.
-        tree.evict_tenant_by_size(100);
-
-        // At budget (count == max_size) is not over budget: still a no-op.
-        tree.evict_tenant_by_size(5);
-
-        assert_eq!(tree.get_used_size_per_tenant(), sizes_before);
-        assert_eq!(get_maintained_counts(&tree), counts_before);
-
-        let (matched, tenant) = tree.prefix_match_legacy("hello");
-        assert_eq!(matched, "hello");
-        assert_eq!(tenant, "tenant1");
-        let (matched, tenant) = tree.prefix_match_legacy("world");
-        assert_eq!(matched, "world");
-        assert_eq!(tenant, "tenant2");
     }
 
     #[test]
@@ -3359,5 +3332,114 @@ mod tests {
             before,
             "None selection must not insert"
         );
+    }
+
+    #[test]
+    fn test_evict_by_size_shared_budget_lru_tenants() {
+        let tree = Tree::new();
+
+        // 8 tenants, 10 chars each: every tenant is under the budget on its
+        // own, but the tree-wide total is double the budget.
+        for t in 0..8 {
+            tree.insert_text(&format!("{t}aaaaaaaaa"), &format!("tenant{t}"));
+        }
+        assert_eq!(tree.total_char_size(), 80);
+
+        tree.evict_tenant_by_size(40);
+
+        assert!(tree.total_char_size() <= 40);
+        // Least-recently-used tenants are evicted first.
+        let sizes = tree.get_used_size_per_tenant();
+        for t in 0..4 {
+            assert_eq!(
+                *sizes.get(&format!("tenant{t}")).unwrap_or(&0),
+                0,
+                "tenant{t} (LRU) should be evicted"
+            );
+        }
+        for t in 4..8 {
+            assert_eq!(
+                *sizes.get(&format!("tenant{t}")).unwrap(),
+                10,
+                "tenant{t} should survive"
+            );
+        }
+    }
+
+    #[test]
+    fn test_evict_by_size_under_budget_is_noop() {
+        let tree = Tree::new();
+        for t in 0..4 {
+            tree.insert_text(&format!("{t}aaaaaaaaa"), &format!("tenant{t}"));
+        }
+        let counts_before = tree.get_tenant_char_count();
+        assert_eq!(tree.total_char_size(), 40);
+
+        // At and above the budget: nothing may change.
+        tree.evict_tenant_by_size(40);
+        tree.evict_tenant_by_size(usize::MAX);
+
+        assert_eq!(tree.get_tenant_char_count(), counts_before);
+        assert_eq!(tree.total_char_size(), 40);
+        assert_eq!(tree.get_used_size_per_tenant(), counts_before);
+        for t in 0..4 {
+            let text = format!("{t}aaaaaaaaa");
+            let (matched, tenant) = tree.prefix_match_legacy(&text);
+            assert_eq!(matched, text);
+            assert_eq!(tenant, format!("tenant{t}"));
+        }
+    }
+
+    #[test]
+    fn test_total_count_consistent_with_tenant_sum() {
+        fn assert_consistent(tree: &Tree) {
+            let sum: usize = tree.get_tenant_char_count().values().sum();
+            assert_eq!(
+                tree.total_char_size(),
+                sum,
+                "total must equal per-tenant sum"
+            );
+        }
+
+        let tree = Tree::new();
+        assert_consistent(&tree);
+
+        // All insert paths, including a re-insert and a skipped insert.
+        tree.insert_text("apple", "tenant1");
+        tree.insert_text("application", "tenant2");
+        tree.insert_text("apple", "tenant1");
+        tree.match_and_insert("banana", "tenant3");
+        tree.match_and_insert_with("bandana", |_| Some("tenant1"));
+        tree.match_and_insert_with("cucumber", |_| None);
+        assert_consistent(&tree);
+
+        // Per-tenant eviction.
+        tree.evict_by_tenant(&Arc::from("tenant1"), 3);
+        assert_consistent(&tree);
+
+        // Global eviction.
+        tree.evict_tenant_by_size(8);
+        assert_consistent(&tree);
+        assert!(tree.total_char_size() <= 8);
+
+        // Tenant purge.
+        tree.remove_tenant_all(&Arc::from("tenant2"));
+        assert_consistent(&tree);
+
+        // Snapshot restore and merge maintain the invariant too.
+        let restored = Tree::from_snapshot(&tree.snapshot());
+        assert_consistent(&restored);
+
+        let other = Tree::new();
+        other.insert_text("delta", "tenant9");
+        tree.merge_tree(&other);
+        assert_consistent(&tree);
+
+        // No-op eviction and reset.
+        tree.evict_tenant_by_size(usize::MAX);
+        assert_consistent(&tree);
+        tree.clear();
+        assert_consistent(&tree);
+        assert_eq!(tree.total_char_size(), 0);
     }
 }

--- a/crates/kv_index/src/token_tree.rs
+++ b/crates/kv_index/src/token_tree.rs
@@ -16,7 +16,7 @@ use std::{
     collections::HashMap,
     hash::{BuildHasherDefault, Hasher},
     sync::{
-        atomic::{AtomicI32, AtomicU64, Ordering},
+        atomic::{AtomicI32, AtomicU64, AtomicUsize, Ordering},
         Arc, Weak,
     },
 };
@@ -313,6 +313,9 @@ pub struct TokenTree {
     root: NodeRef,
     /// Track total tokens per tenant for eviction decisions
     tenant_token_count: DashMap<TenantId, usize>,
+    /// Tree-wide token total (sum of `tenant_token_count`); the budget
+    /// checked by `evict_tenant_by_size`
+    total_token_count: AtomicUsize,
     /// Eviction policy (should match the backend worker's policy)
     eviction_policy: EvictionPolicy,
     /// Page size for token grouping (should match the backend worker's page size)
@@ -323,6 +326,10 @@ impl std::fmt::Debug for TokenTree {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TokenTree")
             .field("tenant_count", &self.tenant_token_count.len())
+            .field(
+                "total_tokens",
+                &self.total_token_count.load(Ordering::Relaxed),
+            )
             .field("eviction_policy", &self.eviction_policy)
             .field("page_size", &self.page_size)
             .finish_non_exhaustive()
@@ -366,6 +373,7 @@ impl TokenTree {
         Self {
             root: Arc::new(Node::new_root()),
             tenant_token_count: DashMap::with_shard_amount(ROOT_SHARD_COUNT),
+            total_token_count: AtomicUsize::new(0),
             eviction_policy: policy,
             page_size,
         }
@@ -417,13 +425,8 @@ impl TokenTree {
             track_lfu,
         );
 
-        // Update tenant token count
-        if tokens_added > 0 {
-            self.tenant_token_count
-                .entry(tenant_id)
-                .and_modify(|c| *c += tokens_added)
-                .or_insert(tokens_added);
-        }
+        // Update tenant token count and tree-wide total
+        self.add_tenant_tokens(tenant_id, tokens_added);
     }
 
     /// Insert `remaining` for `tenant_id` starting the descent at `current`
@@ -1039,12 +1042,7 @@ impl TokenTree {
         }
 
         // Fold insert's token count in once (insert-side bookkeeping).
-        if tokens_added > 0 {
-            self.tenant_token_count
-                .entry(tenant_id)
-                .and_modify(|c| *c += tokens_added)
-                .or_insert(tokens_added);
-        }
+        self.add_tenant_tokens(tenant_id, tokens_added);
 
         PrefixMatchResult {
             tenant: last_tenant.unwrap_or_else(|| intern_tenant("empty")),
@@ -1233,12 +1231,7 @@ impl TokenTree {
                 Self::insert_from(current, remaining, Arc::clone(&tenant_id), track_lfu);
         }
 
-        if tokens_added > 0 {
-            self.tenant_token_count
-                .entry(tenant_id)
-                .and_modify(|c| *c += tokens_added)
-                .or_insert(tokens_added);
-        }
+        self.add_tenant_tokens(tenant_id, tokens_added);
 
         result
     }
@@ -1353,9 +1346,7 @@ impl TokenTree {
             }
         }
 
-        if let Some(mut count) = self.tenant_token_count.get_mut(tenant.as_ref()) {
-            *count = count.saturating_sub(evicted);
-        }
+        self.sub_tenant_tokens(tenant, evicted);
 
         debug!(
             tenant = %tenant.as_ref(),
@@ -1497,33 +1488,141 @@ impl TokenTree {
             .unwrap_or(0)
     }
 
-    /// Clear the tree to empty state.
+    /// Tree-wide token total (sum of per-tenant counts).
+    pub fn total_token_size(&self) -> usize {
+        self.total_token_count.load(Ordering::Relaxed)
+    }
+
+    /// Fold `tokens` into a tenant's count and the tree-wide total.
+    fn add_tenant_tokens(&self, tenant_id: TenantId, tokens: usize) {
+        if tokens == 0 {
+            return;
+        }
+        self.tenant_token_count
+            .entry(tenant_id)
+            .and_modify(|c| *c += tokens)
+            .or_insert(tokens);
+        self.total_token_count.fetch_add(tokens, Ordering::Relaxed);
+    }
+
+    /// Subtract evicted `tokens` from a tenant's count and the tree-wide
+    /// total, clamped to the tenant's current count so the two stay in sync.
+    fn sub_tenant_tokens(&self, tenant: &TenantId, tokens: usize) {
+        if tokens == 0 {
+            return;
+        }
+        if let Some(mut count) = self.tenant_token_count.get_mut(tenant.as_ref()) {
+            let removed = tokens.min(*count);
+            *count -= removed;
+            self.total_token_count.fetch_sub(removed, Ordering::Relaxed);
+        }
+    }
+
+    /// Clear the tree to empty state. Not synchronized with concurrent
+    /// mutation: callers must quiesce writers first.
     pub fn clear(&self) {
         self.root.children.clear();
         self.root.tenant_last_access_time.clear();
         self.tenant_token_count.clear();
+        self.total_token_count.store(0, Ordering::Relaxed);
     }
 
     // TODO: Implement efficient remove_tenant with reverse index.
     // See lib.rs for design options. Current naive O(n) traversal removed.
     // For now, stale entries are cleaned up by LRU eviction.
 
-    /// Evict cache entries by total token count to reduce memory usage.
-    /// Convenience method matching the StringTree API.
+    /// Evict cache entries until the tree-wide token total is at or under
+    /// `max_size`. Matches the StringTree API.
     ///
-    /// For each tenant, reduces their token usage to `max_size` if they exceed it.
+    /// The budget is shared across all tenants of this tree: eviction triggers
+    /// on the tree-wide total (no single tenant has to exceed anything) and
+    /// removes leaves in policy order across tenants — least recently used
+    /// first under LRU — using the same leaf-first machinery as
+    /// [`Self::evict_tenant`].
     pub fn evict_tenant_by_size(&self, max_size: usize) {
-        // Collect tenants that exceed the max size
-        let tenants_to_evict: Vec<TenantId> = self
-            .tenant_token_count
-            .iter()
-            .filter(|entry| *entry.value() > max_size)
-            .map(|entry| Arc::clone(entry.key()))
-            .collect();
+        use std::{cmp::Reverse, collections::BinaryHeap};
 
-        // Evict each tenant
-        for tenant_id in tenants_to_evict {
-            self.evict_tenant(&tenant_id, max_size);
+        let initial_total = self.total_token_size();
+        if initial_total <= max_size {
+            return;
+        }
+
+        let mut leaves: Vec<(NodeRef, TenantId, u64)> = Vec::new();
+        self.collect_all_tenant_leaves(&self.root, &mut leaves);
+
+        // Min-heap by eviction priority (policy-dependent), across all tenants
+        let mut heap: BinaryHeap<Reverse<((i64, u64), usize)>> = BinaryHeap::new();
+        let mut leaf_data: Vec<(NodeRef, TenantId)> = Vec::with_capacity(leaves.len());
+
+        for (node, tenant, ts) in leaves.drain(..) {
+            let priority = self.compute_eviction_priority(&node, ts);
+            let idx = leaf_data.len();
+            leaf_data.push((node, tenant));
+            heap.push(Reverse((priority, idx)));
+        }
+
+        while self.total_token_size() > max_size {
+            let Some(Reverse((_, idx))) = heap.pop() else {
+                break;
+            };
+
+            let (node, tenant) = {
+                let (node, tenant) = &leaf_data[idx];
+                (Arc::clone(node), Arc::clone(tenant))
+            };
+            // Verify this node is still a leaf for this tenant: a concurrent
+            // insert may have attached the tenant to a descendant.
+            if !self.is_tenant_leaf(&node, &tenant) {
+                continue;
+            }
+            let (node_tokens, parent_became_leaf) = self.remove_tenant_and_cleanup(&node, &tenant);
+            if node_tokens > 0 {
+                self.sub_tenant_tokens(&tenant, node_tokens);
+
+                // Incremental leaf promotion (matching SGLang's approach)
+                if let Some((parent_node, parent_ts)) = parent_became_leaf {
+                    let priority = self.compute_eviction_priority(&parent_node, parent_ts);
+                    let new_idx = leaf_data.len();
+                    leaf_data.push((parent_node, tenant));
+                    heap.push(Reverse((priority, new_idx)));
+                }
+            }
+        }
+
+        debug!(
+            evicted = initial_total.saturating_sub(self.total_token_size()),
+            remaining = self.total_token_size(),
+            max_size = max_size,
+            policy = ?self.eviction_policy,
+            "Evicted tokens to tree-wide budget (leaf-first)"
+        );
+    }
+
+    /// Collect `(node, tenant, ts)` for every tenant-leaf of every tenant.
+    fn collect_all_tenant_leaves(
+        &self,
+        node: &NodeRef,
+        result: &mut Vec<(NodeRef, TenantId, u64)>,
+    ) {
+        for child_entry in &node.children {
+            self.collect_all_tenant_leaves(child_entry.value(), result);
+        }
+
+        // Root is never eligible for eviction
+        if Arc::ptr_eq(node, &self.root) {
+            return;
+        }
+        for entry in &node.tenant_last_access_time {
+            let tenant = entry.key();
+            let any_child_has_tenant = node.children.iter().any(|child| {
+                child
+                    .value()
+                    .tenant_last_access_time
+                    .contains_key(tenant.as_ref())
+            });
+            if !any_child_has_tenant {
+                result.push((Arc::clone(node), Arc::clone(tenant), *entry.value()));
+            }
         }
     }
 
@@ -2279,6 +2378,10 @@ mod tests {
         for handle in handles {
             handle.join().unwrap();
         }
+
+        // Tree-wide total stays in sync with per-tenant counts.
+        let sum: usize = tree.get_tenant_token_counts().values().sum();
+        assert_eq!(tree.total_token_size(), sum);
     }
 
     #[test]
@@ -3440,5 +3543,111 @@ mod tests {
                 "prefix {j} not fully cached after concurrent stress (route loss)"
             );
         }
+    }
+
+    #[test]
+    fn test_evict_by_size_shared_budget_lru_tenants() {
+        let tree = TokenTree::new();
+
+        // 8 tenants, 2 pages each: every tenant is far below the budget on
+        // its own, but the tree-wide total is double the budget.
+        for t in 0..8u32 {
+            let tokens = make_tokens(t * 100_000 + 1, 2);
+            tree.insert_tokens(&tokens, &format!("tenant{t}"));
+        }
+        assert_eq!(tree.total_token_size(), 8 * 2 * PAGE_SIZE);
+
+        let max_size = 4 * 2 * PAGE_SIZE;
+        tree.evict_tenant_by_size(max_size);
+
+        assert!(tree.total_token_size() <= max_size);
+        // Least-recently-used tenants are evicted first.
+        for t in 0..4u32 {
+            let tokens = make_tokens(t * 100_000 + 1, 2);
+            let result = tree.match_prefix_with_counts(&tokens);
+            assert_eq!(
+                result.matched_token_count, 0,
+                "tenant{t} (LRU) should be evicted"
+            );
+            let tenant: TenantId = Arc::from(format!("tenant{t}"));
+            assert_eq!(tree.tenant_token_size(&tenant), 0);
+        }
+        for t in 4..8u32 {
+            let tokens = make_tokens(t * 100_000 + 1, 2);
+            let result = tree.match_prefix_with_counts(&tokens);
+            assert_eq!(
+                result.matched_token_count,
+                2 * PAGE_SIZE,
+                "tenant{t} should survive"
+            );
+        }
+    }
+
+    #[test]
+    fn test_evict_by_size_under_budget_is_noop() {
+        let tree = TokenTree::new();
+        for t in 0..4u32 {
+            let tokens = make_tokens(t * 100_000 + 1, 2);
+            tree.insert_tokens(&tokens, &format!("tenant{t}"));
+        }
+        let counts_before = tree.get_tenant_token_counts();
+        assert_eq!(tree.total_token_size(), 4 * 2 * PAGE_SIZE);
+
+        // At and above the budget: nothing may change.
+        tree.evict_tenant_by_size(4 * 2 * PAGE_SIZE);
+        tree.evict_tenant_by_size(usize::MAX);
+
+        assert_eq!(tree.get_tenant_token_counts(), counts_before);
+        assert_eq!(tree.total_token_size(), 4 * 2 * PAGE_SIZE);
+        for t in 0..4u32 {
+            let tokens = make_tokens(t * 100_000 + 1, 2);
+            assert_eq!(
+                tree.match_prefix_with_counts(&tokens).matched_token_count,
+                2 * PAGE_SIZE
+            );
+        }
+    }
+
+    #[test]
+    fn test_total_count_consistent_with_tenant_sum() {
+        fn assert_consistent(tree: &TokenTree) {
+            let sum: usize = tree.get_tenant_token_counts().values().sum();
+            assert_eq!(
+                tree.total_token_size(),
+                sum,
+                "total must equal per-tenant sum"
+            );
+        }
+
+        let tree = TokenTree::new();
+        assert_consistent(&tree);
+
+        // All insert paths, including a re-insert and a skipped insert.
+        for t in 0..6u32 {
+            let tokens = make_tokens(t * 100_000 + 1, 3);
+            tree.insert_tokens(&tokens, &format!("tenant{t}"));
+        }
+        tree.insert_tokens(&make_tokens(1, 3), "tenant0");
+        tree.match_and_insert(&make_tokens(600_001, 2), "tenant1");
+        tree.match_and_insert_with(&make_tokens(700_001, 2), |_| Some("tenant2"));
+        tree.match_and_insert_with(&make_tokens(800_001, 2), |_| None);
+        assert_consistent(&tree);
+
+        // Per-tenant eviction.
+        tree.evict_tenant(&Arc::from("tenant0"), PAGE_SIZE);
+        assert_consistent(&tree);
+
+        // Global eviction.
+        let total = tree.total_token_size();
+        tree.evict_tenant_by_size(total / 2);
+        assert_consistent(&tree);
+        assert!(tree.total_token_size() <= total / 2);
+
+        // No-op eviction and reset.
+        tree.evict_tenant_by_size(usize::MAX);
+        assert_consistent(&tree);
+        tree.clear();
+        assert_consistent(&tree);
+        assert_eq!(tree.total_token_size(), 0);
     }
 }

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -227,7 +227,9 @@ struct CliArgs {
     #[arg(long, default_value_t = 120, help_heading = "Routing Policy")]
     eviction_interval: u64,
 
-    /// Maximum size of the approximation tree for cache-aware routing
+    /// Maximum total size of each model's approximation tree for cache-aware
+    /// routing (chars for HTTP, tokens for gRPC), shared across all workers;
+    /// eviction keeps every tree at or under this bound
     #[arg(long, default_value_t = 67108864, help_heading = "Routing Policy")]
     max_tree_size: usize,
 

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -37,7 +37,8 @@
     balance_abs_threshold:   Absolute load diff threshold for imbalance detection
     balance_rel_threshold:   Relative load ratio threshold for imbalance detection
     eviction_interval_secs:  Interval between LRU eviction cycles
-    max_tree_size:           Max nodes per approximate tree before eviction
+    max_tree_size:           Max total size (chars/tokens) of each model's approximate tree,
+                             shared across all workers; enforced by eviction
     block_size:              Backend KV cache block size for event-driven routing
 */
 


### PR DESCRIPTION
## Description

### Problem

`--max-tree-size` is documented as the "Maximum size of the approximation tree" for cache-aware routing, but both radix trees enforced it **per tenant (per worker URL)**:

- `TokenTree::evict_tenant_by_size` only evicted tenants whose own token count exceeded `max_size`.
- String `Tree::evict_tenant_by_size` walked a cross-tenant LRU heap but skipped every entry whose tenant was individually under `max_size`.

The effective cap per model tree is therefore `N_workers x max_tree_size` — with the budget applied per worker, effective capacity scales with fleet size — and with traffic spread across a fleet no eviction fires at all while the tree keeps growing, so router memory grows without bound until the router OOMs.

### Solution

Enforce `max_tree_size` as what the flag documents: a **per-model tree budget shared across all of that model's workers**. Each tree instance (`cache_aware` keeps one string tree and one token tree per model) now maintains a tree-wide total next to the per-tenant counts — inserts add at the same fold points that update `tenant_token_count` / `tenant_char_count`, eviction subtracts what was actually removed — and `evict_tenant_by_size(max_size)`:

- returns immediately (one atomic load) when the total is at or under the budget;
- otherwise evicts leaf-first across tenants, least-recently-used tenants first (eviction-policy order for `TokenTree`), until the tree-wide total is at or under the budget. No single tenant has to exceed anything for eviction to fire.

Per-tenant eviction entry points (`TokenTree::evict_tenant`, `Tree::evict_by_tenant`, `RadixTree::evict`, `Tree::remove_tenant_all`) keep their semantics, and `evict_tenant_by_size` keeps its signature, so the `cache_aware` eviction cycle works unchanged.

This is a behavior change, and it is exactly the documented meaning of `--max-tree-size`: the flag now actually bounds each model's tree. Multi-model implication: total router tree memory scales as `N_models x max_tree_size`, which is predictable and fair per model group; a router-wide meta-budget across model groups is possible future work, out of scope here.

Overlap note: rebased past #2126 (token-tree ownership counted once, not per traversal) and #2133 (string-tree per-tenant eviction pre-filter). The tree-wide total folds in at the same update sites as the per-tenant counts, so it composes directly with #2126's once-per-attach accounting. #2133's pre-filter is superseded by the one-atomic-load early return here; its `test_eviction_no_op_when_under_budget` encoded the per-tenant threshold (asserting no eviction at a `max_size` below the tree-wide total) and is removed, with its at-budget boundary and match-intact assertions folded into `test_evict_by_size_under_budget_is_noop`. The #2134 eviction-cycle gauges are untouched and keep reporting the same per-tenant sums.

## Changes

- `crates/kv_index/src/token_tree.rs`
  - `total_token_count: AtomicUsize` maintained through `add_tenant_tokens` / `sub_tenant_tokens` at every `tenant_token_count` update site (`insert_tokens`, `match_and_insert`, `match_and_insert_with`, `evict_tenant`, `clear`); new public `total_token_size()`.
  - `evict_tenant_by_size` rewritten: early return under budget; otherwise one cross-tenant leaf heap (`collect_all_tenant_leaves` feeding the existing `compute_eviction_priority` / `remove_tenant_and_cleanup` / leaf-promotion machinery) is drained until the tree-wide total obeys the budget; popped entries are revalidated as still-current tenant leaves before removal (a concurrent insert can attach the tenant deeper), matching the string tree's revalidation.
- `crates/kv_index/src/string_tree.rs`
  - `total_char_count: AtomicUsize` maintained through `add_tenant_chars` / `sub_tenant_chars` at every `tenant_char_count` update site, including snapshot restore and mesh merge (`restore_node`, `merge_nodes`, `accumulate_tenant_counts` became `&self` methods so all counting flows through the helpers) and `remove_tenant_all`; new public `total_char_size()`. `tenant_char_count` is now private (as `TokenTree`'s map already was) so counts only move through the helpers.
  - `evict_tenant_by_size`: early return under budget; the existing cross-tenant LRU heap now pops until the tree-wide total obeys the budget instead of skipping entries whose tenant is individually under the limit. The root node is explicitly excluded from eviction (previously protected implicitly by the per-tenant check, since a root-leaf tenant always had count 0).
- `model_gateway/src/policies/cache_aware.rs`: `max_tree_size` header doc states the shared per-model semantics.
- `model_gateway/src/main.rs`, `bindings/python/src/smg/router_args.py`, `bindings/python/src/smg/router.py`: `--max-tree-size` help text states the shared per-model semantics and the units (chars for HTTP, tokens for gRPC); the stale `2^24` default in the `router.py` docstring is corrected to `2^26`.

## Test Plan

New tests, mirrored across both trees:

- `test_evict_by_size_shared_budget_lru_tenants`: 8 tenants, each far under the old per-tenant threshold, summing to 2x the budget. Eviction fires, brings the total to <= budget, and removes exactly the least-recently-used tenants; the newest tenants' prefixes still fully match. (Under the old semantics this scenario evicted nothing.)
- `test_evict_by_size_under_budget_is_noop`: total at/under budget (including `usize::MAX`) leaves counts, totals, structure, and match results untouched; the path is an atomic load plus early return, so the periodic eviction cycle is cheap when under budget.
- `test_total_count_consistent_with_tenant_sum`: asserts `total == sum(per-tenant counts)` after every phase — all insert paths (including re-inserts and select-`None` skipped inserts), per-tenant eviction, budget eviction, and reset; the string-tree variant additionally covers `remove_tenant_all`, snapshot restore, and mesh merge.
- Token `test_concurrent_operations_with_eviction` now also asserts the total equals the per-tenant sum after concurrent inserts and evictions.

Updated tests that encoded the per-tenant semantics (all string tree; the token tree had no `evict_tenant_by_size` tests):

- `test_simple_eviction`: previously asserted tenant1 (5 chars, at the 5-char limit) survived while only tenant2 (10 chars) was trimmed. Under the shared budget the tree total (15) exceeds the limit, so the least-recently-used leaf — tenant1's "hello" — is evicted first and tenant2 keeps only "world"; the assertions now encode that order.
- `test_advanced_eviction` and `test_concurrent_operations_with_eviction`: previously asserted each tenant's size <= max after eviction; they now assert the tree-wide total <= max, which is strictly stronger for the same scenarios.

Commands:

```
cargo +nightly fmt --all
cargo clippy --all-targets -- -D warnings                              # full workspace
cargo clippy --all-targets -p kv-index --all-features -- -D warnings
cargo test -p kv-index                  # 215 passed
cargo test -p smg --lib policies        # 125 passed
cargo test -p smg --test routing_tests  # 102 passed
```

(Workspace-level `--all-features` additionally enables `opencv-video`, whose native OpenCV build prerequisite is unavailable in this dev environment; no code in this PR is feature-gated.)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
