### PR TITLE
fix(observability): return metrics bind errors and report the bound port

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -734,7 +734,10 @@ class RouterArgs:
             f"--{prefix}prometheus-port",
             type=int,
             default=29000,
-            help="Port to expose Prometheus metrics (default: 29000).",
+            help=(
+                "Port to expose Prometheus metrics (default: 29000)."
+                " 0 binds an OS-assigned ephemeral port, logged at startup."
+            ),
         )
         prometheus_group.add_argument(
             f"--{prefix}prometheus-host",

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -430,7 +430,7 @@ struct CliArgs {
     log_json: bool,
 
     // ==================== Prometheus Metrics ====================
-    /// Port to expose Prometheus metrics
+    /// Port to expose Prometheus metrics; 0 binds an OS-assigned ephemeral port
     #[arg(long, default_value_t = 29000, help_heading = "Prometheus Metrics")]
     prometheus_port: u16,
 

--- a/model_gateway/src/observability/metrics_server.rs
+++ b/model_gateway/src/observability/metrics_server.rs
@@ -1,4 +1,4 @@
-//! HTTP server for the Prometheus metrics endpoint (port 29000).
+//! HTTP server for the Prometheus metrics endpoint (default port 29000).
 //! Serves `GET /metrics` (Prometheus).
 
 use std::{
@@ -35,27 +35,25 @@ async fn bind_metrics_listener(addr: SocketAddr) -> Result<tokio::net::TcpListen
 }
 
 /// Start the metrics HTTP/WS server. Binds eagerly so callers fail fast on
-/// port conflicts or bad addresses.
-#[expect(
-    clippy::expect_used,
-    reason = "startup initialization — metrics server must bind or the process cannot serve metrics"
-)]
+/// port conflicts or bad addresses; port 0 binds an OS-assigned ephemeral
+/// port. Returns the bound address and the server task handle.
 pub async fn start_metrics_server(
     handle: PrometheusHandle,
     host: String,
     port: u16,
-) -> JoinHandle<()> {
+) -> Result<(SocketAddr, JoinHandle<()>), String> {
     let ip_addr: IpAddr = host.parse().unwrap_or_else(|e| {
         error!("Failed to parse metrics host '{host}': {e}, falling back to 0.0.0.0");
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
     });
     let addr = SocketAddr::new(ip_addr, port);
 
-    let listener = bind_metrics_listener(addr)
-        .await
-        .expect("metrics server bind failed");
+    let listener = bind_metrics_listener(addr).await?;
+    let bound_addr = listener
+        .local_addr()
+        .map_err(|e| format!("failed to read metrics server local address: {e}"))?;
 
-    info!("Metrics server listening on {addr} (/metrics)");
+    info!("Metrics server listening on {bound_addr} (/metrics)");
 
     // Spawn upkeep task — required by install_recorder() for histogram maintenance.
     let upkeep_handle = handle.clone();
@@ -78,11 +76,13 @@ pub async fn start_metrics_server(
         clippy::disallowed_methods,
         reason = "metrics server runs for the lifetime of the process"
     )]
-    tokio::spawn(async move {
+    let server_task = tokio::spawn(async move {
         if let Err(e) = axum::serve(listener, app).await {
             error!("Metrics server error: {e}");
         }
-    })
+    });
+
+    Ok((bound_addr, server_task))
 }
 
 #[cfg(test)]
@@ -98,6 +98,39 @@ mod tests {
         let busy = pre.local_addr().unwrap();
         let err = bind_metrics_listener(busy).await.unwrap_err();
         assert!(err.contains(&busy.to_string()), "got: {err}");
+        assert!(err.contains("failed to bind metrics server"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn port_zero_binds_ephemeral_and_serves_metrics() {
+        let handle = metrics_exporter_prometheus::PrometheusBuilder::new()
+            .build_recorder()
+            .handle();
+        let (addr, _server) = start_metrics_server(handle, "127.0.0.1".to_string(), 0)
+            .await
+            .unwrap();
+        assert_ne!(addr.port(), 0);
+
+        let resp = reqwest::get(format!("http://{addr}/metrics"))
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn busy_port_returns_error_instead_of_panicking() {
+        let pre =
+            tokio::net::TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+                .await
+                .unwrap();
+        let busy = pre.local_addr().unwrap();
+
+        let handle = metrics_exporter_prometheus::PrometheusBuilder::new()
+            .build_recorder()
+            .handle();
+        let err = start_metrics_server(handle, "127.0.0.1".to_string(), busy.port())
+            .await
+            .unwrap_err();
         assert!(err.contains("failed to bind metrics server"), "got: {err}");
     }
 }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1039,12 +1039,12 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     // port conflicts or bad addresses.
     if let Some(prometheus_config) = &config.prometheus_config {
         let handle = metrics::start_prometheus(prometheus_config.clone());
-        let _server_handle = metrics_server::start_metrics_server(
+        let (_metrics_addr, _server_handle) = metrics_server::start_metrics_server(
             handle,
             prometheus_config.host.clone(),
             prometheus_config.port,
         )
-        .await;
+        .await?;
         // Tokio runtime self-observability (event-loop canary + sampler).
         // `startup` runs on the main runtime, so the observer lands on —
         // and therefore measures — the runtime that serves requests.

--- a/model_gateway/tests/engine_metrics_test.rs
+++ b/model_gateway/tests/engine_metrics_test.rs
@@ -16,19 +16,17 @@ use smg::observability::{
 
 #[tokio::test]
 async fn engine_pd_gauge_appears_on_metrics_endpoint() {
-    // Reserve a free port, then start the metrics server on it. The recorder is
-    // global and may only be installed once per process; `start_prometheus`
-    // does that install and hands back the handle the server renders.
-    let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = probe.local_addr().unwrap().port();
-    drop(probe);
-
+    // The recorder is global and may only be installed once per process;
+    // `start_prometheus` does that install and hands back the handle the
+    // server renders. Port 0 binds an ephemeral port with no reservation race.
     let handle = start_prometheus(PrometheusConfig {
-        port,
+        port: 0,
         host: "127.0.0.1".to_string(),
         duration_buckets: None,
     });
-    let _server = start_metrics_server(handle, "127.0.0.1".to_string(), port).await;
+    let (addr, _server) = start_metrics_server(handle, "127.0.0.1".to_string(), 0)
+        .await
+        .expect("metrics server binds an ephemeral port");
 
     let response = WorkerLoadResponse {
         timestamp: "t".to_string(),
@@ -46,7 +44,7 @@ async fn engine_pd_gauge_appears_on_metrics_endpoint() {
     };
     Metrics::record_engine_load("grpc://prefill-0:30000", "test-model", &response);
 
-    let body = reqwest::get(format!("http://127.0.0.1:{port}/metrics"))
+    let body = reqwest::get(format!("http://{addr}/metrics"))
         .await
         .expect("metrics endpoint reachable")
         .text()


### PR DESCRIPTION
## Description

### Problem

When the metrics port is already taken, the gateway dies with a `pyo3_runtime.PanicException` and a Rust backtrace in the embedder's logs — the metrics bind is the only startup failure that panics across the FFI instead of returning an error like every other startup path (`metrics_server.rs` used `.expect` on the bind).

This bites launchers that pre-allocate a "free" metrics port and then launch smg after a long engine warmup: the port sits unreserved in the kernel's ephemeral range and can be taken as an outbound connection's source port before smg binds it (observed repeatedly in tokenspeed CI, e.g. https://github.com/lightseekorg/tokenspeed/actions/runs/31729729947/job/94549749972, where the pre-picked port was lost during a 3-minute model load). The race-free alternative — `--prometheus-port 0` — was not usable because smg logged the *requested* address (`Metrics server listening on 0.0.0.0:0`) and gave no way to discover the bound port.

### Solution

- `start_metrics_server` returns `Result<(SocketAddr, JoinHandle<()>), String>`; `startup()` propagates the error. Startup is still fail-fast; embedders now get a clean `RuntimeError` instead of a panic.
- The logged and returned address comes from `TcpListener::local_addr()`, so `--prometheus-port 0` binds an OS-assigned ephemeral port and reports it.
- CLI and Python launcher help document the port-0 semantics.

## Changes

- `model_gateway/src/observability/metrics_server.rs`: no panic path; return bound addr + server task; log the actual bound address; 2 new tests (port-0 bind + `/metrics` scrape, busy-port returns `Err`).
- `model_gateway/src/server.rs`: propagate the bind error with `?`.
- `model_gateway/src/main.rs`, `bindings/python/src/smg/router_args.py`: help text for port 0.
- `model_gateway/tests/engine_metrics_test.rs`: use port 0 and the returned address, removing the test's own bind(0)-then-drop reservation race.

## Test Plan

- `cargo +nightly fmt --all` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings (non-OpenCV variant per CONTRIBUTING).
- `cargo test -p smg --lib observability::metrics_server` — 3 passed (2 new).
- `cargo test -p smg --test engine_metrics_test` — 1 passed.
- Full `cargo test -p smg --lib`: 1525 passed; the two `middleware::metrics` interner tests are parallelism-sensitive on a 72-core box and flake identically on unmodified `main` (verified via stash run: 1 failed there too; all pass in isolation). Unrelated to this change.
- Bindings crate (`smg-python`) compiles under the workspace clippy run; the bindings change itself is help-text only.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (workspace variant, see CONTRIBUTING note on `--all-features`/OpenCV)
- [x] Documentation updated (CLI/Python `--prometheus-port` help)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
