### PR TITLE
fix(kv_index): close node-split races in walkers and replay counts

### DIFF
--- a/crates/kv_index/src/string_tree.rs
+++ b/crates/kv_index/src/string_tree.rs
@@ -264,6 +264,32 @@ struct Node {
     last_tenant: RwLock<Option<TenantId>>,
 }
 
+impl Node {
+    /// Attach `tenant` with `timestamp` unless already present. Returns true
+    /// when this call newly attached the tenant — the atomic winner under
+    /// concurrency, so char accounting tied to it is exact.
+    fn attach_tenant_if_absent(&self, tenant: &TenantId, timestamp: u64) -> bool {
+        match self.tenant_last_access_time.entry(Arc::clone(tenant)) {
+            Entry::Occupied(_) => false,
+            Entry::Vacant(entry) => {
+                entry.insert(timestamp);
+                true
+            }
+        }
+    }
+}
+
+/// True when `node`'s parent pointer currently designates `parent`. A split
+/// re-parents a node inside the same `text` write section that truncates it,
+/// so walkers check this under their `text` read guard to reject a child
+/// re-probed through a stale edge mid-split.
+fn node_parent_is(node: &NodeRef, parent: &NodeRef) -> bool {
+    node.parent
+        .read()
+        .as_ref()
+        .is_some_and(|w| std::ptr::eq(w.as_ptr(), Arc::as_ptr(parent)))
+}
+
 #[derive(Debug)]
 pub struct Tree {
     root: NodeRef,
@@ -480,38 +506,50 @@ impl Tree {
                         // Drop read lock before creating new node
                         drop(matched_node_text);
 
-                        let new_node = Arc::new(Node {
-                            text: RwLock::new(matched_text),
-                            children: new_children_map(),
-                            parent: RwLock::new(Some(Arc::downgrade(&prev))),
-                            tenant_last_access_time: matched_node.tenant_last_access_time.clone(),
-                            last_tenant: RwLock::new(matched_node.last_tenant.read().clone()),
-                        });
-
                         let Some(first_new_char) = contracted_text.first_char() else {
                             // split_at_char with shared_count < char_count guarantees non-empty suffix
                             return;
                         };
+
+                        // Truncate to the suffix, clone the tenant map, and
+                        // re-parent under the new prefix node in one `text`
+                        // write section: lock-free walkers read the text and
+                        // validate the parent pointer under a `text` read
+                        // guard, so they observe the pre-split node or the
+                        // post-split one — never a truncated text still
+                        // reachable through the stale edge (which would
+                        // silently shift their depth on self-similar content).
+                        // Replayers likewise credit the live char count under
+                        // the read guard, so the clone inherits exactly the
+                        // tenants credited for the pre-split span.
+                        let mut matched_node_text_write = matched_node.text.write();
+                        let tenant_map = matched_node.tenant_last_access_time.clone();
+                        let last_tenant = matched_node.last_tenant.read().clone();
+                        let new_node = Arc::new(Node {
+                            text: RwLock::new(matched_text),
+                            children: new_children_map(),
+                            parent: RwLock::new(Some(Arc::downgrade(&prev))),
+                            tenant_last_access_time: tenant_map,
+                            last_tenant: RwLock::new(last_tenant),
+                        });
+                        *matched_node.parent.write() = Some(Arc::downgrade(&new_node));
+                        *matched_node_text_write = contracted_text;
+                        drop(matched_node_text_write);
+
                         new_node
                             .children
                             .insert(first_new_char, Arc::clone(&matched_node));
 
-                        entry.insert(Arc::clone(&new_node));
-
-                        *matched_node.text.write() = contracted_text;
-                        *matched_node.parent.write() = Some(Arc::downgrade(&new_node));
-
-                        // Attach tenant to the new split node (intermediate - no timestamp update)
-                        // The cloned DashMap already has the tenant; just ensure char count is correct
-                        if !new_node
-                            .tenant_last_access_time
-                            .contains_key(tenant_id.as_ref())
-                        {
+                        // Attach before publication (intermediate - no timestamp
+                        // update): the node is unreachable, so the return is
+                        // authoritative and the prefix is credited exactly once
+                        // even against a concurrent same-tenant replay that
+                        // raced the clone above.
+                        if new_node.attach_tenant_if_absent(&tenant_id, 0) {
                             self.add_tenant_chars(&tenant_id, matched_text_count);
-                            new_node
-                                .tenant_last_access_time
-                                .insert(Arc::clone(&tenant_id), 0);
                         }
+
+                        entry.insert(Arc::clone(&new_node));
 
                         InsertStep::Continue {
                             next_prev: new_node,
@@ -521,15 +559,11 @@ impl Tree {
                         // Full match - move to next node (intermediate - no timestamp update)
                         drop(matched_node_text);
 
-                        // Ensure tenant exists at this intermediate node
-                        if !matched_node
-                            .tenant_last_access_time
-                            .contains_key(tenant_id.as_ref())
-                        {
+                        // Ensure tenant exists at this intermediate node,
+                        // counting only on first attach (atomic) so a
+                        // concurrent same-tenant attach can't double-credit.
+                        if matched_node.attach_tenant_if_absent(&tenant_id, 0) {
                             self.add_tenant_chars(&tenant_id, matched_node_text_count);
-                            matched_node
-                                .tenant_last_access_time
-                                .insert(Arc::clone(&tenant_id), 0);
                         }
 
                         InsertStep::Continue {
@@ -572,6 +606,17 @@ impl Tree {
 
             if let Some(matched_node) = child_node {
                 let matched_text_guard = matched_node.text.read();
+                // Stale-edge check: a split re-parents the child inside the
+                // same `text` write section that truncates it, so a parent no
+                // longer equal to `prev` means this text may start deeper than
+                // this edge (on self-similar content the suffix would still
+                // compare equal and silently shift the walk). Re-probe the
+                // edge until the split publishes.
+                if !node_parent_is(&matched_node, &prev) {
+                    drop(matched_text_guard);
+                    std::hint::spin_loop();
+                    continue;
+                }
                 let matched_node_text_count = matched_text_guard.char_count();
 
                 // Use slice-based comparison - no allocation
@@ -714,9 +759,9 @@ impl Tree {
         // The node match resolves its tenant on (its final `curr`): the deepest
         // full-match node, the partial child, or the root if nothing matched.
         let mut match_curr = Arc::clone(&self.root);
-        // (node, char_count) for each full-match edge, in order.
+        // Every full-match node we descended through, in order.
         // Pre-allocated; most matched paths are well under this depth.
-        let mut path: Vec<(NodeRef, usize)> = Vec::with_capacity(16);
+        let mut path: Vec<NodeRef> = Vec::with_capacity(16);
 
         while let Some(first_char) = remaining.chars().next() {
             let child_node = current.children.get(&first_char).map(|e| e.value().clone());
@@ -727,6 +772,12 @@ impl Tree {
             };
 
             let matched_text_guard = matched_node.text.read();
+            // Stale-edge check (see `match_prefix_with_counts`).
+            if !node_parent_is(&matched_node, &current) {
+                drop(matched_text_guard);
+                std::hint::spin_loop();
+                continue;
+            }
             let matched_node_text_count = matched_text_guard.char_count();
             let shared_count = shared_prefix_count(remaining, matched_text_guard.as_str());
             drop(matched_text_guard);
@@ -734,7 +785,7 @@ impl Tree {
             if shared_count == matched_node_text_count {
                 // Full match -> continue. Record for ancestor re-attach.
                 matched_chars += shared_count;
-                path.push((Arc::clone(&matched_node), matched_node_text_count));
+                path.push(Arc::clone(&matched_node));
                 remaining = advance_by_chars(remaining, shared_count);
                 current = Arc::clone(&matched_node);
                 match_curr = matched_node;
@@ -778,14 +829,16 @@ impl Tree {
 
         // Re-attach the inserting tenant to every full-match ancestor node, the
         // epoch-0 intermediate attach `insert_text` performs while descending.
-        for (node, char_count) in &path {
-            if !node
-                .tenant_last_access_time
-                .contains_key(tenant_id.as_ref())
-            {
-                self.add_tenant_chars(&tenant_id, *char_count);
-                node.tenant_last_access_time
-                    .insert(Arc::clone(&tenant_id), 0);
+        for node in &path {
+            // Credit the live char count under the `text` read guard: a
+            // concurrent split truncates the node and clones its tenant map in
+            // one `text` write section, so this ordering decides both what the
+            // tenant now owns and whether the clone inherits it. The
+            // match-time count would over-credit a node truncated since.
+            // Count only on first attach (atomic).
+            let text_guard = node.text.read();
+            if node.attach_tenant_if_absent(&tenant_id, 0) {
+                self.add_tenant_chars(&tenant_id, text_guard.char_count());
             }
         }
 
@@ -878,6 +931,12 @@ impl Tree {
                 }
 
                 let matched_text_guard = matched_node.text.read();
+                // Stale-edge check (see `match_prefix_with_counts`).
+                if !node_parent_is(&matched_node, &prev) {
+                    drop(matched_text_guard);
+                    std::hint::spin_loop();
+                    continue;
+                }
                 let matched_node_text_count = matched_text_guard.char_count();
 
                 // Use slice-based comparison - no allocation
@@ -1726,9 +1785,14 @@ impl Tree {
                         }
                     }
 
-                    // Push local child down as child of split node
-                    *local_child.text.write() = local_remainder_text;
+                    // Push local child down as child of split node. Re-parent
+                    // inside the same `text` write section as the truncation
+                    // so walkers validating the parent under a `text` read
+                    // guard never see the truncated edge as top-level.
+                    let mut local_child_text_write = local_child.text.write();
                     *local_child.parent.write() = Some(Arc::downgrade(&split_node));
+                    *local_child_text_write = local_remainder_text;
+                    drop(local_child_text_write);
                     split_node
                         .children
                         .insert(local_remainder_first, Arc::clone(&local_child));
@@ -3441,5 +3505,75 @@ mod tests {
         tree.clear();
         assert_consistent(&tree);
         assert_eq!(tree.total_char_size(), 0);
+    }
+
+    #[test]
+    fn test_concurrent_match_and_insert_count_and_route_integrity() {
+        const N_PREFIXES: usize = 8;
+        const N_THREADS: usize = 8;
+        const ITERS: usize = 3000;
+        const HEAD_STEP: usize = 8;
+        const TAIL_LEN: usize = 5;
+
+        // Nested shared head "aaa…" (a shorter prefix matching inside a longer
+        // node forces a split) + a disjoint divergent tail per tenant.
+        let prefixes: Vec<String> = (0..N_PREFIXES)
+            .map(|j| {
+                let mut s = "a".repeat(HEAD_STEP * (j + 1));
+                let tail = char::from(b'b' + j as u8);
+                s.extend(std::iter::repeat_n(tail, TAIL_LEN));
+                s
+            })
+            .collect();
+        let tenants: Vec<String> = (0..N_PREFIXES).map(|j| format!("t{j}")).collect();
+        let lens: Vec<usize> = prefixes.iter().map(|p| p.chars().count()).collect();
+
+        let tree = Arc::new(Tree::new());
+        let prefixes = Arc::new(prefixes);
+        let tenants = Arc::new(tenants);
+
+        let handles: Vec<_> = (0..N_THREADS)
+            .map(|t| {
+                let tree = Arc::clone(&tree);
+                let prefixes = Arc::clone(&prefixes);
+                let tenants = Arc::clone(&tenants);
+                thread::spawn(move || {
+                    for i in 0..ITERS {
+                        let j = (t + i) % N_PREFIXES;
+                        if t % 2 == 0 {
+                            let tn = tenants[j].as_str();
+                            tree.match_and_insert_with(&prefixes[j], |_| Some(tn));
+                        } else {
+                            tree.match_and_insert(&prefixes[j], tenants[j].as_str());
+                        }
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("worker panicked (deadlock/corruption)");
+        }
+
+        // Exact, concurrency-independent count: each tenant owns its full path
+        // exactly once regardless of iteration count or interleaving
+        // (first-attach is atomic, split-vs-replay ordered by the text lock).
+        let counts = tree.get_tenant_char_count();
+        for j in 0..N_PREFIXES {
+            let actual = counts.get(&tenants[j]).copied().unwrap_or(0);
+            assert_eq!(
+                actual, lens[j],
+                "tenant {} char count diverged under concurrency: expected {}, got {actual}",
+                tenants[j], lens[j]
+            );
+        }
+
+        // Route integrity: every prefix is still fully cached at the end.
+        for j in 0..N_PREFIXES {
+            let r = tree.match_prefix_with_counts(&prefixes[j]);
+            assert_eq!(
+                r.matched_char_count, lens[j],
+                "prefix {j} not fully cached after concurrent stress (route loss)"
+            );
+        }
     }
 }

--- a/crates/kv_index/src/token_tree.rs
+++ b/crates/kv_index/src/token_tree.rs
@@ -508,26 +508,32 @@ impl TokenTree {
                         let common_len = align_to_page(remaining.len());
                         let prefix_tokens: Vec<TokenId> = child_tokens[..common_len].to_vec();
                         let suffix_page_key = make_page_key(&child_tokens[common_len..]);
-
-                        // Check if tenant already owned the child (tokens already counted)
-                        let tenant_already_owned = child
-                            .tenant_last_access_time
-                            .contains_key(tenant_id.as_ref());
                         drop(child_tokens);
 
-                        // Modify original child to hold only suffix tokens
+                        // Truncate the child to its suffix, clone its tenant
+                        // map, and re-parent it under the intermediate in one
+                        // `tokens` write section: lock-free walkers read the
+                        // length and validate the parent pointer under a
+                        // `tokens` read guard, so they observe the pre-split
+                        // node or the post-split one — never a truncated text
+                        // still reachable through the stale edge (which would
+                        // silently shift their depth on self-similar content).
+                        // Replayers likewise credit the live length under the
+                        // read guard, so the clone inherits exactly the
+                        // tenants credited for the pre-split span.
                         let mut child_tokens_write = child.tokens.write();
+                        let tenant_map = child.tenant_last_access_time.clone();
+                        let last_tenant = child.last_tenant.read().clone();
                         let suffix_tokens: Vec<TokenId> = child_tokens_write[common_len..].to_vec();
                         *child_tokens_write = suffix_tokens;
-                        drop(child_tokens_write);
 
-                        // Create intermediate node with prefix - clone tenant map (O(1))
+                        // Create intermediate node with prefix
                         // Intermediate inherits metadata from child (represents same prefix)
                         let intermediate_node = Arc::new(Node {
                             tokens: ParkingLotRwLock::new(prefix_tokens),
                             children: new_children_map(),
-                            tenant_last_access_time: child.tenant_last_access_time.clone(),
-                            last_tenant: ParkingLotRwLock::new(child.last_tenant.read().clone()),
+                            tenant_last_access_time: tenant_map,
+                            last_tenant: ParkingLotRwLock::new(last_tenant),
                             parent: ParkingLotRwLock::new(Arc::downgrade(&current)),
                             page_key: ParkingLotRwLock::new(Some(page_key)),
                             hit_count: AtomicU64::new(child.hit_count.load(Ordering::Relaxed)),
@@ -535,20 +541,25 @@ impl TokenTree {
                             priority: AtomicI32::new(child.priority.load(Ordering::Relaxed)),
                         });
 
-                        // Add original child (now suffix) as child of intermediate
                         // Update child's parent to point to intermediate
                         child.set_parent(&intermediate_node, suffix_page_key);
+                        drop(child_tokens_write);
+
+                        // Add original child (now suffix) as child of intermediate
                         intermediate_node
                             .children
                             .insert(suffix_page_key, Arc::clone(&child));
 
+                        // Attach before publication: the node is unreachable, so
+                        // the return is authoritative and the prefix is credited
+                        // exactly once even against a concurrent same-tenant
+                        // replay that raced the clone above.
+                        let newly_attached = intermediate_node.touch_tenant(&tenant_id, track_lfu);
+
                         // Replace entry with intermediate node
-                        entry.insert(intermediate_node.clone());
+                        entry.insert(intermediate_node);
 
-                        intermediate_node.touch_tenant(&tenant_id, track_lfu);
-
-                        // Only count new tokens if tenant didn't already own this path
-                        let new_tokens = if tenant_already_owned { 0 } else { common_len };
+                        let new_tokens = if newly_attached { common_len } else { 0 };
                         InsertStep::Done(new_tokens)
                     } else {
                         // Partial match - need to split and add new branch at page boundary
@@ -556,26 +567,24 @@ impl TokenTree {
                         // keep original child as one suffix, create new node for other suffix
                         let prefix_tokens: Vec<TokenId> = child_tokens[..common_len].to_vec();
                         let child_suffix_page_key = make_page_key(&child_tokens[common_len..]);
-
-                        // Check if tenant already owned the child (common prefix already counted)
-                        let tenant_already_owned = child
-                            .tenant_last_access_time
-                            .contains_key(tenant_id.as_ref());
                         drop(child_tokens);
 
-                        // Modify original child to hold only its suffix tokens
+                        // Truncate + tenant-map clone + re-parent in one
+                        // `tokens` write section (see the prefix-split arm
+                        // above).
                         let mut child_tokens_write = child.tokens.write();
+                        let tenant_map = child.tenant_last_access_time.clone();
+                        let last_tenant = child.last_tenant.read().clone();
                         let child_suffix: Vec<TokenId> = child_tokens_write[common_len..].to_vec();
                         *child_tokens_write = child_suffix;
-                        drop(child_tokens_write);
 
-                        // Create intermediate node with common prefix - clone tenant map (O(1))
+                        // Create intermediate node with common prefix
                         // Intermediate inherits metadata from child (represents same prefix)
                         let intermediate_node = Arc::new(Node {
                             tokens: ParkingLotRwLock::new(prefix_tokens),
                             children: new_children_map(),
-                            tenant_last_access_time: child.tenant_last_access_time.clone(),
-                            last_tenant: ParkingLotRwLock::new(child.last_tenant.read().clone()),
+                            tenant_last_access_time: tenant_map,
+                            last_tenant: ParkingLotRwLock::new(last_tenant),
                             parent: ParkingLotRwLock::new(Arc::downgrade(&current)),
                             page_key: ParkingLotRwLock::new(Some(page_key)),
                             hit_count: AtomicU64::new(child.hit_count.load(Ordering::Relaxed)),
@@ -583,9 +592,11 @@ impl TokenTree {
                             priority: AtomicI32::new(child.priority.load(Ordering::Relaxed)),
                         });
 
-                        // Add original child (now suffix) as child of intermediate
                         // Update child's parent to point to intermediate
                         child.set_parent(&intermediate_node, child_suffix_page_key);
+                        drop(child_tokens_write);
+
+                        // Add original child (now suffix) as child of intermediate
                         intermediate_node
                             .children
                             .insert(child_suffix_page_key, Arc::clone(&child));
@@ -603,13 +614,13 @@ impl TokenTree {
                             0
                         };
 
+                        // Attach before publication (see the prefix-split arm).
+                        let newly_attached = intermediate_node.touch_tenant(&tenant_id, track_lfu);
+
                         // Replace entry with intermediate node
-                        entry.insert(intermediate_node.clone());
+                        entry.insert(intermediate_node);
 
-                        intermediate_node.touch_tenant(&tenant_id, track_lfu);
-
-                        // Count: new branch tokens + common prefix only if tenant is new
-                        let common_tokens = if tenant_already_owned { 0 } else { common_len };
+                        let common_tokens = if newly_attached { common_len } else { 0 };
                         InsertStep::Done(new_branch_tokens + common_tokens)
                     }
                 }
@@ -669,6 +680,7 @@ impl TokenTree {
 
         enum MatchStep {
             Done,
+            Retry,
             Continue {
                 next: NodeRef,
                 advance: usize,
@@ -686,11 +698,22 @@ impl TokenTree {
 
             let step = match current.children.get(&page_key) {
                 None => MatchStep::Done,
-                Some(child_ref) => {
+                Some(child_ref) => 'probe: {
                     let child = Arc::clone(child_ref.value());
                     drop(child_ref);
 
                     let child_tokens = child.tokens.read();
+                    // Stale-edge check: a split re-parents the child inside
+                    // the same `tokens` write section that truncates it, so a
+                    // parent no longer equal to `current` means this text may
+                    // start deeper than this edge (on self-similar content the
+                    // suffix would still compare equal and silently shift the
+                    // walk). Re-probe the edge until the split publishes.
+                    if !std::ptr::eq(child.parent.read().as_ptr(), Arc::as_ptr(&current)) {
+                        drop(child_tokens);
+                        std::hint::spin_loop();
+                        break 'probe MatchStep::Retry;
+                    }
 
                     // Count matching tokens
                     let match_len = remaining
@@ -739,6 +762,7 @@ impl TokenTree {
 
             match step {
                 MatchStep::Done => break,
+                MatchStep::Retry => continue,
                 MatchStep::PartialMatch { matched, tenant } => {
                     matched_tokens += matched;
                     if let Some(t) = tenant {
@@ -921,22 +945,22 @@ impl TokenTree {
                         let common_len = align_to_page(remaining.len());
                         let prefix_tokens: Vec<TokenId> = child_tokens[..common_len].to_vec();
                         let suffix_page_key = make_page_key(&child_tokens[common_len..]);
-
-                        let tenant_already_owned = child
-                            .tenant_last_access_time
-                            .contains_key(tenant_id.as_ref());
                         drop(child_tokens);
 
+                        // Truncate + tenant-map clone + re-parent in one
+                        // `tokens` write section (see `insert_from`'s
+                        // prefix-split arm).
                         let mut child_tokens_write = child.tokens.write();
+                        let tenant_map = child.tenant_last_access_time.clone();
+                        let last_tenant = child.last_tenant.read().clone();
                         let suffix_tokens: Vec<TokenId> = child_tokens_write[common_len..].to_vec();
                         *child_tokens_write = suffix_tokens;
-                        drop(child_tokens_write);
 
                         let intermediate_node = Arc::new(Node {
                             tokens: ParkingLotRwLock::new(prefix_tokens),
                             children: new_children_map(),
-                            tenant_last_access_time: child.tenant_last_access_time.clone(),
-                            last_tenant: ParkingLotRwLock::new(child.last_tenant.read().clone()),
+                            tenant_last_access_time: tenant_map,
+                            last_tenant: ParkingLotRwLock::new(last_tenant),
                             parent: ParkingLotRwLock::new(Arc::downgrade(&current)),
                             page_key: ParkingLotRwLock::new(Some(page_key)),
                             hit_count: AtomicU64::new(child.hit_count.load(Ordering::Relaxed)),
@@ -945,15 +969,18 @@ impl TokenTree {
                         });
 
                         child.set_parent(&intermediate_node, suffix_page_key);
+                        drop(child_tokens_write);
+
                         intermediate_node
                             .children
                             .insert(suffix_page_key, Arc::clone(&child));
 
-                        entry.insert(intermediate_node.clone());
+                        // Attach before publication (see `insert_from`).
+                        let newly_attached = intermediate_node.touch_tenant(&tenant_id, track_lfu);
 
-                        intermediate_node.touch_tenant(&tenant_id, track_lfu);
+                        entry.insert(intermediate_node);
 
-                        let new_tokens = if tenant_already_owned { 0 } else { common_len };
+                        let new_tokens = if newly_attached { common_len } else { 0 };
                         Step::Done(new_tokens)
                     } else {
                         // Partial match -> split and add a new branch at the page
@@ -974,22 +1001,22 @@ impl TokenTree {
 
                         let prefix_tokens: Vec<TokenId> = child_tokens[..common_len].to_vec();
                         let child_suffix_page_key = make_page_key(&child_tokens[common_len..]);
-
-                        let tenant_already_owned = child
-                            .tenant_last_access_time
-                            .contains_key(tenant_id.as_ref());
                         drop(child_tokens);
 
+                        // Truncate + tenant-map clone + re-parent in one
+                        // `tokens` write section (see `insert_from`'s
+                        // prefix-split arm).
                         let mut child_tokens_write = child.tokens.write();
+                        let tenant_map = child.tenant_last_access_time.clone();
+                        let last_tenant = child.last_tenant.read().clone();
                         let child_suffix: Vec<TokenId> = child_tokens_write[common_len..].to_vec();
                         *child_tokens_write = child_suffix;
-                        drop(child_tokens_write);
 
                         let intermediate_node = Arc::new(Node {
                             tokens: ParkingLotRwLock::new(prefix_tokens),
                             children: new_children_map(),
-                            tenant_last_access_time: child.tenant_last_access_time.clone(),
-                            last_tenant: ParkingLotRwLock::new(child.last_tenant.read().clone()),
+                            tenant_last_access_time: tenant_map,
+                            last_tenant: ParkingLotRwLock::new(last_tenant),
                             parent: ParkingLotRwLock::new(Arc::downgrade(&current)),
                             page_key: ParkingLotRwLock::new(Some(page_key)),
                             hit_count: AtomicU64::new(child.hit_count.load(Ordering::Relaxed)),
@@ -998,6 +1025,8 @@ impl TokenTree {
                         });
 
                         child.set_parent(&intermediate_node, child_suffix_page_key);
+                        drop(child_tokens_write);
+
                         intermediate_node
                             .children
                             .insert(child_suffix_page_key, Arc::clone(&child));
@@ -1014,11 +1043,12 @@ impl TokenTree {
                             0
                         };
 
-                        entry.insert(intermediate_node.clone());
+                        // Attach before publication (see `insert_from`).
+                        let newly_attached = intermediate_node.touch_tenant(&tenant_id, track_lfu);
 
-                        intermediate_node.touch_tenant(&tenant_id, track_lfu);
+                        entry.insert(intermediate_node);
 
-                        let common_tokens = if tenant_already_owned { 0 } else { common_len };
+                        let common_tokens = if newly_attached { common_len } else { 0 };
                         Step::Done(new_branch_tokens + common_tokens)
                     }
                 }
@@ -1099,15 +1129,16 @@ impl TokenTree {
         let mut last_tenant: Option<TenantId> = None;
         let mut remaining = tokens;
         let mut current = Arc::clone(&self.root);
-        // (node, advance) for each edge we descended through, in order.
+        // Every full-match node we descended through, in order.
         // Pre-allocated; most matched paths are well under this depth.
-        let mut path: Vec<(NodeRef, usize)> = Vec::with_capacity(16);
+        let mut path: Vec<NodeRef> = Vec::with_capacity(16);
         // Once match would stop (all-evicted node / partial), freeze the match
         // result but keep descending for insert (insert's reach is a superset).
         let mut match_frozen = false;
 
         enum MatchStep {
             Stop,
+            Retry,
             Continue { next: NodeRef, advance: usize },
         }
 
@@ -1116,11 +1147,17 @@ impl TokenTree {
 
             let step = match current.children.get(&page_key) {
                 None => MatchStep::Stop,
-                Some(child_ref) => {
+                Some(child_ref) => 'probe: {
                     let child = Arc::clone(child_ref.value());
                     drop(child_ref);
 
                     let child_tokens = child.tokens.read();
+                    // Stale-edge check (see `match_prefix_with_counts`).
+                    if !std::ptr::eq(child.parent.read().as_ptr(), Arc::as_ptr(&current)) {
+                        drop(child_tokens);
+                        std::hint::spin_loop();
+                        break 'probe MatchStep::Retry;
+                    }
                     let match_len = remaining
                         .iter()
                         .zip(child_tokens.iter())
@@ -1174,8 +1211,9 @@ impl TokenTree {
 
             match step {
                 MatchStep::Stop => break,
+                MatchStep::Retry => continue,
                 MatchStep::Continue { next, advance } => {
-                    path.push((Arc::clone(&next), advance));
+                    path.push(Arc::clone(&next));
                     remaining = &remaining[advance..];
                     current = next;
                 }
@@ -1210,12 +1248,17 @@ impl TokenTree {
 
         // Replay insert's per-node work on every edge the match descended:
         // `insert_tokens` touches the inserting tenant on each full-match node
-        // and counts its `advance` tokens.
-        for (node, advance) in &path {
-            // Count only newly-attached edges (atomic via touch_tenant): the
-            // selected tenant usually already owns the matched prefix.
+        // and counts its tokens.
+        for node in &path {
+            // Credit the live length under the `tokens` read guard: a
+            // concurrent split truncates the node and clones its tenant map in
+            // one `tokens` write section, so this ordering decides both what
+            // the tenant now owns and whether the clone inherits it. The
+            // match-time length would over-credit a node truncated since.
+            // Count only newly-attached edges (atomic via touch_tenant).
+            let node_tokens = node.tokens.read();
             if node.touch_tenant(&tenant_id, track_lfu) {
-                tokens_added += *advance;
+                tokens_added += node_tokens.len();
             }
         }
 


### PR DESCRIPTION
## Motivation

The `unit-tests` lane flakes on `token_tree::tests::test_concurrent_match_and_insert_count_and_route_integrity` (`tenant t6 token count diverged under concurrency: expected 128, got 144`) — reproducible locally in a handful of runs. Root-causing it surfaced a second, worse race in the same split machinery.

A node split performs truncate-child / clone-tenant-map / republish-edge / re-parent as separate steps. Concurrent lock-free readers can interleave between them:

1. **Replay over-count** (the CI flake): `match_and_insert_with` records the matched span per node during the match descent, then credits the selected tenant during the insert replay. A split that truncates a path node between the two phases leaves the tenant attached only to the suffix while credited for the full pre-split span; when the tenant later attaches to the new prefix node, the shared pages are counted twice — exactly one `PAGE_SIZE` per event (128 → 144). Tenant budgets drift upward permanently, so eviction fires early for hot tenants.
2. **Depth-shifted walks** (found stress-testing the first fix): a walker that probes the stale edge but reads the already-truncated text full-matches the suffix content as if it started at the edge's depth. On self-similar content (repeated pages, repeated characters — padding, boilerplate) the walk silently shifts deeper by the prefix length: it attaches tenants to nodes off their real path, splices phantom duplicate branches, and returns inflated match results. The string tree published the prefix node **before** truncating the child, which is the same hazard through the fresh edge. The entry-locked insert paths are immune; the `children.get()`-based match paths are not.

The string tree's replay loop also still had the non-atomic `contains_key` → credit → `insert` sequence, so two concurrent replays for the same tenant could both credit a node (the token tree got atomic first-attach in #2126).

## Modifications

- **Splits** (both `insert_from` arms and both inline `match_and_insert` arms in the token tree; `insert_from` and the mesh-merge local split in the string tree): truncate the child, clone its tenant map, and re-parent it under the new prefix inside **one** `tokens`/`text` write section; attach the splitting tenant to the prefix node **before** publication and derive its credit from the atomic attach result (replacing the racy `tenant_already_owned` pre-check). The string split now truncates before publishing, matching the token tree's order.
- **Replay loops**: credit the **live** node length read under the `tokens`/`text` read guard — ordered against the split's write section, the clone inherits exactly the tenants credited for the pre-split span. String tree gains `Node::attach_tenant_if_absent` (atomic first-attach, epoch-0) used by its replay loop and `insert_from`'s full-match arm.
- **Lock-free walkers** (`match_prefix_with_counts` and the fused match descent in both trees; `prefix_match_tenant` in the string tree): under the same read guard, validate that the child's parent pointer still designates the probed edge; a mismatch means a split is mid-flight — re-probe the edge (bounded spin until the split publishes).
- New string-tree concurrency test mirroring the token one: nested self-similar heads force splits under concurrent match-and-insert traffic; asserts exact per-tenant char accounting and route integrity.

## Test Plan

- Reproduction: on the parent commit, the token concurrency test fails 3 of 5 local runs with the exact CI signature (`t6 expected 128, got 144`); with only the accounting fix applied, the new string test still fails ~1/150 runs with `+13` phantom-branch inflation (duplicate tail leaf at the wrong depth, verified by tree-layout dump).
- With the full fix: **700/700 clean runs** of both concurrency tests.
- `cargo test -p kv-index` — all tests pass.
- `cargo +nightly fmt --all` — clean; `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test -p smg` — all suites pass.

## Related Issues

Completes the exact-accounting work started in #2126 (atomic first-attach for the token tree).
