### PR TITLE
feat(bindings): expose prefix_hash knobs through the Python launcher

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -395,6 +395,8 @@ struct Router {
     block_size: usize,
     balance_token_usage_threshold: f32,
     overload_token_usage_threshold: f32,
+    prefix_token_count: usize,
+    prefix_hash_load_factor: f64,
     least_load_kv_pressure_weight: f64,
     least_load_default_throughput: f64,
     least_load_mean_prefill_tokens: u32,
@@ -606,8 +608,8 @@ impl Router {
                 },
                 PolicyType::ConsistentHashing => ConfigPolicyConfig::ConsistentHashing,
                 PolicyType::PrefixHash => ConfigPolicyConfig::PrefixHash {
-                    prefix_token_count: 256,
-                    load_factor: 1.25,
+                    prefix_token_count: self.prefix_token_count,
+                    load_factor: self.prefix_hash_load_factor,
                 },
             })
         };
@@ -1002,6 +1004,8 @@ impl Router {
         worker_startup_delay = 0,
         worker_ports_annotation = String::from("smg.ai/worker-ports"),
         zmq_engine_count = None,
+        prefix_token_count = 256,
+        prefix_hash_load_factor = 1.25,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -1132,6 +1136,8 @@ impl Router {
         worker_startup_delay: u64,
         worker_ports_annotation: String,
         zmq_engine_count: Option<usize>,
+        prefix_token_count: usize,
+        prefix_hash_load_factor: f64,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1171,6 +1177,8 @@ impl Router {
             block_size,
             balance_token_usage_threshold,
             overload_token_usage_threshold,
+            prefix_token_count,
+            prefix_hash_load_factor,
             least_load_kv_pressure_weight,
             least_load_default_throughput,
             least_load_mean_prefill_tokens,

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -165,6 +165,12 @@ class Router:
         cache_threshold: Cache threshold (0.0-1.0) for cache-aware routing. Routes to
             cached worker if the match rate exceeds threshold, otherwise routes to the
             worker with the smallest tree. Default: 0.5
+        prefix_token_count: Number of prefix tokens hashed by the prefix_hash
+            policy. Size it past any shared system prompt so distinct
+            conversations hash apart. Default: 256
+        prefix_hash_load_factor: Load factor above which the prefix_hash policy
+            walks the ring instead of using the hashed worker (multiple of the
+            average load). Default: 1.25
         balance_abs_threshold: Load balancing is triggered when (max_load - min_load) >
             abs_threshold AND max_load > min_load * rel_threshold. Otherwise, use cache
             aware. Default: 32

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -206,6 +206,8 @@ class RouterArgs:
     worker_startup_delay: int = 0
     # DP engines per startup ZMQ worker (grouped worker; None/1 = ungrouped)
     zmq_engine_count: int | None = None
+    prefix_token_count: int = 256
+    prefix_hash_load_factor: float = 1.25
 
     @staticmethod
     def add_cli_args(
@@ -386,6 +388,18 @@ class RouterArgs:
             type=float,
             default=RouterArgs.cache_threshold,
             help="Cache threshold (0.0-1.0) for cache-aware routing",
+        )
+        routing_group.add_argument(
+            f"--{prefix}prefix-token-count",
+            type=int,
+            default=RouterArgs.prefix_token_count,
+            help="Number of prefix tokens hashed by the prefix_hash policy",
+        )
+        routing_group.add_argument(
+            f"--{prefix}prefix-hash-load-factor",
+            type=float,
+            default=RouterArgs.prefix_hash_load_factor,
+            help="Load factor above which prefix_hash walks the ring (multiple of average load)",
         )
         routing_group.add_argument(
             f"--{prefix}least-load-kv-pressure-weight",

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -1033,3 +1033,40 @@ class TestParseRouterArgs:
 
         # SystemExit with code 0 indicates help was displayed
         assert exc_info.value.code == 0
+
+
+class TestPrefixHashArgs:
+    """The prefix_hash knobs parse, default, and honor the router prefix."""
+
+    def test_defaults(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser)
+        namespace = parser.parse_args([])
+        router_args = RouterArgs.from_cli_args(namespace)
+        assert router_args.prefix_token_count == 256
+        assert router_args.prefix_hash_load_factor == 1.25
+
+    def test_flags(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser)
+        namespace = parser.parse_args(
+            ["--prefix-token-count", "4096", "--prefix-hash-load-factor", "1.5"]
+        )
+        router_args = RouterArgs.from_cli_args(namespace)
+        assert router_args.prefix_token_count == 4096
+        assert router_args.prefix_hash_load_factor == 1.5
+
+    def test_router_prefix_flags(self):
+        parser = argparse.ArgumentParser()
+        RouterArgs.add_cli_args(parser, use_router_prefix=True)
+        namespace = parser.parse_args(
+            [
+                "--router-prefix-token-count",
+                "8192",
+                "--router-prefix-hash-load-factor",
+                "2.0",
+            ]
+        )
+        router_args = RouterArgs.from_cli_args(namespace, use_router_prefix=True)
+        assert router_args.prefix_token_count == 8192
+        assert router_args.prefix_hash_load_factor == 2.0


### PR DESCRIPTION
## Motivation

The `prefix_hash` policy is tunable from the Rust CLI (`--prefix-token-count`, `--prefix-hash-load-factor`) but not through the Python bindings: the PyO3 `Router` constructor hardcodes `prefix_token_count: 256, load_factor: 1.25` when building the policy config, and the launcher exposes no flags. Deployments that start the router through the Python launcher therefore cannot size the hash window.

The window size is not a nicety — it decides whether the policy works at all. With a shared system prompt longer than the window (256 tokens is smaller than most), every request hashes the system prompt alone, all conversations collapse onto one ring point, and bounded-load walking degrades the policy to least-load with extra steps. The window must exceed the shared prefix so distinct conversations hash apart.

## Modifications

- `bindings/python/src/lib.rs`: `prefix_token_count` and `prefix_hash_load_factor` become `Router` constructor parameters (defaults unchanged: 256 / 1.25) and feed `PolicyConfig::PrefixHash` instead of hardcoded literals.
- `bindings/python/src/smg/router_args.py`: new `--prefix-token-count` and `--prefix-hash-load-factor` flags (respecting the `router-` prefix mode); dataclass fields flow through `from_cli_args` and `Router.from_args` automatically.
- `bindings/python/src/smg/router.py`: docstring entries for both parameters.

No changes to `model_gateway` or the policy itself; defaults are byte-identical, so existing launches behave the same.

## Test Plan

- `cargo +nightly fmt --all` — clean
- `cargo build -p smg-python` — compiles
- `ruff check --fix` / `ruff format` (pre-commit pins v0.15.0) — clean, no diffs
- `python -m py_compile` on the touched launcher files
- `pytest tests/test_arg_parser.py -k PrefixHash` — 3 passed (defaults, explicit flags, `--router-prefix-*` variant) against the built extension
- New parameters appended after all existing ones on every surface (dataclass, `#[pyo3(signature)]`, `fn new`), so positional callers are unaffected

## Related Issues

None.
