### PR TITLE
fix(router): track in-flight load under every HTTP policy

### DIFF
--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -468,11 +468,7 @@ impl Router {
             }
         };
 
-        let policy = self.policy_registry.get_policy_or_default(model_id);
-
-        let load_guard = ["cache_aware", "manual"]
-            .contains(&policy.name())
-            .then(|| WorkerLoadGuard::new(worker.clone(), headers));
+        let load_guard = WorkerLoadGuard::new(worker.clone(), headers);
 
         // Note: Using borrowed reference avoids heap allocation
         events::RequestSentEvent { url: worker.url() }.emit();
@@ -763,9 +759,7 @@ impl Router {
         );
         let worker = available[idx].clone();
 
-        let load_guard = ["cache_aware", "manual"]
-            .contains(&policy.name())
-            .then(|| WorkerLoadGuard::new(worker.clone(), headers));
+        let load_guard = WorkerLoadGuard::new(worker.clone(), headers);
 
         let mut headers_with_trace = headers.cloned().unwrap_or_default();
         inject_trace_context_http(&mut headers_with_trace);
@@ -949,9 +943,7 @@ impl Router {
             let mut response = Response::new(body);
             *response.status_mut() = status;
             *response.headers_mut() = response_headers;
-            if let Some(guard) = load_guard {
-                response = AttachedBody::wrap_response(response, guard);
-            }
+            response = AttachedBody::wrap_response(response, load_guard);
             response
         } else {
             let response_headers = header_utils::preserve_response_headers(res.headers());
@@ -1054,7 +1046,7 @@ impl Router {
         canonical_model: Option<&str>,
         worker: &dyn Worker,
         is_stream: bool,
-        load_guard: Option<WorkerLoadGuard>,
+        load_guard: WorkerLoadGuard,
     ) -> Response {
         let api_key = worker.api_key().cloned();
         let endpoint_url = worker.endpoint_url(route);
@@ -1154,9 +1146,7 @@ impl Router {
 
             // Attach load guard to response body for proper RAII lifecycle
             // Guard is dropped when response body is consumed or client disconnects
-            if let Some(guard) = load_guard {
-                response = AttachedBody::wrap_response(response, guard);
-            }
+            response = AttachedBody::wrap_response(response, load_guard);
             response
         } else {
             // For non-streaming requests, preserve headers

--- a/model_gateway/tests/routing/load_balancing_test.rs
+++ b/model_gateway/tests/routing/load_balancing_test.rs
@@ -370,3 +370,80 @@ mod worker_response_delay_tests {
         ctx.shutdown().await;
     }
 }
+
+#[cfg(test)]
+mod inflight_load_tests {
+    use std::{sync::Arc, time::Duration};
+
+    use super::*;
+    use crate::common::mock_worker::{set_scheduler_controls, HoldGate, SchedulerControls};
+
+    /// The in-flight counter is a worker property, not a policy's private
+    /// state: `least_load`, `power_of_two` and `prefix_hash` all rank workers
+    /// by `Worker::load()`, and the mesh and `running_requests` metrics report
+    /// it. So the router has to hold a guard for every request, whichever
+    /// policy picked the worker — here `random`, which never reads it.
+    #[expect(clippy::disallowed_methods, reason = "test infrastructure")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_inflight_load_tracked_for_load_agnostic_policy() {
+        const WORKER_PORT: u16 = 19410;
+
+        let gate = HoldGate::new();
+        set_scheduler_controls(
+            WORKER_PORT,
+            SchedulerControls {
+                max_running_requests: None,
+                hold_gate: Some(Arc::clone(&gate)),
+            },
+        );
+
+        let config = TestRouterConfig::random(3140);
+        let ctx = AppTestContext::new_with_config(
+            config,
+            TestWorkerConfig::healthy_workers(WORKER_PORT, 1),
+        )
+        .await;
+        let app = ctx.create_app();
+
+        let worker = ctx
+            .app_context
+            .worker_registry
+            .get_all()
+            .into_iter()
+            .next()
+            .expect("the mock worker is registered");
+        assert_eq!(worker.load(), 0, "no requests in flight yet");
+
+        let payload = json!({ "text": "held request", "stream": false });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+        let held = tokio::spawn(async move { app.oneshot(req).await.unwrap() });
+
+        tokio::time::timeout(Duration::from_secs(8), gate.wait_for_arrivals(1))
+            .await
+            .expect("request never reached the worker");
+        assert_eq!(
+            worker.load(),
+            1,
+            "a request parked at the worker must be counted as in flight"
+        );
+
+        gate.release();
+        let resp = tokio::time::timeout(Duration::from_secs(8), held)
+            .await
+            .expect("held request did not complete in time")
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            worker.load(),
+            0,
+            "the guard must release the slot once the request finishes"
+        );
+
+        ctx.shutdown().await;
+    }
+}


### PR DESCRIPTION
## Description

### Problem

The regular HTTP router only attached a `WorkerLoadGuard` when the active policy was `cache_aware` or `manual`. Under every other policy `Worker::load()` stayed at zero for the whole life of the request. The gRPC and PD routers already hold a guard for every request, so this was an HTTP-path-only gap.

Three policies rank candidates by that counter whenever a worker has no fresh load snapshot:

- `least_load` — `least_load.rs:187` falls back to `worker.load()` as join-shortest-queue when the fleet reports no loads, and `:183` uses it to estimate drain time when only peers report.
- `power_of_two` — `power_of_two.rs:83-84` compares the two sampled workers on `load()`.
- `prefix_hash` — compares a worker's load against the fleet average to decide whether its ring hit is overloaded.

With the counter pinned at zero those comparisons are vacuous. Every worker looks equally idle, `min_by_key` returns the first candidate every time, and the policies collapse to "always pick the first worker". `prefix_hash` never observes an overloaded worker, so its bounded-load walk can never trigger. The running-requests metric and the mesh worker state read the same counter and under-report for the same reason.

### Solution

Attach the guard unconditionally, the way the gRPC and PD routers already do. The counter then tracks real in-flight work under every policy, and the load comparisons become meaningful. Nothing else changes: the guard is RAII, so the decrement still rides the existing drop.

## Changes

- `model_gateway/src/routers/http/router.rs`: drop the policy allowlist at both `send_typed_request` call sites so the guard is created unconditionally; both streaming attaches take a plain `WorkerLoadGuard`.
- Remove the `policy` binding that existed only to feed the allowlist.
- `model_gateway/tests/routing/load_balancing_test.rs`: new `inflight_load_tests` module.

## Test Plan

`test_inflight_load_tracked_for_load_agnostic_policy` starts a `random`-policy router — a policy outside the old allowlist — holds a request open with a scheduler gate, and samples `Worker::load()` at three points:

| sample point | before | after |
|---|---|---|
| idle | 0 | 0 |
| request in flight | **0** | **1** |
| request complete | 0 | 0 |

The test fails on `main` at the middle row and passes with this change.

- `cargo +nightly fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean. `--all-features` cannot build locally: it pulls `opencv 0.99`, whose build script needs a system OpenCV install; that configuration is covered by CI (`pr-test-rust.yml:292`).
- `cargo test -p smg` — 2099 passed, 0 failed, 22 binaries

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
