### PR TITLE
ci(nightly): add express input for amd64-only fast builds

### DIFF
--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -5,14 +5,25 @@ on:
     # 06:00 UTC daily — 2 hours before nightly benchmarks (08:00 UTC)
     - cron: '0 6 * * *'
   workflow_dispatch:
+    inputs:
+      express:
+        description: 'amd64-only fast build (skips the QEMU-emulated arm64 half and the floating :nightly tag)'
+        type: boolean
+        default: false
 
 concurrency:
-  group: nightly-docker
+  # Express builds run in their own lane so a fast one-off never cancels
+  # (or waits on) the comprehensive nightly. Concurrent runs are safe:
+  # express never touches the floating :nightly tag.
+  group: nightly-docker-${{ github.event_name == 'workflow_dispatch' && inputs.express && 'express' || 'full' }}
   cancel-in-progress: true
 
 permissions:
   contents: read
   packages: write
+
+env:
+  EXPRESS: ${{ github.event_name == 'workflow_dispatch' && inputs.express && 'true' || 'false' }}
 
 jobs:
   build-and-push:
@@ -26,6 +37,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up QEMU
+        if: env.EXPRESS != 'true'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
@@ -38,18 +50,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compute image tags
+      - name: Compute image tags and platforms
         id: tags
         env:
           OWNER: ${{ github.repository_owner }}
         run: |
           SUFFIX="$(date -u +%Y%m%d)-${GITHUB_SHA::7}"
-          {
-            echo "list<<EOF"
-            echo "ghcr.io/${OWNER}/smg:nightly"
-            echo "ghcr.io/${OWNER}/smg:nightly-${SUFFIX}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          if [ "$EXPRESS" = "true" ]; then
+            # amd64-only: the floating :nightly stays multi-arch by not
+            # retagging it here; consumers pin the suffixed tag.
+            echo "platforms=linux/amd64" >> "$GITHUB_OUTPUT"
+            {
+              echo "list<<EOF"
+              echo "ghcr.io/${OWNER}/smg:nightly-${SUFFIX}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "platforms=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
+            {
+              echo "list<<EOF"
+              echo "ghcr.io/${OWNER}/smg:nightly"
+              echo "ghcr.io/${OWNER}/smg:nightly-${SUFFIX}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -60,4 +84,4 @@ jobs:
           tags: ${{ steps.tags.outputs.list }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.tags.outputs.platforms }}


### PR DESCRIPTION
## Motivation

The nightly Docker build takes ~90 minutes (the last scheduled run spent 90.3 min in `Build and push`). The dominant cost is the `linux/arm64` half of the matrix: it compiles the entire Rust workspace — and, on cache-miss nights, ffmpeg and OpenCV from source — under QEMU emulation on the x86 runner. When a nightly image is needed quickly to validate a just-merged fix on an amd64 fleet, the emulated arm64 build buys nothing and multiplies the wait.

## Modifications

- `workflow_dispatch` gains a boolean `express` input (default `false`), surfaced to the job as the `EXPRESS` env var.
- When `EXPRESS` is true:
  - `platforms` drops to `linux/amd64` and the QEMU setup step is skipped.
  - Only the suffixed `nightly-<date>-<sha>` tag is pushed — the floating `:nightly` tag is left alone so it always remains the multi-arch comprehensive build (an amd64-only manifest would otherwise break arm64 consumers of `:nightly` until the next scheduled run).
- Express runs use their own concurrency lane (`nightly-docker-express`) so a fast one-off never cancels or queues behind the scheduled comprehensive build. Concurrent runs are safe: the tag sets only overlap on the suffixed tag, where a comprehensive rebuild of the same commit simply overwrites amd64-only with multi-arch.
- Scheduled runs are unchanged: `inputs` is empty on `schedule` events, so `EXPRESS` evaluates to `false` and the full matrix builds as before.

Usage: `gh workflow run nightly-docker.yml -f express=true`

## Test Plan

- YAML validated; expression paths checked for all three event shapes (schedule → full; dispatch with `express=true` → amd64-only, suffixed tag only; dispatch default → full).
- The shared `type=gha` layer cache is used identically in both modes, so express runs also pre-warm the amd64 layers for the next comprehensive build.

## Related Issues

None.
