### PR TITLE
fix(workflow): reclaim workflow state when waiters time out

### DIFF
--- a/crates/workflow/src/engine.rs
+++ b/crates/workflow/src/engine.rs
@@ -1149,6 +1149,10 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
 
         loop {
             if start.elapsed() > timeout_duration {
+                // Only removes already-terminal state; a still-running
+                // workflow stays readable and is reclaimed by the periodic
+                // cleanup task once it terminates.
+                self.state_store.cleanup_if_terminal(instance_id).await;
                 return Err(format!(
                     "Workflow timeout after {}s for {}",
                     timeout_duration.as_secs(),

--- a/crates/workflow/tests/workflow_test.rs
+++ b/crates/workflow/tests/workflow_test.rs
@@ -9,11 +9,15 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use tokio::time::sleep;
+use tokio::{
+    sync::Notify,
+    time::{sleep, timeout},
+};
 use wfaas::{
-    BackoffStrategy, FailureAction, LoggingSubscriber, RetryPolicy, StepDefinition, StepExecutor,
-    StepId, StepResult, StepStatus, ValidationError, WorkflowContext, WorkflowData,
-    WorkflowDefinition, WorkflowEngine, WorkflowError, WorkflowResult, WorkflowStatus,
+    BackoffStrategy, FailureAction, LoggingSubscriber, RetryPolicy, StateStore, StepDefinition,
+    StepExecutor, StepId, StepResult, StepStatus, ValidationError, WorkflowContext, WorkflowData,
+    WorkflowDefinition, WorkflowEngine, WorkflowError, WorkflowInstanceId, WorkflowResult,
+    WorkflowStatus,
 };
 
 /// Test workflow data type for integration tests.
@@ -1513,4 +1517,204 @@ async fn test_skip_does_not_clobber_parallel_context_mutation() {
         Some("survived"),
         "a Skip step clobbered a parallel step's committed context mutation"
     );
+}
+
+// ============================================================================
+// Terminal State Reclamation Tests
+// ============================================================================
+
+/// Poll until the workflow reaches `Completed`, bounded at 1s total.
+async fn wait_until_completed(
+    engine: &WorkflowEngine<TestWorkflowData>,
+    instance_id: WorkflowInstanceId,
+) -> bool {
+    for _ in 0..50 {
+        if engine
+            .get_status(instance_id)
+            .await
+            .is_ok_and(|state| state.status == WorkflowStatus::Completed)
+        {
+            return true;
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    false
+}
+
+fn single_step_workflow(id: &str) -> WorkflowDefinition<TestWorkflowData> {
+    WorkflowDefinition::new(id, "Single Step").add_step(StepDefinition::new(
+        "step1",
+        "Step 1",
+        Arc::new(AlwaysSucceedStep),
+    ))
+}
+
+struct BlockUntilNotifiedStep {
+    notify: Arc<Notify>,
+}
+
+#[async_trait::async_trait]
+impl StepExecutor<TestWorkflowData> for BlockUntilNotifiedStep {
+    async fn execute(
+        &self,
+        _context: &mut WorkflowContext<TestWorkflowData>,
+    ) -> WorkflowResult<StepResult> {
+        self.notify.notified().await;
+        Ok(StepResult::Success)
+    }
+}
+
+fn blocked_workflow(id: &str, notify: Arc<Notify>) -> WorkflowDefinition<TestWorkflowData> {
+    WorkflowDefinition::new(id, "Blocked").add_step(StepDefinition::new(
+        "blocked_step",
+        "Blocked Step",
+        Arc::new(BlockUntilNotifiedStep { notify }),
+    ))
+}
+
+#[tokio::test]
+async fn test_sweep_reclaims_state_after_waiter_timeout() {
+    let engine: WorkflowEngine<TestWorkflowData> = WorkflowEngine::new();
+    let notify = Arc::new(Notify::new());
+
+    let workflow = blocked_workflow("waiter_timeout", Arc::clone(&notify));
+    let workflow_id = workflow.id.clone();
+    engine.register_workflow(workflow).unwrap();
+    let instance_id = engine
+        .start_workflow(workflow_id, TestWorkflowData::default())
+        .await
+        .unwrap();
+
+    let err = engine
+        .wait_for_completion(instance_id, "test", Duration::from_millis(50))
+        .await
+        .unwrap_err();
+    assert!(
+        err.contains("timeout"),
+        "expected timeout error, got: {err}"
+    );
+
+    // The timed-out waiter must not remove a still-running workflow's state,
+    // and the sweep must not reclaim non-terminal state even with a zero TTL.
+    assert_eq!(
+        engine.get_status(instance_id).await.unwrap().status,
+        WorkflowStatus::Running
+    );
+    assert_eq!(
+        engine
+            .state_store()
+            .cleanup_old_workflows(Duration::ZERO)
+            .await,
+        0
+    );
+
+    notify.notify_one();
+    assert!(
+        wait_until_completed(&engine, instance_id).await,
+        "workflow did not complete after notify"
+    );
+
+    // The workflow outlived its waiter; the sweep reclaims the terminal state.
+    assert_eq!(
+        engine
+            .state_store()
+            .cleanup_old_workflows(Duration::ZERO)
+            .await,
+        1
+    );
+    assert!(matches!(
+        engine.get_status(instance_id).await,
+        Err(WorkflowError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn test_waiter_timeout_reclaims_already_terminal_state() {
+    let engine: WorkflowEngine<TestWorkflowData> = WorkflowEngine::new();
+    let notify = Arc::new(Notify::new());
+
+    let workflow = blocked_workflow("timeout_terminal", Arc::clone(&notify));
+    let workflow_id = workflow.id.clone();
+    engine.register_workflow(workflow).unwrap();
+    let instance_id = engine
+        .start_workflow(workflow_id, TestWorkflowData::default())
+        .await
+        .unwrap();
+
+    // The waiter sees Running at t=0 and sleeps 100ms, past its 50ms timeout;
+    // the workflow terminates mid-sleep (notify at t=20ms), so the timeout
+    // branch runs against an already-terminal state and must reclaim it.
+    let (result, ()) = tokio::join!(
+        engine.wait_for_completion(instance_id, "test", Duration::from_millis(50)),
+        async {
+            sleep(Duration::from_millis(20)).await;
+            notify.notify_one();
+        }
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("timeout"),
+        "expected timeout error, got: {err}"
+    );
+    assert!(matches!(
+        engine.get_status(instance_id).await,
+        Err(WorkflowError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn test_wait_for_completion_removes_terminal_state() {
+    let engine: WorkflowEngine<TestWorkflowData> = WorkflowEngine::new();
+
+    let workflow = single_step_workflow("terminal_cleanup");
+    let workflow_id = workflow.id.clone();
+    engine.register_workflow(workflow).unwrap();
+    let instance_id = engine
+        .start_workflow(workflow_id, TestWorkflowData::default())
+        .await
+        .unwrap();
+
+    engine
+        .wait_for_completion(instance_id, "test", Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        engine.get_status(instance_id).await,
+        Err(WorkflowError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn test_cleanup_task_reclaims_state_and_stops_on_shutdown() {
+    let engine: WorkflowEngine<TestWorkflowData> = WorkflowEngine::new();
+    let handle = engine.start_cleanup_task(Some(Duration::ZERO), Some(Duration::from_millis(20)));
+
+    let workflow = single_step_workflow("cleanup_task");
+    let workflow_id = workflow.id.clone();
+    engine.register_workflow(workflow).unwrap();
+    let instance_id = engine
+        .start_workflow(workflow_id, TestWorkflowData::default())
+        .await
+        .unwrap();
+
+    // No waiter runs; only the cleanup task can reclaim the terminal state.
+    let mut reclaimed = false;
+    for _ in 0..50 {
+        if matches!(
+            engine.get_status(instance_id).await,
+            Err(WorkflowError::NotFound(_))
+        ) {
+            reclaimed = true;
+            break;
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+    assert!(reclaimed, "cleanup task did not reclaim terminal state");
+
+    engine.shutdown();
+    timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("cleanup task did not stop on shutdown")
+        .unwrap();
 }

--- a/model_gateway/src/workflow/engines.rs
+++ b/model_gateway/src/workflow/engines.rs
@@ -3,7 +3,7 @@
 //! This module provides a collection of typed workflow engines for different workflow types.
 //! Each workflow type has its own engine with compile-time type safety.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use wfaas::{EventSubscriber, InMemoryStore, WorkflowEngine};
 
@@ -16,6 +16,15 @@ use super::{
     WorkerUpdateWorkflowData,
 };
 use crate::{config::RouterConfig, workflow::data::WorkerWorkflowData};
+
+/// Retention for terminal workflow state after its last update. Waiters poll
+/// at sub-second cadence and observe a terminal state within seconds, so this
+/// only has to outlive that window while bounding state leaked by waiters
+/// that timed out before their workflow terminated.
+const TERMINAL_STATE_TTL: Duration = Duration::from_secs(300);
+
+/// How often the background sweep reclaims expired terminal state.
+const STATE_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Type alias for the unified worker registration workflow engine
 pub type WorkerRegistrationEngine =
@@ -67,7 +76,9 @@ pub struct WorkflowEngines {
 }
 
 impl WorkflowEngines {
-    /// Create and initialize all workflow engines with their workflow definitions
+    /// Create and initialize all workflow engines with their workflow definitions.
+    ///
+    /// Must be called within a Tokio runtime: it spawns the periodic state sweepers.
     #[expect(
         clippy::expect_used,
         reason = "Workflow registration uses compile-time-known step/transition definitions that cannot fail at runtime — a failure here indicates a programming error in workflow construction"
@@ -114,7 +125,7 @@ impl WorkflowEngines {
             .register_workflow(create_wasm_module_removal_workflow())
             .expect("wasm_module_removal workflow should be valid");
 
-        Self {
+        let engines = Self {
             worker_registration: Arc::new(worker_registration),
             worker_removal: Arc::new(worker_removal),
             worker_update: Arc::new(worker_update),
@@ -122,7 +133,29 @@ impl WorkflowEngines {
             tokenizer: Arc::new(tokenizer),
             wasm_registration: Arc::new(wasm_registration),
             wasm_removal: Arc::new(wasm_removal),
-        }
+        };
+        engines.start_state_sweepers();
+        engines
+    }
+
+    /// Reclaim terminal workflow state whose waiter timed out before the
+    /// workflow terminated; waiter-side cleanup runs only when the waiter
+    /// observes the terminal state. The tasks stop on engine shutdown.
+    fn start_state_sweepers(&self) {
+        self.worker_registration
+            .start_cleanup_task(Some(TERMINAL_STATE_TTL), Some(STATE_SWEEP_INTERVAL));
+        self.worker_removal
+            .start_cleanup_task(Some(TERMINAL_STATE_TTL), Some(STATE_SWEEP_INTERVAL));
+        self.worker_update
+            .start_cleanup_task(Some(TERMINAL_STATE_TTL), Some(STATE_SWEEP_INTERVAL));
+        self.mcp
+            .start_cleanup_task(Some(TERMINAL_STATE_TTL), Some(STATE_SWEEP_INTERVAL));
+        self.tokenizer
+            .start_cleanup_task(Some(TERMINAL_STATE_TTL), Some(STATE_SWEEP_INTERVAL));
+        self.wasm_registration
+            .start_cleanup_task(Some(TERMINAL_STATE_TTL), Some(STATE_SWEEP_INTERVAL));
+        self.wasm_removal
+            .start_cleanup_task(Some(TERMINAL_STATE_TTL), Some(STATE_SWEEP_INTERVAL));
     }
 
     /// Subscribe an event subscriber to all workflow engines


### PR DESCRIPTION
## Description

### Problem

Every worker add/remove/update (and MCP/tokenizer/WASM module) job runs a wfaas workflow and waits on it via `wait_for_completion`. That method only deletes the workflow's state when it observes a terminal status; its timeout branch returns without any cleanup. The engines built in `WorkflowEngines::new` also never start the engine's periodic cleanup task (`start_cleanup_task` had no callers), so a workflow that outlives its waiter — e.g. `AddWorker` against a pod that never comes up within `worker_startup_timeout_secs + 30` — leaves its terminal `WorkflowState` (WorkerSpec, step states, error strings; ~1-4KB each) in the `InMemoryStore` forever. Under sustained pod churn this accumulates without bound.

### Solution

Close both holes:

- `wait_for_completion`'s timeout branch now attempts `cleanup_if_terminal` before returning, reclaiming the state immediately when the workflow terminated during the waiter's final poll interval. It only removes already-terminal state, so a still-running workflow stays readable.
- `WorkflowEngines::new` starts the engine's existing periodic cleanup task on all seven engines: terminal states are reclaimed once they are 5 minutes past their last update, swept every 60s. Non-terminal states are never touched by the sweep.

Retention choice: the only readers of these state stores are the `wait_for_completion` waiters in the job queue, which poll at 100ms-2s intervals and delete the state themselves as soon as they observe a terminal status. A live waiter therefore reads a terminal state within ~2s of the transition, and states of running workflows are immune to the sweep no matter how long they run (the 2h MCP registration window included, since the TTL clock only matters once the terminal transition bumps `updated_at`). Five minutes of post-terminal retention leaves ample margin over that ~2s window while bounding steady-state memory under churn to a few hundred KB instead of unbounded growth.

## Changes

- `crates/workflow/src/engine.rs`: `wait_for_completion` timeout branch attempts `cleanup_if_terminal` before returning.
- `model_gateway/src/workflow/engines.rs`: `WorkflowEngines::new` starts the periodic state sweeper on every engine (TTL 300s, interval 60s) and documents the runtime requirement.
- `crates/workflow/tests/workflow_test.rs`: tests for waiter-timeout + sweep reclamation, timeout-branch reclamation of already-terminal state, terminal-path cleanup, and the cleanup task end to end.

## Test Plan

- `cargo test -p wfaas` — 28 passed. New tests drive the cleanup deterministically (direct sweep calls or a 20ms task interval; the three reclamation tests were additionally run 10x consecutively without flakes):
  - `test_sweep_reclaims_state_after_waiter_timeout`: waiter times out at 50ms against a blocked workflow; asserts the timed-out waiter and a zero-TTL sweep both leave the running state readable, then completes the workflow and asserts one sweep pass removes it.
  - `test_waiter_timeout_reclaims_already_terminal_state`: workflow terminates during the waiter's final poll sleep; asserts the timeout branch itself reclaims the state.
  - `test_wait_for_completion_removes_terminal_state`: normal terminal-path cleanup still removes state.
  - `test_cleanup_task_reclaims_state_and_stops_on_shutdown`: `start_cleanup_task` reclaims a terminal state with no waiter involved and exits on `shutdown()`.
- `cargo test -p smg --lib workflow` — 58 passed.
- `cargo test -p smg` — full suite including integration test binaries, 0 failures.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

