### PR TITLE
fix(protocols): prefer token ids over text for routing

### DIFF
--- a/crates/protocols/src/generate.rs
+++ b/crates/protocols/src/generate.rs
@@ -237,12 +237,13 @@ impl GenerationRequest for GenerateRequest {
     }
 
     fn routing_tokens(&self) -> Option<&[i32]> {
-        // Mirrors extract_text_for_routing priority: explicit text wins.
-        match (&self.text, &self.input_ids) {
-            (None, Some(InputIds::Single(ids))) => Some(ids),
+        // Token ids win over text: they key routing on what the backend KV
+        // cache keys on. Empty ids fall back to text.
+        match &self.input_ids {
+            Some(InputIds::Single(ids)) if !ids.is_empty() => Some(ids),
             // A batch is dispatched to a single worker; the first sequence is
             // the best available affinity signal.
-            (None, Some(InputIds::Batch(seqs))) => seqs
+            Some(InputIds::Batch(seqs)) => seqs
                 .first()
                 .map(Vec::as_slice)
                 .filter(|ids| !ids.is_empty()),
@@ -336,10 +337,21 @@ mod tests {
     }
 
     #[test]
-    fn routing_tokens_text_takes_priority() {
+    fn routing_tokens_prefer_input_ids_over_text() {
         let mut r = req();
         r.text = Some("hello".to_string());
         r.input_ids = Some(InputIds::Single(vec![1, 2, 3]));
+        assert_eq!(r.routing_tokens(), Some(&[1, 2, 3][..]));
+
+        r.input_ids = Some(InputIds::Batch(vec![vec![4, 5], vec![6]]));
+        assert_eq!(r.routing_tokens(), Some(&[4, 5][..]));
+    }
+
+    #[test]
+    fn routing_tokens_none_for_empty_input_ids_with_text() {
+        let mut r = req();
+        r.text = Some("hello".to_string());
+        r.input_ids = Some(InputIds::Single(vec![]));
         assert_eq!(r.routing_tokens(), None);
         assert_eq!(r.extract_text_for_routing(), "hello");
     }


### PR DESCRIPTION
## Description

### Problem

`GenerateRequest::routing_tokens()` returns `None` whenever the request carries both `text` and `input_ids`, so the router falls back to character-based text matching even though token ids are available. Token-based policies (cache-aware token tree with page-aligned matching, `prefix_hash` token hashing) key on exactly what the backend's KV cache keys on, while text matching is only an approximation of token boundaries. Both fields describe the same prompt, so ignoring the tokens just degrades routing quality.

### Solution

Prefer `input_ids` over `text` for routing:

- non-empty `InputIds::Single` → route on the token ids, regardless of `text`
- empty `InputIds::Single`, batch, or absent → `None` (text fallback, as before)

The empty-ids case now also returns `None` instead of an empty slice, so routing never keys on zero tokens.

This changes only the worker-selection input, never what is forwarded to the backend: in both `router.rs` and `pd_router.rs` the routing text/tokens feed only worker selection (`select_worker_for_model` / the PD dispatch context), while the request body is serialized and proxied unmodified.

Side benefit: `route_typed_request` only materializes the routing text when `routing_tokens()` is `None`, so requests carrying both fields now skip the text rendering entirely — cheaper on top of the better routing signal.

## Changes

- `crates/protocols/src/generate.rs`: `routing_tokens()` returns non-empty `InputIds::Single` token ids regardless of `text`; empty ids return `None`. Batch handling is unchanged.
- Tests: replaced `routing_tokens_text_takes_priority` with `routing_tokens_prefer_input_ids_over_text`; added `routing_tokens_none_for_empty_input_ids_with_text` covering the empty-ids text fallback.

## Test Plan

- `cargo +nightly fmt --all --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (`--all-features` pulls opencv, which does not build locally)
- `cargo test -p openai-protocol` — 218 passed, 0 failed (includes the new `routing_tokens_prefer_input_ids_over_text` and `routing_tokens_none_for_empty_input_ids_with_text`)
- `cargo test -p smg` — lib plus all integration test binaries: 2128 passed, 0 failed
- `cargo build -p smg-python` and `cargo build -p smg-golang` — both build clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
