### PR TITLE
fix(router): cap upstream body buffering and sanitize upstream error-code labels

### DIFF
--- a/model_gateway/src/middleware/metrics.rs
+++ b/model_gateway/src/middleware/metrics.rs
@@ -268,6 +268,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn upstream_forged_error_codes_do_not_grow_interner() {
+        use axum::{
+            extract::Path,
+            http::HeaderValue,
+            response::{IntoResponse, Response},
+        };
+
+        use crate::{
+            observability::inflight_tracker::InFlightRequestTracker,
+            routers::error::HEADER_X_SMG_ERROR_CODE,
+        };
+
+        // Simulates a backend minting a fresh X-SMG-Error-Code per response
+        // (rebuilt responses preserve upstream headers). Only gateway-set
+        // codes may become metric labels, so the interner must stay flat.
+        let app = Router::new()
+            .route(
+                "/echo/{id}",
+                get(|Path(id): Path<String>| async move {
+                    let mut response: Response = "ok".into_response();
+                    response.headers_mut().insert(
+                        HEADER_X_SMG_ERROR_CODE,
+                        HeaderValue::from_str(&format!("evil-{id}")).unwrap(),
+                    );
+                    response
+                }),
+            )
+            .layer(HttpMetricsLayer::new(InFlightRequestTracker::new()));
+
+        let send = |uri: String| {
+            let app = app.clone();
+            async move {
+                let response = app
+                    .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                    .await
+                    .unwrap();
+                assert!(response.status().is_success());
+            }
+        };
+
+        send("/echo/warmup".to_owned()).await;
+        let size_before = interner_size();
+
+        const ITERS: usize = 1000;
+        for i in 0..ITERS {
+            send(format!("/echo/{i}")).await;
+        }
+
+        let growth = interner_size().saturating_sub(size_before);
+        assert!(
+            growth < 100,
+            "interner grew by {growth} for {ITERS} distinct upstream error codes"
+        );
+    }
+
+    #[tokio::test]
     async fn distinct_ids_on_matched_route_do_not_grow_interner() {
         // Drive the real `HttpMetricsLayer`. Every request matches the dynamic
         // route `/v1/responses/{response_id}`, so each distinct id must record

--- a/model_gateway/src/routers/error.rs
+++ b/model_gateway/src/routers/error.rs
@@ -24,6 +24,12 @@ struct ErrorDetail<'a> {
 
 pub const HEADER_X_SMG_ERROR_CODE: &str = "X-SMG-Error-Code";
 
+/// Gateway-minted error code, carried as a process-local response extension.
+/// Upstream responses can forge the `X-SMG-Error-Code` header (rebuilt
+/// responses preserve upstream headers) but can never inject an extension.
+#[derive(Clone)]
+struct GatewayErrorCode(String);
+
 pub fn internal_error(code: impl Into<String>, message: impl Into<String>) -> Response {
     create_error(StatusCode::INTERNAL_SERVER_ERROR, code, message)
 }
@@ -77,7 +83,7 @@ pub fn create_error(
         headers.insert(HEADER_X_SMG_ERROR_CODE, val);
     }
 
-    (
+    let mut response = (
         status,
         headers,
         Json(ErrorResponse {
@@ -89,7 +95,9 @@ pub fn create_error(
             },
         }),
     )
-        .into_response()
+        .into_response();
+    response.extensions_mut().insert(GatewayErrorCode(code_str));
+    response
 }
 
 fn status_code_to_str(status_code: StatusCode) -> &'static str {
@@ -106,12 +114,16 @@ pub fn model_not_found(model: &str) -> Response {
     )
 }
 
+/// Error-code metric label for a response.
+///
+/// Reads only the [`GatewayErrorCode`] extension set by [`create_error`],
+/// never the `X-SMG-Error-Code` header: a backend-supplied header value would
+/// otherwise mint unbounded metric label values.
 pub fn extract_error_code_from_response<B>(response: &Response<B>) -> &str {
     response
-        .headers()
-        .get(HEADER_X_SMG_ERROR_CODE)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or_default()
+        .extensions()
+        .get::<GatewayErrorCode>()
+        .map_or("", |code| code.0.as_str())
 }
 
 #[expect(
@@ -165,6 +177,47 @@ pub fn sanitize_error_body(body: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extract_error_code_reads_gateway_minted_code() {
+        let response = create_error(StatusCode::NOT_FOUND, "model_not_found", "nope");
+
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "model_not_found"
+        );
+        // The client-facing header is still set.
+        assert_eq!(
+            response.headers().get(HEADER_X_SMG_ERROR_CODE).unwrap(),
+            "model_not_found"
+        );
+    }
+
+    #[test]
+    fn extract_error_code_ignores_upstream_supplied_header() {
+        // A response rebuilt from preserved upstream headers carries the
+        // header but no extension; it must not become a metric label.
+        let mut response = StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        response.headers_mut().insert(
+            HEADER_X_SMG_ERROR_CODE,
+            HeaderValue::from_static("upstream-minted-code"),
+        );
+
+        assert_eq!(extract_error_code_from_response(&response), "");
+    }
+
+    #[test]
+    fn extract_error_code_survives_header_tampering() {
+        let mut response = create_error(StatusCode::BAD_GATEWAY, "upstream_error", "boom");
+        response
+            .headers_mut()
+            .insert(HEADER_X_SMG_ERROR_CODE, HeaderValue::from_static("forged"));
+
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "upstream_error"
+        );
+    }
 
     #[test]
     fn test_sanitize_org_id() {

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -7,8 +7,8 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use bytes::Bytes;
-use futures_util::{stream, StreamExt};
+use bytes::{Bytes, BytesMut};
+use futures_util::{stream, Stream, StreamExt};
 use openai_protocol::{
     chat::ChatCompletionRequest,
     classify::ClassifyRequest,
@@ -31,7 +31,7 @@ use reqwest::{
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::{
     app_context::AppContext,
@@ -71,6 +71,8 @@ pub struct Router {
     policy_registry: Arc<PolicyRegistry>,
     client: Client,
     retry_config: RetryConfig,
+    /// Cap on buffered worker response bodies, mirroring the ingress limit.
+    max_payload_size: usize,
     realtime_registry: Arc<RealtimeRegistry>,
     webrtc_bind_addr: Option<std::net::IpAddr>,
     webrtc_stun_server: Option<String>,
@@ -134,6 +136,7 @@ impl Router {
             policy_registry: ctx.policy_registry.clone(),
             client: ctx.client.clone(),
             retry_config: ctx.router_config.effective_retry_config(),
+            max_payload_size: ctx.router_config.max_payload_size,
             realtime_registry: ctx.realtime_registry.clone(),
             webrtc_bind_addr: ctx.webrtc_bind_addr,
             webrtc_stun_server: ctx.webrtc_stun_server.clone(),
@@ -1004,6 +1007,36 @@ impl Router {
         response
     }
 
+    /// Buffer a worker response body, capped at `limit` bytes; a larger body
+    /// is a misbehaving worker and yields a 502 before memory balloons.
+    async fn read_worker_body_capped<S, E>(mut stream: S, limit: usize) -> Result<Bytes, Response>
+    where
+        S: Stream<Item = Result<Bytes, E>> + Unpin,
+        E: std::fmt::Display,
+    {
+        let mut body = BytesMut::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(e) => {
+                    return Err(error::internal_error(
+                        "read_response_body_failed",
+                        format!("Failed to get response body: {e}"),
+                    ));
+                }
+            };
+            if body.len().saturating_add(chunk.len()) > limit {
+                warn!(limit, "Worker response exceeded the body limit");
+                return Err(error::bad_gateway(
+                    "upstream_response_too_large",
+                    format!("Response from worker exceeded {limit} bytes"),
+                ));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(body.freeze())
+    }
+
     // Send typed request directly without conversion.
     //
     // `canonical_model` is set only when the client addressed the model by an
@@ -1129,17 +1162,21 @@ impl Router {
             // For non-streaming requests, preserve headers
             let response_headers = header_utils::preserve_response_headers(res.headers());
 
-            let response = match res.bytes().await {
+            // Cap the buffered read at the ingress payload limit; this is the
+            // point where an upstream body is first pulled into memory.
+            let response = match Self::read_worker_body_capped(
+                res.bytes_stream(),
+                self.max_payload_size,
+            )
+            .await
+            {
                 Ok(body) => {
                     let mut response = Response::new(Body::from(body));
                     *response.status_mut() = status;
                     *response.headers_mut() = response_headers;
                     response
                 }
-                Err(e) => {
-                    let error_msg = format!("Failed to get response body: {e}");
-                    error::internal_error("read_response_body_failed", error_msg)
-                }
+                Err(error_response) => error_response,
             };
 
             // load_guard dropped here automatically after response body is read
@@ -1154,14 +1191,49 @@ impl Router {
     /// has to be canonicalized here. `canonical_model` is set only when the
     /// client addressed the model by an alias; reporting the alias would make
     /// this route disagree with every other one about which model ran.
+    ///
+    /// The worker body read is capped at `max_body_bytes`; a larger body is a
+    /// misbehaving worker and yields a 502.
     async fn build_rerank_response(
         req: &RerankRequest,
         canonical_model: Option<&str>,
         response: Response,
-    ) -> anyhow::Result<Response> {
+        max_body_bytes: usize,
+    ) -> Response {
         let (_, response_body) = response.into_parts();
-        let body_bytes = to_bytes(response_body, usize::MAX).await?;
-        let rerank_results = serde_json::from_slice::<Vec<RerankResult>>(&body_bytes)?;
+        let body_bytes = match to_bytes(response_body, max_body_bytes).await {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                if e.source()
+                    .and_then(|s| s.downcast_ref::<http_body_util::LengthLimitError>())
+                    .is_some()
+                {
+                    warn!(
+                        limit = max_body_bytes,
+                        "Rerank worker response exceeded the body limit"
+                    );
+                    return error::bad_gateway(
+                        "upstream_response_too_large",
+                        format!("Rerank response from worker exceeded {max_body_bytes} bytes"),
+                    );
+                }
+                error!("Failed to read rerank worker response: {e}");
+                return error::internal_error(
+                    "rerank_response_build_failed",
+                    "Failed to build rerank response",
+                );
+            }
+        };
+        let rerank_results = match serde_json::from_slice::<Vec<RerankResult>>(&body_bytes) {
+            Ok(results) => results,
+            Err(e) => {
+                error!("Failed to build rerank response: {e}");
+                return error::internal_error(
+                    "rerank_response_build_failed",
+                    "Failed to build rerank response",
+                );
+            }
+        };
         let model = canonical_model.map_or_else(|| req.model.clone(), ToOwned::to_owned);
         let mut rerank_response = RerankResponse::new(rerank_results, model, req.rid.clone());
         // Sorting is handled by Python worker (serving_rerank.py)
@@ -1171,7 +1243,7 @@ impl Router {
         if !req.return_documents {
             rerank_response.drop_documents();
         }
-        Ok(Json(rerank_response).into_response())
+        Json(rerank_response).into_response()
     }
 }
 
@@ -1415,16 +1487,13 @@ impl RouterTrait for Router {
             .route_typed_request(headers, body, "/v1/rerank", model_id)
             .await;
         if response.status().is_success() {
-            match Self::build_rerank_response(body, canonical_model.as_deref(), response).await {
-                Ok(rerank_response) => rerank_response,
-                Err(e) => {
-                    error!("Failed to build rerank response: {}", e);
-                    return error::internal_error(
-                        "rerank_response_build_failed",
-                        "Failed to build rerank response",
-                    );
-                }
-            }
+            Self::build_rerank_response(
+                body,
+                canonical_model.as_deref(),
+                response,
+                self.max_payload_size,
+            )
+            .await
         } else {
             response
         }
@@ -1593,6 +1662,7 @@ mod tests {
             policy_registry,
             client: Client::new(),
             retry_config: RetryConfig::default(),
+            max_payload_size: 536_870_912,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,
@@ -1638,5 +1708,113 @@ mod tests {
 
         let worker = router.worker_registry.get_by_url(&url).unwrap();
         assert!(worker.is_healthy());
+    }
+
+    fn rerank_request() -> RerankRequest {
+        RerankRequest {
+            query: "q".to_string(),
+            documents: vec!["d1".to_string(), "d2".to_string()],
+            model: "test-model".to_string(),
+            top_k: Some(1),
+            return_documents: false,
+            rid: None,
+            user: None,
+        }
+    }
+
+    fn rerank_worker_body() -> Vec<u8> {
+        serde_json::to_vec(&vec![
+            RerankResult {
+                score: 0.9,
+                document: Some("d1".to_string()),
+                index: 0,
+                meta_info: None,
+            },
+            RerankResult {
+                score: 0.5,
+                document: Some("d2".to_string()),
+                index: 1,
+                meta_info: None,
+            },
+        ])
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn build_rerank_response_accepts_body_at_limit() {
+        let req = rerank_request();
+        let body = rerank_worker_body();
+        let limit = body.len();
+        let upstream = Response::new(Body::from(body));
+
+        let response = Router::build_rerank_response(&req, None, upstream, limit).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let rerank: RerankResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(rerank.model, "test-model");
+        assert_eq!(rerank.results.len(), 1);
+        assert_eq!(rerank.results[0].document, None);
+    }
+
+    #[tokio::test]
+    async fn build_rerank_response_caps_oversized_body_with_502() {
+        let req = rerank_request();
+        let body = rerank_worker_body();
+        let limit = body.len() - 1;
+        let upstream = Response::new(Body::from(body));
+
+        let response = Router::build_rerank_response(&req, None, upstream, limit).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "upstream_response_too_large"
+        );
+    }
+
+    fn body_chunks(chunks: &[&'static [u8]]) -> Vec<Result<Bytes, String>> {
+        chunks.iter().map(|c| Ok(Bytes::from_static(c))).collect()
+    }
+
+    #[tokio::test]
+    async fn read_worker_body_capped_accepts_body_at_limit() {
+        let chunks = body_chunks(&[b"abc", b"def", b"gh"]);
+
+        let body = Router::read_worker_body_capped(stream::iter(chunks), 8)
+            .await
+            .unwrap();
+
+        assert_eq!(body.as_ref(), b"abcdefgh");
+    }
+
+    #[tokio::test]
+    async fn read_worker_body_capped_rejects_oversized_body_with_502() {
+        let chunks = body_chunks(&[b"abc", b"def", b"gh"]);
+
+        let response = Router::read_worker_body_capped(stream::iter(chunks), 7)
+            .await
+            .unwrap_err();
+
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "upstream_response_too_large"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_worker_body_capped_maps_read_failure_to_500() {
+        let chunks = vec![Ok(Bytes::from_static(b"abc")), Err("boom".to_string())];
+
+        let response = Router::read_worker_body_capped(stream::iter(chunks), 8)
+            .await
+            .unwrap_err();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            extract_error_code_from_response(&response),
+            "read_response_body_failed"
+        );
     }
 }

--- a/model_gateway/tests/api/api_endpoints_test.rs
+++ b/model_gateway/tests/api/api_endpoints_test.rs
@@ -1903,6 +1903,92 @@ mod rerank_tests {
     }
 
     #[tokio::test]
+    async fn test_rerank_oversized_worker_body_returns_502() {
+        // Upstream rerank reads are capped at max_payload_size; the mock
+        // worker inflates its response via "PAD:<n>" documents, which echo
+        // back as n-byte strings.
+        let mut config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .random_policy()
+            .host("127.0.0.1")
+            .port(3002)
+            .max_payload_size(16 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(1)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(64)
+            .queue_timeout_secs(60)
+            .build_unchecked();
+        config.health_check.disable_health_check = true;
+
+        let ctx = AppTestContext::new_with_config(
+            config,
+            vec![MockWorkerConfig {
+                port: 18112,
+                worker_type: WorkerType::Regular,
+                health_status: HealthStatus::Healthy,
+                response_delay_ms: 0,
+                fail_rate: 0.0,
+            }],
+        )
+        .await;
+
+        let app = ctx.create_app();
+
+        // Worker response (~64KB document) exceeds the 16KB cap.
+        let payload = json!({
+            "query": "test query",
+            "documents": ["PAD:65536"],
+            "model": "mock-model",
+            "return_documents": true
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/rerank")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            resp.headers().get("x-smg-error-code").unwrap(),
+            "upstream_response_too_large"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body_json["error"]["code"], "upstream_response_too_large");
+
+        // A worker response under the cap is rebuilt normally.
+        let payload = json!({
+            "query": "test query",
+            "documents": ["PAD:1024"],
+            "model": "mock-model",
+            "return_documents": true
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/rerank")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body_json["results"].as_array().unwrap().len(), 1);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn test_v1_rerank_compatibility() {
         let ctx = AppTestContext::new(vec![MockWorkerConfig {
             port: 18110,

--- a/model_gateway/tests/common/mock_worker.rs
+++ b/model_gateway/tests/common/mock_worker.rs
@@ -1684,6 +1684,7 @@ async fn audio_transcriptions_handler(
 // Minimal rerank handler returning mock results; router shapes final response
 #[expect(
     clippy::unwrap_used,
+    clippy::expect_used,
     reason = "test helper - panicking on failure is intentional"
 )]
 async fn rerank_handler(
@@ -1714,9 +1715,17 @@ async fn rerank_handler(
     let mut mock_results = Vec::new();
     for (i, doc) in documents.iter().enumerate() {
         let score = 0.95 - (i as f32 * 0.1); // Decreasing scores
+
+        // "PAD:<n>" documents are echoed back as n-byte strings so tests can
+        // make the worker return a body far larger than the request.
+        let doc = doc.as_str().unwrap_or("");
+        let doc = match doc.strip_prefix("PAD:") {
+            Some(n) => "x".repeat(n.parse().expect("PAD size must be a usize")),
+            None => doc.to_string(),
+        };
         let result = serde_json::json!({
             "score": score,
-            "document": doc.as_str().unwrap_or(""),
+            "document": doc,
             "index": i,
             "meta_info": {
                 "confidence": if score > 0.9 { "high" } else { "medium" }


### PR DESCRIPTION
## Description

### Problem

Two response-hardening gaps against misbehaving or hostile backends:

1. `send_typed_request` buffered every non-streaming worker response with an unbounded `res.bytes()` read, and the rerank rebuild then re-read the buffered body with `to_bytes(body, usize::MAX)` — so a worker returning an oversized body could balloon router memory before JSON parsing even starts. The remaining `usize::MAX` body reads under `routers/` and `middleware/` are test-only.
2. `record_http_response` / `record_router_upstream_response` intern the `X-SMG-Error-Code` value as a metric label, and responses rebuilt from worker responses preserve upstream headers, so a hostile or buggy backend could mint unbounded `error_code` label values (and never-freed interner entries). #2093 bounded the client-controlled labels; the backend-controlled channel was still open.

### Solution

1. Cap the buffered worker-body read at the configured `max_payload_size` (default 512MB) — the limit the gateway already enforces on ingress bodies, so a worker response is never buffered beyond what a client is allowed to send, and no new knob is needed. The cap sits in `send_typed_request`, the point where an upstream body first enters memory (capping only the rerank rebuild would bound a body that had already been fully buffered), and accumulation stops as soon as the limit is crossed. Exceeding it returns `502 upstream_response_too_large` (the worker misbehaved, so a gateway-fault 500 would be wrong) and now also feeds the circuit breaker and retry path like any other worker fault; other read failures keep today's `500 read_response_body_failed`, and the rerank rebuild keeps a bounded read with the same limit as its own contract. Streaming responses are untouched: they are relayed chunk-by-chunk under backpressure and never buffered whole.
2. Only trust error codes the gateway itself sets: `create_error` — the sole producer of `X-SMG-Error-Code` — now also stores the code in a process-local response extension, and `extract_error_code_from_response` reads only that extension. Upstream responses can never inject an extension, so no backend-controlled value reaches the label regardless of which proxy path rebuilt the response, and gateway-emitted codes are recorded exactly as before. Routing the label through the #2093 bounded interner was considered instead, but a backend flooding the cap would collapse later gateway codes to the `other` sentinel; the extension keeps them fully intact. Client-visible behavior is unchanged: gateway errors still carry the header, and upstream headers still pass through.

## Changes

- `routers/error.rs`: `GatewayErrorCode` response extension set by `create_error`; `extract_error_code_from_response` reads only the extension, never the header.
- `routers/http/router.rs`: `Router` carries `max_payload_size`; `send_typed_request` buffers non-streaming worker bodies through `read_worker_body_capped`, which stops accumulating at the cap and maps overflow to `502 upstream_response_too_large`; `build_rerank_response` keeps a bounded read instead of `usize::MAX`.
- `middleware/metrics.rs`: test proving per-response forged `X-SMG-Error-Code` values leave the interner flat.
- `tests/common/mock_worker.rs`: rerank handler echoes `PAD:<n>` documents as n-byte strings so a small request can produce an oversized worker response.
- `tests/api/api_endpoints_test.rs`: end-to-end oversized-rerank test.

## Test Plan

- `cargo test -p smg --lib -- extract_error_code build_rerank_response read_worker_body_capped upstream_forged` — 9 new tests: gateway codes extracted intact with the client header still set; an upstream-supplied header is ignored; a forged header cannot override a gateway code; 1000 distinct forged codes leave the interner flat; the capped reader accepts a multi-chunk body exactly at the limit, rejects one over it with `502 upstream_response_too_large`, and maps a mid-body read failure to `500 read_response_body_failed`; a rerank body exactly at the limit passes through with `top_k`/document handling unchanged; a body over the limit returns 502.
- `cargo test -p smg --test api_tests -- rerank` — 7 passed, including new `test_rerank_oversized_worker_body_returns_502`: with a 16KB cap, a ~64KB mock worker body returns 502 with the code in header and body, and a ~1KB body is rebuilt normally.
- `cargo test -p smg` — all 23 targets green.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
