### PR TITLE
fix(bindings): propagate load_monitor_interval to load_check_interval_secs

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -589,10 +589,10 @@ impl Router {
                     overload_token_usage_threshold: self.overload_token_usage_threshold,
                 },
                 PolicyType::PowerOfTwo => ConfigPolicyConfig::PowerOfTwo {
-                    load_check_interval_secs: 5,
+                    load_check_interval_secs: self.load_monitor_interval,
                 },
                 PolicyType::LeastLoad => ConfigPolicyConfig::LeastLoad {
-                    load_check_interval_secs: 5,
+                    load_check_interval_secs: self.load_monitor_interval,
                     kv_pressure_weight: self.least_load_kv_pressure_weight,
                     mean_prefill_tokens: self.least_load_mean_prefill_tokens,
                     default_throughput: self.least_load_default_throughput,

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -490,6 +490,12 @@ pub enum PolicyConfig {
         overload_token_usage_threshold: f32,
     },
 
+    /// Power-of-two choices load balancing policy.
+    /// Randomly selects two workers and routes to the one with lower load.
+    /// TODO: Implement per-policy load monitoring intervals.
+    /// Currently, load_check_interval_secs is populated from RouterConfig.load_monitor_interval_secs,
+    /// but WorkerMonitor does not yet use per-policy intervals. This field is reserved for
+    /// future support of different polling cadences per policy.
     #[serde(rename = "power_of_two")]
     PowerOfTwo { load_check_interval_secs: u64 },
 
@@ -499,6 +505,10 @@ pub enum PolicyConfig {
     /// from the load monitor with in-flight correction. See `policies/least_load.rs`.
     #[serde(rename = "least_load")]
     LeastLoad {
+        /// TODO: Implement per-policy load monitoring intervals.
+        /// Currently, load_check_interval_secs is populated from RouterConfig.load_monitor_interval_secs,
+        /// but WorkerMonitor does not yet use per-policy intervals. This field is reserved for
+        /// future support of different polling cadences per policy.
         #[serde(default = "default_least_load_interval")]
         load_check_interval_secs: u64,
         /// KV-pressure weight `λ_t` (seconds): the time-cost of KV contention,

--- a/model_gateway/src/policies/factory.rs
+++ b/model_gateway/src/policies/factory.rs
@@ -19,17 +19,25 @@ impl PolicyFactory {
             PolicyConfig::Random => Arc::new(RandomPolicy::new()),
             PolicyConfig::RoundRobin => Arc::new(RoundRobinPolicy::new()),
             PolicyConfig::Passthrough => Arc::new(PassthroughPolicy::new()),
-            PolicyConfig::PowerOfTwo { .. } => Arc::new(PowerOfTwoPolicy::new()),
+            PolicyConfig::PowerOfTwo { .. } => {
+                // TODO: Pass load_check_interval_secs to WorkerMonitor for per-policy polling intervals.
+                // Currently, WorkerMonitor uses RouterConfig.load_monitor_interval_secs globally.
+                Arc::new(PowerOfTwoPolicy::new())
+            }
             PolicyConfig::LeastLoad {
                 kv_pressure_weight,
                 mean_prefill_tokens,
                 default_throughput,
                 ..
-            } => Arc::new(LeastLoadPolicy::with_params(
-                *kv_pressure_weight,
-                *mean_prefill_tokens,
-                *default_throughput,
-            )),
+            } => {
+                // TODO: Pass load_check_interval_secs to WorkerMonitor for per-policy polling intervals.
+                // Currently, WorkerMonitor uses RouterConfig.load_monitor_interval_secs globally.
+                Arc::new(LeastLoadPolicy::with_params(
+                    *kv_pressure_weight,
+                    *mean_prefill_tokens,
+                    *default_throughput,
+                ))
+            }
             PolicyConfig::CacheAware {
                 cache_threshold,
                 balance_abs_threshold,


### PR DESCRIPTION
## Description

### Problem

The `load_check_interval_secs` field in `PolicyConfig::PowerOfTwo` and `PolicyConfig::LeastLoad` is hardcoded to 5 seconds in `bindings/python/src/lib.rs`, causing a disconnect between the router's configured `load_monitor_interval` and the policy configuration. While `--load-monitor-interval` is actually used by WorkerMonitor (via RouterConfig), the PolicyConfig field doesn't reflect this value, creating confusion and preventing future per-policy polling interval support. This inconsistency makes the codebase harder to understand and maintain.

### Solution

- Replace hardcoded `load_check_interval_secs: 5` with actual `self.load_monitor_interval` value from the router config
- Add TODO comments documenting this field as reserved for future per-policy polling intervals
- Ensure PolicyConfig now reflects the router's load_monitor_interval_secs value, enabling proper propagation from Python CLI through to the Rust config layer

## Changes

- **bindings/python/src/lib.rs** (lines 590-598): Replace hardcoded `5` with `self.load_monitor_interval` for both PowerOfTwo and LeastLoad policies
- **model_gateway/src/config/types.rs** (lines 495-501, 508-514): Add comprehensive TODO comments documenting:
  - Current behavior: load_check_interval_secs is populated but not yet used by WorkerMonitor
  - Future plan: Support different polling intervals per policy
  - Reference: Reserved for future implementation
- **model_gateway/src/policies/factory.rs** (lines 22-42): Add TODO comments in policy creation to document the planned feature

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

Manual verification:
1. Build: `cargo build`
2. Run with explicit `--load-monitor-interval`:
   ```bash
   python -m smg.launch_router \
     --worker-urls http://worker:8000 \
     --policy power_of_two \
     --load-monitor-interval 15
   ```

Verify PolicyConfig now contains the specified interval instead of hardcoded 5
Test with least_load policy to ensure both policies receive correct intervals
Before: PolicyConfig.PowerOfTwo/LeastLoad.load_check_interval_secs = 5 (hardcoded)
After: PolicyConfig.PowerOfTwo/LeastLoad.load_check_interval_secs = actual router interval

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
