### PR TITLE
fix(router): import Bytes for the stream-relay channel type

### DIFF
--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -7,6 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use bytes::Bytes;
 use futures_util::{stream, StreamExt};
 use openai_protocol::{
     chat::ChatCompletionRequest,
@@ -851,7 +852,7 @@ impl Router {
             // is slow, the upstream relay awaits on `send` rather than piling
             // chunks in memory.
             const STREAM_RELAY_BUFFER: usize = 32;
-            let (tx, rx) = mpsc::channel::<Result<bytes::Bytes, String>>(STREAM_RELAY_BUFFER);
+            let (tx, rx) = mpsc::channel::<Result<Bytes, String>>(STREAM_RELAY_BUFFER);
             // Attribute worker-level and router-level outcomes to the actual
             // stream completion from inside the relay task: a mid-stream error
             // after a 2xx header, or a non-streaming 5xx header returned under


### PR DESCRIPTION
## Motivation

`main`'s lint lane is currently red: the stream-relay channel in `send_typed_request` (model_gateway/src/routers/http/router.rs) names `bytes::Bytes` by full path, which trips the workspace-wide `unused_qualifications` lint. Every open PR now fails the `lint` job through no fault of its own.

## Modifications

- Import `bytes::Bytes` in `model_gateway/src/routers/http/router.rs` and drop the path qualification on the relay channel's type parameter.

## Test Plan

- `cargo +nightly fmt --all` — clean
- `cargo clippy -p smg --lib -- -D warnings` — clean (previously failed with `unnecessary qualification`)
- `cargo clippy -p smg --all-targets -- -D warnings` — clean

One-line type-path change; no behavior difference.

## Related Issues

Unblocks the `lint` lane for all open PRs (first observed on #2138's run).
