### PR TITLE
fix(allocator): harden jemalloc artifact builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,12 @@
 rustflags = []
 incremental = true
 
+[env]
+# Linux aarch64 distributions must run on 4 KiB, 16 KiB, and 64 KiB page
+# kernels. tikv-jemalloc-sys checks this target-qualified variable before the
+# generic JEMALLOC_SYS_WITH_LG_PAGE value, including during cross-compilation.
+AARCH64_UNKNOWN_LINUX_GNU_JEMALLOC_SYS_WITH_LG_PAGE = { value = "16", force = true }
+
 [target.aarch64-apple-darwin]
 rustflags = [
     "-C", "link-arg=-undefined",

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - .cargo/config.toml
       - docker/Dockerfile
       - bindings/python/pyproject.toml
   workflow_dispatch:

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -64,6 +64,10 @@ jobs:
         with:
           path: smg-repo
 
+      - name: Set up QEMU for aarch64 verification
+        if: matrix.platform == 'linux' && matrix.target == 'aarch64' && matrix.manylinux == '2_28'
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -117,6 +121,20 @@ jobs:
 
       - name: List built packages
         run: ${{ matrix.ls || 'ls -lh' }} smg-repo/bindings/python/dist/
+
+      - name: Verify aarch64 wheel allocator
+        if: matrix.platform == 'linux' && matrix.target == 'aarch64' && matrix.manylinux == '2_28'
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v "$PWD/smg-repo/bindings/python/dist:/dist:ro" \
+            -e '_RJEM_MALLOC_CONF=stats_print:true,stats_print_opts:J' \
+            python:3.13-slim \
+            sh -c 'set -eu
+              wheel=$(find /dist -name "*.whl" -print -quit)
+              test -n "$wheel"
+              pip install --no-deps "$wheel" >/dev/null
+              python3 -c "from smg import smg_rs" 2>/tmp/jemalloc-stats
+              grep -F \"page\":65536 /tmp/jemalloc-stats'
 
       - name: Check packages
         run: twine check --strict smg-repo/bindings/python/dist/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: codespell
         additional_dependencies: ['tomli']
-        args: ['-L', 'cann,thi,makro,wil,rouge,PRIS,hel,te,ans,ser,wit,WIT,implementors,caf,nin,Nin,doubleclick']
+        args: ['-L', 'cann,thi,makro,wil,rouge,PRIS,hel,te,ans,ser,wit,WIT,implementors,caf,nin,Nin,doubleclick,allocatedp']
         exclude: |
           (?x)^(
             src/proto/.*\.proto$|

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ serde_tuple = "1.1.3"
 zeromq = { version = "0.6.0", default-features = false, features = ["tokio-runtime", "all-transport"] }
 chrono = { version = "0.4" }
 dashmap = "6.2.1"
-tikv-jemallocator = { version = "0.6", features = ["stats", "profiling", "background_threads_runtime_support", "disable_initial_exec_tls"] }
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
+tikv-jemallocator = { version = "0.6", default-features = false, features = ["background_threads_runtime_support"] }
+tikv-jemalloc-ctl = { version = "0.6", default-features = false }
 http = "1.4.2"
 lru = "0.18.0"
 num-traits = "0.2"

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -23,7 +23,8 @@ reqwest = { version = "0.13", default-features = false }
 
 [dependencies.smg]
 path = "../../model_gateway"
-default-features = true
+default-features = false
+features = ["grpc-client"]
 
 [dependencies.openai-protocol]
 workspace = true
@@ -41,6 +42,7 @@ workspace = true
 default = []
 opencv-video = ["smg/opencv-video"]
 vendored-openssl = ["smg/vendored-openssl"]
+jemalloc-profiling = ["smg/jemalloc-profiling", "tikv-jemallocator/profiling"]
 
 [profile.release]
 opt-level = "z"     # Optimize for size
@@ -66,4 +68,7 @@ codegen-units = 256
 workspace = true
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_env = "musl")))'.dependencies]
-tikv-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true, features = ["disable_initial_exec_tls"] }
+
+[target.'cfg(all(not(target_env = "msvc"), not(target_env = "musl")))'.dev-dependencies]
+tikv-jemalloc-ctl = { workspace = true }

--- a/bindings/golang/src/lib.rs
+++ b/bindings/golang/src/lib.rs
@@ -77,6 +77,20 @@ mod tokenizer;
 mod tool_parser;
 mod utils;
 
+#[cfg(all(test, not(target_env = "msvc"), not(target_env = "musl")))]
+mod allocator_tests {
+    #[test]
+    fn rust_allocations_use_global_jemalloc() {
+        let allocated =
+            tikv_jemalloc_ctl::thread::allocatedp::read().expect("thread allocation counter");
+        let before = allocated.get();
+        let allocation = std::hint::black_box(vec![0_u8; 1024 * 1024]);
+        let after = allocated.get();
+        assert!(after > before, "Rust allocation bypassed jemalloc");
+        std::hint::black_box(&allocation);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -15,7 +15,8 @@ serde_yaml = "0.9"
 
 [dependencies.smg]
 path = "../../model_gateway"
-default-features = true
+default-features = false
+features = ["grpc-client", "jemalloc-stats"]
 
 [dependencies.smg-auth]
 workspace = true
@@ -36,6 +37,7 @@ workspace = true
 default = ["pyo3/extension-module"]
 opencv-video = ["smg/opencv-video"]
 vendored-openssl = ["smg/vendored-openssl"]
+jemalloc-profiling = ["smg/jemalloc-profiling", "tikv-jemallocator/profiling"]
 
 [profile.ci]
 inherits = "release"
@@ -48,4 +50,4 @@ strip = true
 workspace = true
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_env = "musl")))'.dependencies]
-tikv-jemallocator = { workspace = true }
+tikv-jemallocator = { workspace = true, features = ["disable_initial_exec_tls"] }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1471,6 +1471,8 @@ fn get_available_reasoning_parsers() -> Vec<String> {
 
 #[pymodule]
 fn smg_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    observability::metrics::register_jemalloc_as_global_allocator();
+
     m.add_class::<PolicyType>()?;
     m.add_class::<BackendType>()?;
     m.add_class::<HistoryBackendType>()?;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -165,12 +165,20 @@ RUN uv pip install maturin \
 
 ######################### ROUTER IMAGE #########################
 FROM base AS router-image
+ARG TARGETARCH
 
 # Copy the built package from the build image
 COPY --from=build-image /opt/smg/bindings/python/dist/*.whl dist/
 
-# Build the package and install
-RUN uv pip install --force-reinstall dist/*.whl
+# Install the package and verify arm64's allocator configuration. BuildKit
+# supplies TARGETARCH separately for each platform in a multi-arch build.
+RUN uv pip install --force-reinstall dist/*.whl \
+    && if [ "${TARGETARCH}" = "arm64" ]; then \
+         jemalloc_stats="$(_RJEM_MALLOC_CONF=stats_print:true python3 -c 'from smg import smg_rs' 2>&1)" \
+         && printf '%s\n' "${jemalloc_stats}" | grep -F "Page size: 65536"; \
+       else \
+         python3 -c 'from smg import smg_rs'; \
+       fi
 
 # Clean up unnecessary files to reduce the image size
 RUN rm -rf /root/.cache dist/ \

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -15,9 +15,11 @@ readme = "../README.md"
 categories = ["web-programming", "network-programming"]
 
 [features]
-default = ["grpc-client"]
+default = ["grpc-client", "jemalloc-stats"]
 grpc-client = []
 grpc-server = []
+jemalloc-stats = ["tikv-jemallocator/stats", "dep:tikv-jemalloc-ctl"]
+jemalloc-profiling = ["tikv-jemallocator/profiling"]
 opencv-video = ["llm-multimodal/opencv-video"]
 mm-rdma = ["smg-mm-rdma/nixl"]
 # Client-injection seam for this crate's own K8s discovery integration tests
@@ -238,4 +240,4 @@ workspace = true
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_env = "musl")))'.dependencies]
 tikv-jemallocator = { workspace = true }
-tikv-jemalloc-ctl = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true, features = ["stats"] }

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -19,7 +19,7 @@ use smg::{
         TokenizerCacheConfig, TraceConfig,
     },
     observability::{
-        metrics::PrometheusConfig,
+        metrics::{register_jemalloc_as_global_allocator, PrometheusConfig},
         otel_trace::{is_otel_enabled, shutdown_otel},
     },
     server::{self, ServerConfig},
@@ -1712,6 +1712,8 @@ impl CliArgs {
     reason = "pre-logger startup output and version display"
 )]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    register_jemalloc_as_global_allocator();
+
     // Check for version flags before parsing other args to avoid errors
     let args: Vec<String> = std::env::args().collect();
     for arg in &args {

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -182,8 +182,28 @@ impl Default for PrometheusConfig {
 /// `PrometheusBuilder::upkeep_timeout()` in `start_prometheus`.
 pub(crate) const UPKEEP_INTERVAL_SECS: u64 = 5 * 60;
 
+/// Marks jemalloc as the final artifact's Rust global allocator.
+///
+/// Call this before [`start_prometheus`] only from a binary or extension that
+/// declares `tikv_jemallocator::Jemalloc` with `#[global_allocator]`. Keeping
+/// this registration at the artifact boundary prevents `smg` rlib consumers
+/// that use the system allocator from publishing statistics for an unused
+/// linked jemalloc instance.
+pub fn register_jemalloc_as_global_allocator() {
+    #[cfg(all(
+        feature = "jemalloc-stats",
+        not(target_env = "msvc"),
+        not(target_env = "musl")
+    ))]
+    allocator_stats::register_global_allocator();
+}
+
 pub(crate) fn init_metrics() {
-    #[cfg(all(not(target_env = "msvc"), not(target_env = "musl")))]
+    #[cfg(all(
+        feature = "jemalloc-stats",
+        not(target_env = "msvc"),
+        not(target_env = "musl")
+    ))]
     allocator_stats::describe();
 
     // Layer 1: HTTP metrics
@@ -523,32 +543,55 @@ pub fn start_prometheus(config: PrometheusConfig) -> PrometheusHandle {
         .expect("failed to set event loop delay buckets")
         .install_recorder()
         .inspect(|_| {
-            #[cfg(all(not(target_env = "msvc"), not(target_env = "musl")))]
+            #[cfg(all(
+                feature = "jemalloc-stats",
+                not(target_env = "msvc"),
+                not(target_env = "musl")
+            ))]
             allocator_stats::start_reporting();
         })
         .expect("failed to install Prometheus recorder")
 }
 
-#[cfg(all(not(target_env = "msvc"), not(target_env = "musl")))]
+#[cfg(all(
+    feature = "jemalloc-stats",
+    not(target_env = "msvc"),
+    not(target_env = "musl")
+))]
 pub(crate) mod allocator_stats {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use metrics::{describe_gauge, gauge};
 
+    static JEMALLOC_IS_GLOBAL: AtomicBool = AtomicBool::new(false);
+
+    pub(super) fn register_global_allocator() {
+        JEMALLOC_IS_GLOBAL.store(true, Ordering::Release);
+    }
+
+    fn is_global_allocator() -> bool {
+        JEMALLOC_IS_GLOBAL.load(Ordering::Acquire)
+    }
+
     pub(crate) fn describe() {
+        if !is_global_allocator() {
+            return;
+        }
         describe_gauge!(
             "smg_allocator_allocated_bytes",
-            "Bytes in live allocations (jemalloc stats.allocated)"
+            "Bytes in live Rust allocations managed by SMG's jemalloc instance"
         );
         describe_gauge!(
             "smg_allocator_active_bytes",
-            "Bytes in active pages (jemalloc stats.active)"
+            "Bytes in active pages for SMG's Rust jemalloc heap"
         );
         describe_gauge!(
             "smg_allocator_resident_bytes",
-            "Bytes resident per the allocator (jemalloc stats.resident)"
+            "Upper bound on resident bytes for SMG's Rust jemalloc heap"
         );
         describe_gauge!(
             "smg_allocator_metadata_bytes",
-            "Allocator metadata bytes (jemalloc stats.metadata)"
+            "Metadata bytes for SMG's Rust jemalloc instance"
         );
     }
 
@@ -571,9 +614,12 @@ pub(crate) mod allocator_stats {
         }
     }
 
-    /// Gauges are truthful when jemalloc is the global allocator, which every
-    /// shipped artifact declares.
+    /// Registration at the final-artifact boundary keeps these gauges tied to
+    /// Rust's actual global allocator.
     pub(crate) fn start_reporting() {
+        if !is_global_allocator() {
+            return;
+        }
         record();
         // Plain thread: metrics must not depend on a runtime being alive.
         let _ = std::thread::Builder::new()
@@ -587,11 +633,13 @@ pub(crate) mod allocator_stats {
     #[cfg(test)]
     mod tests {
         #[test]
-        fn jemalloc_stats_readable() {
+        fn jemalloc_stats_interface_readable() {
             use tikv_jemalloc_ctl::{epoch, stats};
             epoch::advance().expect("epoch advance");
             stats::allocated::read().expect("stats.allocated readable");
+            stats::active::read().expect("stats.active readable");
             stats::resident::read().expect("stats.resident readable");
+            stats::metadata::read().expect("stats.metadata readable");
         }
     }
 }

--- a/model_gateway/tests/allocator_artifact_test.rs
+++ b/model_gateway/tests/allocator_artifact_test.rs
@@ -1,0 +1,35 @@
+//! Verifies that the shipped SMG executable owns the expected jemalloc.
+
+#![cfg(all(
+    feature = "jemalloc-stats",
+    not(target_env = "msvc"),
+    not(target_env = "musl")
+))]
+
+use std::process::Command;
+
+#[test]
+fn smg_binary_uses_global_jemalloc() {
+    let output = Command::new(env!("CARGO_BIN_EXE_smg"))
+        .arg("--version")
+        .env("_RJEM_MALLOC_CONF", "stats_print:true,stats_print_opts:J")
+        .output()
+        .expect("run the SMG executable");
+    assert!(
+        output.status.success(),
+        "SMG executable failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stats = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stats.contains("\"jemalloc\""),
+        "SMG executable did not emit jemalloc statistics: {stats}"
+    );
+
+    #[cfg(all(target_arch = "aarch64", target_env = "gnu"))]
+    assert!(
+        stats.contains("\"page\":65536"),
+        "aarch64 SMG executable was not built for 64 KiB page compatibility: {stats}"
+    );
+}

--- a/model_gateway/tests/allocator_metrics_test.rs
+++ b/model_gateway/tests/allocator_metrics_test.rs
@@ -1,0 +1,51 @@
+//! Verifies the final-artifact contract for jemalloc metrics.
+//!
+//! This integration test is a separate executable, so it can declare the same
+//! global allocator and registration sequence used by the shipped SMG binary.
+
+#![cfg(all(
+    feature = "jemalloc-stats",
+    not(target_env = "msvc"),
+    not(target_env = "musl")
+))]
+
+use smg::observability::metrics::{
+    register_jemalloc_as_global_allocator, start_prometheus, PrometheusConfig,
+};
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[test]
+fn registered_global_jemalloc_exposes_allocator_gauges() {
+    use tikv_jemalloc_ctl::thread;
+
+    // A cumulative, thread-local counter proves an ordinary Rust allocation
+    // went through the declared global jemalloc without races from other tests.
+    let allocated = thread::allocatedp::read().expect("thread allocation counter");
+    let before = allocated.get();
+    let allocation = std::hint::black_box(vec![0_u8; 1024 * 1024]);
+    let after = allocated.get();
+    assert!(after > before, "Rust allocation bypassed jemalloc");
+    std::hint::black_box(&allocation);
+
+    register_jemalloc_as_global_allocator();
+    let handle = start_prometheus(PrometheusConfig {
+        port: 0,
+        host: "127.0.0.1".to_string(),
+        duration_buckets: None,
+    });
+    let body = handle.render();
+
+    for metric in [
+        "smg_allocator_allocated_bytes",
+        "smg_allocator_active_bytes",
+        "smg_allocator_resident_bytes",
+        "smg_allocator_metadata_bytes",
+    ] {
+        assert!(
+            body.lines().any(|line| line.starts_with(metric)),
+            "registered allocator metric {metric} missing:\n{body}"
+        );
+    }
+}

--- a/model_gateway/tests/engine_metrics_test.rs
+++ b/model_gateway/tests/engine_metrics_test.rs
@@ -66,4 +66,8 @@ async fn engine_pd_gauge_appears_on_metrics_endpoint() {
             .any(|l| l.starts_with("smg_engine_running_requests{")),
         "core engine sample missing from /metrics:\n{body}"
     );
+    assert!(
+        !body.contains("smg_allocator_"),
+        "an rlib consumer that did not register jemalloc exposed allocator gauges:\n{body}"
+    );
 }


### PR DESCRIPTION
## Description

### Problem

The global jemalloc integration added in #2125 left several final-artifact contracts implicit:

- Cross-compiled Linux/aarch64 artifacts could inherit a 4 KiB builder page size and then fail on a 64 KiB runtime kernel.
- `stats`, `profiling`, and `disable_initial_exec_tls` were enabled for every artifact even though their requirements differ.
- An `smg` rlib consumer could publish allocator gauges without using jemalloc as its Rust global allocator.
- Release jobs built the artifacts but did not verify the jemalloc configuration embedded in the final wheel or image.

### Solution

Keep jemalloc as the Rust global allocator in the standalone binary and both language bindings, while making its configuration artifact-specific. Linux/aarch64 GNU builds now use a target-qualified 64 KiB page setting, profiling is opt-in, the dynamic-library TLS setting is scoped to the Python and Go bindings, and allocator metrics require registration by the final artifact. Release and integration tests inspect the actual built artifacts.

## Changes

- Pin `AARCH64_UNKNOWN_LINUX_GNU_JEMALLOC_SYS_WITH_LG_PAGE=16` in Cargo's source configuration so native and cross builds use the same aarch64 contract.
- Split jemalloc stats and profiling into explicit features; retain stats for the router/Python artifacts and make profiling opt-in.
- Scope `disable_initial_exec_tls` to the Python and Go cdylibs.
- Register allocator metrics only from artifacts that declare jemalloc globally, with positive and negative metric tests.
- Verify the standalone binary, Go binding, aarch64 wheel under QEMU, and arm64 Docker image use the expected allocator configuration.

## Test Plan

- `rustup run nightly cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings` (the documented no-OpenCV fallback)
- `cargo clippy -p smg -p smg-python -p smg-golang --all-targets --features jemalloc-profiling -- -D warnings`
- `cargo test -p smg --test allocator_artifact_test` on a native 64 KiB aarch64 host: the real `smg` executable reports `"page":65536`
- `cargo test -p smg --test allocator_metrics_test`
- `cargo test -p smg --test engine_metrics_test`
- `cargo test -p smg-golang allocator_tests::rust_allocations_use_global_jemalloc`
- `make python-dev`, followed by importing the built extension with jemalloc stats enabled: `"page":65536`, `"stats":true`, `"prof":false`
- Parsed both modified workflow files as YAML and syntax-checked the aarch64 wheel verification shell step.

The serialized workspace test run passed all SMG and allocator suites. Three pre-existing `smg-grpc-client` invalid-endpoint assertions remain environment-specific because this host resolves the sentinel hostname `endpoint`; that crate is unchanged by this PR.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] Clippy passes (`cargo clippy --workspace --all-targets -- -D warnings`, the documented no-OpenCV fallback)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

Refs: #2125
